### PR TITLE
ci(#678): fail when the roadmap table and GitHub disagree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # `docs/roadmap/README.md` declares itself the source of truth for what is open, and its update
+  # rule ("the same PR that opens or closes an issue updates the table") is a convention until
+  # something fails when it is not kept. This is that something.
+  #
+  # Its own job rather than a step in `compile`: the check reads issue state, so it needs a token
+  # scope the build jobs do not have. Adding `issues: read` to the workflow-level `permissions`
+  # would hand it to every job instead of the one that needs it. It is also not in
+  # `run-repo-guards.py`, whose contract is plain Python needing neither Xcode nor a network.
+  roadmap:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Self-test the roadmap drift guard (#678)
+        # Offline, fixtures only. Asserts the guard fails on a stale row, on an open issue nobody
+        # added, and on a row pointing at no issue — and that it refuses (exit 2) rather than
+        # reporting clean on a truncated issue list or a table it could not parse.
+        run: bash Scripts/test-roadmap-table-guard.sh
+
+      - name: Roadmap table matches GitHub (#678)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 Scripts/roadmap-table-matches-github.py
+
   compile:
     runs-on: macos-15
     timeout-minutes: 60

--- a/Scripts/roadmap-table-matches-github.py
+++ b/Scripts/roadmap-table-matches-github.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Fails when `docs/roadmap/README.md` disagrees with GitHub about what is open.
+
+`docs/roadmap/README.md` declares itself the source of truth for what is open and in what order.
+Its own update rule says the same PR that opens or closes an issue updates its table, and then
+admits what that is worth: "a convention is a claim", and the stronger form is a check that fails
+when the table and GitHub disagree. This is that check.
+
+WHAT IT ENFORCES, AND WHY EACH DIRECTION IS NEEDED
+--------------------------------------------------
+1. Every row in the table states the state GitHub reports. Catches a row that was never flipped
+   when its issue closed.
+2. Every issue GitHub reports OPEN appears in the table. Catches the drift the first direction
+   cannot see: an issue nobody ever added. This was already true when the check was written —
+   #683 was open and absent — so it is not a hypothetical.
+
+The reverse of (2) is deliberately NOT enforced: the table is not required to list every closed
+issue that has ever existed, only to be right about the ones it does list.
+
+WHAT WOULD MAKE THIS VACUOUS, AND WHAT STOPS IT
+------------------------------------------------
+- **A truncated issue list.** `gh issue list` caps at `--limit`, and a capped result looks exactly
+  like a complete one. Written against `--limit 200` this check would have compared against the
+  newest 200 of 239 issues and reported clean. If the result count reaches the limit, this exits
+  `CANNOT_DETERMINE` rather than passing on a list it cannot prove is whole.
+- **An unparseable table.** Zero parsed rows compares nothing and passes trivially. That is
+  `CANNOT_DETERMINE` too, not clean.
+
+Both are distinguished from a clean run by exit code, so CI cannot read "I could not tell" as "no
+drift". `Scripts/test-roadmap-table-guard.sh` drives each of these paths and asserts the codes.
+
+Exit: 0 = table agrees · 1 = drift, listed on stdout · 2 = could not determine
+"""
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+
+OK, DRIFT, CANNOT_DETERMINE = 0, 1, 2
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEFAULT_ROADMAP = os.path.join(REPO_ROOT, "docs", "roadmap", "README.md")
+
+# Matches both table shapes in the file: `| ADR-001 | #284 | OPEN | ... |` and `| #308 | OPEN | ... |`
+ROW = re.compile(r"\|\s*#(\d+)\s*\|\s*(OPEN|closed)\s*\|")
+
+ISSUE_LIMIT = 1000
+
+
+def parse_table(path):
+    with open(path, encoding="utf-8") as handle:
+        text = handle.read()
+    return {int(number): state.upper() for number, state in ROW.findall(text)}
+
+
+def fetch_issues(fixture):
+    """Returns (issues, error). `issues` maps number -> OPEN/CLOSED."""
+    if fixture:
+        with open(fixture, encoding="utf-8") as handle:
+            rows = json.load(handle)
+    else:
+        try:
+            out = subprocess.run(
+                ["gh", "issue", "list", "--state", "all",
+                 "--limit", str(ISSUE_LIMIT), "--json", "number,state"],
+                capture_output=True, text=True, check=True).stdout
+        except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+            return None, f"could not ask GitHub for issue state: {exc}"
+        rows = json.loads(out)
+
+    if len(rows) >= ISSUE_LIMIT:
+        return None, (
+            f"`gh issue list` returned {len(rows)} rows against a --limit of {ISSUE_LIMIT}, so the "
+            "list may be truncated. Comparing against a partial list would report clean while "
+            "missing every issue past the cap. Raise the limit or paginate.")
+    return {int(r["number"]): str(r["state"]).upper() for r in rows}, None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--roadmap", default=DEFAULT_ROADMAP)
+    ap.add_argument("--issues-json", default=None,
+                    help="read issue state from this JSON file instead of calling gh (self-test)")
+    args = ap.parse_args()
+
+    if not os.path.exists(args.roadmap):
+        print(f"CANNOT DETERMINE: no roadmap at {args.roadmap}")
+        return CANNOT_DETERMINE
+
+    table = parse_table(args.roadmap)
+    if not table:
+        print(f"CANNOT DETERMINE: parsed 0 issue rows from {args.roadmap}. An empty table agrees "
+              "with everything, which is not the same as being correct.")
+        return CANNOT_DETERMINE
+
+    issues, error = fetch_issues(args.issues_json)
+    if error:
+        print(f"CANNOT DETERMINE: {error}")
+        return CANNOT_DETERMINE
+
+    wrong_state = []
+    not_an_issue = []
+    for number, claimed in sorted(table.items()):
+        actual = issues.get(number)
+        if actual is None:
+            not_an_issue.append(number)
+        elif actual != claimed:
+            wrong_state.append((number, claimed, actual))
+
+    open_and_absent = sorted(n for n, s in issues.items() if s == "OPEN" and n not in table)
+
+    if not (wrong_state or not_an_issue or open_and_absent):
+        print(f"roadmap table agrees with GitHub: {len(table)} rows, "
+              f"{sum(1 for s in issues.values() if s == 'OPEN')} open issues all listed")
+        return OK
+
+    print(f"roadmap table disagrees with GitHub ({args.roadmap}):")
+    for number, claimed, actual in wrong_state:
+        print(f"  #{number}: table says {claimed}, GitHub says {actual}")
+    for number in not_an_issue:
+        print(f"  #{number}: listed in the table, but GitHub has no such issue")
+    for number in open_and_absent:
+        print(f"  #{number}: open on GitHub, absent from the table")
+    print("\nThe table is the source of truth for what is open. Update it in this PR.")
+    return DRIFT
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Scripts/test-roadmap-table-guard.sh
+++ b/Scripts/test-roadmap-table-guard.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Proves `Scripts/roadmap-table-matches-github.py` can fail, and fails for the right reason.
+#
+# A drift guard that has only ever been watched pass is decoration. Each case below is a defect the
+# guard exists to catch, plus the two cases where it must refuse to answer rather than report clean:
+# a truncated issue list and a table it could not parse. Those two are the ones that would silently
+# turn the guard off, so they assert exit 2 specifically — not merely "non-zero".
+#
+# Runs entirely on fixtures: no network, no `gh`, no repository state.
+set -uo pipefail
+
+GUARD="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/roadmap-table-matches-github.py"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+FAILURES=0
+
+# Asserts the guard exits with $1 for the given roadmap/issues pair. $2 is the case name.
+expect_exit() {
+  local want="$1" name="$2" roadmap="$3" issues="$4"
+  local got=0 out
+  out="$(python3 "$GUARD" --roadmap "$roadmap" --issues-json "$issues" 2>&1)" || got=$?
+  if [ "$got" != "$want" ]; then
+    printf 'FAIL  %-46s expected exit %s, got %s\n%s\n' "$name" "$want" "$got" "$out"
+    FAILURES=$((FAILURES + 1))
+  else
+    printf 'ok    %-46s exit %s\n' "$name" "$got"
+  fi
+}
+
+# --- fixtures -----------------------------------------------------------------------------------
+cat > "$TMP/issues-ok.json" <<'JSON'
+[{"number":284,"state":"OPEN"},{"number":285,"state":"CLOSED"},{"number":300,"state":"OPEN"}]
+JSON
+
+cat > "$TMP/roadmap-ok.md" <<'MD'
+| ADR | issue | state | what it is waiting on |
+|---|---|---|---|
+| ADR-001 | #284 | OPEN | a thing |
+| ADR-002 | #285 | closed | |
+
+| issue | state | what it is waiting on |
+|---|---|---|
+| #300 | OPEN | another thing |
+MD
+
+# A row that was never flipped when its issue closed.
+sed 's/| #300 | OPEN |/| #300 | closed |/' "$TMP/roadmap-ok.md" > "$TMP/roadmap-stale-state.md"
+
+# An issue nobody ever added to the table — the direction a row-by-row check cannot see.
+cat > "$TMP/issues-extra-open.json" <<'JSON'
+[{"number":284,"state":"OPEN"},{"number":285,"state":"CLOSED"},{"number":300,"state":"OPEN"},
+ {"number":683,"state":"OPEN"}]
+JSON
+
+# A table row pointing at an issue that does not exist.
+cat > "$TMP/issues-missing.json" <<'JSON'
+[{"number":284,"state":"OPEN"},{"number":285,"state":"CLOSED"}]
+JSON
+
+# Prose with no table rows at all: agrees with everything, proves nothing.
+printf '# Roadmap\n\nNo table here yet.\n' > "$TMP/roadmap-empty.md"
+
+# A list that hit the cap. Every row is consistent with the table, so only the length betrays it.
+python3 - "$TMP/issues-truncated.json" <<'PY'
+import json, sys
+rows = [{"number": 284, "state": "OPEN"}, {"number": 285, "state": "CLOSED"},
+        {"number": 300, "state": "OPEN"}]
+rows += [{"number": 10_000 + i, "state": "CLOSED"} for i in range(1000 - len(rows))]
+json.dump(rows, open(sys.argv[1], "w"))
+PY
+
+# --- cases --------------------------------------------------------------------------------------
+expect_exit 0 "agreeing table passes"                    "$TMP/roadmap-ok.md"           "$TMP/issues-ok.json"
+expect_exit 1 "row not flipped when the issue closed"    "$TMP/roadmap-stale-state.md"  "$TMP/issues-ok.json"
+expect_exit 1 "open issue absent from the table"         "$TMP/roadmap-ok.md"           "$TMP/issues-extra-open.json"
+expect_exit 1 "table row for a nonexistent issue"        "$TMP/roadmap-ok.md"           "$TMP/issues-missing.json"
+expect_exit 2 "truncated issue list is not 'clean'"      "$TMP/roadmap-ok.md"           "$TMP/issues-truncated.json"
+expect_exit 2 "unparseable table is not 'clean'"         "$TMP/roadmap-empty.md"        "$TMP/issues-ok.json"
+expect_exit 2 "absent roadmap file is not 'clean'"       "$TMP/nope.md"                 "$TMP/issues-ok.json"
+
+# The failing cases must name the issue they are about, or the report is unusable in CI.
+OUT="$(python3 "$GUARD" --roadmap "$TMP/roadmap-ok.md" --issues-json "$TMP/issues-extra-open.json" 2>&1)" || true
+if printf '%s' "$OUT" | grep -q '#683'; then
+  printf 'ok    %-46s names the drifting issue\n' "report content"
+else
+  printf 'FAIL  %-46s did not name #683:\n%s\n' "report content" "$OUT"
+  FAILURES=$((FAILURES + 1))
+fi
+
+if [ "$FAILURES" -ne 0 ]; then
+  printf '\n%s case(s) failed: the drift guard does not behave as documented.\n' "$FAILURES"
+  exit 1
+fi
+printf '\nall cases passed: the guard fails on drift and refuses on partial input.\n'

--- a/Tests/LogicProMCPTests/Issue668RefreshCoalescingTests.swift
+++ b/Tests/LogicProMCPTests/Issue668RefreshCoalescingTests.swift
@@ -223,32 +223,42 @@ struct Issue668RefreshCoalescingTests {
 
     @Test("a debounced write is not reported as a refresh")
     func debouncedWriteIsNotReportedAsRefreshed() async {
-        let cache = StateCache()
         // The occlusion debounce absorbs the first two empty track reads while a document is open
         // and the cache is non-empty, returning without touching tracks, timestamp, or revision.
-        // The conditional wrapper still answers `true`, because the compare-and-swap DID accept —
-        // and that `true` used to reach `refresh_cache`'s `refreshed`. "CAS accepted" is not
-        // "the cache advanced", and the receipt claims the second.
+        // The older `updateTracks(_:ifCurrent:)` still answers `true` there, because the
+        // compare-and-swap DID accept — and that `true` used to reach `refresh_cache`'s
+        // `refreshed`. "CAS accepted" is not "the cache advanced", and the receipt claims the
+        // second. `applyTracks` is the fix, so it is what this measures.
+        //
+        // This drove the poller through a real `AccessibilityChannel` until 2026-08-24, which made
+        // it a statement about the machine rather than about the code: the debounce only engages
+        // when the AX read comes back empty, so the test passed with Logic closed and failed with a
+        // project open. It failed exactly that way in a ship gate while CI, which has no Logic,
+        // stayed green — an environmental accident encoded as a contract.
+        let cache = StateCache()
         await cache.updateTracks([TrackState(id: 0, name: "Kept", type: .audio)])
         await cache.updateDocumentState(true)
-        let revisionBefore = await cache.currentVersion(for: .tracks)
+        let observed = await cache.currentVersion(for: .tracks)
 
-        let keys = KeyRecorder()
-        let poller = StatePoller(
-            axChannel: AccessibilityChannel(),
-            cache: cache,
-            runtime: .init(hasVisibleWindow: { true }),
-            postPoll: { keys.add($0) }
-        )
-        _ = await poller.refreshNow()
+        let applied = await cache.applyTracks([], ifCurrent: observed)
 
-        // Precondition: the debounce must actually have fired, or this measures nothing.
-        let revisionAfter = await cache.currentVersion(for: .tracks)
-        #expect(revisionAfter == revisionBefore, "tracks advanced; the debounce never engaged")
+        #expect(!applied, "the CAS accepted but the cache did not advance; that is not a refresh")
+        #expect(await cache.currentVersion(for: .tracks) == observed, "the revision moved")
         #expect(await cache.getTracks().first?.name == "Kept", "the cache was overwritten")
 
-        #expect(!keys.sawTracks(), "a write that changed nothing was reported as a refresh")
+        // The negative above is only worth something if the same call can answer `true`. A read
+        // that genuinely carries new content is not absorbed, and must be reported as a refresh.
+        let advanced = await cache.applyTracks(
+            [TrackState(id: 0, name: "Replaced", type: .audio)], ifCurrent: observed)
+        #expect(advanced, "a write that changed the cache was not reported as a refresh")
+        #expect(await cache.currentVersion(for: .tracks) != observed)
     }
+
+    /// NOT covered here: that `applied == false` stops the poller emitting a `tracks` cache key.
+    /// `StatePoller` takes a concrete `AccessibilityChannel`, so there is no seam to hand it a
+    /// controlled read, and the only way to reach that link is to walk whatever Logic is doing —
+    /// which is what made the test above environment-coupled. Stating the gap rather than
+    /// re-introducing a check that passes for the wrong reason.
 
     @Test("no cycle begins once a stop is requested, including from a cycle stop does not own")
     func stopQuiescesACycleItDoesNotOwn() async {

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -18,20 +18,26 @@ without the other**. That is the failure this file exists to end.
 "when someone remembers" is stale within two weeks — measured, that is exactly how its predecessor
 got here.
 
-That rule is a convention, and a convention is a claim. The stronger form is a CI check that fails
-when this table disagrees with GitHub, and it is tracked separately (#678 follow-up) so the document
-lands correct before a machine starts enforcing it. **Until that check exists, treat this file as
-verified only as far as its "measured" date.**
+That rule is a convention, and a convention is a claim. **The check now exists**:
+`Scripts/roadmap-table-matches-github.py` runs in CI and fails when this table and GitHub disagree —
+either a row that was never flipped, or an open issue nobody added. It refuses (exit 2) rather than
+reporting clean when it cannot tell: a `gh issue list` result that hit its own `--limit` looks
+identical to a complete one, and written against `--limit 200` this check would have compared
+against the newest 200 of 239 issues and passed. `Scripts/test-roadmap-table-guard.sh` drives every
+one of those paths and asserts the exit codes, so the guard has been watched fail.
 
-## State — measured 2026-08-24
+It does not check the prose. The "waiting on" column, the order, and the state block below are still
+claims dated by the "measured" line, and only issue numbers and open/closed are mechanised.
+
+## State — measured 2026-08-24 at `d02d85f4`
 
 ```
-open PRs 0 · main bd943f5 · v3.14.0 published
+open PRs 0 · v3.14.0 published · 19 open issues
 ```
 
 | ADR | issue | state | what it is waiting on |
 |---|---|---|---|
-| ADR-001 | #284 | OPEN | 6 of 7 LPMCP-PRD-001 contracts open; five are `release.yml` requirements |
+| ADR-001 | #284 | OPEN | 6 of 7 LPMCP-PRD-001 contracts open; `R-SEM` splits 23 read-only (15 already pass) / 49 mutating awaiting a write-and-readback qualification mode that does not exist / 37 mutating with a waiver route |
 | ADR-002 | #285 | closed | |
 | ADR-003 | #286 | closed | |
 | ADR-004 | #287 | closed | |
@@ -42,7 +48,7 @@ open PRs 0 · main bd943f5 · v3.14.0 published
 | ADR-009 | #292 | OPEN | apply-back expansion on Wave-0 insert work; #299 and #301 consume it |
 | ADR-010 | #293 | OPEN | provider exists (10 modules); its collector was written against a fixture shape Logic does not produce |
 | ADR-011 | #299 | OPEN | behind #292 |
-| ADR-012 | #300 | OPEN | **implemented and registered** — `audio.analyze_file`, `audio.recommend_eq`; gated behind `LOGIC_MCP_ADR012_SPECTRAL_EQ=1`, so what is open is promotion, not implementation |
+| ADR-012 | #300 | OPEN | **implemented and registered**, gated behind `LOGIC_MCP_ADR012_SPECTRAL_EQ=1`; measured working (injected 250 Hz recovered at 253.98 Hz, control silent) but promotion would ship three band artifacts — see the issue |
 | ADR-013 | #301 | OPEN | **zero band operations registered** — no public surface; the AX plane a readback needs is not exposed |
 | ADR-014 | #302 | OPEN | R1 shipped; R2 blocked on `columnResolveFailed` — `kAXColumns` absent on the live Event List |
 | ADR-015 | #303 | OPEN | behind #293 |
@@ -59,6 +65,7 @@ Also open, outside the ADR set:
 | #373 | OPEN | Phase B needs live readback; `logic://tracks` is cache-served, so a stale read passes the same equality check |
 | #448 | OPEN | layout readback is deliverable; colour and reorder need a definition of "verified" for a write nothing can read back |
 | #678 | OPEN | this file |
+| #683 | OPEN | external report — MCU feedback from Logic Pro Creator Studio wedges the loop; four hypotheses refuted or weakened by measurement, blocked on a `sample` from the reporter's host |
 
 ### Three reopen reasons, checked rather than inferred
 
@@ -79,7 +86,10 @@ next step is a measurement and the honest outcome may be a scope decision with t
 attached — not a silent deferral.
 
 1. **#284** — the release gate. Five of its six open contracts are `release.yml` requirements, so
-   most of it is repo-side work rather than live work. `R-SEM` is the large one and depends on #373.
+   most of it is repo-side work rather than live work. `R-SEM` is the large one, and measuring it
+   on 2026-08-24 moved its blocker: the 49 mutating operations with a verification plan are waiting
+   on a write-and-readback qualification mode that does not exist, which the #284 matrix does not
+   supply. #373 covers a smaller part of it than "depends on #373" suggested.
 2. **#290** — the selector atlas, because every capability below addresses Logic through AX
    selectors and ad-hoc selectors are the measured source of wrong-target behaviour.
 3. **#293 → #303** — readback before the transforms that must take their expected values from it.

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -66,6 +66,7 @@ Also open, outside the ADR set:
 | #448 | OPEN | layout readback is deliverable; colour and reorder need a definition of "verified" for a write nothing can read back |
 | #678 | OPEN | this file |
 | #683 | OPEN | external report — MCU feedback from Logic Pro Creator Studio wedges the loop; four hypotheses refuted or weakened by measurement, blocked on a `sample` from the reporter's host |
+| #685 | OPEN | `mixer.set_pan`/`set_volume` abandon the nudge loop on a single `nil` AX read and leave the fader partway; measured 4/4 short on the first call of a process, root cause identified |
 
 ### Three reopen reasons, checked rather than inferred
 


### PR DESCRIPTION
`docs/roadmap/README.md` declares itself the source of truth for what is open. Its update rule — the same PR that opens or closes an issue updates the table — was a convention, and the file said so itself: *"a convention is a claim. The stronger form is a CI check that fails when this table disagrees with GitHub."* This is that check.

## It found drift on its first run

`#683` was open and absent from the table. A row-by-row comparison cannot see that, which is why the guard enforces both directions:

- every row states the state GitHub reports — catches a row nobody flipped when its issue closed
- every open issue appears in the table — catches an issue nobody ever added

The reverse of the second is deliberately not enforced: the table need not list every closed issue that ever existed, only be right about the ones it lists.

## It refuses rather than passing when it cannot tell

`gh issue list` caps at `--limit`, and a capped result is indistinguishable from a complete one. Written against `--limit 200`, this check would have compared against the newest 200 of 239 issues and reported clean. That case exits 2, as does a table it could not parse (an empty table agrees with everything). CI cannot read "could not tell" as "no drift".

## The guard has been watched fail

`Scripts/test-roadmap-table-guard.sh` — offline, fixtures only, no `gh`:

```
ok    agreeing table passes                          exit 0
ok    row not flipped when the issue closed          exit 1
ok    open issue absent from the table               exit 1
ok    table row for a nonexistent issue              exit 1
ok    truncated issue list is not 'clean'            exit 2
ok    unparseable table is not 'clean'               exit 2
ok    absent roadmap file is not 'clean'             exit 2
ok    report content                                 names the drifting issue
```

The two refusal cases assert exit 2 specifically rather than "non-zero", because those are the paths that would silently switch the guard off.

## Placement

Its own job, not a step in `compile`: it reads issue state, so it needs `issues: read`, and putting that in the workflow-level `permissions` would hand it to every job instead of the one that needs it. `compile`, `test` and `build` keep `contents: read` unchanged.

It is also not named `check-*.py`, so `run-repo-guards.py` does not pick it up — that runner's stated contract is plain Python needing neither Xcode nor a network, and this needs both `gh` and a token.

## Table content in the same commit

Adds `#683`; corrects the ADR-012 and R-SEM rows against measurements taken today; and drops the standing claim that R-SEM depends on #373 — measured, its large piece (49 mutating operations) waits on a write-and-read-back qualification mode that does not exist, which the #284 matrix does not supply.

## Gates

```
public-surface preflight   PASS
ship gate                  PASS — 3945 tests, live evidence n/a (no Sources/ or live-harness change)
```

Not verified: whether the job's `GH_TOKEN` resolves as expected on a fork pull request. It reads public issue state only, so the failure mode is exit 2 (refuses), not a false pass.

Closes #678
