### PR TITLE
fix(#685): a failed AX read no longer abandons the write partway

### DIFF
--- a/Scripts/livekit/live_290_selectors_resolve_by_identity.py
+++ b/Scripts/livekit/live_290_selectors_resolve_by_identity.py
@@ -233,6 +233,22 @@ ev.check("290/the-envelope-names-the-control-it-drove",
          f"state={envelope.get('state') if isinstance(envelope, dict) else None!r}",
          None)
 
+# #685: the same write, asked whether it FINISHED. The loop used to abandon partway on a single
+# failed AX read and return success with the fader left short — measured 58% to 87% of the
+# requested travel, four runs of four. The counterexample is that state: a receipt that names the
+# distance it had to travel and a step count well under it.
+ev.falsifiable(
+    "685/the-write-reached-its-target",
+    lambda e: (isinstance(e, dict) and e.get("reached_target") is True
+               and isinstance(e.get("detents_to_target"), (int, float))
+               and isinstance(e.get("nudge_steps"), int)
+               and e["nudge_steps"] >= e["detents_to_target"] - 1),
+    envelope,
+    {"reached_target": False, "detents_to_target": 7.76, "nudge_steps": 3},
+    "the fader reached the requested level, and the steps issued account for the distance",
+    mutation="restore `guard let next = extractSliderValue(...) else { break }`: one dropped read "
+             "ends the loop and the fader stops short")
+
 after = ev.shot("290/after", settle_region=RAIL, window_title=arrange_title)
 ev.visual("290/the-pan-knob-moved-in-the-pixels",
           before["file"], after["file"], RAIL, subject=RAIL_SUBJECT,

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Mixer.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Mixer.swift
@@ -208,7 +208,30 @@ extension AccessibilityChannel {
         // Closed-loop AXIncrement/AXDecrement nudge toward `targetRaw`. Stops on
         // reaching/crossing the target (landing on the nearer detent) or when no
         // detent moves the value (rail / unresponsive).
-        var current = AXValueExtractors.extractSliderValue(slider, runtime: runtime.ax)
+        // #685: both exits below used to be silent, and the measurement showed what that cost. On
+        // the FIRST call of a fresh process — where the AX round trip is slow and the read
+        // intermittently fails — the loop abandoned the write partway, four runs of four, moving
+        // 58% to 87% of the requested travel and returning success with the fader left somewhere
+        // nobody asked for.
+        //
+        // A nil read is the ABSENCE of an answer, not the answer "it did not move", so it is
+        // retried with backoff before being treated as terminal. And a value unchanged 25ms after
+        // an increment is a rail OR a read that has not caught up; those are indistinguishable at
+        // that timescale, so stagnation is confirmed against a longer settle before it is believed.
+        func readSlider() -> Double? {
+            var wait: UInt32 = 25_000
+            for _ in 0..<4 {
+                if let value = AXValueExtractors.extractSliderValue(slider, runtime: runtime.ax) {
+                    return value
+                }
+                usleep(wait)
+                wait *= 2
+            }
+            return nil
+        }
+
+        let startRaw = readSlider()
+        var current = startRaw
         var steps = 0
         var stagnant = 0
         let maxSteps = 64
@@ -218,7 +241,11 @@ extension AccessibilityChannel {
             _ = AXHelpers.performAction(slider, goingUp ? kAXIncrementAction : kAXDecrementAction, runtime: runtime.ax)
             steps += 1
             usleep(25_000)
-            guard let next = AXValueExtractors.extractSliderValue(slider, runtime: runtime.ax) else { break }
+            guard var next = readSlider() else { break }
+            if next == cur {
+                usleep(150_000)
+                next = readSlider() ?? next
+            }
             let crossed = (cur < targetRaw && next >= targetRaw) || (cur > targetRaw && next <= targetRaw)
             if crossed {
                 // Land on whichever of cur/next is closer to the target.
@@ -232,7 +259,11 @@ extension AccessibilityChannel {
             current = next
         }
 
-        let observedRaw = AXValueExtractors.extractSliderValue(slider, runtime: runtime.ax)
+        // Retried too, and for the same reason. This read is what decides State A versus State B:
+        // a write that landed correctly and then failed its ONE verification read is reported as
+        // unverified, which is honest about the read and wrong about the write. Measured after the
+        // loop was fixed — a run that reached its target still came back State B here.
+        let observedRaw = readSlider()
         let observedAfter = readContract()
         // One detent is ~10 raw units; "verified" means we converged to the
         // nearest AX-representable detent (within ~half a detent of target).
@@ -253,6 +284,11 @@ extension AccessibilityChannel {
             "verify_source": "ax_slider",
             "write_method": "ax_increment_decrement",
             "nudge_steps": steps,
+            // #685: `nudge_steps` alone is not checkable — a partial move and a complete one look
+            // the same in it. These two are what a caller, a log or an evidence document needs to
+            // see that the loop stopped short, without re-reading the fader to find out.
+            "detents_to_target": startRaw.map { ((abs(targetRaw - $0) / 10.0) * 100).rounded() / 100 } ?? NSNull(),
+            "reached_target": convergedToNearestDetent,
             "quantization_note": "Logic exposes this fader to AX in ~10-raw-unit detents; observed is the nearest representable level to requested.",
         ]
         if convergedToNearestDetent, let actual = observedAfter {

--- a/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
+++ b/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
@@ -579,9 +579,39 @@ private func makeAXBackedAccessibilityChannel(
 /// #107: a logic runtime whose AXIncrement/AXDecrement move a slider by one
 /// ~10-raw-unit detent (clamped to AXMin/AXMax), so the closed-loop nudge
 /// writer (`mixer.set_volume`/`set_pan`) converges against a fake AX tree.
-private func nudgeResponsiveLogicRuntime(_ builder: FakeAXRuntimeBuilder, app: AXUIElement) -> AXLogicProElements.Runtime {
-    builder.makeLogicRuntime(
+/// #685: counts reads so a fixture can drop every Nth one, which is what the AX layer was measured
+/// doing on the first call of a fresh process.
+private final class ReadDropper: @unchecked Sendable {
+    private let lock = NSLock()
+    private var seen = 0
+    private let every: Int
+    init(every: Int) { self.every = every }
+    func shouldDrop() -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        seen += 1
+        return every > 0 && seen % every == 0
+    }
+}
+
+private func nudgeResponsiveLogicRuntime(
+    _ builder: FakeAXRuntimeBuilder,
+    app: AXUIElement,
+    dropEveryNthSliderRead: Int = 0
+) -> AXLogicProElements.Runtime {
+    let dropper = ReadDropper(every: dropEveryNthSliderRead)
+    let handler: @Sendable (AXUIElement, String) -> AnyObject?? = { element, attribute in
+            guard attribute == (kAXValueAttribute as String),
+                  (builder.attributeValue(element, kAXRoleAttribute as String) as? String)
+                      == (kAXSliderRole as String) else { return AnyObject??.none }
+            // `.some(nil)` is "handled, and the answer is nil" — an AX read that failed, not an
+            // element without a value.
+            return dropper.shouldDrop() ? .some(nil) : AnyObject??.none
+    }
+    let dropReads: (@Sendable (AXUIElement, String) -> AnyObject??)? =
+        dropEveryNthSliderRead == 0 ? nil : handler
+    return builder.makeLogicRuntime(
         appElement: app,
+        attributeValueHandler: dropReads,
         setAttributeHandler: nil,
         performActionHandler: { element, action in
             let number: @Sendable (String) -> Double? = { attr in
@@ -4396,4 +4426,56 @@ func issue604DismissalSummaryReportsTheObservation() {
     #expect(nothingThere.summary.contains("No panel-shaped window was open"))
     // The one thing it must never say when nothing was there: that it cleared something.
     #expect(!nothingThere.summary.contains("cleared"))
+}
+
+/// #685 — an intermittent AX read must not abandon the write partway.
+///
+/// Measured on the first call of a fresh process, four runs of four: the loop moved 58% to 87% of
+/// the requested travel and returned success, leaving the fader somewhere nobody asked for. Two
+/// exits were silent — `guard let next = read() else { break }` on a single nil, and a two-sample
+/// stagnation counter that reads a slow round trip as a rail.
+///
+/// The fixture drops every third slider read. Before the fix the first drop ends the loop; the
+/// fader stops short and `verified` is false.
+@Test func testMixerWriteSurvivesAnIntermittentSliderRead() async throws {
+    let builder = FakeAXRuntimeBuilder()
+    let app = builder.element(6850)
+    let window = builder.element(6851)
+    builder.setAttribute(app, kAXMainWindowAttribute as String, window)
+    let controls = attachTrackHeaderRail(
+        builder, window: window, siblings: [], baseID: 6_860,
+        volume: (value: 173, min: 0, max: 233),
+        pan: (value: 64, min: 0, max: 127)
+    )
+    let channel = makeAXBackedAccessibilityChannel(
+        builder: builder, app: app,
+        logicRuntime: nudgeResponsiveLogicRuntime(builder, app: app, dropEveryNthSliderRead: 3)
+    )
+
+    // 0.5 is about seven detents away from the fader's starting raw 173, so the loop has to survive
+    // several drops rather than one lucky read.
+    let result = await channel.execute(operation: "mixer.set_volume", params: ["index": "0", "value": "0.5"])
+    #expect(result.isSuccess)
+    let obj = decodeAccessibilityJSON(result.message)
+
+    let raw = (builder.attributeValue(controls.volume, kAXValueAttribute as String) as? NSNumber)?.doubleValue
+        ?? (builder.attributeValue(controls.volume, kAXValueAttribute as String) as? Double) ?? -1
+    #expect(raw >= 90 && raw <= 110,
+            "the fader stopped short of the ~98 target detent at raw \(raw) — a dropped read ended the write")
+    // Bound with `try #require` rather than compared against a boolean literal. That comparison is
+    // always-pass on this toolchain and proves nothing, which is the dead-assertion shape the
+    // repository's guard rejects — it caught this test's first draft doing exactly that.
+    let verified = try #require(obj["verified"] as? Bool)
+    #expect(verified, "a partial move was reported as verified")
+    let reached = try #require(obj["reached_target"] as? Bool)
+    #expect(reached, "the loop stopped short of the target")
+
+    // The envelope has to make a shortfall visible without re-reading the fader. `nudge_steps`
+    // alone cannot: a complete move and a partial one look identical in it.
+    #expect(obj["detents_to_target"] != nil, "the envelope does not say how far it had to go")
+    let required = (obj["detents_to_target"] as? NSNumber)?.doubleValue ?? -1
+    let issued = (obj["nudge_steps"] as? NSNumber)?.doubleValue ?? -1
+    #expect(required > 1, "the fixture did not actually require several detents")
+    #expect(issued >= required - 1,
+            "issued \(issued) of about \(required) detents — the loop gave up early")
 }

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -73,7 +73,7 @@ Also open, outside the ADR set:
 | #448 | OPEN | layout readback is deliverable; colour and reorder need a definition of "verified" for a write nothing can read back |
 | #678 | closed | the drift guard and this file's update rule shipped in #684 |
 | #683 | OPEN | external report — MCU feedback from Logic Pro Creator Studio wedges the loop; four hypotheses refuted or weakened by measurement, blocked on a `sample` from the reporter's host |
-| #685 | OPEN | `mixer.set_pan`/`set_volume` abandon the nudge loop on a single `nil` AX read and leave the fader partway; measured 4/4 short on the first call of a process, root cause identified |
+| #685 | closed | fixed in this pull request — the nudge loop no longer abandons a write on one failed AX read |
 
 ### Three reopen reasons, checked rather than inferred
 


### PR DESCRIPTION
`mixer.set_pan` and `set_volume` drive their fader with a closed-loop `AXIncrement`/`AXDecrement` nudge. Two of its exits were silent, and on the **first call of a fresh process** — where the AX round trip is slow and the read intermittently fails — the loop gave up early and returned success with the fader left somewhere nobody asked for.

## Measured before, four runs of four

Each the first call of a new process:

```
needed -4.86 detents, issued 3   (62%)
needed +5.76 detents, issued 5   (87%)
needed -6.86 detents, issued 4   (58%)
needed +4.76 detents, issued 4   (84%)
```

All four State B. Subsequent calls in the same process were correct, which is what made it look like flakiness rather than a defect.

## The two silent exits

```swift
guard let next = extractSliderValue(...) else { break }   // one failed read ends the write
if next == cur { stagnant += 1; if stagnant >= 2 { break } }  // slow read reads as a rail
```

A `nil` read is the **absence of an answer**, not the answer "it did not move" — it is retried with backoff before being treated as terminal. And a value unchanged 25 ms after an increment is a rail **or** a read that has not caught up; those are indistinguishable at that timescale, so stagnation is confirmed against a longer settle before it is believed.

## A third one, found by measuring after the fix

The final verification read was still a single call. A run that reached its target came back **State B**, because the one read that decides State A had failed — honest about the read, wrong about the write. It is retried for the same reason.

## Measured after, five first-calls

```
 tgt   before   need  used  reached  state
-0.6  +0.6378   7.86     8    True      A
-0.6  -0.6220   0.14     1    True      A
+0.6  -0.6220   7.76     8    True      A
-0.6  +0.6378   7.86     8    True      A
+0.6  -0.6220   7.76     8    True      A
```

Every one reaches its target, all State A — including the case already within a detent, which was State B before.

## The envelope can now show a shortfall

`nudge_steps` alone is not checkable: a complete move and a partial one look identical in it. `detents_to_target` and `reached_target` mean a caller, a log or an evidence document can see the loop stopped short without re-reading the fader.

## Mutation-tested

The regression test drops **every third slider read** against the existing nudge fixture. Restoring the single-`nil` break makes it issue **one** of about seven detents, and the failure message says so:

```
Expectation failed: (issued → 1.0) >= (required - 1 → 6.5)
```

The repository's dead-assertion guard also caught this test's first draft comparing an optional against a boolean literal — bound with `try #require` now.

## Gates

```
public-surface preflight   PASS
ship gate                  PASS
live evidence @ a6f59b50   ok — 11 checks, 11 passed, 6 counterexamples, 0 unrejected
```

Closes #685
