### PR TITLE
chore(livekit): drop the mutation_flips / mutation_backed aliases

### DIFF
--- a/Scripts/livekit/evidence.py
+++ b/Scripts/livekit/evidence.py
@@ -530,13 +530,6 @@ class Evidence:
             "kind": "check", "tag": tag, "passed": bool(passed),
             "expected": expected, "observed": observed,
             "mutation": mutation or None, "mutation_claimed": bool(mutation),
-            # `mutation_flips` is the old name, emitted for one release. The live gate takes
-            # `is_clean` from origin/main on purpose and RECOMPUTES the summary from these
-            # records rather than reading the one written here — so the trusted copy counts
-            # the field IT knows. Renaming a record field is therefore a wire change to an
-            # external reader, not a local one, and needs the same two-step a renamed summary
-            # key does. Land this, then delete both aliases in a follow-up.
-            "mutation_flips": bool(mutation),
         })
         return bool(passed)
 
@@ -577,7 +570,6 @@ class Evidence:
                          "counterexample": repr(counterexample)[:400],
                          "rejected_the_counterexample": not counter_ok},
             "mutation": mutation or None, "mutation_claimed": bool(mutation),
-            "mutation_flips": bool(mutation),   # transitional alias, see check()
             "has_counterexample": True,
             "counterexample_rejected": not counter_ok,
         })
@@ -821,13 +813,6 @@ def summarize(recs, out=None):
         "checks": len(checks),
         "passed": sum(1 for c in checks if c.get("passed")),
         "mutation_claimed": sum(1 for c in checks if c.get("mutation_claimed")),
-        # Alias, and it has to be here for one release. The live gate extracts `is_clean` from
-        # origin/main deliberately — a branch may not edit its own judge — so while the trusted copy
-        # still requires `mutation_backed`, a document carrying only the new name is missing a
-        # required key and the gate refuses it. Renaming a key a trusted external reader depends on
-        # is the same chicken-and-egg as a pull request closing its own issue: emit both, land the
-        # rename, then delete this line in a follow-up.
-        "mutation_backed": sum(1 for c in checks if c.get("mutation_claimed")),
         "checks_with_a_counterexample": sum(1 for c in checks if c.get("has_counterexample")),
         "counterexamples_not_rejected":
             sum(1 for c in checks if c.get("has_counterexample") and not c.get("counterexample_rejected")),
@@ -859,7 +844,7 @@ def summarize(recs, out=None):
 # was clean, and the newest condition was the one that vanished quietly. Listing the keys fixes the
 # shape of the bug rather than the one clause where it was noticed.
 _REQUIRED_SUMMARY_KEYS = (
-    "checks", "passed", "mutation_claimed", "mutation_backed", "operations_driven",
+    "checks", "passed", "mutation_claimed", "operations_driven",
     "checks_with_a_counterexample", "counterexamples_not_rejected",
     "captures", "captures_unsettled", "captures_straddling_displays",
     "restorations_failed", "cached_reads_used_as_live",

--- a/Scripts/livekit/test_evidence.py
+++ b/Scripts/livekit/test_evidence.py
@@ -17,8 +17,7 @@ import evidence as E  # noqa: E402
 # A complete, honest summary: one check that names a mutation, one driven operation, one capture,
 # one visual with a subject, one recording, nothing gone wrong.
 GOOD = {
-    "checks": 1, "passed": 1, "mutation_claimed": 1, "mutation_backed": 1,
-    "operations_driven": 1,
+    "checks": 1, "passed": 1, "mutation_claimed": 1, "operations_driven": 1,
     "checks_with_a_counterexample": 0, "counterexamples_not_rejected": 0,
     "captures": 1, "captures_unsettled": 0, "captures_straddling_displays": 0,
     "restorations_failed": 0, "cached_reads_used_as_live": 0,


### PR DESCRIPTION
The follow-up #688 promised. The rename landed on `main`, so the trusted copy of `is_clean` now counts `mutation_claimed` off the records, and the old names have served their one release.

Both aliases are removed:

- `mutation_flips` on each check record
- `mutation_backed` in the summary and in `_REQUIRED_SUMMARY_KEYS`

The docstrings keep the old names as history. A reader who finds `mutation_flips` in an evidence document written before today should be able to learn what it was and why it stopped being that — deleting the explanation along with the field would take the reason with it.

## Why the two-step was necessary at all

Worth stating plainly, because it is not obvious and it cost a gate cycle to find: the live gate extracts its rule from `origin/main` on purpose — a branch may not edit its own judge — and it **recomputes the summary from the records** rather than reading the one the harness wrote. That makes a record field a wire format for an external reader, not a local detail. Aliasing only the summary key was not enough, and the gate said so.

## Gates

```
public-surface preflight   PASS
ship gate                  PASS — 3950 tests
live evidence              n/a — touches neither Sources/ nor a live harness
```
