### PR TITLE
fix(#290): identify the track-header pan slider instead of eliminating to it

### DIFF
--- a/Scripts/check-ax-locator-census.py
+++ b/Scripts/check-ax-locator-census.py
@@ -67,7 +67,7 @@ import sys
 # defect was fixed, which is the only direction it is allowed to move. The check fails when the
 # count comes in UNDER budget too, on purpose: ground gained and not recorded is ground that the
 # next change can quietly give back.
-BLIND_SITE_BUDGET = 57
+BLIND_SITE_BUDGET = 56
 
 SEARCH_ROOTS = ("Sources", "Scripts")
 

--- a/Scripts/livekit/live_290_header_pan_is_identified.py
+++ b/Scripts/livekit/live_290_header_pan_is_identified.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Live proof that the track-header pan slider is IDENTIFIED rather than eliminated to.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_290_header_pan_is_identified.py <worktree> <full-40-char-head-sha>
+
+WHAT THIS PROVES
+----------------
+`--probe-selection-census` is the product's own instrument for "how many candidates survive the
+discriminator a site applies". It measured `findPanControlInHeader` at ZERO survivors of two
+sliders, which by that probe's own rule means the site was selecting by index — it fell through to
+"the slider that is not the volume fader" on every header. This run asks the same instrument the
+same question at this head and records the answer.
+
+It also drives the control the identity now names, and shows the write lands on the track it was
+aimed at and no other. A selector that resolves confidently to the wrong element is worse than one
+that refuses, so "it resolved" is not on its own the property worth having.
+
+WHAT IT DOES NOT PROVE
+----------------------
+Only the Korean help string is measured. `AXHelp` is what carries the pan slider's name here, and
+this host runs one locale — so nothing in this run says the same is true of an English or Japanese
+Logic. On a locale whose help text carries none of the hint's variants the predicate yields
+nothing and the site falls through to elimination exactly as it did before, which is why that
+fallback was kept rather than deleted.
+
+It does not exercise the ambiguity refusal either. Inducing two sliders that both name themselves
+pan would mean editing the tree being measured; that half is covered by
+`Issue290HeaderPanIdentityTests.ambiguityRefuses` and by the mutation showing the pre-fix predicate
+returns the first in tree order instead of refusing.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+CHOOSER_TITLES = ("Choose a Project", "프로젝트 선택")
+SITE = "AXLogicProElements.findPanControlInHeader"
+
+
+def osa(script):
+    r = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
+    return (r.stdout or "").strip()
+
+
+def window_titles():
+    raw = osa('tell application "System Events" to tell process "Logic Pro" to '
+              'return name of every window')
+    return [t.strip() for t in raw.split(",") if t.strip()] if raw else []
+
+
+titles = [t for t in window_titles() if not any(c in t for c in CHOOSER_TITLES)]
+ev.check("290/precondition-a-project-is-open", bool(titles),
+         "Logic has a project window, so track headers exist to resolve a pan slider in",
+         f"windows={window_titles()!r}", None)
+if not titles:
+    print(json.dumps(ev.write(), indent=1)); sys.exit(1)
+
+arrange_title = titles[0]
+
+# The rail's own AXDescription is localized — `트랙 헤더` on this host — so the English selector the
+# other harnesses use finds nothing here. Both are tried, and which one answered is recorded, so a
+# run cannot be filed under a layout it did not measure.
+RAIL, RAIL_SUBJECT = ev.located_band("트랙 헤더")
+rail_selector = "트랙 헤더"
+if RAIL is None:
+    RAIL, RAIL_SUBJECT = ev.located_band("Tracks header")
+    rail_selector = "Tracks header"
+ev.check("290/precondition-the-track-header-rail-is-located",
+         RAIL is not None and bool(RAIL_SUBJECT),
+         "the capture band is resolved from the live tree, so what the pixels below show is the rail "
+         "that was actually found rather than a rectangle someone remembered",
+         f"selector={rail_selector!r} band={RAIL!r} subject={RAIL_SUBJECT!r}", None)
+if RAIL is None:
+    print(json.dumps(ev.write(), indent=1)); sys.exit(1)
+
+# ---- the census, asked of the product at this head -------------------------------------------
+census = subprocess.run([E.BIN, "--probe-selection-census"], capture_output=True, text=True)
+try:
+    sites = json.loads(census.stdout or "{}").get("sites", [])
+except json.JSONDecodeError:
+    sites = []
+row = next((s for s in sites if isinstance(s, dict) and s.get("site", "").startswith(SITE)), None)
+ev.note("290/selection-census", {"row": row, "sites": len(sites)})
+
+ev.check("290/the-pan-slider-names-itself",
+         isinstance(row, dict) and row.get("survivors") == 1 and row.get("identified") is True,
+         "exactly one slider on the header survives the pan discriminator, and the census calls the "
+         "answer unambiguous — measured at ZERO survivors before this change, which by the probe's "
+         "own rule is the site selecting by index",
+         f"row={row!r}",
+         "revert headerPanSliderCandidates to matching headerPanHint against the children's "
+         "AXDescription: survivors returns to 0 and this check goes red")
+
+d = E.Driver()
+time.sleep(3)
+
+
+def pans():
+    d.tool("logic_system", "refresh_cache", {})
+    time.sleep(1.2)
+    body = d.resource("logic://tracks") or {}
+    rows = body.get("data") if isinstance(body.get("data"), list) else []
+    return body, [r.get("pan") for r in rows]
+
+
+body, before_pans = pans()
+age = body.get("cache_age_sec")
+ev.provenance("290/track-pans", f"state_poller_cache_{body.get('data_source')}",
+              round(age, 2) if isinstance(age, (int, float)) else None,
+              bool(body.get("readable")))
+ev.check("290/precondition-the-poller-reads-this-project",
+         bool(body.get("readable")) and len(before_pans) >= 2,
+         "the track list is readable and has at least two tracks, so 'only the aimed track moved' is "
+         "a claim this run can actually test rather than a vacuous one",
+         f"readable={body.get('readable')!r} reason={body.get('reason')!r} pans={before_pans!r}",
+         None)
+if not body.get("readable") or len(before_pans) < 2:
+    d.close(); print(json.dumps(ev.write(), indent=1)); sys.exit(1)
+
+rec = ev.record_screen(seconds=120)
+before = ev.shot("290/before", settle_region=RAIL, window_title=arrange_title)
+
+# Aim away from wherever it currently sits, so the assertion cannot pass by the knob already being
+# where it was asked to go.
+target = -0.7 if (before_pans[0] or 0) > -0.3 else 0.7
+envelope = d.tool("logic_mixer", "set_pan", {"track": 0, "value": target})
+time.sleep(1.5)
+ev.note("290/set-pan", envelope if isinstance(envelope, dict) else {"raw": str(envelope)[:200]})
+
+_, after_pans = pans()
+moved = [i for i, (b, a) in enumerate(zip(before_pans, after_pans)) if b != a]
+
+ev.check("290/the-write-lands-on-the-track-it-was-aimed-at",
+         moved == [0],
+         "track 0's pan changed and no other track's did — a selector that resolves confidently to "
+         "the wrong element is worse than one that refuses, so resolving is not on its own the "
+         "property worth having",
+         f"target={target} before={before_pans!r} after={after_pans!r} moved={moved!r}",
+         "resolve the header by tree order instead of identity: on a header whose first slider is "
+         "not the pan control the write lands elsewhere and `moved` stops being [0]")
+
+ev.check("290/the-envelope-names-the-control-it-drove",
+         isinstance(envelope, dict)
+         and (envelope.get("target_identity") or {}).get("control") == "pan"
+         and (envelope.get("target_identity") or {}).get("track_index") == 0,
+         "the receipt names the control and the track, so the claim above is checkable against what "
+         "the product says it did rather than only against what moved",
+         f"target_identity={envelope.get('target_identity') if isinstance(envelope, dict) else None!r} "
+         f"state={envelope.get('state') if isinstance(envelope, dict) else None!r}",
+         None)
+
+after = ev.shot("290/after", settle_region=RAIL, window_title=arrange_title)
+ev.visual("290/the-pan-knob-moved-in-the-pixels",
+          before["file"], after["file"], RAIL, subject=RAIL_SUBJECT,
+          expect_change=True,
+          why="the rail is where the pan knob lives; if AX reported a new value while these pixels "
+              "were identical, the write would have been recorded somewhere the user cannot see")
+
+# ---- put it back --------------------------------------------------------------------------
+restore = d.tool("logic_mixer", "set_pan", {"track": 0, "value": before_pans[0]})
+time.sleep(1.5)
+_, final_pans = pans()
+ev.note("290/restore", {"envelope": restore if isinstance(restore, dict) else str(restore)[:200],
+                        "final": final_pans})
+d.close()
+
+# One detent is ~10 raw units of 127, i.e. ~0.157 in contract units; the fader is not continuous,
+# so "back where it was" is the nearest representable level and not the exact float.
+back = (before_pans[0] is not None and final_pans and final_pans[0] is not None
+        and abs(final_pans[0] - before_pans[0]) <= 0.16)
+ev.restored("290/the-pan-is-back-where-it-started",
+            back,
+            f"track 0's pan was {before_pans[0]!r} at the start and is {final_pans[0] if final_pans else None!r} "
+            "now, within one AX detent")
+
+ev.stop_recording(rec)
+out = ev.write()
+print(json.dumps(out, indent=1))
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -972,10 +972,21 @@ enum AXLocalePolicy {
     )
 
     /// Track-header pan slider locator (header-level).
+    /// No longer consulted in production as of 2026-08-24. `headerPanSliderCandidates` was its only
+    /// caller and now uses `sliderPanHint` via `sliderText`, which reads `AXHelp` and is what
+    /// identifies the same control on a mixer strip — this set searched children's `AXDescription`
+    /// and measured zero survivors on every header.
+    ///
+    /// Left in place rather than deleted. Its `팬` variant is not in `sliderPanHint`, so removing it
+    /// would drop a label from the repository on the strength of one measurement, in one locale, on
+    /// one Logic version — a narrowing dressed up as a cleanup. Whether `팬` belongs in
+    /// `sliderPanHint`, and whether this set should then go, is a separate question with its own
+    /// evidence: no tree measured so far contains `팬` at all, and `팬` does not occur inside
+    /// `패닝` (different syllables), so it has never been the variant doing the work.
     static let headerPanHint = LabelSet(
         canonical: "pan",
         variants: ["팬", "밸런스"],
-        rationale: "Locates the track-header pan slider by child description; read-only locator (structural fallback exists)."
+        rationale: "Retired locator for the track-header pan slider; superseded by sliderPanHint."
     )
 
     /// Track-header rail description (normalized exact match).

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+Mixer.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+Mixer.swift
@@ -66,23 +66,72 @@ extension AXLogicProElements {
         among sliders: [AXUIElement],
         runtime: AXHelpers.Runtime = .production
     ) -> [AXUIElement] {
-        sliders.filter { slider in
-            AXHelpers.getChildren(slider, runtime: runtime).contains { child in
-                let desc = (AXHelpers.getDescription(child, runtime: runtime) ?? "").lowercased()
-                return AXLocalePolicy.headerPanHint.containsAny(in: desc)
-            }
-        }
+        // This used to run its own predicate — `headerPanHint` against the CHILDREN's
+        // `AXDescription` — and `--probe-selection-census` measured it at zero survivors of two
+        // sliders on every header, so `findPanControlInHeader` reached its elimination fallback
+        // every time.
+        //
+        // Measured 2026-08-24, Logic 12.x (ko), read off the live tree: the header pan slider has
+        // no `AXDescription`, and no `AXIdentifier` — that attribute is absent from the element
+        // entirely. What it carries is `AXHelp` = "패닝 노브 및 밸런스 노브".
+        //
+        // The product already had a predicate that reads that. `sliderText` searches
+        // identifier + description + title + HELP, and `sliderPanHint` carries `패닝` and `밸런스`;
+        // it is what `findPanControl` uses for mixer strips, where the same census measured one
+        // survivor of two. So this was not a missing capability, it was a second, weaker copy of an
+        // existing one — used on headers only, and never matching. Deleting the copy is the fix.
+        //
+        // Checked that it still separates the pair rather than assuming it: the volume fader's
+        // searchable text ("볼륨", "볼륨 페이더. …") carries none of `pan` / `panning` / `패닝` /
+        // `밸런스`. `sliderText` also excludes send and zoom sliders, which the deleted copy did
+        // not — strictly narrower, not wider.
+        sliders.filter { sliderText($0, runtime: runtime).isPanControl }
     }
 
+    /// `AXMaxValue` of a track-header pan slider, measured at 127 against the volume fader's 233.
+    ///
+    /// A value-range signature, so unlike the help text it does not depend on locale. Used only to
+    /// separate candidates when the hint leaves more than one — never on its own, because a range
+    /// is a weaker claim about identity than a name.
+    static let headerPanSliderMaxValue: Double = 127
+
     /// Header-level pan-slider selection (split out for deterministic testing).
+    ///
+    /// Only the Korean help string is measured. On a locale whose `AXHelp` carries none of the
+    /// hint's variants the predicate yields nothing, and this falls through to elimination exactly
+    /// as it did before — so an unmeasured locale is no worse off, and never silently better.
     static func findPanControlInHeader(_ header: AXUIElement, runtime: AXHelpers.Runtime = .production) -> AXUIElement? {
         let sliders = AXHelpers.findAllDescendants(of: header, role: kAXSliderRole, maxDepth: 4, runtime: runtime)
-        if let pan = headerPanSliderCandidates(among: sliders, runtime: runtime).first {
-            return pan
+        let candidates = headerPanSliderCandidates(among: sliders, runtime: runtime)
+
+        if candidates.count == 1 { return candidates[0] }
+
+        if candidates.count > 1 {
+            // Narrow by the value-range signature before giving up — it does not depend on locale.
+            let ranged = candidates.filter { slider in
+                let maxValue: Double? = AXHelpers.getAttribute(
+                    slider, kAXMaxValueAttribute as String, runtime: runtime)
+                return maxValue.map { abs($0 - headerPanSliderMaxValue) < 0.5 } ?? false
+            }
+            if ranged.count == 1 { return ranged[0] }
+            // Refusing, not choosing. Returning the first in tree order is what the census on #628
+            // exists to find, and here there is nothing left to distinguish them by.
+            Log.info("findPanControlInHeader: \(candidates.count) sliders carry a pan identity and "
+                + "\(ranged.count) carry the measured range; refusing rather than picking one",
+                subsystem: "ax")
+            return nil
         }
-        // Fallback: the slider that is NOT the volume fader.
+
+        // No slider named itself. Elimination is the last resort, and it is only correct while
+        // there are exactly two sliders and the other one IS named — an asymmetry the code relied
+        // on without stating. Saying so means a tree where it stops holding leaves a trace.
         let volume = findVolumeFader(in: header, runtime: runtime)
-        return sliders.first { volume == nil || !CFEqual($0, volume!) }
+        let eliminated = sliders.first { volume == nil || !CFEqual($0, volume!) }
+        if eliminated != nil {
+            Log.info("findPanControlInHeader: no slider among \(sliders.count) carries a pan "
+                + "identity; selecting by elimination against the volume fader", subsystem: "ax")
+        }
+        return eliminated
     }
 
     /// Find a volume fader for a specific track index within the mixer.

--- a/Tests/LogicProMCPTests/Issue290HeaderPanIdentityTests.swift
+++ b/Tests/LogicProMCPTests/Issue290HeaderPanIdentityTests.swift
@@ -1,0 +1,135 @@
+@preconcurrency import ApplicationServices
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+/// #290 — the track-header pan slider is selected by identity, not by elimination.
+///
+/// `--probe-selection-census` measured `findPanControlInHeader` at **zero survivors of two
+/// sliders** on Logic 12.x (ko): its predicate searched the children's `AXDescription` for
+/// `headerPanHint`, and the pan slider has no `AXDescription` at all — nor an `AXIdentifier`, which
+/// is absent from the element entirely. So the site fell through to "the slider that is not the
+/// volume fader" on every header.
+///
+/// The strings below are transcribed from that live tree, not invented. A fixture written from
+/// memory would pass while describing a UI Logic does not produce, which is the failure the census
+/// itself exists to catch.
+@Suite("Issue290HeaderPanIdentity")
+struct Issue290HeaderPanIdentityTests {
+
+    private static let panHelp = "패닝 노브 및 밸런스 노브. 트랙 신호를 스테레오 필드에 위치하려면 수직으로 드래그합니다."
+    private static let volumeHelp = "볼륨 페이더. 트랙의 재생 볼륨을 설정합니다."
+
+    /// A header holding `sliders` in tree order. Each tuple is (description, help, maxValue).
+    private static func header(
+        _ sliders: [(description: String?, help: String?, maxValue: Double?)]
+    ) -> (element: AXUIElement, sliders: [AXUIElement], runtime: AXHelpers.Runtime) {
+        let builder = FakeAXRuntimeBuilder()
+        let header = builder.element(1)
+        builder.setAttribute(header, kAXRoleAttribute as String, kAXGroupRole as String)
+
+        var elements: [AXUIElement] = []
+        for (offset, spec) in sliders.enumerated() {
+            let slider = builder.element(offset + 2)
+            builder.setAttribute(slider, kAXRoleAttribute as String, kAXSliderRole as String)
+            if let description = spec.description {
+                builder.setAttribute(slider, kAXDescriptionAttribute as String, description)
+            }
+            if let help = spec.help {
+                builder.setAttribute(slider, kAXHelpAttribute as String, help)
+            }
+            if let maxValue = spec.maxValue {
+                builder.setAttribute(slider, kAXMaxValueAttribute as String, maxValue)
+            }
+            elements.append(slider)
+        }
+        builder.setChildren(header, elements)
+        return (header, elements, builder.makeAXRuntime())
+    }
+
+    @Test("the pan slider is found by its own help text, not by being the one left over")
+    func identityRatherThanElimination() {
+        // A third, nameless slider placed FIRST. Elimination returns "the first slider that is not
+        // the volume fader", which is this one — so on the previous code this header resolves to
+        // the wrong control while reporting nothing. Identity has to reach past it.
+        let tree = Self.header([
+            (description: nil, help: nil, maxValue: nil),                        // decoy, first
+            (description: nil, help: Self.panHelp, maxValue: 127),               // pan
+            (description: "볼륨", help: Self.volumeHelp, maxValue: 233),          // volume
+        ])
+
+        let found = AXLogicProElements.findPanControlInHeader(tree.element, runtime: tree.runtime)
+
+        #expect(found != nil, "the header did not resolve at all")
+        if let pan = found {
+            #expect(CFEqual(pan, tree.sliders[1]), "resolved to a slider that never named itself")
+            #expect(!CFEqual(pan, tree.sliders[0]), "resolved to the decoy — this is elimination")
+        }
+    }
+
+    @Test("the volume fader is not mistaken for the pan control")
+    func volumeIsNotPan() {
+        let tree = Self.header([
+            (description: nil, help: Self.panHelp, maxValue: 127),
+            (description: "볼륨", help: Self.volumeHelp, maxValue: 233),
+        ])
+
+        let candidates = AXLogicProElements.headerPanSliderCandidates(
+            among: tree.sliders, runtime: tree.runtime)
+
+        // One, not both: the separation is the point. Two candidates here would mean the hint
+        // matches the volume fader's text as well, and the count below is what would catch it.
+        #expect(candidates.count == 1, "\(candidates.count) sliders claimed to be the pan control")
+        if let only = candidates.first {
+            #expect(CFEqual(only, tree.sliders[0]))
+        }
+    }
+
+    @Test("two sliders that both name themselves pan are refused, not resolved to the first")
+    func ambiguityRefuses() {
+        let tree = Self.header([
+            (description: nil, help: Self.panHelp, maxValue: 127),
+            (description: nil, help: Self.panHelp, maxValue: 127),
+            (description: "볼륨", help: Self.volumeHelp, maxValue: 233),
+        ])
+
+        // Returning tree.sliders[0] here is exactly what the #628 census exists to find: a choice
+        // among equals, made silently. There is nothing left to tell these two apart, so the honest
+        // answer is that the header did not resolve.
+        #expect(AXLogicProElements.findPanControlInHeader(tree.element, runtime: tree.runtime) == nil)
+    }
+
+    @Test("the value range separates two candidates when the help text cannot")
+    func valueRangeNarrows() {
+        // Same ambiguity as above, except one of the two carries the volume fader's range. The pan
+        // slider's AXMaxValue was measured at 127 against the volume fader's 233, and unlike the
+        // help string that signature does not depend on locale.
+        let tree = Self.header([
+            (description: nil, help: Self.panHelp, maxValue: 233),
+            (description: nil, help: Self.panHelp, maxValue: 127),
+        ])
+
+        let found = AXLogicProElements.findPanControlInHeader(tree.element, runtime: tree.runtime)
+        #expect(found != nil)
+        if let found {
+            #expect(CFEqual(found, tree.sliders[1]), "narrowed to the slider with the wrong range")
+        }
+    }
+
+    @Test("a header where nothing names itself still resolves by elimination")
+    func eliminationSurvivesForUnmeasuredTrees() {
+        // Only the Korean help string is measured. A locale whose help text carries none of the
+        // hint's variants must be no worse off than before this change — it falls through to
+        // elimination exactly as it did, rather than losing the control entirely.
+        let tree = Self.header([
+            (description: "볼륨", help: nil, maxValue: 233),
+            (description: nil, help: nil, maxValue: 127),
+        ])
+
+        let found = AXLogicProElements.findPanControlInHeader(tree.element, runtime: tree.runtime)
+        #expect(found != nil)
+        if let found {
+            #expect(CFEqual(found, tree.sliders[1]), "elimination stopped working")
+        }
+    }
+}


### PR DESCRIPTION
`--probe-selection-census` — the product's own instrument for "how many candidates survive the discriminator a site applies" — measured `findPanControlInHeader` at **zero survivors of two sliders** on every track header. By that probe's own rule, a survivor count of zero means the site is selecting by index. It fell through to its fallback, "the slider that is not the volume fader", every single time.

That fallback is only correct while there are exactly two sliders and the other one is named. Neither condition is stated anywhere.

## Why it found nothing

Read off the live tree (Logic 12.x, ko):

```
pan     AXDescription (absent)   AXMinValue 0  AXMaxValue 127
        AXHelp "패닝 노브 및 밸런스 노브. …"

volume  AXDescription "볼륨"      AXMinValue 0  AXMaxValue 233
        AXHelp "볼륨 페이더. …"
```

Neither element exposes `AXIdentifier` — it is absent from the attribute list entirely, so the selector model's highest-priority evidence does not exist for this control. The pan slider's name lives in `AXHelp`, and `headerPanSliderCandidates` was searching the **children's `AXDescription`**.

## The fix is a deletion

The product already had a predicate that reads `AXHelp`. `sliderText` searches identifier + description + title + help, and `sliderPanHint` carries `패닝` and `밸런스`; it is what `findPanControl` uses for mixer strips, where the same census measured **one** survivor of two.

So this was never a missing capability. It was a second, weaker copy of an existing one, used on headers only, and never matching. The copy is gone.

Strictly narrower, not wider: `sliderText` also excludes send and zoom sliders, which the deleted predicate did not. Checked rather than assumed that the hint still separates the pair — the volume fader's searchable text carries none of `pan` / `panning` / `패닝` / `밸런스`.

Ambiguity now refuses instead of taking the first in tree order, narrowing first by `AXMaxValue` (127 vs 233 — a signature that, unlike help text, does not depend on locale). Elimination survives as the last resort for trees where nothing names itself, and now says so in the log.

## Measured, before and after, on the same tree

```
findPanControlInHeader   gathered 2   survivors 0 -> 1   unambiguous false -> true
```

and the identity path targets what elimination did: `set_pan` on tracks 0 and 2 moved only those two, both State A, track 1 untouched.

## Mutation-tested, not reported all-green

Unit tests are hermetic against a synthetic tree. With the predicate reverted, **three of five fail**, and the discriminating one reports resolving to the decoy slider rather than the pan slider. The two that still pass describe behaviour this change does not alter.

The live harness was mutation-tested the same way: reverted predicate → harness exits 1 with `290/the-pan-slider-names-itself` red at `survivors: 0, identified: False`. The other live checks stay green under that mutation, correctly — elimination happens to reach the right control on a two-slider header, which is why the census row rather than the write outcome is the check carrying this change.

## What this does not cover

One locale. `AXHelp` is what carries the name here and this host runs Korean; nothing in the run says the same holds for an English or Japanese Logic. On a locale whose help text matches none of the variants the predicate yields nothing and the site falls through to elimination exactly as before — which is why the fallback was kept rather than deleted. `headerPanHint` is likewise left in place with a note: its `팬` variant is not in `sliderPanHint`, and removing it would drop a label on the strength of one measurement.

The ambiguity refusal is not exercised live — inducing two sliders that both name themselves pan means editing the tree being measured. It is covered by unit test and mutation.

## Gates

```
public-surface preflight   PASS
ship gate                  PASS
live evidence @ 1f25dd7e   ok — 6/6 checks, 2 captures, 1 visual, 1 recording, 0 unclean dimensions
```

Advances #290; does not close it — this is one row of the atlas, not the atlas.
