### PR TITLE
fix(#678): let a closing pull request mark its own issue closed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,15 @@ jobs:
         run: bash Scripts/test-roadmap-table-guard.sh
 
       - name: Roadmap table matches GitHub (#678)
+        # `--pr` is passed only on a pull request, and only so the table may mark closed the issues
+        # THAT pull request says it closes. Without it a PR closing an issue has no truthful row to
+        # write: open while it is open, stale the instant it merges — which is what turned main red
+        # on #684's own merge commit. On a push to main no number is passed and nothing is exempt.
         env:
           GH_TOKEN: ${{ github.token }}
-        run: python3 Scripts/roadmap-table-matches-github.py
+        run: |
+          python3 Scripts/roadmap-table-matches-github.py \
+            ${{ github.event.pull_request.number && format('--pr {0}', github.event.pull_request.number) || '' }}
 
   compile:
     runs-on: macos-15

--- a/Scripts/roadmap-table-matches-github.py
+++ b/Scripts/roadmap-table-matches-github.py
@@ -40,6 +40,9 @@ import sys
 
 OK, DRIFT, CANNOT_DETERMINE = 0, 1, 2
 
+# `Closes #12`, `fixes #12`, `Resolved: #12` — the forms GitHub itself acts on.
+CLOSES = re.compile(r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b[:\s]*#(\d+)", re.I)
+
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DEFAULT_ROADMAP = os.path.join(REPO_ROOT, "docs", "roadmap", "README.md")
 
@@ -78,11 +81,40 @@ def fetch_issues(fixture):
     return {int(r["number"]): str(r["state"]).upper() for r in rows}, None
 
 
+def pending_closes(pr, body=None):
+    """Issues a pull request declares it closes, which the table may mark closed early.
+
+    A PR that closes an issue cannot describe the result truthfully in its own diff: while it is
+    open the issue is open, and the moment it merges the issue is closed and the table it just
+    landed is stale. Enforcing both directions with no exception makes that window unavoidable —
+    #684 shipped this guard, closed #678, and turned `main` red on the merge commit.
+
+    So on a pull request the table is allowed to be AHEAD of GitHub, but only for the issues that
+    pull request says it closes. That is not a general "closed rows are unchecked" hole: on a push
+    to `main` no PR number is passed, no issue is exempt, and a row that claims an open issue is
+    closed still fails — which is the direction that hides live work.
+    """
+    if body is None:
+        if not pr:
+            return set()
+        try:
+            out = subprocess.run(["gh", "pr", "view", str(pr), "--json", "body", "-q", ".body"],
+                                 capture_output=True, text=True, check=True).stdout
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            return None  # asked, could not tell — the caller refuses rather than guessing
+        body = out
+    return {int(n) for n in CLOSES.findall(body or "")}
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--roadmap", default=DEFAULT_ROADMAP)
     ap.add_argument("--issues-json", default=None,
                     help="read issue state from this JSON file instead of calling gh (self-test)")
+    ap.add_argument("--pr", default=None,
+                    help="pull request number; its `Closes #N` issues may be marked closed early")
+    ap.add_argument("--pr-body", default=None,
+                    help="use this text as the pull request body instead of asking gh (self-test)")
     args = ap.parse_args()
 
     if not os.path.exists(args.roadmap):
@@ -100,6 +132,13 @@ def main():
         print(f"CANNOT DETERMINE: {error}")
         return CANNOT_DETERMINE
 
+    pending = pending_closes(args.pr, args.pr_body)
+    if pending is None:
+        print("CANNOT DETERMINE: a pull request number was given but its body could not be read, "
+              "so which issues it closes is unknown. Guessing would either invent an exemption or "
+              "fail a correct table.")
+        return CANNOT_DETERMINE
+
     wrong_state = []
     not_an_issue = []
     for number, claimed in sorted(table.items()):
@@ -107,8 +146,14 @@ def main():
         if actual is None:
             not_an_issue.append(number)
         elif actual != claimed:
+            # The one allowed disagreement: this PR closes it, and the table already says so.
+            if claimed == "CLOSED" and actual == "OPEN" and number in pending:
+                continue
             wrong_state.append((number, claimed, actual))
 
+    # No exemption here, deliberately. A pull request that closes an issue still has to LIST it —
+    # marked closed — and exempting it from this direction would let the closing PR delete the row
+    # instead, which is the drift this half exists to catch.
     open_and_absent = sorted(n for n, s in issues.items() if s == "OPEN" and n not in table)
 
     if not (wrong_state or not_an_issue or open_and_absent):

--- a/Scripts/test-roadmap-table-guard.sh
+++ b/Scripts/test-roadmap-table-guard.sh
@@ -16,10 +16,17 @@ trap 'rm -rf "$TMP"' EXIT
 FAILURES=0
 
 # Asserts the guard exits with $1 for the given roadmap/issues pair. $2 is the case name.
+# $5, when given, is a pull-request body: the guard then allows the table to be ahead of GitHub
+# for the issues that body says the PR closes.
 expect_exit() {
-  local want="$1" name="$2" roadmap="$3" issues="$4"
+  local want="$1" name="$2" roadmap="$3" issues="$4" prbody="${5-}"
   local got=0 out
-  out="$(python3 "$GUARD" --roadmap "$roadmap" --issues-json "$issues" 2>&1)" || got=$?
+  if [ -n "$prbody" ]; then
+    out="$(python3 "$GUARD" --roadmap "$roadmap" --issues-json "$issues" \
+             --pr 1 --pr-body "$prbody" 2>&1)" || got=$?
+  else
+    out="$(python3 "$GUARD" --roadmap "$roadmap" --issues-json "$issues" 2>&1)" || got=$?
+  fi
   if [ "$got" != "$want" ]; then
     printf 'FAIL  %-46s expected exit %s, got %s\n%s\n' "$name" "$want" "$got" "$out"
     FAILURES=$((FAILURES + 1))
@@ -78,6 +85,29 @@ expect_exit 1 "table row for a nonexistent issue"        "$TMP/roadmap-ok.md"   
 expect_exit 2 "truncated issue list is not 'clean'"      "$TMP/roadmap-ok.md"           "$TMP/issues-truncated.json"
 expect_exit 2 "unparseable table is not 'clean'"         "$TMP/roadmap-empty.md"        "$TMP/issues-ok.json"
 expect_exit 2 "absent roadmap file is not 'clean'"       "$TMP/nope.md"                 "$TMP/issues-ok.json"
+
+# --- the closing-PR window ----------------------------------------------------------------------
+# A pull request that closes an issue cannot describe the result truthfully in its own diff. Marked
+# closed early it disagrees with GitHub; left open it lands stale the moment it merges. #684 hit the
+# second and turned main red. The table may run ahead, but only for what the PR says it closes.
+sed 's/| #300 | OPEN |/| #300 | closed |/' "$TMP/roadmap-ok.md" > "$TMP/roadmap-ahead.md"
+
+expect_exit 1 "a row ahead of GitHub fails without a PR"  "$TMP/roadmap-ahead.md" "$TMP/issues-ok.json"
+expect_exit 0 "the PR that closes it may mark it closed"  "$TMP/roadmap-ahead.md" "$TMP/issues-ok.json" \
+  "Adds the thing.
+
+Closes #300"
+expect_exit 1 "a PR closing something else grants nothing" "$TMP/roadmap-ahead.md" "$TMP/issues-ok.json" \
+  "Closes #284"
+# The exemption runs one way only. Claiming an issue is OPEN when GitHub closed it is staleness,
+# and no PR body excuses it — that is what #684's merge produced.
+sed 's/| #285 | closed |/| #285 | OPEN |/' "$TMP/roadmap-ok.md" > "$TMP/roadmap-behind.md"
+expect_exit 1 "a stale OPEN row is not excused by a PR"   "$TMP/roadmap-behind.md" "$TMP/issues-ok.json" \
+  "Closes #285"
+# And the exemption does not let the closing PR DELETE the row instead of flipping it.
+grep -v '| #300 |' "$TMP/roadmap-ok.md" > "$TMP/roadmap-dropped.md"
+expect_exit 1 "the closing PR must still list the issue"  "$TMP/roadmap-dropped.md" "$TMP/issues-ok.json" \
+  "Closes #300"
 
 # The failing cases must name the issue they are about, or the report is unusable in CI.
 OUT="$(python3 "$GUARD" --roadmap "$TMP/roadmap-ok.md" --issues-json "$TMP/issues-extra-open.json" 2>&1)" || true

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -26,6 +26,13 @@ identical to a complete one, and written against `--limit 200` this check would 
 against the newest 200 of 239 issues and passed. `Scripts/test-roadmap-table-guard.sh` drives every
 one of those paths and asserts the exit codes, so the guard has been watched fail.
 
+One exception, and it is narrow: **a pull request may mark closed the issues it says it closes.**
+Without it a closing PR has no truthful row to write — open while it is open, stale the instant it
+merges — and #684 hit exactly that, turning `main` red on its own merge commit. The exemption
+applies only to issues named in that PR's `Closes #N`, only in the ahead direction, and not at all
+on a push to `main`; a row claiming an open issue is closed still fails, and the closing PR must
+still list the issue rather than delete its row.
+
 It does not check the prose. The "waiting on" column, the order, and the state block below are still
 claims dated by the "measured" line, and only issue numbers and open/closed are mechanised.
 
@@ -64,7 +71,7 @@ Also open, outside the ADR set:
 | #369 | OPEN | Export panel AX-opaque — no accessible path to per-track stems |
 | #373 | OPEN | Phase B needs live readback; `logic://tracks` is cache-served, so a stale read passes the same equality check |
 | #448 | OPEN | layout readback is deliverable; colour and reorder need a definition of "verified" for a write nothing can read back |
-| #678 | OPEN | this file |
+| #678 | closed | the drift guard and this file's update rule shipped in #684 |
 | #683 | OPEN | external report — MCU feedback from Logic Pro Creator Studio wedges the loop; four hypotheses refuted or weakened by measurement, blocked on a `sample` from the reporter's host |
 | #685 | OPEN | `mixer.set_pan`/`set_volume` abandon the nudge loop on a single `nil` AX read and leave the fader partway; measured 4/4 short on the first call of a process, root cause identified |
 


### PR DESCRIPTION
The drift guard turned `main` red on the merge commit that shipped it.

#684 closed #678, and #684's table said `#678 | OPEN` — correctly, because it *was* open for as long as that pull request was. The moment it merged, the row was stale, and the guard running on the push to `main` reported exactly that:

```
#678: table says OPEN, GitHub says CLOSED
```

That is the guard working. It is also a rule that cannot be satisfied: a pull request that closes an issue has no truthful row to write. `OPEN` is right until it merges and wrong after; `closed` is wrong until it merges and right after.

## The exemption, and why it is not a hole

On a pull request the table may run **ahead** of GitHub — but only for the issues that pull request's body says it closes.

- **One direction only.** A row claiming an open issue is closed still fails, with or without a PR body. That is the direction that hides live work.
- **The closing PR must still list the issue**, marked closed. Exempting it from the "every open issue appears" check would let the row be deleted instead of flipped, which is worse than the drift being fixed.
- **A PR closing a different issue grants nothing.**
- **On a push to `main` no PR number is passed**, so nothing is exempt at all — the enforcement that matters is unchanged.
- **Asked for a PR body and unable to read it, the guard exits 2** rather than inventing an exemption or failing a correct table.

Each of those is a self-test case, including the two that turn the exemption into a hole if they are missing:

```
ok    a row ahead of GitHub fails without a PR       exit 1
ok    the PR that closes it may mark it closed       exit 0
ok    a PR closing something else grants nothing     exit 1
ok    a stale OPEN row is not excused by a PR        exit 1
ok    the closing PR must still list the issue       exit 1
```

Twelve cases now, all passing, offline on fixtures.

## Also in this commit

The stale `#678` row is corrected, so `main` goes green again.

## Gates

```
public-surface preflight   PASS
ship gate                  PASS — full suite green, live evidence n/a (no Sources/ change)
```

Note this PR does not itself close an issue, so it does not exercise the new exemption in CI — the exemption is covered by the fixture cases above. The first PR to exercise it live will be the next one that carries a `Closes #N`.
