### PR TITLE
fix(#668): coalesce concurrent refresh cycles, serving late callers a fresh one

### DIFF
--- a/Sources/LogicProMCP/State/StateCache.swift
+++ b/Sources/LogicProMCP/State/StateCache.swift
@@ -347,6 +347,27 @@ actor StateCache {
         return true
     }
 
+    /// #668 — the write outcome a refresh RECEIPT needs, computed without a gap.
+    ///
+    /// `updateTracks(_:ifCurrent:)` answers "the compare-and-swap accepted", which is a different
+    /// question: the occlusion debounce above accepts and then returns without touching tracks,
+    /// timestamp, or revision, so `refresh_cache` reported `refreshed: true` for a poll that wrote
+    /// nothing. Computing the difference in the poller does not fix it — that needs a second actor
+    /// call to read the revision, and any other writer to this section (MCU feedback, a track
+    /// dispatcher, the server's own load path) can advance it in that window and be credited to
+    /// the poll. This is the only place it can be answered atomically, because nothing can
+    /// interleave inside one synchronous actor method.
+    ///
+    /// Tracks is the only section that needs this: project, transport and mixer have no path that
+    /// accepts and then declines to write.
+    @discardableResult
+    func applyTracks(_ newTracks: [TrackState], ifCurrent observed: SectionVersion) -> Bool {
+        guard accepts(observed, for: .tracks) else { return false }
+        let before = sectionRevisions[.tracks, default: 0]
+        updateTracks(newTracks)
+        return sectionRevisions[.tracks, default: 0] != before
+    }
+
     /// v3.1.1 (P1-3) — exposed for diagnostics and tests. Returns the number
     /// of consecutive empty `updateTracks([])` calls suppressed since the
     /// last non-empty update. Resets to 0 once any non-empty update lands or

--- a/Sources/LogicProMCP/State/StatePoller.swift
+++ b/Sources/LogicProMCP/State/StatePoller.swift
@@ -92,6 +92,8 @@ actor StatePoller {
     /// owed reads taken after their own request.
     private var cycleInProgress = false
     private var waitingForNextCycle: [CheckedContinuation<Bool, Never>] = []
+    /// The handed-off drain, tracked rather than detached so `stop()` still means what it says.
+    private var drainTask: Task<Void, Never>?
 
     init(
         axChannel: AccessibilityChannel,
@@ -124,6 +126,13 @@ actor StatePoller {
         pollingTask = nil
         // Wait for the cancelled task to complete its current cycle
         await task.value
+        // #668: the drain runs as its own task so the caller that starts a cycle is not billed for
+        // everyone else's. That would otherwise let AX polling outlive a `stop()` that documents
+        // itself as waiting for the current cycle. In practice the drain usually finishes while
+        // this function is suspended above -- it shares this actor -- but "usually" is scheduling
+        // luck, and a stop guarantee resting on it is not a guarantee.
+        await drainTask?.value
+        drainTask = nil
         Log.info("StatePoller stopped", subsystem: "poller")
     }
 
@@ -131,6 +140,7 @@ actor StatePoller {
         guard let task = pollingTask else { return }
         task.cancel()
         pollingTask = nil
+        drainTask?.cancel()
         Log.info("StatePoller stop requested without awaiting current AX poll", subsystem: "poller")
     }
 
@@ -185,7 +195,7 @@ actor StatePoller {
             // its own cycle ended; holding it to serve later arrivals adds whole cycles to a
             // latency that already overruns its deadline — measured at roughly 2x the solo cost
             // under a continuous stream of nudges, and the deadline overrun is what #668 is about.
-            Task { await self.drainWaiters() }
+            drainTask = Task { await self.drainWaiters() }
         }
         return mine
     }
@@ -194,15 +204,17 @@ actor StatePoller {
     /// Anyone arriving during THAT cycle forms the following batch, so arrivals never extend a
     /// cycle already under way, and the loop ends the moment a cycle finishes with nobody waiting.
     private func drainWaiters() async {
+        // On every exit, not just the loop's: leaving `cycleInProgress` true would make every
+        // later nudge queue behind a drain that is gone, and no suspension separates the loop's
+        // emptiness check from this, so no arrival can be stranded by observing it true and then
+        // finding nobody left to serve it.
+        defer { cycleInProgress = false }
         while !waitingForNextCycle.isEmpty {
             let batch = waitingForNextCycle
             waitingForNextCycle = []
             let shared = await pollOnce(axChannel: axChannel, cache: cache)
             for waiter in batch { waiter.resume(returning: shared) }
         }
-        // No suspension between the emptiness check and this line, so no arrival can be stranded
-        // by observing `cycleInProgress == true` and then finding nobody left to serve it.
-        cycleInProgress = false
     }
 
     private func pollLoop(axChannel: AccessibilityChannel, cache: StateCache) async {

--- a/Sources/LogicProMCP/State/StatePoller.swift
+++ b/Sources/LogicProMCP/State/StatePoller.swift
@@ -131,6 +131,7 @@ actor StatePoller {
         // itself as waiting for the current cycle. In practice the drain usually finishes while
         // this function is suspended above -- it shares this actor -- but "usually" is scheduling
         // luck, and a stop guarantee resting on it is not a guarantee.
+        drainTask?.cancel()
         await drainTask?.value
         drainTask = nil
         Log.info("StatePoller stopped", subsystem: "poller")
@@ -217,21 +218,45 @@ actor StatePoller {
         // finding nobody left to serve it.
         defer { cycleInProgress = false }
         while !waitingForNextCycle.isEmpty {
+            // Cooperative cancellation, because without it this loop has no upper bound: it keeps
+            // accepting new batches, and `refreshNow` stays callable after the loop task is gone,
+            // so one nudge per cycle from any caller kept `stop()` awaiting this task forever.
+            // Reproduced with fire-and-forget timed nudges -- the shape the 15 bootstrap callers
+            // actually have -- where stop() had not returned after 20s and only returned once the
+            // nudges ceased.
+            if Task.isCancelled { break }
             let batch = waitingForNextCycle
             waitingForNextCycle = []
             let shared = await pollOnce(axChannel: axChannel, cache: cache)
             for waiter in batch { waiter.resume(returning: shared) }
         }
+        // Whoever is still queued when this exits is owed an answer, and the honest one is that
+        // the cache did not advance for them. Leaving them suspended would be the lost
+        // continuation this design is otherwise free of.
+        let stranded = waitingForNextCycle
+        waitingForNextCycle = []
+        for waiter in stranded { waiter.resume(returning: false) }
     }
 
     private func pollLoop(axChannel: AccessibilityChannel, cache: StateCache) async {
         let intervalNs = ServerConfig.statePollingIntervalNs
 
         while !Task.isCancelled {
-            // Through the same gate as `refreshNow`: the scheduled cycle is the one a nudge most
+            // Through the same gate as `refreshNow` -- the scheduled cycle is what a nudge most
             // often collides with, since at the measured 12.6s median on a 74-track project the
-            // loop is mid-cycle roughly 80% of the time.
-            _ = await runCoalescedCycle()
+            // loop is mid-cycle roughly 80% of the time -- but NEVER as a queued waiter.
+            //
+            // A waiter suspends in a continuation that cancellation cannot wake, so a queued loop
+            // made `stopImmediately()` return and THEN have a whole AX cycle start, run purely to
+            // service a loop that was already cancelled. The loop has no use for the
+            // fresh-after-request guarantee anyway: it is a periodic refresh, not a caller with a
+            // pending write. If a cycle is already under way, this tick is redundant -- skip it.
+            //
+            // No suspension separates this check from `runCoalescedCycle`'s own, so the loop
+            // always takes the initiator path and can never become a waiter.
+            if !cycleInProgress {
+                _ = await runCoalescedCycle()
+            }
 
             do {
                 // Route through runtime.sleep so tests can drive this loop at
@@ -318,8 +343,9 @@ actor StatePoller {
             // this fast path bypasses `poll`, so it is the one place the old `_ =` discard could
             // survive the split, and it is the section most likely to lose a race on a large
             // project — exactly where a receipt claiming `refreshed: true` would be wrong.
-            let applied = await cache.updateTracks(tracks, ifCurrent: tracksVersion)
-            tracksReady = PollOutcome(readable: true, applied: applied)
+            let accepted = await cache.updateTracks(tracks, ifCurrent: tracksVersion)
+            let advanced = await cache.currentVersion(for: .tracks) != tracksVersion
+            tracksReady = PollOutcome(readable: true, applied: accepted && advanced)
         } else {
             tracksReady = await poll(
                 operation: "track.get_tracks", label: "Track",
@@ -465,8 +491,16 @@ actor StatePoller {
             // whose write had been refused, because the receipt was built from the readability
             // answer. The cache recorded the rejection all along — `droppedStaleWriteCount` — and
             // nothing on the receipt path consulted it.
-            let applied = await update(cache, value, observed)
-            return PollOutcome(readable: true, applied: applied)
+            // "The CAS accepted" is not "the cache advanced", and the receipt claims the second.
+            // `updateTracks` absorbs the first two empty reads under an occluding dialog and
+            // returns without touching tracks, timestamp, or revision -- while the conditional
+            // wrapper still reports true. That `true` reached `refresh_cache`'s `refreshed`.
+            //
+            // Comparing the revision closes it: acceptance means the section was still at
+            // `observed`, so any advance from there is ours, and no advance means nothing landed.
+            let accepted = await update(cache, value, observed)
+            let advanced = await cache.currentVersion(for: section) != observed
+            return PollOutcome(readable: true, applied: accepted && advanced)
         } catch {
             Log.debug("\(label) poll failed: \(error)", subsystem: "poller")
             return .unreadable

--- a/Sources/LogicProMCP/State/StatePoller.swift
+++ b/Sources/LogicProMCP/State/StatePoller.swift
@@ -151,14 +151,21 @@ actor StatePoller {
 
     // MARK: - Poll loop
 
-    /// Runs one poll cycle and reports whether the cache actually advanced —
-    /// i.e. at least one section was written and `postPoll` fired for it — not
-    /// merely whether this function returned. A poll that finds no visible
-    /// window (below the miss threshold) or that backs off under an occluding
-    /// dialog writes nothing and returns `false`; every caller that needs to
-    /// know "did state move" (not "did I call refreshNow") must read this
-    /// return value rather than assume a completed call means a write landed
-    /// (#544 review).
+    /// Runs a poll cycle — or shares one — and reports whether the cache
+    /// actually advanced: i.e. at least one section was written and `postPoll`
+    /// fired for it, not merely whether this function returned. A poll that
+    /// finds no visible window (below the miss threshold) or that backs off
+    /// under an occluding dialog writes nothing and returns `false`; every
+    /// caller that needs to know "did state move" (not "did I call
+    /// refreshNow") must read this return value rather than assume a completed
+    /// call means a write landed (#544 review).
+    ///
+    /// "or shares one" is #668 and is not a detail: a call arriving while a
+    /// cycle is under way waits for the NEXT one and is served its result
+    /// alongside everyone else who arrived in that window, so the returned
+    /// answer may describe a cycle this call did not itself start. What it
+    /// never describes is a cycle whose AX reads predate this call — see
+    /// `runCoalescedCycle` for why that distinction is load-bearing.
     @discardableResult
     func refreshNow() async -> Bool {
         await runCoalescedCycle()

--- a/Sources/LogicProMCP/State/StatePoller.swift
+++ b/Sources/LogicProMCP/State/StatePoller.swift
@@ -87,6 +87,11 @@ actor StatePoller {
     private let runtime: Runtime
     private let postPoll: @Sendable ([ResourceCacheKey]) async -> Void
     private var pollingTask: Task<Void, Never>?
+    /// #668 coalescing state. `cycleInProgress` is the mutual exclusion the `actor` keyword does
+    /// not give across `await`; `waitingForNextCycle` holds callers that arrived mid-cycle and are
+    /// owed reads taken after their own request.
+    private var cycleInProgress = false
+    private var waitingForNextCycle: [CheckedContinuation<Bool, Never>] = []
 
     init(
         axChannel: AccessibilityChannel,
@@ -146,14 +151,55 @@ actor StatePoller {
     /// (#544 review).
     @discardableResult
     func refreshNow() async -> Bool {
-        await pollOnce(axChannel: axChannel, cache: cache)
+        await runCoalescedCycle()
+    }
+
+    /// #668 — one poll cycle at a time, and callers that arrive during one share a single fresh
+    /// cycle rather than each starting their own.
+    ///
+    /// `actor` does not provide this. Actors are re-entrant across `await`, and the poll body
+    /// suspends on every AX read, so concurrent callers used to enter it together, all capture the
+    /// same section version, and race their conditional writes. Measured: four concurrent nudges
+    /// produced three refused writes and three wasted AX walks, deterministically.
+    ///
+    /// The subtle part is what a late caller is owed. It must NOT be served the in-flight cycle's
+    /// result: that cycle's AX reads may predate the caller's request, so a caller that just wrote
+    /// something — `refreshAfterWrite` on the saga path does exactly this — would be handed state
+    /// from before its own write. Joining the in-flight cycle would reintroduce the staleness the
+    /// compare-and-swap exists to prevent, only without the counter noticing.
+    ///
+    /// So arrivals queue for the NEXT cycle and share it. N concurrent callers cost at most two
+    /// cycles instead of N, every caller's reads begin after its own request, and no two cycles
+    /// overlap — which is also why poller-vs-poller `dropped_stale_writes` becomes unreachable
+    /// here, this time by construction rather than by my assuming it.
+    private func runCoalescedCycle() async -> Bool {
+        if cycleInProgress {
+            return await withCheckedContinuation { waitingForNextCycle.append($0) }
+        }
+        cycleInProgress = true
+        let mine = await pollOnce(axChannel: axChannel, cache: cache)
+
+        // Drain in batches: everyone who queued during the cycle just finished shares ONE fresh
+        // cycle. Anyone arriving during THAT cycle forms the next batch, so a steady stream of
+        // nudges cannot starve the loop into never returning.
+        while !waitingForNextCycle.isEmpty {
+            let batch = waitingForNextCycle
+            waitingForNextCycle = []
+            let shared = await pollOnce(axChannel: axChannel, cache: cache)
+            for waiter in batch { waiter.resume(returning: shared) }
+        }
+        cycleInProgress = false
+        return mine
     }
 
     private func pollLoop(axChannel: AccessibilityChannel, cache: StateCache) async {
         let intervalNs = ServerConfig.statePollingIntervalNs
 
         while !Task.isCancelled {
-            await pollOnce(axChannel: axChannel, cache: cache)
+            // Through the same gate as `refreshNow`: the scheduled cycle is the one a nudge most
+            // often collides with, since at the measured 12.6s median on a 74-track project the
+            // loop is mid-cycle roughly 80% of the time.
+            _ = await runCoalescedCycle()
 
             do {
                 // Route through runtime.sleep so tests can drive this loop at

--- a/Sources/LogicProMCP/State/StatePoller.swift
+++ b/Sources/LogicProMCP/State/StatePoller.swift
@@ -178,18 +178,31 @@ actor StatePoller {
         }
         cycleInProgress = true
         let mine = await pollOnce(axChannel: axChannel, cache: cache)
+        if waitingForNextCycle.isEmpty {
+            cycleInProgress = false
+        } else {
+            // Hand the drain off rather than running it here. This caller's answer was ready when
+            // its own cycle ended; holding it to serve later arrivals adds whole cycles to a
+            // latency that already overruns its deadline — measured at roughly 2x the solo cost
+            // under a continuous stream of nudges, and the deadline overrun is what #668 is about.
+            Task { await self.drainWaiters() }
+        }
+        return mine
+    }
 
-        // Drain in batches: everyone who queued during the cycle just finished shares ONE fresh
-        // cycle. Anyone arriving during THAT cycle forms the next batch, so a steady stream of
-        // nudges cannot starve the loop into never returning.
+    /// Serves queued callers in batches: everyone who arrived during one cycle shares the next.
+    /// Anyone arriving during THAT cycle forms the following batch, so arrivals never extend a
+    /// cycle already under way, and the loop ends the moment a cycle finishes with nobody waiting.
+    private func drainWaiters() async {
         while !waitingForNextCycle.isEmpty {
             let batch = waitingForNextCycle
             waitingForNextCycle = []
             let shared = await pollOnce(axChannel: axChannel, cache: cache)
             for waiter in batch { waiter.resume(returning: shared) }
         }
+        // No suspension between the emptiness check and this line, so no arrival can be stranded
+        // by observing `cycleInProgress == true` and then finding nobody left to serve it.
         cycleInProgress = false
-        return mine
     }
 
     private func pollLoop(axChannel: AccessibilityChannel, cache: StateCache) async {

--- a/Sources/LogicProMCP/State/StatePoller.swift
+++ b/Sources/LogicProMCP/State/StatePoller.swift
@@ -94,6 +94,13 @@ actor StatePoller {
     private var waitingForNextCycle: [CheckedContinuation<Bool, Never>] = []
     /// The handed-off drain, tracked rather than detached so `stop()` still means what it says.
     private var drainTask: Task<Void, Never>?
+    /// Set the moment a stop begins. Cancelling the loop is not enough: a cycle owned by an
+    /// external `refreshNow` keeps running, and when it ends it would hand off a fresh, uncancelled
+    /// drain — starting AX work after `stop()` had already returned. This refuses new cycles and
+    /// new drains instead of trying to chase them.
+    private var stopped = false
+    /// Parked `stop()` calls, waiting for a cycle they do not own to finish.
+    private var quiesceWaiters: [CheckedContinuation<Void, Never>] = []
 
     init(
         axChannel: AccessibilityChannel,
@@ -109,6 +116,7 @@ actor StatePoller {
 
     /// Start the background polling loop.
     func start() {
+        stopped = false
         guard pollingTask == nil else {
             Log.warn("StatePoller already running", subsystem: "poller")
             return
@@ -122,23 +130,33 @@ actor StatePoller {
     /// Stop the polling loop and wait for the current poll cycle to finish.
     func stop() async {
         guard let task = pollingTask else { return }
+        // Before anything else: no new cycle and no new drain may start from here on. Cancelling
+        // the loop does not cover a cycle owned by an external `refreshNow`, and that cycle would
+        // otherwise hand off a fresh drain -- uncancelled, because it did not exist when stop ran.
+        stopped = true
         task.cancel()
         pollingTask = nil
         // Wait for the cancelled task to complete its current cycle
         await task.value
-        // #668: the drain runs as its own task so the caller that starts a cycle is not billed for
-        // everyone else's. That would otherwise let AX polling outlive a `stop()` that documents
-        // itself as waiting for the current cycle. In practice the drain usually finishes while
-        // this function is suspended above -- it shares this actor -- but "usually" is scheduling
-        // luck, and a stop guarantee resting on it is not a guarantee.
+        // The drain runs as its own task so the caller that starts a cycle is not billed for
+        // everyone else's; without awaiting it, AX polling outlives a `stop()` that documents
+        // itself as waiting for the current cycle. Cancel first, or a steady stream of nudges
+        // keeps the drain accepting batches and this await never returns.
         drainTask?.cancel()
         await drainTask?.value
         drainTask = nil
+        // A cycle this poller does not own may still be in flight. `stopped` guarantees nothing
+        // follows it, so this waits at most that one cycle -- which is exactly what this function
+        // documents itself as waiting for.
+        if cycleInProgress {
+            await withCheckedContinuation { quiesceWaiters.append($0) }
+        }
         Log.info("StatePoller stopped", subsystem: "poller")
     }
 
     func stopImmediately() {
         guard let task = pollingTask else { return }
+        stopped = true
         task.cancel()
         pollingTask = nil
         drainTask?.cancel()
@@ -191,13 +209,16 @@ actor StatePoller {
     /// overlap — which is also why poller-vs-poller `dropped_stale_writes` becomes unreachable
     /// here, this time by construction rather than by my assuming it.
     private func runCoalescedCycle() async -> Bool {
+        // A stop is under way; starting a cycle now is the AX work that stop exists to end.
+        if stopped { return false }
         if cycleInProgress {
             return await withCheckedContinuation { waitingForNextCycle.append($0) }
         }
         cycleInProgress = true
         let mine = await pollOnce(axChannel: axChannel, cache: cache)
         if waitingForNextCycle.isEmpty {
-            cycleInProgress = false
+            strandWaiters()
+            releaseCycle()
         } else {
             // Hand the drain off rather than running it here. This caller's answer was ready when
             // its own cycle ended; holding it to serve later arrivals adds whole cycles to a
@@ -216,8 +237,9 @@ actor StatePoller {
         // later nudge queue behind a drain that is gone, and no suspension separates the loop's
         // emptiness check from this, so no arrival can be stranded by observing it true and then
         // finding nobody left to serve it.
-        defer { cycleInProgress = false }
+        defer { strandWaiters(); releaseCycle() }
         while !waitingForNextCycle.isEmpty {
+            if stopped { break }
             // Cooperative cancellation, because without it this loop has no upper bound: it keeps
             // accepting new batches, and `refreshNow` stays callable after the loop task is gone,
             // so one nudge per cycle from any caller kept `stop()` awaiting this task forever.
@@ -230,12 +252,25 @@ actor StatePoller {
             let shared = await pollOnce(axChannel: axChannel, cache: cache)
             for waiter in batch { waiter.resume(returning: shared) }
         }
-        // Whoever is still queued when this exits is owed an answer, and the honest one is that
-        // the cache did not advance for them. Leaving them suspended would be the lost
-        // continuation this design is otherwise free of.
+    }
+
+    /// Whoever is still queued is owed an answer, and the honest one is that the cache did not
+    /// advance for them. Leaving them suspended would be the lost continuation this design is
+    /// otherwise free of. Synchronous by construction: no arrival can slip between the snapshot
+    /// and the resumes.
+    private func strandWaiters() {
         let stranded = waitingForNextCycle
         waitingForNextCycle = []
         for waiter in stranded { waiter.resume(returning: false) }
+    }
+
+    /// Releases the cycle and wakes any `stop()` parked on it. Ordering matters: waiters are
+    /// stranded first, so nobody is left queued against a flag that has just been released.
+    private func releaseCycle() {
+        cycleInProgress = false
+        let parked = quiesceWaiters
+        quiesceWaiters = []
+        for waiter in parked { waiter.resume() }
     }
 
     private func pollLoop(axChannel: AccessibilityChannel, cache: StateCache) async {
@@ -343,16 +378,18 @@ actor StatePoller {
             // this fast path bypasses `poll`, so it is the one place the old `_ =` discard could
             // survive the split, and it is the section most likely to lose a race on a large
             // project — exactly where a receipt claiming `refreshed: true` would be wrong.
-            let accepted = await cache.updateTracks(tracks, ifCurrent: tracksVersion)
-            let advanced = await cache.currentVersion(for: .tracks) != tracksVersion
-            tracksReady = PollOutcome(readable: true, applied: accepted && advanced)
+            // `applyTracks`, not `updateTracks`: the answer must come from inside the cache.
+            // Comparing revisions out here needs a second actor call, and another writer to this
+            // section can advance it in that window and be credited to this poll.
+            let applied = await cache.applyTracks(tracks, ifCurrent: tracksVersion)
+            tracksReady = PollOutcome(readable: true, applied: applied)
         } else {
             tracksReady = await poll(
                 operation: "track.get_tracks", label: "Track",
                 section: .tracks,
                 axChannel: axChannel, cache: cache, as: [TrackState].self
             ) { cache, tracks, observed in
-                await cache.updateTracks(tracks, ifCurrent: observed)
+                await cache.applyTracks(tracks, ifCurrent: observed)
             }
         }
         if tracksReady.applied { cacheKeys.append(.tracks) }
@@ -498,9 +535,11 @@ actor StatePoller {
             //
             // Comparing the revision closes it: acceptance means the section was still at
             // `observed`, so any advance from there is ours, and no advance means nothing landed.
-            let accepted = await update(cache, value, observed)
-            let advanced = await cache.currentVersion(for: section) != observed
-            return PollOutcome(readable: true, applied: accepted && advanced)
+            // The closure is what knows whether the cache advanced, and it answers atomically
+            // inside the cache actor. Reading the revision here instead would leave a window for
+            // another writer to advance the section and be credited to this poll.
+            let applied = await update(cache, value, observed)
+            return PollOutcome(readable: true, applied: applied)
         } catch {
             Log.debug("\(label) poll failed: \(error)", subsystem: "poller")
             return .unreadable

--- a/Tests/LogicProMCPTests/Issue668RefreshCoalescingTests.swift
+++ b/Tests/LogicProMCPTests/Issue668RefreshCoalescingTests.swift
@@ -334,26 +334,47 @@ struct Issue668RefreshCoalescingTests {
         #expect(cycles.value() == atStop, "a nudge after stop() started a cycle")
     }
 
-    @Test("a steady stream of nudges does not starve the initiator")
+    @Test("callers arriving during a cycle are batched rather than served one cycle each")
     func drainingTerminates() async {
         let cycles = Counter()
-        let poller = Self.makePoller(cache: StateCache(), cycles: cycles)
+        let entered = Counter()
+        let hold = OneShotGate()
+        let poller = StatePoller(
+            axChannel: AccessibilityChannel(),
+            cache: StateCache(),
+            runtime: .init(hasVisibleWindow: { cycles.bump(); return true }),
+            // Holding the cycle open here is what makes the overlap a fact instead of a hope.
+            postPoll: { _ in entered.bump(); await hold.wait() }
+        )
 
-        // The drain loop serves waiters in batches, so callers arriving during the shared cycle
-        // form the next batch rather than extending the current one. If it instead served each
-        // arrival individually, a continuous stream would keep the first caller suspended.
-        await withTaskGroup(of: Void.self) { group in
-            for i in 0..<12 {
-                group.addTask {
-                    try? await Task.sleep(for: .milliseconds(20 * i))
-                    _ = await poller.refreshNow()
-                }
-            }
+        // The first draft spread twelve nudges 20ms apart and asserted the cycle count came out
+        // under twelve. That assumed a cycle outlasts the gaps between arrivals — and it does, on a
+        // machine where the AX walk takes a second. It failed in the ship gate at 0.235s for the
+        // whole test: with AX answering instantly, nothing overlapped, and twelve nudges each
+        // getting their own cycle is *correct* behaviour, not a batching failure. The assertion was
+        // demanding sharing in a run where there was nothing to share.
+        let callers = (0..<12).map { _ in Task { _ = await poller.refreshNow() } }
+
+        // Once one cycle is parked inside postPoll the gate is held, so every later arrival must
+        // queue. No sleep decides that; the gate does.
+        while entered.value() == 0 { await Task.yield() }
+        while cycles.value() < 2 && entered.value() == 1 {
+            // Give the queued callers a chance to register before releasing. They cannot start a
+            // cycle while the first is held, so this cannot race ahead of the property.
+            await Task.yield()
+            if entered.value() > 1 { break }
+            try? await Task.sleep(for: .milliseconds(50))
+            break
         }
+        hold.open()
+        for caller in callers { _ = await caller.value }
 
-        // Twelve nudges spread across the run, batched into far fewer cycles. The point is that it
-        // finished at all and did not run one cycle per caller.
-        #expect(cycles.value() < 12, "\(cycles.value()) cycles for 12 nudges; batching did nothing")
+        // Eleven callers queued behind one held cycle share the drain rather than each running
+        // their own. The bound is generous because how many land in the first batch is scheduling;
+        // twelve would mean nothing was shared at all.
+        #expect(cycles.value() < 12,
+                "\(cycles.value()) cycles for 12 nudges; nothing was batched")
+        #expect(cycles.value() >= 1, "no cycle ran")
     }
 }
 
@@ -362,6 +383,27 @@ private final class KeyRecorder: @unchecked Sendable {
     private let lock = NSLock()
     func add(_ k: [ResourceCacheKey]) { lock.lock(); seen.append(contentsOf: k); lock.unlock() }
     func sawTracks() -> Bool { lock.lock(); defer { lock.unlock() }; return seen.contains(.tracks) }
+}
+
+private final class OneShotGate: @unchecked Sendable {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+    private let lock = NSLock()
+    func open() {
+        lock.lock()
+        guard !isOpen else { lock.unlock(); return }
+        isOpen = true
+        let parked = waiters; waiters = []
+        lock.unlock()
+        for w in parked { w.resume() }
+    }
+    func wait() async {
+        await withCheckedContinuation { (c: CheckedContinuation<Void, Never>) in
+            lock.lock()
+            if isOpen { lock.unlock(); c.resume(); return }
+            waiters.append(c); lock.unlock()
+        }
+    }
 }
 
 private final class Flag: @unchecked Sendable {

--- a/Tests/LogicProMCPTests/Issue668RefreshCoalescingTests.swift
+++ b/Tests/LogicProMCPTests/Issue668RefreshCoalescingTests.swift
@@ -107,6 +107,28 @@ struct Issue668RefreshCoalescingTests {
         #expect(await cache.getHasDocument(), "the poller declared the document closed")
     }
 
+    @Test("the initiator returns without waiting for the callers it queued")
+    func initiatorIsNotHeldByTheDrain() async {
+        let cycles = Counter()
+        let poller = Self.makePoller(cache: StateCache(), cycles: cycles)
+        let waiterFinished = Flag()
+
+        // The caller that finds the poller idle runs the cycle. Its own answer is ready when that
+        // cycle ends — but a first draft served the queued callers before returning, so the
+        // initiator paid for their cycles too. Measured at ~1.4x its solo latency under a stream of
+        // nudges, against a 25s deadline the cycle already overruns on a 74-track project. Whole
+        // extra cycles on the critical path make #668 worse, not better.
+        async let initiator: Bool = poller.refreshNow()
+        try? await Task.sleep(for: .milliseconds(300))  // land inside the initiator's cycle
+        let queued = Task { _ = await poller.refreshNow(); waiterFinished.set() }
+        _ = await initiator
+
+        // The queued caller is owed a FRESH cycle, which cannot have finished yet. If the initiator
+        // had drained before returning, that cycle would be complete and this flag set.
+        #expect(!waiterFinished.isSet(), "the initiator waited for the queued caller's cycle")
+        _ = await queued.value
+    }
+
     @Test("a steady stream of nudges does not starve the initiator")
     func drainingTerminates() async {
         let cycles = Counter()
@@ -128,6 +150,13 @@ struct Issue668RefreshCoalescingTests {
         // finished at all and did not run one cycle per caller.
         #expect(cycles.value() < 12, "\(cycles.value()) cycles for 12 nudges; batching did nothing")
     }
+}
+
+private final class Flag: @unchecked Sendable {
+    private var v = false
+    private let lock = NSLock()
+    func set() { lock.lock(); v = true; lock.unlock() }
+    func isSet() -> Bool { lock.lock(); defer { lock.unlock() }; return v }
 }
 
 private final class Counter: @unchecked Sendable {

--- a/Tests/LogicProMCPTests/Issue668RefreshCoalescingTests.swift
+++ b/Tests/LogicProMCPTests/Issue668RefreshCoalescingTests.swift
@@ -2,104 +2,137 @@ import Foundation
 import Testing
 @testable import LogicProMCP
 
-/// #668 — what happens when several callers nudge `refresh_cache` at once.
+/// #668 — concurrent `refresh_cache` nudges share cycles instead of each starting one.
 ///
 /// The census on that issue found 19 in-tree callers that ignore the result and use this purely as
 /// a "hurry up" signal inside their own polling loops: `Scripts/live-e2e-test.py` at `timeout=3`
 /// (x4) and `Scripts/logic_session_bootstrap.py` at 5s (x15). None of them coordinate.
 ///
-/// I first wrote these tests asserting that `StatePoller` being an actor means concurrent nudges
-/// queue rather than interleave. **That is wrong, and measuring it is what corrected me.** Swift
-/// actors are re-entrant across `await`: `pollOnce` suspends on every AX read and on `postPoll`, so
-/// concurrent nudges enter the poll body, all capture the same section version before any of them
-/// writes, and then race their conditional writes. One wins and the rest are refused.
-///
-/// Two consequences follow, and both contradict what I had recorded on #668 and #289:
-///
-///  1. Poller-vs-poller compare-and-swap rejection is **reachable**, not structurally impossible.
-///     Four concurrent nudges produce three dropped writes, deterministically, with no live Logic
-///     involved at all. `dropped_stale_writes` — the counter I could not make move — moves here.
-///
-///  2. The wasted work is the real cost. All four cycles pay for the full AX walk; three of them
-///     then have their result thrown away. At the 12.6s median measured on a 74-track project that
-///     is roughly 38s of AX work discarded to answer one question, while each caller waits on a
-///     3-5s budget. Coalescing would collapse those four cycles into one.
+/// Before coalescing, this suite pinned the damage: four concurrent nudges entered the poll body
+/// together, all captured the same section version, and three had their conditional writes refused
+/// after paying for the whole AX walk. `actor` did not prevent that — actors are re-entrant across
+/// `await`, and the poll body suspends on every AX read. The assertions below are the same
+/// measurements inverted, which is what makes the change visible rather than merely claimed.
 @Suite("Issue668RefreshCoalescing")
 struct Issue668RefreshCoalescingTests {
 
-    @Test("concurrent nudges race their writes; the losers are refused, not queued")
-    func concurrentNudgesRaceRatherThanQueue() async {
-        let cache = StateCache()
-        let emissions = Recorder()
-        let poller = StatePoller(
+    /// Counts cycles at `hasVisibleWindow`, which the poll body calls exactly once per cycle before
+    /// its first suspension.
+    ///
+    /// It must NOT be counted at `postPoll`. `postPoll` fires only when a section was written, so
+    /// under the racing behaviour this suite exists to detect, three of four cycles are refused,
+    /// emit nothing, and go uncounted — the counter reads "2 cycles" for four full AX walks and the
+    /// test passes for the wrong reason. That is exactly what happened: the cycle-count assertion
+    /// below stayed green against a mutant with coalescing removed, and only re-aiming the
+    /// instrument exposed it.
+    private static func makePoller(cache: StateCache, cycles: Counter) -> StatePoller {
+        StatePoller(
             axChannel: AccessibilityChannel(),
             cache: cache,
-            runtime: .init(hasVisibleWindow: { true }),
-            postPoll: { keys in emissions.add(keys.count) }
+            runtime: .init(hasVisibleWindow: { cycles.bump(); return true }),
+            postPoll: { _ in }
         )
+    }
+
+    @Test("concurrent nudges no longer race: no write is refused")
+    func concurrentNudgesDoNotDropWrites() async {
+        let cache = StateCache()
+        let poller = Self.makePoller(cache: cache, cycles: Counter())
 
         let droppedBefore = await cache.droppedStaleWriteCount(for: .tracks)
-        var receipts: [Bool] = []
         await withTaskGroup(of: Bool.self) { group in
             for _ in 0..<4 { group.addTask { await poller.refreshNow() } }
-            for await didAdvance in group { receipts.append(didAdvance) }
+            for await _ in group {}
         }
         let dropped = await cache.droppedStaleWriteCount(for: .tracks) - droppedBefore
 
-        // Measured 3 dropped / 1 emission on four consecutive runs. The count is asserted as a
-        // property rather than as the exact 3: the interleaving is structural (every task suspends
-        // on the AX read before any write lands) but how many land is not something this test can
-        // guarantee on every machine, and a test that pins a timing-shaped number is a test that
-        // fails for reasons unrelated to the code.
-        #expect(dropped >= 1,
-                "no write was refused, so the concurrent nudges did not actually overlap (measured 3)")
-        #expect(receipts.contains(false),
-                "every nudge claimed the cache advanced, but they cannot all have won the race")
-        #expect(emissions.count() < receipts.count,
-                "postPoll fired once per nudge, so no write was dropped after all (measured 1 of 4)")
-
-        // The wasted work is the point: the losers did the whole AX walk before being refused.
-        #expect(receipts.count == 4, "all four cycles ran; nothing merged them")
+        // This is the assertion that inverted. Measured at 3 before coalescing, deterministically
+        // over four runs; the cycles cannot overlap now, so no two capture the same version.
+        #expect(dropped == 0, "a write was refused, so two cycles still overlapped")
     }
 
-    @Test("a refused write still leaves the section readable")
-    func refusedWriteDoesNotMakeTheDocumentLookClosed() async {
-        let cache = StateCache()
-        let poller = StatePoller(
-            axChannel: AccessibilityChannel(),
-            cache: cache,
-            runtime: .init(hasVisibleWindow: { true }),
-            postPoll: { _ in }
-        )
+    @Test("four concurrent nudges cost two cycles, not four")
+    func concurrentNudgesShareACycle() async {
+        let cycles = Counter()
+        let poller = Self.makePoller(cache: StateCache(), cycles: cycles)
 
-        // `hasDocument` defaults to true, so asserting it after a poll would pass whether or not
-        // the poll did anything. Drive it false first: then the assertion is answering "did the
-        // poll set it", not "was it already set".
-        await cache.updateDocumentState(false)
-        #expect(!(await cache.getHasDocument()), "precondition not established")
-
-        // Losing the race must not read as "the document went away". This is the asymmetry the
-        // receipt fix rests on: `hasDocument` is built from readability, the receipt from the write
-        // outcome, and only the second one is allowed to go false when a race is lost.
         await withTaskGroup(of: Bool.self) { group in
             for _ in 0..<4 { group.addTask { await poller.refreshNow() } }
             for await _ in group {}
         }
 
-        #expect(await cache.droppedStaleWriteCount(for: .tracks) >= 1, "no race occurred to test")
-        #expect(await cache.getHasDocument(),
-                "refused writes made the poller declare the document closed")
+        // One cycle for whoever arrived first, one shared by the three that arrived during it.
+        // The bound is what matters, not the exact 2: which callers land inside the first cycle
+        // depends on scheduling, and a test that pins a timing-shaped number fails for reasons
+        // unrelated to the code. Four would mean nothing was shared.
+        #expect(cycles.value() <= 2, "\(cycles.value()) cycles ran; the nudges did not share one")
+        #expect(cycles.value() >= 1, "no cycle ran at all")
+    }
 
-        // STATED LIMIT: this does not catch `hasDocument = projectReady.applied || …`. In a race
-        // one write always wins, so that mutation would still leave the flag true here. What pins
-        // the readable/applied asymmetry is `Issue668RefreshReceiptTests`; this pins that the
-        // combination of a refused write and a live document does not close the document.
+    @Test("a late caller is served a cycle that began after its request, not the one in flight")
+    func lateCallerIsNotServedStaleReads() async {
+        let cycles = Counter()
+        let poller = Self.makePoller(cache: StateCache(), cycles: cycles)
+
+        // The hazard this guards is concrete: `refreshAfterWrite` on the saga path nudges the
+        // poller immediately after a write. If a late caller were handed the in-flight cycle's
+        // result, it would receive AX reads taken BEFORE its own write and the saga would proceed
+        // on state that predates it — the staleness the compare-and-swap exists to prevent, with
+        // nothing left to count it. So arrivals wait for a fresh cycle.
+        async let first: Bool = poller.refreshNow()
+        try? await Task.sleep(for: .milliseconds(300))  // land inside the first cycle
+        async let second: Bool = poller.refreshNow()
+        _ = await [first, second]
+
+        #expect(cycles.value() == 2,
+                "the late caller was served the in-flight cycle instead of a fresh one")
+    }
+
+    @Test("a refused write still leaves the section readable")
+    func refusedWriteDoesNotMakeTheDocumentLookClosed() async {
+        let cache = StateCache()
+        let poller = Self.makePoller(cache: cache, cycles: Counter())
+
+        // `hasDocument` defaults to true, so asserting it after a poll would pass whether or not
+        // the poll did anything. Drive it false first: then the assertion answers "did the poll
+        // set it", not "was it already set".
+        await cache.updateDocumentState(false)
+        #expect(!(await cache.getHasDocument()), "precondition not established")
+
+        await withTaskGroup(of: Bool.self) { group in
+            for _ in 0..<4 { group.addTask { await poller.refreshNow() } }
+            for await _ in group {}
+        }
+
+        #expect(await cache.getHasDocument(), "the poller declared the document closed")
+    }
+
+    @Test("a steady stream of nudges does not starve the initiator")
+    func drainingTerminates() async {
+        let cycles = Counter()
+        let poller = Self.makePoller(cache: StateCache(), cycles: cycles)
+
+        // The drain loop serves waiters in batches, so callers arriving during the shared cycle
+        // form the next batch rather than extending the current one. If it instead served each
+        // arrival individually, a continuous stream would keep the first caller suspended.
+        await withTaskGroup(of: Void.self) { group in
+            for i in 0..<12 {
+                group.addTask {
+                    try? await Task.sleep(for: .milliseconds(20 * i))
+                    _ = await poller.refreshNow()
+                }
+            }
+        }
+
+        // Twelve nudges spread across the run, batched into far fewer cycles. The point is that it
+        // finished at all and did not run one cycle per caller.
+        #expect(cycles.value() < 12, "\(cycles.value()) cycles for 12 nudges; batching did nothing")
     }
 }
 
-private final class Recorder: @unchecked Sendable {
-    private var counts: [Int] = []
+private final class Counter: @unchecked Sendable {
+    private var n = 0
     private let lock = NSLock()
-    func add(_ n: Int) { lock.lock(); counts.append(n); lock.unlock() }
-    func count() -> Int { lock.lock(); defer { lock.unlock() }; return counts.count }
+    func bump() { lock.lock(); n += 1; lock.unlock() }
+    func value() -> Int { lock.lock(); defer { lock.unlock() }; return n }
 }

--- a/Tests/LogicProMCPTests/Issue668RefreshCoalescingTests.swift
+++ b/Tests/LogicProMCPTests/Issue668RefreshCoalescingTests.swift
@@ -158,6 +158,98 @@ struct Issue668RefreshCoalescingTests {
         for waiter in waiters { _ = await waiter.value }
     }
 
+    @Test("stop() returns while nudges keep arriving")
+    func stopIsBoundedUnderContinuousNudges() async {
+        let poller = Self.makePoller(cache: StateCache(), cycles: Counter())
+        await poller.start()
+        let halt = Flag()
+        // Fire-and-forget on a timer, which is the shape the 15 bootstrap callers actually have:
+        // nothing waits for a previous result, so a nudge lands while the drain's own cycle is
+        // still running. My first attempt at this test had each sender await its own result, which
+        // left a gap where the queue was briefly empty — and it passed against the defect.
+        let sender = Task {
+            while !halt.isSet() {
+                Task { _ = await poller.refreshNow() }
+                try? await Task.sleep(for: .milliseconds(50))
+            }
+        }
+        try? await Task.sleep(for: .milliseconds(400))
+
+        // The drain kept accepting new batches and `refreshNow` stays callable after the loop task
+        // is gone, so one nudge per cycle held `stop()` open indefinitely — measured at over 20s
+        // with no sign of returning, ending only when the nudges did.
+        let returned = Flag()
+        let stopper = Task { await poller.stop(); returned.set() }
+        try? await Task.sleep(for: .seconds(12))
+        let stoppedInTime = returned.isSet()
+
+        halt.set()
+        sender.cancel()
+        _ = await stopper.value
+        #expect(stoppedInTime, "stop() was still waiting after 12s of continuous nudges")
+    }
+
+    @Test("stopImmediately() does not leave a cycle about to start")
+    func stopImmediatelyStartsNoNewCycle() async {
+        let cycles = Counter()
+        let poller = StatePoller(
+            axChannel: AccessibilityChannel(),
+            cache: StateCache(),
+            runtime: .init(hasVisibleWindow: { cycles.bump(); return true },
+                           sleep: { _ in try await Task.sleep(nanoseconds: 1_000) }),
+            postPoll: { _ in try? await Task.sleep(for: .milliseconds(200)) }
+        )
+        // An external nudge takes the flag first, so the loop reaches the gate while a cycle runs.
+        let nudge = Task { _ = await poller.refreshNow() }
+        try? await Task.sleep(for: .milliseconds(50))
+        await poller.start()
+        try? await Task.sleep(for: .milliseconds(300))
+
+        // A queued loop suspends in a continuation cancellation cannot wake, so it used to be
+        // served by a whole AX cycle that began AFTER stopImmediately() had returned — work done
+        // purely for a loop that was already cancelled. The loop now skips a redundant tick
+        // instead of queueing.
+        await poller.stopImmediately()
+        let atReturn = cycles.value()
+        // Long enough for the in-flight cycle to END and any drain it spawns to run. An earlier
+        // 3s window closed before the initiator had even finished, so the test reported "no new
+        // cycles" about a stretch of time in which nothing had happened yet.
+        try? await Task.sleep(for: .seconds(8))
+
+        #expect(cycles.value() == atReturn,
+                "\(cycles.value() - atReturn) cycle(s) began after stopImmediately() returned")
+        _ = await nudge.value
+    }
+
+    @Test("a debounced write is not reported as a refresh")
+    func debouncedWriteIsNotReportedAsRefreshed() async {
+        let cache = StateCache()
+        // The occlusion debounce absorbs the first two empty track reads while a document is open
+        // and the cache is non-empty, returning without touching tracks, timestamp, or revision.
+        // The conditional wrapper still answers `true`, because the compare-and-swap DID accept —
+        // and that `true` used to reach `refresh_cache`'s `refreshed`. "CAS accepted" is not
+        // "the cache advanced", and the receipt claims the second.
+        await cache.updateTracks([TrackState(id: 0, name: "Kept", type: .audio)])
+        await cache.updateDocumentState(true)
+        let revisionBefore = await cache.currentVersion(for: .tracks)
+
+        let keys = KeyRecorder()
+        let poller = StatePoller(
+            axChannel: AccessibilityChannel(),
+            cache: cache,
+            runtime: .init(hasVisibleWindow: { true }),
+            postPoll: { keys.add($0) }
+        )
+        _ = await poller.refreshNow()
+
+        // Precondition: the debounce must actually have fired, or this measures nothing.
+        let revisionAfter = await cache.currentVersion(for: .tracks)
+        #expect(revisionAfter == revisionBefore, "tracks advanced; the debounce never engaged")
+        #expect(await cache.getTracks().first?.name == "Kept", "the cache was overwritten")
+
+        #expect(!keys.sawTracks(), "a write that changed nothing was reported as a refresh")
+    }
+
     @Test("a steady stream of nudges does not starve the initiator")
     func drainingTerminates() async {
         let cycles = Counter()
@@ -179,6 +271,13 @@ struct Issue668RefreshCoalescingTests {
         // finished at all and did not run one cycle per caller.
         #expect(cycles.value() < 12, "\(cycles.value()) cycles for 12 nudges; batching did nothing")
     }
+}
+
+private final class KeyRecorder: @unchecked Sendable {
+    private var seen: [ResourceCacheKey] = []
+    private let lock = NSLock()
+    func add(_ k: [ResourceCacheKey]) { lock.lock(); seen.append(contentsOf: k); lock.unlock() }
+    func sawTracks() -> Bool { lock.lock(); defer { lock.unlock() }; return seen.contains(.tracks) }
 }
 
 private final class Flag: @unchecked Sendable {

--- a/Tests/LogicProMCPTests/Issue668RefreshCoalescingTests.swift
+++ b/Tests/LogicProMCPTests/Issue668RefreshCoalescingTests.swift
@@ -250,6 +250,90 @@ struct Issue668RefreshCoalescingTests {
         #expect(!keys.sawTracks(), "a write that changed nothing was reported as a refresh")
     }
 
+    @Test("no cycle begins once a stop is requested, including from a cycle stop does not own")
+    func stopQuiescesACycleItDoesNotOwn() async {
+        let cycles = Counter()
+        let poller = StatePoller(
+            axChannel: AccessibilityChannel(),
+            cache: StateCache(),
+            runtime: .init(hasVisibleWindow: { cycles.bump(); return true },
+                           sleep: { _ in try await Task.sleep(nanoseconds: 1_000) }),
+            postPoll: { _ in try? await Task.sleep(for: .milliseconds(200)) }
+        )
+        // An external nudge owns the cycle, so the loop skips its tick and sleeps. Cancelling the
+        // loop then leaves `drainTask` nil, and stop() used to await nothing and return — after
+        // which the external cycle would find the queued callers and hand off a fresh,
+        // uncancelled drain, running AX work past the stop.
+        let owner = Task { _ = await poller.refreshNow() }
+        try? await Task.sleep(for: .milliseconds(50))
+        await poller.start()
+        let queued = (0..<2).map { _ in Task { _ = await poller.refreshNow() } }
+        try? await Task.sleep(for: .milliseconds(250))
+
+        // Sampled when stop is REQUESTED, not when it returns. Measuring after the return hides
+        // the defect: stop parks on the cycle it does not own, so a drain spawned in the meantime
+        // finishes inside the wait and its cycle is invisible to an after-the-fact comparison.
+        let atRequest = cycles.value()
+        await poller.stop()
+        try? await Task.sleep(for: .seconds(6))
+
+        #expect(cycles.value() == atRequest,
+                "\(cycles.value() - atRequest) cycle(s) began after the stop was requested")
+        _ = await owner.value
+        for q in queued { _ = await q.value }
+    }
+
+    @Test("stop() does not return while a cycle it does not own is still running")
+    func stopWaitsForACycleItDoesNotOwn() async {
+        let cycleEnded = Flag()
+        let poller = StatePoller(
+            axChannel: AccessibilityChannel(),
+            cache: StateCache(),
+            runtime: .init(hasVisibleWindow: { true },
+                           sleep: { _ in try await Task.sleep(nanoseconds: 1_000) }),
+            postPoll: { _ in
+                try? await Task.sleep(for: .seconds(1))
+                cycleEnded.set()
+            }
+        )
+        // Cancelling the loop covers only cycles the loop owns. An external `refreshNow` holding
+        // the gate keeps running AX after stop() has cancelled everything it can see, so stop()
+        // parks until the cycle releases — otherwise it reports the poller stopped while the
+        // poller is mid-walk.
+        let owner = Task { _ = await poller.refreshNow() }
+        try? await Task.sleep(for: .milliseconds(50))
+        await poller.start()
+        try? await Task.sleep(for: .milliseconds(200))
+
+        await poller.stop()
+        #expect(cycleEnded.isSet(), "stop() returned while a cycle was still running")
+        _ = await owner.value
+    }
+
+    @Test("a nudge arriving after stop() does not restart AX work")
+    func nudgeAfterStopIsRefused() async {
+        let cycles = Counter()
+        let poller = StatePoller(
+            axChannel: AccessibilityChannel(),
+            cache: StateCache(),
+            runtime: .init(hasVisibleWindow: { cycles.bump(); return true },
+                           sleep: { _ in try await Task.sleep(nanoseconds: 1_000) }),
+            postPoll: { _ in }
+        )
+        await poller.start()
+        try? await Task.sleep(for: .milliseconds(200))
+        await poller.stop()
+
+        // `refresh_cache` stays reachable after the poller stops — the tool does not know about
+        // the lifecycle. Serving it would walk AX on a poller that has been told to stop, which is
+        // the work stop exists to end, so it is refused and answers honestly that nothing advanced.
+        let atStop = cycles.value()
+        let advanced = await poller.refreshNow()
+
+        #expect(!advanced, "a nudge after stop() claimed the cache advanced")
+        #expect(cycles.value() == atStop, "a nudge after stop() started a cycle")
+    }
+
     @Test("a steady stream of nudges does not starve the initiator")
     func drainingTerminates() async {
         let cycles = Counter()

--- a/Tests/LogicProMCPTests/Issue668RefreshCoalescingTests.swift
+++ b/Tests/LogicProMCPTests/Issue668RefreshCoalescingTests.swift
@@ -129,6 +129,35 @@ struct Issue668RefreshCoalescingTests {
         _ = await queued.value
     }
 
+    @Test("stop() still waits for the cycles it is documented to wait for")
+    func stopCoversTheHandedOffDrain() async {
+        let resolved = Counter()
+        let poller = StatePoller(
+            axChannel: AccessibilityChannel(),
+            cache: StateCache(),
+            runtime: .init(hasVisibleWindow: { true },
+                           sleep: { _ in try await Task.sleep(nanoseconds: 1_000) }),
+            postPoll: { _ in try? await Task.sleep(for: .seconds(1)) }
+        )
+        await poller.start()
+        let waiters = (0..<3).map { _ in Task { _ = await poller.refreshNow(); resolved.bump() } }
+        try? await Task.sleep(for: .milliseconds(400))
+
+        // Handing the drain to its own task let AX polling outlive a `stop()` whose own
+        // documentation says it waits for the current cycle. It usually finished in time anyway,
+        // because it shares this actor and `stop()` suspends — but that is scheduling luck, and a
+        // stop guarantee resting on luck is not a guarantee. Measured over three runs each:
+        // unawaited left 3 of 3 callers unresolved every time; awaited left 0, 1, 1.
+        let pendingBefore = 3 - resolved.value()
+        await poller.stop()
+        let unresolved = 3 - resolved.value()
+
+        #expect(pendingBefore > 0, "no drain was outstanding, so this measured nothing")
+        #expect(unresolved < pendingBefore,
+                "stop() returned without waiting for any of the drain it handed off")
+        for waiter in waiters { _ = await waiter.value }
+    }
+
     @Test("a steady stream of nudges does not starve the initiator")
     func drainingTerminates() async {
         let cycles = Counter()


### PR DESCRIPTION
Builds on #674. One poll cycle runs at a time, and callers arriving during one share a single **fresh** cycle.

| | before | after |
|---|---|---|
| cycles for 4 concurrent nudges | 4 | **2** |
| refused writes (`dropped_stale_writes`) | 3 | **0** |

`actor` never provided this: actors are re-entrant across `await` and the poll body suspends on every AX read, so concurrent callers entered together, captured the same section version, and raced. On a 74-track project the scheduled loop is mid-cycle ~80% of the time, so a `refresh_cache` arriving at random usually collided with it, paid for a whole AX walk, and correctly reported that nothing had advanced.

## The design decision, and why it is not the obvious one

**A late caller is not handed the in-flight cycle.** Those AX reads may predate the caller's request, and `refreshAfterWrite` on the saga path nudges immediately *after* a write — so joining would hand it state from before its own write. That reintroduces the staleness the compare-and-swap exists to prevent, except with nothing left to count it, because no two cycles would overlap any more. Arrivals queue for the **next** cycle and share that.

## Seven defects, all mine, all fixed

Three I found by reading the code back against its contract; four came from three rounds of adversarial review by `gpt-5.6-sol` at xhigh.

| found by | defect |
|---|---|
| reading | fast path hardcoded `applied: true` |
| reading | the initiator was billed for everyone else's cycles (~1.4x its solo latency) |
| reading | `stop()` no longer covered the drain it handed off |
| review r1 | `stopImmediately()` returned, **then** a cycle began |
| review r1 | `stop()` could hang forever under continuous nudges |
| review r1 | `refreshed: true` for a debounced write — I had filed this as a "stated limit"; wrong call |
| review r2 | that debounce fix still had a TOCTOU; acceptance+advancement is only equivalent computed **inside** the cache actor |
| review r2 | skipping the loop tick let `stop()` miss a future drain |

Round 3 found nothing merge-blocking.

**One guard did not survive its own mutation test.** A `|| stopped` in the hand-off was redundant with the drain's check — no mutation of it could be made to fail. It is gone rather than defended. Every remaining guard is individually mutation-tested:

| guard removed | test that fails |
|---|---|
| entry stopped-check | nudge-after-stop |
| drain stopped-break | stop-quiesce |
| quiesce wait | stop-waits-for-a-cycle |
| `applyTracks` advance measurement | debounced-write |
| coalescing bypassed | drops 3, cycles 4 of 4 |
| late callers join in-flight | staleness test |
| drain on the initiator's path | initiator-latency test |

## A test of mine failed the gate, and the duration gave it away

The batching test spread twelve nudges 20ms apart and asserted the count came out under twelve. It failed at **0.235s for the whole test** — with AX answering instantly nothing overlapped, and twelve nudges each getting their own cycle is *correct*. It was demanding sharing where there was nothing to share. The cycle is now held open by a gate until the queued callers arrive: the overlap is a fact the test creates, not one it hopes the scheduler provides.

## Gate

```
SHIP GATE PASS — full suite 3941 passed; live evidence bound to this head
live_519_region_op_on_a_localized_logic  8/8 clean
```

## Honest limit

**A late caller's worst case is still two cycles** — the remainder of the in-flight one plus a fresh one — which at the 12.6s median sits on the 25s deadline. Not a regression, but coalescing alone should not be assumed to bring `refresh_cache` inside its budget. **#668 stays open.**