### PR TITLE
fix(#290): the transport bar narrows instead of taking the first in tree order

### DIFF
--- a/Scripts/livekit/live_290_selectors_resolve_by_identity.py
+++ b/Scripts/livekit/live_290_selectors_resolve_by_identity.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""Live proof that the track header's selectors resolve by IDENTITY, not by position.
+"""Live proof that the selectors #290's census covers resolve by IDENTITY, not by position.
 
 Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
-        python3 live_290_header_selectors_resolve_by_identity.py <worktree> <full-40-char-head-sha>
+        python3 live_290_selectors_resolve_by_identity.py <worktree> <full-40-char-head-sha>
 
 WHAT THIS PROVES
 ----------------
@@ -144,6 +144,23 @@ for site in TOGGLE_SITES:
         f"{site} leaves exactly one candidate on the header and the census calls it unambiguous",
         mutation="widen the toggle predicate to any checkbox carrying a description: several "
                  "survive and the census stops calling the answer unambiguous")
+
+# The transport container is the last site the census reported ambiguous. The raw keyword scan
+# still leaves five survivors — it over-accepts on false friends like "play" inside "Catch
+# Playhead" — but the site no longer reduces that by tree order. The counterexample is the state
+# this change is about: several survivors and nothing chosen among them.
+narrowed = next((s for s in sites if isinstance(s, dict)
+                 and s.get("site", "").startswith("AXLogicProElements.getTransportBar")), None)
+ev.falsifiable(
+    "290/the-transport-bar-narrows-instead-of-taking-tree-order",
+    one_unambiguous_survivor,
+    narrowed,
+    {"site": "AXLogicProElements.getTransportBar (after narrowing)",
+     "gathered": 5, "survivors": 5, "identified": False},
+    "the keyword scan's survivors reduce to exactly one after the control-bar discriminators, and "
+    "the census calls the answer unambiguous",
+    mutation="return survivors.first from transportContainerFinalists: five survive, nothing "
+             "narrows them, and the site is back to choosing by tree order")
 
 d = E.Driver()
 time.sleep(3)

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+Transport.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+Transport.swift
@@ -57,43 +57,45 @@ extension AXLogicProElements {
         let groups = AXHelpers.findAllDescendants(of: window, role: kAXGroupRole, maxDepth: 6, runtime: runtime.ax)
         let survivors = transportContainerCandidates(among: groups, runtime: runtime)
         if let candidate = survivors.first {
-            // #628: the element returned is UNCHANGED — still the first survivor in tree order.
-            // What changes is that a tree-order choice among several now says so.
+            // Reached only when `getControlBar` could NOT identify one, so more than one survivor
+            // here means both the discriminated route and the keyword scan failed to resolve.
             //
-            // Measured on Logic 12.3, one project, one track: thirty-seven groups gathered, FOUR
-            // survive. Two of the four are the arrange area, because the predicate accepts any
-            // container holding two or more transport-keyword controls.
+            // The keyword scan over-accepts, and the cause is measured. It takes any container
+            // holding two or more transport-keyword controls, and the arrange area qualifies on
+            // substrings of labels that are not transport controls at all: "play" inside "Catch
+            // Playhead", "loop" inside "Show/Hide Live Loops Grid". (The cause first written here
+            // was "a track header holds a record-arm checkbox"; instrumenting the predicate
+            // disproved it — `record` never matched.) The false-friend guard rejects those, and
+            // survivors went 4 -> 2 on a one-track project. Measured again 2026-08-28 on this
+            // machine: five survivors, and adding three tracks moved `gathered` by three while
+            // leaving `survivors` at five — so the count is not a function of project size, and
+            // what accounts for four versus five is not established.
             //
-            // The cause first written here was "a track header holds a record-arm checkbox".
-            // That was WRONG and instrumenting the predicate disproved it — `record` never
-            // matched. The arrange area qualified on substrings of labels that are not transport
-            // controls at all: "play" inside "Catch Playhead", "loop" inside "Show/Hide Live
-            // Loops Grid". The false-friend guard rejects exactly those, and survivors went 4 -> 2
-            // live. Corrected here after the same stale sentence was found still standing in
-            // production having been fixed only in the test file.
+            // Whatever that count is, tree order was the wrong way to reduce it.
             //
-            // Deliberately not a refusal. Which of the four this accessor SHOULD return is a
-            // question about its contract — whether "transport bar" and "control bar" name the same
-            // thing — and that is a decision, not a measurement. A discriminator is available when
-            // someone makes it: description narrows four to two, and #633's "holds a checkbox"
-            // separates those two.
-            // Reached only when `getControlBar` could NOT identify one, so a count above one here
-            // now means both the discriminated route and the keyword scan failed to resolve — a
-            // strictly narrower and more interesting event than before.
-            //
-            // Written to stderr, which the live-evidence harness discards
-            // (`Scripts/livekit/evidence.py:184` runs the server with `stderr=DEVNULL`). So this
-            // reaches an operator reading the server log and does NOT reach the evidence document.
-            // Said here rather than left implied, because a line that cannot reach the channel the
-            // gate reads is not "making it visible" to the gate.
-            if survivors.count > 1 {
-                Log.info(
-                    "getTransportBar: getControlBar did not identify one, and \(survivors.count) "
-                        + "groups matched looksLikeTransportContainer; returning the first in tree order",
-                    subsystem: "ax"
-                )
+            // Log lines below go to stderr, which the live-evidence harness discards
+            // (`Scripts/livekit/evidence.py` runs the server with `stderr=DEVNULL`). They reach an
+            // operator reading the server log and do NOT reach the evidence document — said rather
+            // than left implied, because a line that cannot reach the channel the gate reads is not
+            // "making it visible" to the gate.
+            _ = candidate
+            let finalists = transportContainerFinalists(among: survivors, runtime: runtime.ax)
+            if finalists.count == 1 {
+                return finalists[0]
             }
-            return candidate
+            // Refusing, not choosing. Reaching here means the discriminated route failed AND the
+            // narrowed keyword scan cannot tell its candidates apart, which is a tree this code has
+            // never been measured against. Every caller writes `?? …` or guards on nil, and
+            // ADR-007's version policy is explicit that an unknown signature fails closed rather
+            // than guessing — returning the first in tree order is the wrong-target behaviour that
+            // policy names.
+            Log.info(
+                "getTransportBar: getControlBar did not identify one, \(survivors.count) groups "
+                    + "matched the keyword scan and \(finalists.count) survived narrowing; "
+                    + "refusing rather than picking one",
+                subsystem: "ax"
+            )
+            return nil
         }
 
         return looksLikeTransportContainer(window, runtime: runtime.ax) ? window : nil
@@ -109,6 +111,58 @@ extension AXLogicProElements {
         runtime: Runtime = .production
     ) -> [AXUIElement] {
         groups.filter { looksLikeTransportContainer($0, runtime: runtime.ax) }
+    }
+
+    /// The keyword scan's survivors, reduced by the discriminators `getControlBar` already applies.
+    ///
+    /// This answers the contract question the site deferred — whether "transport bar" and "control
+    /// bar" name the same thing — and the evidence answered it rather than a preference:
+    /// `getTransportBar` tries `getControlBar()` FIRST and every caller writes one or the other;
+    /// `--probe-selection-census` measures both paths returning the SAME element on a live tree;
+    /// and the group Logic labels is `Control Bar` / `컨트롤 막대`. They are one thing, so the scan
+    /// narrows the way the discriminated route does instead of choosing by tree order.
+    ///
+    /// Split out for the reason the other predicates were: the census must call the same reduction
+    /// the product runs, not a copy that can drift from it. A returned count other than one is what
+    /// the site refuses on, so this is also the number worth measuring.
+    static func transportContainerFinalists(
+        among survivors: [AXUIElement],
+        runtime: AXHelpers.Runtime = .production
+    ) -> [AXUIElement] {
+        if survivors.count <= 1 { return survivors }
+
+        func labelled(_ pool: [AXUIElement]) -> [AXUIElement] {
+            pool.filter { group in
+                AXLocalePolicy.controlBarGroupLabel.matches(
+                    AXHelpers.getDescription(group, runtime: runtime) ?? "", mode: .exactStrict)
+            }
+        }
+
+        // CAPABILITY BEFORE NAME, and the order is load-bearing. The site's first branch already
+        // says why — "Name and capability are different questions and this caller needs the
+        // second one" — and #628 measured the shape that makes it concrete: a group described
+        // `Control Bar` holding NOTHING, beside one that works. Narrowing by label first picks the
+        // shell, which is the regression `Issue628TransportAmbiguityTests` exists to catch, and it
+        // caught this function's first draft doing exactly that.
+        //
+        // Capability is `transportControlKeywordHits`, the SAME test the first branch validates
+        // `getControlBar` with — not `getControlBar`'s own "holds a checkbox", which was this
+        // function's second draft and which the same test also caught: it describes the real
+        // Logic bar but not a container whose transport controls are buttons.
+        let withControls = survivors.filter { group in
+            !transportControlKeywordHits(in: group, runtime: runtime).isEmpty
+        }
+        if withControls.count == 1 { return withControls }
+        if withControls.count > 1 {
+            // Several bars hold a control; now the name is the discriminator that is left.
+            let named = labelled(withControls)
+            return named.count == 1 ? named : (named.isEmpty ? withControls : named)
+        }
+
+        // Nothing holds a control. A lone group that at least names itself is still more than tree
+        // order — the same last resort `getControlBar` takes before giving up.
+        let named = labelled(survivors)
+        return named.count == 1 ? named : []
     }
 
     /// Find a specific transport button by its title or description.

--- a/Sources/LogicProMCP/MainEntrypoint.swift
+++ b/Sources/LogicProMCP/MainEntrypoint.swift
@@ -376,6 +376,17 @@ enum MainEntrypoint {
             record("AXLogicProElements.looksLikeTransportContainer",
                    groups6.count,
                    groups6.filter { AXLogicProElements.looksLikeTransportContainer($0, runtime: ax) }.count)
+            // The row above is the RAW discriminator's survivor count. It is not what the site
+            // resolves to any more: `getTransportBar` narrows those survivors by the control-bar
+            // label and the holds-a-control test, and refuses unless exactly one is left. Measuring
+            // only the raw count would keep reporting the site as ambiguous after it stopped being.
+            let transportSurvivors = groups6.filter {
+                AXLogicProElements.looksLikeTransportContainer($0, runtime: ax)
+            }
+            record("AXLogicProElements.getTransportBar (after narrowing)",
+                   transportSurvivors.count,
+                   AXLogicProElements.transportContainerFinalists(
+                       among: transportSurvivors, runtime: ax).count)
 
             // Sites whose collection is gathered from something other than the window. The input is
             // resolved through the product's own accessor, so a site that cannot be reached in this

--- a/Tests/LogicProMCPTests/Issue290TransportBarNarrowingTests.swift
+++ b/Tests/LogicProMCPTests/Issue290TransportBarNarrowingTests.swift
@@ -1,0 +1,130 @@
+@preconcurrency import ApplicationServices
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+/// #290 — `getTransportBar`'s keyword scan narrows instead of taking the first in tree order.
+///
+/// The scan over-accepts: it takes any container holding two or more transport-keyword controls,
+/// and the arrange area qualifies on substrings of labels that are not transport controls — "play"
+/// inside "Catch Playhead", "loop" inside "Show/Hide Live Loops Grid". Measured at five survivors
+/// on this machine. The site used to return `survivors.first`.
+///
+/// Which one it SHOULD return was recorded as a contract question, and the evidence answers it:
+/// `getControlBar()` is tried first, every caller writes one or the other, the census measures both
+/// paths returning the same element, and Logic labels the group `Control Bar` / `컨트롤 막대`. So
+/// the scan narrows by the discriminators the control-bar route already uses, and refuses when they
+/// leave more than one.
+@Suite("Issue290TransportBarNarrowing")
+struct Issue290TransportBarNarrowingTests {
+
+    /// `groups` is (description, holdsACheckbox).
+    private static func tree(
+        _ groups: [(description: String?, holdsCheckbox: Bool)]
+    ) -> (elements: [AXUIElement], runtime: AXHelpers.Runtime) {
+        let builder = FakeAXRuntimeBuilder()
+        var out: [AXUIElement] = []
+        var next = 100
+        for (offset, spec) in groups.enumerated() {
+            let group = builder.element(offset + 1)
+            builder.setAttribute(group, kAXRoleAttribute as String, kAXGroupRole as String)
+            if let description = spec.description {
+                builder.setAttribute(group, kAXDescriptionAttribute as String, description)
+            }
+            if spec.holdsCheckbox {
+                // Named `Play`, because capability here is `transportControlKeywordHits` and a
+                // nameless checkbox is not a transport control. The first version of this fixture
+                // set only the role, and the group it built held a control by the letter of the
+                // helper's parameter and by nothing the product would recognise.
+                let box = builder.element(next); next += 1
+                builder.setAttribute(box, kAXRoleAttribute as String, kAXCheckBoxRole as String)
+                builder.setAttribute(box, kAXDescriptionAttribute as String, "Play")
+                builder.setChildren(group, [box])
+            }
+            out.append(group)
+        }
+        return (out, builder.makeAXRuntime())
+    }
+
+    private static func finalists(
+        _ groups: [(description: String?, holdsCheckbox: Bool)]
+    ) -> (count: Int, index: Int?, elements: [AXUIElement]) {
+        let t = Self.tree(groups)
+        let picked = AXLogicProElements.transportContainerFinalists(among: t.elements, runtime: t.runtime)
+        let index = picked.count == 1 ? t.elements.firstIndex(where: { CFEqual($0, picked[0]) }) : nil
+        return (picked.count, index, picked)
+    }
+
+    @Test("a single survivor is returned untouched")
+    func singleSurvivorUnchanged() {
+        #expect(Self.finalists([(nil, false)]).count == 1)
+    }
+
+    @Test("the labelled bar that holds a control wins over unlabelled look-alikes")
+    func labelAndControlWin() {
+        // The measured shape: the arrange area qualifies on false friends and carries no
+        // control-bar label; the real bar carries both.
+        let r = Self.finalists([
+            (description: "Tracks contents", holdsCheckbox: true),   // false friend, first in order
+            (description: "Control Bar", holdsCheckbox: true),       // the real one
+            (description: nil, holdsCheckbox: false),
+        ])
+        #expect(r.count == 1)
+        #expect(r.index == 1, "took something other than the labelled bar")
+    }
+
+    @Test("the Korean label resolves the same way")
+    func koreanLabel() {
+        let r = Self.finalists([
+            (description: "트랙 콘텐츠", holdsCheckbox: true),
+            (description: "컨트롤 막대", holdsCheckbox: true),
+        ])
+        #expect(r.count == 1)
+        #expect(r.index == 1)
+    }
+
+    @Test("with two labelled bars, holding a control separates them")
+    func holdingAControlSeparatesTwoLabelled() {
+        // The measured #628 shape: two groups both described "Control Bar", one with twenty direct
+        // checkboxes and one with none.
+        let r = Self.finalists([
+            (description: "Control Bar", holdsCheckbox: false),
+            (description: "Control Bar", holdsCheckbox: true),
+        ])
+        #expect(r.count == 1)
+        #expect(r.index == 1, "took the bar that holds no control")
+    }
+
+    @Test("a lone labelled bar holding no control still beats tree order")
+    func loneLabelledWithoutControls() {
+        let r = Self.finalists([
+            (description: nil, holdsCheckbox: false),
+            (description: "Control Bar", holdsCheckbox: false),
+        ])
+        #expect(r.count == 1)
+        #expect(r.index == 1)
+    }
+
+    @Test("two indistinguishable candidates are refused, not resolved to the first")
+    func indistinguishableIsRefused() {
+        // This is the assertion the change is about. Returning index 0 here is what the site did,
+        // and it is the wrong-target behaviour ADR-007's version policy names.
+        #expect(Self.finalists([
+            (description: "Control Bar", holdsCheckbox: true),
+            (description: "Control Bar", holdsCheckbox: true),
+        ]).count != 1)
+    }
+
+    @Test("the label must match the whole description, not appear inside one")
+    func labelIsNotASubstringMatch() {
+        // `.exactStrict`, the mode `getControlBar` uses. A containment match would let a group
+        // called "Hide Control Bar" be taken for the bar — the same false-friend class the keyword
+        // scan already fails on, and the reason this narrowing exists.
+        let r = Self.finalists([
+            (description: "Hide Control Bar", holdsCheckbox: true),
+            (description: "Control Bar", holdsCheckbox: true),
+        ])
+        #expect(r.count == 1)
+        #expect(r.index == 1, "a description merely containing the label was accepted")
+    }
+}


### PR DESCRIPTION
The site recorded its own open question and left it:

> Deliberately not a refusal. Which of the four this accessor SHOULD return is a question about its contract — whether "transport bar" and "control bar" name the same thing — and that is a decision, not a measurement.

## The evidence answers it

- `getTransportBar` tries `getControlBar()` **first**, and every caller writes one or the other
- `--probe-selection-census` measures both paths returning the **same element** on a live tree
- the group Logic labels is `Control Bar` / `컨트롤 막대`

They are one thing. So the keyword scan narrows the way the discriminated route does, and refuses when it cannot.

## Capability before name — the order is load-bearing

Two existing tests caught two wrong drafts, which is worth recording because both looked right:

```
narrow by label first          -> picks a labelled shell holding NOTHING, the exact
                                  regression Issue628TransportAmbiguityTests exists to catch
capability = "holds a checkbox" -> describes the real Logic bar, but not a container whose
                                  transport controls are buttons — the same test again
```

Capability is `transportControlKeywordHits`, the same test the site's first branch already validates `getControlBar` with. The site's own comment had said it: *"Name and capability are different questions and this caller needs the second one."*

## Measured live

```
looksLikeTransportContainer          gathered 51   survivors 5   ambiguous
getTransportBar (after narrowing)    gathered  5   survivors 1   unambiguous
```

Both rows are reported. The raw scan still over-accepts — it takes any container holding two or more transport-keyword controls, and the arrange area qualifies on "play" inside "Catch Playhead" — so measuring only the raw count would keep calling the site ambiguous after it stopped being. The census calls the same reduction the product runs, not a copy.

**This was the last ambiguous row.** All nine census sites now resolve unambiguously.

## Refusal

More than one finalist returns `nil`. Every caller guards on that, and ADR-007's version policy is explicit that an unknown signature fails closed — returning the first in tree order is the wrong-target behaviour it names.

## Mutation-tested

Restoring tree order fails **six of fifteen** cases across the new suite and #628's. The one case that stays green under that mutation is "a single survivor is returned untouched", correctly — that path is unchanged.

## Gates

```
public-surface preflight   PASS
ship gate                  PASS — 3950+ tests
live evidence @ 334f5d39   ok — 10 checks, 10 passed, 5 counterexamples, 0 unrejected
```

The harness is renamed: it no longer covers only the header.

Advances #290. Does not close it — the atlas type, per-variant fixtures, the resolver and the drift report are still unwritten.
