### PR TITLE
feat(#373): a Phase-B readback must prove it postdates the mutation it witnesses

### DIFF
--- a/Sources/LogicProMCP/Qualification/QualificationReadbackFreshness.swift
+++ b/Sources/LogicProMCP/Qualification/QualificationReadbackFreshness.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Whether a Phase-B readback may be believed — #373.
+///
+/// Phase B is "pre-state → mutation → independent readback → restore → restore-readback", and its
+/// recorded blocker was that `logic://tracks` is served from the poller cache: a cache that never
+/// moved satisfies a value-equality check exactly as well as a fresh read does. The proposed remedy
+/// was a second, non-cached read path.
+///
+/// Measured 2026-08-24 against live Logic, one `tracks.create_audio` with a readback either side:
+///
+///     PRE   source=ax_live  fetched_at=…T01:19:00.078Z  cache_age_sec=0.80  tracks=1
+///     MUT   observed_delta=1  state=A
+///     POST  source=ax_live  fetched_at=…T01:19:06.135Z  cache_age_sec=0.28  tracks=2
+///
+/// The envelope already carries the proof. `fetched_at` advanced past the mutation and `source`
+/// distinguishes a live walk from a cache or default answer, so the freshness requirement is an
+/// assertion on fields that ship today rather than a new read path.
+///
+/// The clause that does the work is `fetchedAt > mutationStartedAt`: a stale envelope fails it by
+/// construction, whatever its values say. The other two are there because a check that cannot see
+/// its subject reports absence as agreement — `source` absent or `default` means the poller never
+/// read, and a missing `cache_age_sec` means the envelope is not the one this rule was measured on.
+enum QualificationReadbackFreshness {
+    /// The three fields `ResourceHandlers+StateReaders` publishes on every state envelope.
+    struct Envelope: Equatable, Sendable {
+        let source: String?
+        let fetchedAt: Date?
+        let cacheAgeSeconds: Double?
+
+        init(source: String?, fetchedAt: Date?, cacheAgeSeconds: Double?) {
+            self.source = source
+            self.fetchedAt = fetchedAt
+            self.cacheAgeSeconds = cacheAgeSeconds
+        }
+    }
+
+    /// Why a readback was refused, named rather than reduced to `false`. A Phase-B recipe that
+    /// logs "inadmissible" and nothing else cannot tell a stale cache from an unread poller, and
+    /// those two failures call for opposite responses.
+    enum Verdict: Equatable, Sendable {
+        case admissible
+        /// The poller never produced a live walk — `source` is `cache`, `default`, or absent.
+        case notLive(source: String?)
+        /// The envelope predates the mutation it is supposed to witness.
+        case predatesMutation(fetchedAt: Date, mutationStartedAt: Date)
+        /// `fetched_at` is absent, so the envelope cannot be placed in time at all.
+        case unplaceableInTime
+        /// `cache_age_sec` is absent; this is not the envelope shape the rule was measured against.
+        case ageAbsent
+
+        var isAdmissible: Bool { self == .admissible }
+    }
+
+    /// The one source token that means "the poller walked Accessibility for this answer".
+    /// `cache` and `default` are the other two `ResourceHandlers` emits, and both are refusals here.
+    static let liveSourceToken = "ax_live"
+
+    static func verdict(for envelope: Envelope, mutationStartedAt: Date) -> Verdict {
+        guard envelope.source == liveSourceToken else {
+            return .notLive(source: envelope.source)
+        }
+        guard let fetchedAt = envelope.fetchedAt else {
+            return .unplaceableInTime
+        }
+        // Strictly after: an envelope stamped at the same instant as the mutation started cannot
+        // have observed its effect, and equality is exactly the case a coarse clock produces.
+        guard fetchedAt > mutationStartedAt else {
+            return .predatesMutation(fetchedAt: fetchedAt, mutationStartedAt: mutationStartedAt)
+        }
+        guard envelope.cacheAgeSeconds != nil else {
+            return .ageAbsent
+        }
+        return .admissible
+    }
+}

--- a/Tests/LogicProMCPTests/QualificationReadbackFreshnessTests.swift
+++ b/Tests/LogicProMCPTests/QualificationReadbackFreshnessTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+/// #373 Phase B — a readback is only evidence if it can be shown to postdate the mutation.
+///
+/// The values here are the ones measured live on 2026-08-24 (`tracks.create_audio`, readback either
+/// side), so the admissible case is a transcription of a real envelope rather than a shape invented
+/// to make the rule pass.
+@Suite("QualificationReadbackFreshness")
+struct QualificationReadbackFreshnessTests {
+    private static let mutationStart = ISO8601DateFormatter().date(from: "2026-08-24T01:19:03Z")!
+    private static let postMutation = ISO8601DateFormatter().date(from: "2026-08-24T01:19:06Z")!
+    private static let preMutation = ISO8601DateFormatter().date(from: "2026-08-24T01:19:00Z")!
+
+    private static func envelope(
+        source: String? = "ax_live",
+        fetchedAt: Date? = postMutation,
+        age: Double? = 0.28
+    ) -> QualificationReadbackFreshness.Envelope {
+        .init(source: source, fetchedAt: fetchedAt, cacheAgeSeconds: age)
+    }
+
+    @Test("the measured live envelope is admissible")
+    func measuredEnvelopePasses() {
+        #expect(QualificationReadbackFreshness
+            .verdict(for: Self.envelope(), mutationStartedAt: Self.mutationStart) == .admissible)
+    }
+
+    @Test("a cache that never moved is refused, which is the defect Phase B was blocked on")
+    func staleCacheIsRefused() {
+        // The PRE envelope from the same live run: correct shape, correct source, simply older than
+        // the mutation. A value-equality check cannot tell this from the POST envelope; this can.
+        let verdict = QualificationReadbackFreshness.verdict(
+            for: Self.envelope(fetchedAt: Self.preMutation, age: 0.80),
+            mutationStartedAt: Self.mutationStart)
+        #expect(verdict == .predatesMutation(fetchedAt: Self.preMutation,
+                                             mutationStartedAt: Self.mutationStart))
+    }
+
+    @Test("an envelope stamped exactly at the mutation start cannot have witnessed it")
+    func sameInstantIsRefused() {
+        // Equality is what a coarse clock produces, so it is the case most likely to appear and be
+        // waved through by a `>=`.
+        #expect(!QualificationReadbackFreshness.verdict(
+            for: Self.envelope(fetchedAt: Self.mutationStart),
+            mutationStartedAt: Self.mutationStart).isAdmissible)
+    }
+
+    @Test("cache and default sources are refused by name, not merged into one failure")
+    func nonLiveSourcesAreNamed() {
+        for source in ["cache", "default", nil] as [String?] {
+            let verdict = QualificationReadbackFreshness.verdict(
+                for: Self.envelope(source: source), mutationStartedAt: Self.mutationStart)
+            #expect(verdict == .notLive(source: source),
+                    "source \(source ?? "nil") should be refused as not-live, got \(verdict)")
+        }
+    }
+
+    @Test("an unplaceable or wrong-shaped envelope is refused rather than assumed fresh")
+    func missingFieldsAreRefused() {
+        // A check that reports agreement when it cannot see its subject is the failure this suite
+        // exists to avoid: absence of a timestamp is not evidence of freshness.
+        #expect(QualificationReadbackFreshness.verdict(
+            for: Self.envelope(fetchedAt: nil),
+            mutationStartedAt: Self.mutationStart) == .unplaceableInTime)
+        #expect(QualificationReadbackFreshness.verdict(
+            for: Self.envelope(age: nil),
+            mutationStartedAt: Self.mutationStart) == .ageAbsent)
+    }
+}


### PR DESCRIPTION
First concrete piece of #373 Phase B. It removes the reason Phase B was recorded as blocked.

## The blocker, and why it does not need what it asked for

Phase B is *pre-state → mutation → independent readback → restore → restore-readback*. Its recorded blocker: `logic://tracks` is served from the poller cache, so **a cache that never moved satisfies a value-equality check exactly as well as a fresh read does.** The remedy on the issue was a second, non-cached read path.

It does not need one. Measured against live Logic — one `tracks.create_audio`, readback either side:

```
PRE   source=ax_live  fetched_at=…T01:19:00.078Z  cache_age_sec=0.80  tracks=1
MUT   observed_delta=1  state=A
POST  source=ax_live  fetched_at=…T01:19:06.135Z  cache_age_sec=0.28  tracks=2
```

`fetched_at` advanced past the mutation and `source` already distinguishes a live walk from a cache or default answer. **The freshness requirement is an assertion on fields that ship today.**

## The rule

```
admissible iff  source == "ax_live"
           and  fetchedAt > mutationStartedAt
           and  cacheAgeSeconds is present
```

The middle clause does the work: a stale envelope fails it **by construction**, whatever its values say. Strict `>`, not `>=` — equality is what a coarse clock produces, so it is the case most likely to appear and be waved through.

The other two exist because a check that cannot see its subject reports absence as agreement. `source` absent or `default` means the poller never walked; a missing `cache_age_sec` means this is not the envelope shape the rule was measured on. Both are refusals, and the verdict **names which** — a recipe that logs "inadmissible" cannot tell a stale cache from an unread poller, and those call for opposite responses.

## Mutation-tested, each clause by the test that names it

| mutation | caught by |
|---|---|
| `>` relaxed to `>=` | same-instant test |
| `cache_age_sec` check dropped | missing-fields test |
| absent timestamp read as fresh | missing-fields test |

The admissible fixture is a transcription of the real POST envelope above, not a shape invented to make the rule pass.

## Stated limit

**Nothing consumes this yet.** It makes the freshness claim available, not enforced: no Phase-B recipe asserts it, and `semanticReadbackValidated` still returns `nil` for every mutating operation — which is why R-SEM counts 111/111 missing. Wiring it changes what counts as passed, so it is deliberately not bundled here.

```
SHIP GATE PASS — full suite 3941 passed; live evidence bound to this head
live_519_region_op_on_a_localized_logic  8/8 clean
```
