### PR TITLE
feat(#290): measure the three track-header toggle locators

### DIFF
--- a/Scripts/livekit/live_290_header_selectors_resolve_by_identity.py
+++ b/Scripts/livekit/live_290_header_selectors_resolve_by_identity.py
@@ -171,6 +171,19 @@ ev.check("290/precondition-the-poller-reads-this-project",
 if not body.get("readable") or len(before_pans) < 2:
     d.close(); print(json.dumps(ev.write(), indent=1)); sys.exit(1)
 
+# The visual below asserts that track 0's pan knob moved IN THE PIXELS, which silently requires
+# track 0's header to be on screen. It is not, on a project with enough tracks to fill the rail and
+# the mixer open — measured: at six tracks the rail showed 오디오 3-5 and the write to track 0
+# changed nothing inside the band, so a correct write produced a red visual for a reason that had
+# nothing to do with the code.
+#
+# The precondition is established through the product rather than assumed: selecting the track
+# scrolls its header into the rail. `tracks.select` addresses by index, not by position on screen,
+# so this does not reintroduce a coordinate.
+select = d.tool("logic_tracks", "select", {"index": 0})
+ev.note("290/scroll-target-into-view", select if isinstance(select, dict) else {"raw": str(select)[:200]})
+time.sleep(1.5)
+
 rec = ev.record_screen(seconds=120)
 before = ev.shot("290/before", settle_region=RAIL, window_title=arrange_title)
 

--- a/Scripts/livekit/live_290_header_selectors_resolve_by_identity.py
+++ b/Scripts/livekit/live_290_header_selectors_resolve_by_identity.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""Live proof that the track-header pan slider is IDENTIFIED rather than eliminated to.
+"""Live proof that the track header's selectors resolve by IDENTITY, not by position.
 
 Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
-        python3 live_290_header_pan_is_identified.py <worktree> <full-40-char-head-sha>
+        python3 live_290_header_selectors_resolve_by_identity.py <worktree> <full-40-char-head-sha>
 
 WHAT THIS PROVES
 ----------------
@@ -15,6 +15,12 @@ same question at this head and records the answer.
 It also drives the control the identity now names, and shows the write lands on the track it was
 aimed at and no other. A selector that resolves confidently to the wrong element is worse than one
 that refuses, so "it resolved" is not on its own the property worth having.
+
+The mute, solo and record-arm locators are measured in the same pass. They were absent from that
+probe until their callers were enumerated — the predicate closes over a `labels:` parameter, and a
+survivor count taken with one label set says as much about the argument as about the tree. There
+are exactly three callers and each passes a fixed `AXLocalePolicy` set, so these rows carry the
+product's own arguments.
 
 WHAT IT DOES NOT PROVE
 ----------------------
@@ -120,6 +126,24 @@ ev.falsifiable(
     "rule is the site selecting by index",
     mutation="revert headerPanSliderCandidates to matching headerPanHint against the children's "
              "AXDescription: survivors returns to 0 and this check goes red")
+
+# The three toggle locators, measured with the label sets the product itself passes. Their
+# counterexample is the shape that made them worth measuring: a header where the discriminator
+# accepts more than one checkbox, which is the wrong-target failure ADR-007 exists to stop. A
+# predicate that only asks "did something survive" accepts it, and this rejects that predicate.
+TOGGLE_SITES = ["AXLogicProElements.findTrackMuteButton",
+                "AXLogicProElements.findTrackSoloButton",
+                "AXLogicProElements.findTrackArmButton"]
+for site in TOGGLE_SITES:
+    trow = next((s for s in sites if isinstance(s, dict) and s.get("site", "").startswith(site)), None)
+    ev.falsifiable(
+        f"290/{site.rsplit('.', 1)[-1]}-resolves-to-exactly-one",
+        one_unambiguous_survivor,
+        trow,
+        {"site": site, "gathered": 4, "survivors": 2, "identified": False},
+        f"{site} leaves exactly one candidate on the header and the census calls it unambiguous",
+        mutation="widen the toggle predicate to any checkbox carrying a description: several "
+                 "survive and the census stops calling the answer unambiguous")
 
 d = E.Driver()
 time.sleep(3)

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+Tracks.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+Tracks.swift
@@ -431,6 +431,32 @@ extension AXLogicProElements {
     /// found its element). This unifies all three on the checkbox-first match
     /// using the centralized `AXLocalePolicy` label sets, keeping the legacy
     /// `AXButton` description/title fallback for build drift.
+    /// Every checkbox on a header the toggle locator would accept for `labels`, in tree order.
+    ///
+    /// Split out for the same reason `headerPanSliderCandidates` was: `--probe-selection-census`
+    /// measures how many candidates survive the discriminator a site applies, and it has to call the
+    /// SAME predicate the product runs. A copy drifts, and then the probe measures a rule the
+    /// product no longer follows — which is the failure that census is itself a census of.
+    ///
+    /// This site was deliberately absent from that probe, with the reason recorded: the predicate
+    /// closes over `labels`, so a survivor count taken with one label set says as much about the
+    /// argument as about the tree, and "parameterised sites need their callers enumerated first".
+    /// They are now enumerated — there are exactly three (`findTrackMuteButton`,
+    /// `findTrackSoloButton`, `findTrackArmButton`) and each passes a fixed `AXLocalePolicy` set,
+    /// so measuring all three measures the product's arguments rather than the probe author's.
+    static func trackToggleCandidates(
+        among checkboxes: [AXUIElement],
+        labels: [String],
+        runtime: AXHelpers.Runtime = .production
+    ) -> [AXUIElement] {
+        checkboxes.filter { cb in
+            guard let desc = AXHelpers.getDescription(cb, runtime: runtime) else { return false }
+            // Exact match preserves the historical arm locator semantics;
+            // prefix match tolerates trailing state suffixes some builds append.
+            return labels.contains(desc) || labels.contains { !$0.isEmpty && desc.hasPrefix($0) }
+        }
+    }
+
     static func findTrackToggleControl(
         in header: AXUIElement,
         labels: [String],
@@ -440,12 +466,8 @@ extension AXLogicProElements {
         let checkboxes = AXHelpers.findAllDescendants(
             of: header, role: kAXCheckBoxRole, maxDepth: 4, runtime: runtime.ax
         )
-        if let match = checkboxes.first(where: { cb in
-            guard let desc = AXHelpers.getDescription(cb, runtime: runtime.ax) else { return false }
-            // Exact match preserves the historical arm locator semantics;
-            // prefix match tolerates trailing state suffixes some builds append.
-            return labels.contains(desc) || labels.contains { !$0.isEmpty && desc.hasPrefix($0) }
-        }) {
+        let candidates = trackToggleCandidates(among: checkboxes, labels: labels, runtime: runtime.ax)
+        if let match = candidates.first {
             return match
         }
         // Legacy fallback: AXButton with description prefix / single-letter title.

--- a/Sources/LogicProMCP/MainEntrypoint.swift
+++ b/Sources/LogicProMCP/MainEntrypoint.swift
@@ -395,11 +395,39 @@ enum MainEntrypoint {
                                 "unreachable": "no control bar in this UI state"])
             }
 
-            // `Tracks.swift:443` is deliberately absent. Its predicate closes over a `labels:
-            // [String]` PARAMETER, so its survivor count is a function of the caller's argument and
-            // not of the tree alone — measuring it with one label set would report a number that
-            // says as much about the arguments I chose as about Logic. Parameterised sites need
-            // their callers enumerated first, which is separate work.
+            // The toggle locator was deliberately absent here. Its predicate closes over a
+            // `labels: [String]` PARAMETER, so a survivor count taken with one label set says as
+            // much about the argument as about the tree, and parameterised sites needed their
+            // callers enumerated first.
+            //
+            // They are enumerated now, and the answer is why this can be measured: there are
+            // exactly THREE production callers — mute, solo, arm — and every one passes a fixed
+            // `AXLocalePolicy` set rather than an arbitrary array. So the three rows below carry
+            // the product's own arguments, not a probe author's choice, and the count means what
+            // the other rows mean.
+            //
+            // The predicate is called, not reimplemented: `trackToggleCandidates` is the same
+            // function `findTrackToggleControl` selects from.
+            if let header = AXLogicProElements.findTrackHeader(at: 0) {
+                let boxes = AXHelpers.findAllDescendants(
+                    of: header, role: "AXCheckBox", maxDepth: 4, runtime: ax)
+                for (site, labels) in [
+                    ("AXLogicProElements.findTrackMuteButton",
+                     AXLocalePolicy.trackMuteButton.labels),
+                    ("AXLogicProElements.findTrackSoloButton",
+                     AXLocalePolicy.trackSoloButton.labels),
+                    ("AXLogicProElements.findTrackArmButton",
+                     AXLocalePolicy.trackRecordEnableCheckbox.labels),
+                ] {
+                    record(site, boxes.count,
+                           AXLogicProElements.trackToggleCandidates(
+                               among: boxes, labels: labels, runtime: ax).count)
+                }
+            } else {
+                results.append(["site": "AXLogicProElements.findTrackMute/Solo/ArmButton",
+                                "unreachable": "no track header at index 0 in this UI state"])
+            }
+
             if let header = AXLogicProElements.findTrackHeader(at: 0) {
                 let sliders = AXHelpers.findAllDescendants(
                     of: header, role: "AXSlider", maxDepth: 4, runtime: ax)


### PR DESCRIPTION
`--probe-selection-census` left the toggle locator out, and said why:

> `Tracks.swift:443` is deliberately absent. Its predicate closes over a `labels: [String]` PARAMETER, so its survivor count is a function of the caller's argument and not of the tree alone — measuring it with one label set would report a number that says as much about the arguments I chose as about Logic. Parameterised sites need their callers enumerated first, which is separate work.

That is the separate work.

## The enumeration is the answer

There are exactly **three** production callers — `findTrackMuteButton`, `findTrackSoloButton`, `findTrackArmButton` — and every one passes a fixed `AXLocalePolicy` set rather than an arbitrary array. So all three can be measured with the **product's own** arguments, and the numbers mean what the other rows mean.

## The predicate is extracted, not copied

`trackToggleCandidates` is the same function `findTrackToggleControl` now selects from — for the reason the header-pan site already records: a copy drifts, and then the probe measures a rule the product no longer runs, which is the failure this census is a census of. Behaviour-preserving; the existing `Issue106` locator tests pass unchanged.

## Measured live

Logic 12.x (ko), one track header:

```
findTrackMuteButton   gathered 4  survivors 1  unambiguous
findTrackSoloButton   gathered 4  survivors 1  unambiguous
findTrackArmButton    gathered 4  survivors 1  unambiguous
```

The census now covers **nine** call sites. One remains ambiguous: `looksLikeTransportContainer` at five survivors — whose consumer prefers `getControlBar()` and so does not reach it.

## Harness

Renamed to match what it now covers. The three new checks use `falsifiable()`, and their counterexample is the shape that made these worth measuring: a header where the discriminator accepts **two** checkboxes — the wrong-target failure ADR-007 exists to stop. A predicate that only asks "did something survive" accepts that state; the counterexample rejects such a predicate.

```
9 checks, 9 passed · 4 with a counterexample, 0 unrejected
2 captures · 1 visual · 1 recording · 0 unclean dimensions
```

## Gates

```
public-surface preflight   PASS
ship gate                  PASS — 3950 tests
live evidence @ 3cd8c33c   ok
```

Advances #290. Does not close it — the atlas type, the per-variant fixtures, the resolver and the drift report are still unwritten.

---

## Second commit: the pixel assertion was depending on scroll position

Found while the branch was open, because an unrelated measurement added three tracks to the fixture.

The visual assertion says track 0's pan knob moved in the pixels. That silently requires track 0's header to be **on screen**, and the harness never said so. At six tracks with the mixer open, the rail showed tracks 3–5, track 0 was scrolled out, and a write that landed correctly — its readback check green — produced a **red visual**.

A correct write failing for a reason with nothing to do with the code is the same environment coupling the #668 debounce test had, in the other direction.

The precondition is now established through the product instead of assumed: selecting the track scrolls its header into the rail. `tracks.select` addresses by index rather than by position on screen, so it does not reintroduce a coordinate.

```
live evidence @ 5065a1aa   ok — 9 checks, 9 passed, 4 counterexamples, 0 unrejected
ship gate                  PASS
```

Branch was rebased onto main after #689 landed, then force-pushed with lease — owner-approved, unmerged branch, no reviews on it.
