### PR TITLE
feat(livekit): make a check prove it can reject the state it names

### DIFF
--- a/Scripts/livekit/evidence.py
+++ b/Scripts/livekit/evidence.py
@@ -14,8 +14,11 @@ What it refuses to let you record:
   resulting image is not what the user sees. Every capture records which display it fell wholly within.
 - **A whole-window diff as a visual assertion.** A full-window comparison changes when the clock ticks.
   `visual()` requires an explicit region and states what it expected to happen there.
-- **A check that cannot fail.** `check()` requires you to name the mutation you applied to the product
-  that flipped it. A check nobody has seen fail is not evidence.
+- **A check that cannot fail.** `check()` requires you to NAME a mutation you believe would flip it —
+  which is a claim, and the field says so (`mutation_claimed`). `falsifiable()` is the form that
+  establishes something: it hands the assertion to this module, which runs it against the observation
+  AND against a counterexample the author wrote down, and passes only if the first is accepted and the
+  second REJECTED. A condition that cannot fail fails there.
 - **A cached read presented as live.** `provenance()` records the source and age of any value that did
   not come from a fresh read, and marks it unusable as live evidence.
 
@@ -507,16 +510,78 @@ class Evidence:
     def check(self, tag, passed, expected, observed, mutation):
         """Assert something about the run.
 
-        `mutation` names the change to the PRODUCT that was seen to flip this check. A check whose
-        mutation is unknown is recorded with `mutation_flips: false` and the gate refuses the run — a
-        check nobody has watched fail is decoration.
+        `mutation` NAMES a change to the product the author believes would flip this check. The
+        field recording it is called `mutation_claimed` because that is all it is. It was called
+        `mutation_flips` until 2026-08-28, one word away from a claim nothing here establishes:
+        nobody reruns the build with the mutation applied, so `bool(mutation)` only ever meant "a
+        non-empty string was supplied". The docstring above it said "a check nobody has watched fail
+        is decoration" while the value beneath it counted decoration.
+
+        Requiring a mutant receipt was considered and rejected. The live gate hashes every
+        `*.evidence.json` at a head against the shipped release binary, and a mutant binary has a
+        different digest by construction — so a receipt cannot live in that directory at all, and
+        exempting it would move the trust rather than establish it. A second GUI run against another
+        binary in another UI state also cannot show that the NAMED mutation caused the red; it shows
+        only that something did.
+
+        `falsifiable()` below is the cheap form that does establish something.
         """
         self.records.append({
             "kind": "check", "tag": tag, "passed": bool(passed),
             "expected": expected, "observed": observed,
-            "mutation": mutation or None, "mutation_flips": bool(mutation),
+            "mutation": mutation or None, "mutation_claimed": bool(mutation),
+            # `mutation_flips` is the old name, emitted for one release. The live gate takes
+            # `is_clean` from origin/main on purpose and RECOMPUTES the summary from these
+            # records rather than reading the one written here — so the trusted copy counts
+            # the field IT knows. Renaming a record field is therefore a wire change to an
+            # external reader, not a local one, and needs the same two-step a renamed summary
+            # key does. Land this, then delete both aliases in a follow-up.
+            "mutation_flips": bool(mutation),
         })
         return bool(passed)
+
+    def falsifiable(self, tag, predicate, observation, counterexample, expected, mutation=None):
+        """A check whose assertion is run against a state it MUST reject, in the same run.
+
+        `check()` records whether the author's condition held. It cannot notice a condition that
+        could not have failed — a constant, a field that is never read, a comparison too weak to
+        reject the state it names. Those pass live and pass everywhere.
+
+        So the predicate is handed to the framework and the framework calls it twice: once on what
+        the run observed, once on an explicit counterexample the author had to write down. The check
+        passes only when the first is accepted AND the second is rejected. An author cannot supply
+        the second result; there is no parameter for it.
+
+        This costs no rebuild and no second Logic session, and it catches the defects that make an
+        assertion decoration. What it does NOT establish is that the check would catch a real
+        regression in the product — only that its condition can distinguish the observation from one
+        stated alternative. That boundary is the tag and that counterexample, and nothing wider.
+        """
+        try:
+            live_ok = bool(predicate(observation))
+        except Exception as exc:                       # noqa: BLE001 - recorded, not swallowed
+            live_ok, observation = False, f"predicate raised on the observation: {exc!r}"
+        try:
+            counter_ok = bool(predicate(counterexample))
+        except Exception as exc:                       # noqa: BLE001
+            # A predicate that throws on the counterexample has not rejected it on the merits, and
+            # reading a crash as a rejection is how a broken condition looks strong.
+            counter_ok, counterexample = True, f"predicate raised on the counterexample: {exc!r}"
+
+        passed = live_ok and not counter_ok
+        self.records.append({
+            "kind": "check", "tag": tag, "passed": passed,
+            "expected": expected,
+            "observed": {"observation": repr(observation)[:400],
+                         "accepted_the_observation": live_ok,
+                         "counterexample": repr(counterexample)[:400],
+                         "rejected_the_counterexample": not counter_ok},
+            "mutation": mutation or None, "mutation_claimed": bool(mutation),
+            "mutation_flips": bool(mutation),   # transitional alias, see check()
+            "has_counterexample": True,
+            "counterexample_rejected": not counter_ok,
+        })
+        return passed
 
     def provenance(self, tag, source, cache_age_sec, usable):
         """Record where a value came from when it did not come from a fresh read."""
@@ -755,7 +820,17 @@ def summarize(recs, out=None):
         "file": out,
         "checks": len(checks),
         "passed": sum(1 for c in checks if c.get("passed")),
-        "mutation_backed": sum(1 for c in checks if c.get("mutation_flips")),
+        "mutation_claimed": sum(1 for c in checks if c.get("mutation_claimed")),
+        # Alias, and it has to be here for one release. The live gate extracts `is_clean` from
+        # origin/main deliberately — a branch may not edit its own judge — so while the trusted copy
+        # still requires `mutation_backed`, a document carrying only the new name is missing a
+        # required key and the gate refuses it. Renaming a key a trusted external reader depends on
+        # is the same chicken-and-egg as a pull request closing its own issue: emit both, land the
+        # rename, then delete this line in a follow-up.
+        "mutation_backed": sum(1 for c in checks if c.get("mutation_claimed")),
+        "checks_with_a_counterexample": sum(1 for c in checks if c.get("has_counterexample")),
+        "counterexamples_not_rejected":
+            sum(1 for c in checks if c.get("has_counterexample") and not c.get("counterexample_rejected")),
         "captures_unsettled": sum(1 for c in caps if not c.get("settled")),
         "captures_straddling_displays":
             sum(1 for c in caps if not c.get("display", {}).get("wholly_within")),
@@ -779,12 +854,13 @@ def summarize(recs, out=None):
 # Every counter `is_clean` reads. A summary missing any of them is not clean.
 #
 # The polarity used to depend on which key it was: `summary.get("visual_assertions_without_a_subject", 0) == 0`
-# passed when the key was ABSENT, while `summary.get("mutation_backed", 0) > 0` failed when absent.
+# passed when the key was ABSENT, while `summary.get("mutation_claimed", 0) > 0` failed when absent.
 # So a summary carrying the new counters but not that one — an older _summary, a hand-built dict —
 # was clean, and the newest condition was the one that vanished quietly. Listing the keys fixes the
 # shape of the bug rather than the one clause where it was noticed.
 _REQUIRED_SUMMARY_KEYS = (
-    "checks", "passed", "mutation_backed", "operations_driven",
+    "checks", "passed", "mutation_claimed", "mutation_backed", "operations_driven",
+    "checks_with_a_counterexample", "counterexamples_not_rejected",
     "captures", "captures_unsettled", "captures_straddling_displays",
     "restorations_failed", "cached_reads_used_as_live",
     "visual_assertions", "visual_failed", "visual_assertions_without_a_subject",
@@ -814,9 +890,17 @@ def is_clean(summary):
       * `operations_driven` counts tool calls, not successful ones. A warm-up call, a read, or a
         call that came back a transport error each increment it. It rules out a harness that never
         touched the product; it does not show the run drove its own subject.
-      * `mutation_backed` counts checks that NAME a mutation. Naming is not demonstrating — the
+      * `mutation_claimed` counts checks that NAME a mutation. Naming is not demonstrating — the
         string is prose, and nothing here reruns the build with the mutation applied. Whether the
         named mutation would actually flip that check is the author's claim and a reviewer's job.
+        It was called `mutation_backed` until 2026-08-28, which read as though something backed it.
+      * `counterexamples_not_rejected` is enforced and `checks_with_a_counterexample` is NOT, yet.
+        A `falsifiable()` check whose predicate accepts the state it was supposed to reject fails
+        immediately — that clause is real. Requiring every harness to HAVE one is the clause with
+        teeth, and it is left counted-but-unenforced for the same reason
+        `visual_assertions_without_a_subject` was: thirty-odd harnesses predate the affordance, and
+        turning the whole live suite red in one step invites someone to delete the clause instead of
+        converting the call sites. Enforce it when the count reaches the harness count, not before.
       * a subject is any non-empty string. That it truthfully names what the rectangle contains is
         not checkable here.
 
@@ -842,7 +926,8 @@ def is_clean(summary):
         and summary["captures"] > 0
         and summary["visual_assertions"] > 0
         and summary["recordings"] > 0
-        and summary["mutation_backed"] > 0
+        and summary["mutation_claimed"] > 0
+        and summary["counterexamples_not_rejected"] == 0
         and summary["operations_driven"] > 0
         # ... and nothing it did may have gone wrong.
         and summary["visual_failed"] == 0

--- a/Scripts/livekit/live_290_header_pan_is_identified.py
+++ b/Scripts/livekit/live_290_header_pan_is_identified.py
@@ -100,14 +100,26 @@ except json.JSONDecodeError:
 row = next((s for s in sites if isinstance(s, dict) and s.get("site", "").startswith(SITE)), None)
 ev.note("290/selection-census", {"row": row, "sites": len(sites)})
 
-ev.check("290/the-pan-slider-names-itself",
-         isinstance(row, dict) and row.get("survivors") == 1 and row.get("identified") is True,
-         "exactly one slider on the header survives the pan discriminator, and the census calls the "
-         "answer unambiguous — measured at ZERO survivors before this change, which by the probe's "
-         "own rule is the site selecting by index",
-         f"row={row!r}",
-         "revert headerPanSliderCandidates to matching headerPanHint against the children's "
-         "AXDescription: survivors returns to 0 and this check goes red")
+def one_unambiguous_survivor(r):
+    return isinstance(r, dict) and r.get("survivors") == 1 and r.get("identified") is True
+
+
+# The counterexample is not invented: it is the row this census actually printed before the fix, on
+# this machine, transcribed. `falsifiable` runs the same predicate against both, so a condition that
+# would also accept the pre-fix state fails here rather than passing live and proving nothing.
+PRE_FIX_ROW = {"site": SITE + " (header pan slider)",
+               "gathered": 2, "survivors": 0, "identified": False}
+
+ev.falsifiable(
+    "290/the-pan-slider-names-itself",
+    one_unambiguous_survivor,
+    row,
+    PRE_FIX_ROW,
+    "exactly one slider on the header survives the pan discriminator, and the census calls the "
+    "answer unambiguous — measured at ZERO survivors before this change, which by the probe's own "
+    "rule is the site selecting by index",
+    mutation="revert headerPanSliderCandidates to matching headerPanHint against the children's "
+             "AXDescription: survivors returns to 0 and this check goes red")
 
 d = E.Driver()
 time.sleep(3)

--- a/Scripts/livekit/test_evidence.py
+++ b/Scripts/livekit/test_evidence.py
@@ -17,7 +17,9 @@ import evidence as E  # noqa: E402
 # A complete, honest summary: one check that names a mutation, one driven operation, one capture,
 # one visual with a subject, one recording, nothing gone wrong.
 GOOD = {
-    "checks": 1, "passed": 1, "mutation_backed": 1, "operations_driven": 1,
+    "checks": 1, "passed": 1, "mutation_claimed": 1, "mutation_backed": 1,
+    "operations_driven": 1,
+    "checks_with_a_counterexample": 0, "counterexamples_not_rejected": 0,
     "captures": 1, "captures_unsettled": 0, "captures_straddling_displays": 0,
     "restorations_failed": 0, "cached_reads_used_as_live": 0,
     "visual_assertions": 1, "visual_failed": 0, "visual_assertions_without_a_subject": 0,
@@ -32,7 +34,9 @@ CASES = [
     (False, {**GOOD, "captures": 0}, "no capture — nothing was unsettled because nothing was shot"),
     (False, {**GOOD, "recordings": 0}, "no screen recording"),
     (False, {**GOOD, "operations_driven": 0}, "never called the product"),
-    (False, {**GOOD, "mutation_backed": 0}, "no check names a mutation"),
+    (False, {**GOOD, "mutation_claimed": 0}, "no check names a mutation"),
+    (False, {**GOOD, "counterexamples_not_rejected": 1},
+     "a counterexample the assertion failed to reject"),
     (False, {**GOOD, "checks": 0, "passed": 0}, "no checks"),
     # Absence must never be clean, for EVERY key — the polarity used to depend on which one.
     *[(False, {k: v for k, v in GOOD.items() if k != key}, f"summary missing {key!r}")
@@ -325,6 +329,44 @@ shapes.append(("is_clean() returns a bool", isinstance(E.is_clean(out), bool)))
 shapes.append(("the driven visual named a subject", out["visual_assertions_without_a_subject"] == 0))
 shapes.append(("have_tools() returns a list", isinstance(E.have_tools(), list)))
 shapes.append(("_safe_name() returns a str", isinstance(E._safe_name("x"), str)))
+# --- falsifiable(): the assertion is run against a state it must reject -------------------------
+# The whole point is that a condition which cannot fail must not pass here. Each case below is a
+# predicate defect that `check()` records as green, because `check()` only ever sees the author's
+# own boolean.
+fev = E.Evidence("f" * 40, tmp, name="falsifiable_cases")
+FCASES = [
+    ("a real condition passes",              lambda o: o["survivors"] == 1, True),
+    ("a constant-true predicate fails",      lambda o: True,                False),
+    ("a predicate that rejects the observation fails", lambda o: False,     False),
+    ("a condition too weak to reject the counterexample fails",
+     lambda o: "survivors" in o,                                            False),
+    ("a predicate that raises on the counterexample fails",
+     lambda o: o["survivors"] == 1 or o["missing"],                         False),
+]
+OBS = {"survivors": 1, "identified": True}
+COUNTER = {"survivors": 0, "identified": False}
+for why, pred, want in FCASES:
+    got = fev.falsifiable(f"f/{why}", pred, OBS, COUNTER, "expected", mutation=None)
+    shapes.append((f"falsifiable: {why}", got is want))
+
+frecords = [r for r in fev.records if r["kind"] == "check"]
+shapes.append(("falsifiable records a counterexample on every check",
+               all(r.get("has_counterexample") for r in frecords)))
+# The rejection is COMPUTED. There is no parameter for it, and the recorded value has to follow the
+# predicate rather than anything the caller said — that is the difference from `mutation_claimed`.
+shapes.append(("the constant-true case records the counterexample as NOT rejected",
+               frecords[1]["counterexample_rejected"] is False))
+shapes.append(("the real condition records it as rejected",
+               frecords[0]["counterexample_rejected"] is True))
+fsummary = fev.write()
+shapes.append(("the summary counts them", fsummary["checks_with_a_counterexample"] == len(FCASES)))
+# THREE of the five, not four. The always-false predicate DOES reject the counterexample — it
+# rejects everything — and fails for the other reason, that it rejected the observation too. The two
+# failure modes are separate and the counter must only see its own: a predicate that cannot accept
+# anything is a broken check, but it is not a check that failed to discriminate.
+shapes.append(("and counts only the ones that failed to reject",
+               fsummary["counterexamples_not_rejected"] == 3))
+
 for why, ok in shapes:
     failed += 0 if ok else 1
     print(f"{'ok  ' if ok else 'FAIL'} shape: {why}")

--- a/Scripts/livekit/test_harness_evidence_coverage.py
+++ b/Scripts/livekit/test_harness_evidence_coverage.py
@@ -41,7 +41,7 @@ for paths, expected, why in [
 # Through the REAL `E.summarize` and `E.is_clean`, not a copy of the predicate: a test that
 # reimplements the rule agrees with itself no matter what the code says.
 CLEAN = {"records": [
-    {"kind": "check", "passed": True, "mutation_flips": True},
+    {"kind": "check", "passed": True, "mutation_claimed": True},
     {"kind": "capture", "settled": True, "display": {"wholly_within": True}},
     {"kind": "visual", "passed": True, "subject": "Tracks header", "region": [0, 0, 1, 1]},
     {"kind": "recording"},


### PR DESCRIPTION
`check()` recorded `"mutation_flips": bool(mutation)` while the docstring directly above it said *"a check nobody has watched fail is decoration"*. The value only ever meant a non-empty string was supplied. Nothing reran the build with the mutation applied — so the counter `is_clean()` gates on counted decoration.

## The obvious fix does not work

A mutant receipt — a second evidence document at the same head, produced with the mutation applied, in which the named check is red — cannot exist. The live gate hashes **every** `*.evidence.json` at a head against the shipped release binary, and a mutant binary has a different digest by construction. Exempting it would relocate the trust rather than establish it: instead of *"this mutation flipped the check"* the gate would trust *"this red document came from that mutation"*. And a second GUI run, against another binary in another UI state, cannot show that the **named** mutation caused the red — only that something did.

So the field is renamed to what it is, `mutation_claimed`, and the cheap form that establishes something is added beside it.

## `falsifiable()`

```python
ev.falsifiable(tag, predicate, observation, counterexample, expected, mutation=None)
```

The assertion is handed to the framework, which calls it **twice**: once on what the run observed, once on a counterexample the author had to write down. It passes only when the first is accepted **and** the second rejected. There is no parameter for the second result — an author cannot assert it.

A constant, a field nothing reads, a comparison too weak to reject the state it names: all pass `check()` and fail here. No rebuild, no second live run.

**Demonstrated, not asserted.** Weakening the first call site's predicate to one that also accepts the pre-fix state:

```
MUTANT   harness exit=1   passed 5/6   counterexamples_not_rejected: 1
```

That predicate is *true of the live observation* — `check()` would have recorded it green.

## First call site

#290's census check. Its counterexample is not invented: it is the row that census actually printed before the fix, transcribed.

## What is enforced, and what is only counted

`counterexamples_not_rejected == 0` is enforced now. Requiring every harness to **have** a counterexample is the clause with teeth, and it is left counted-but-unenforced for the reason `visual_assertions_without_a_subject` was: thirty-odd harnesses predate the affordance, and turning the live suite red in one step invites someone to delete the clause instead of converting the call sites. Enforce it when the count reaches the harness count.

## The transitional aliases, and why both are needed

Both the record field and the summary key keep their old names for one release.

The live gate extracts `is_clean` from `origin/main` on purpose — a branch may not edit its own judge — and it **recomputes the summary from the records** rather than reading the one written here. So renaming a record field is a wire change to an external reader, not a local one.

Measured rather than predicted: the first attempt aliased only the summary key, and the gate still refused with `COVERAGE FAIL: evidence present but not clean`. Running main's judge against the document showed why — it counted `mutation_backed: 0`, because it looks for `mutation_flips` in the records.

Same chicken-and-egg as a pull request closing its own issue. Emit both, land the rename, drop both aliases in a follow-up.

## Gates

```
public-surface preflight   PASS
live gate @ 3585110b       PASS  (coverage rule from origin/main)
ship gate                  PASS  — 3950 tests
```

## Credit

The mutant-receipt proposal was mine; it was refuted, and `falsifiable()` proposed, in an independent read-only review by gpt-5.6-sol run locally. It read `evidence.py`, `test_evidence.py`, `harness_evidence_coverage.py`, `lpm-live-gate.sh` and three harnesses, and the binary-digest argument above is the one that killed the original proposal.

Advances #290's instrument; does not close anything.
