### PR TITLE
fix(#300): a band that measured nothing no longer reports silence

### DIFF
--- a/Scripts/livekit/live_290_selectors_resolve_by_identity.py
+++ b/Scripts/livekit/live_290_selectors_resolve_by_identity.py
@@ -162,8 +162,47 @@ ev.falsifiable(
     mutation="return survivors.first from transportContainerFinalists: five survive, nothing "
              "narrows them, and the site is back to choosing by tree order")
 
+# #300: the spectral surface is flag-gated, and `E.Driver` inherits this process's environment, so
+# setting it here reaches the server it spawns. The flag gates only the spectral commands, so the
+# rest of this run is unaffected.
+os.environ["LOGIC_MCP_ADR012_SPECTRAL_EQ"] = "1"
+
 d = E.Driver()
 time.sleep(3)
+
+# #300: a band whose edges enclose no FFT bin used to report `floorDbfs`, which reads as "this
+# region is silent" — a false statement about the audio rather than a small one about the grid.
+# Driven through the running binary rather than asserted from the source, because the gate's
+# evidence would otherwise be about this branch's OTHER change and nothing about this one.
+_SOUND = "/System/Library/Sounds/Submarine.aiff"
+spectrum = d.tool("logic_audio", "analyze_spectrum", {"path": _SOUND}) if os.path.exists(_SOUND) else {}
+ev.note("300/analyze-spectrum", {"path": _SOUND,
+                                 "bands": len((spectrum or {}).get("bands") or []),
+                                 "unmeasured": [round(b["centerHz"], 3)
+                                                for b in ((spectrum or {}).get("bands") or [])
+                                                if b.get("measured") is False]})
+
+
+def flags_what_it_could_not_measure(body):
+    bands = (body or {}).get("bands") or []
+    if not bands:
+        return False
+    unmeasured = [b for b in bands if b.get("measured") is False]
+    # Some band must be flagged, AND every flagged one must be sitting at the floor — a band that
+    # claims it measured nothing while reporting real energy is the opposite error.
+    return bool(unmeasured) and all(b.get("energyDb", 0) <= -79.9 for b in unmeasured)
+
+
+ev.falsifiable(
+    "300/a-band-that-measured-nothing-says-so",
+    flags_what_it_could_not_measure,
+    spectrum,
+    # The pre-change output: the same sixty bands, every one claiming to be a reading.
+    {"bands": [{"centerHz": 25.198, "energyDb": -80, "measured": True},
+               {"centerHz": 1000.0, "energyDb": -30, "measured": True}]},
+    "the analyser flags the bands its grid cannot resolve, and every flagged band is at the floor",
+    mutation="return `true` from measurableBands: nothing is flagged and a floor reading is "
+             "published as silence again")
 
 
 def pans():

--- a/Sources/LogicProMCP/SpectralEQ/AudioFeatureExtractionEngine.swift
+++ b/Sources/LogicProMCP/SpectralEQ/AudioFeatureExtractionEngine.swift
@@ -192,6 +192,40 @@ enum AudioFeatureExtractionEngine {
         )
     }
 
+    /// Which bands this grid can actually measure at `sampleRate`.
+    ///
+    /// A band is measurable when its edges enclose at least one FFT bin of the window it is
+    /// stitched from — LF below the crossover, HF at or above it, the same rule the splice uses. It
+    /// is not a runtime count: the splice is deterministic, so the answer follows from the grid and
+    /// the sample rate alone.
+    ///
+    /// Bands 0 and n-1 are always measurable and it is not because their edges enclose a bin.
+    /// `bandIndex(forFrequency:)` sends everything below the first edge to band 0 and everything
+    /// above the last to band n-1, so both receive energy from OUTSIDE their nominal range. That is
+    /// a separate defect — band 0's `energyDb` is the sum of all sub-18.9 Hz content, not the 20 Hz
+    /// band's — and this function does not paper over it by calling those bands unmeasured.
+    static func measurableBands(grid: BandGrid, sampleRate: Double, config: Config = .default) -> [Bool] {
+        let n = grid.centers.count
+        guard n > 0, sampleRate > 0 else { return [] }
+        return (0..<n).map { i in
+            let window = grid.edges[i] < config.crossoverHz ? config.windowLarge : config.windowSmall
+            let df = sampleRate / Double(window)
+            guard df > 0 else { return false }
+            let nyquist = df * Double(window / 2)
+            // Band 0 collects every bin below `edges[1]`, DC included, so it always receives.
+            if i == 0 { return true }
+            // The top band collects everything at or above its lower edge — which is nothing at all
+            // when Nyquist is below that edge. Marking it measurable unconditionally was this
+            // function's first draft, and the test that counts unmeasurable bands above Nyquist
+            // caught it: at 11.025 kHz the top band receives no bin and still claimed to.
+            if i == n - 1 { return nyquist >= grid.edges[i] }
+            // The lowest bin index at or above the band's lower edge, and whether it is still below
+            // the upper edge — i.e. does any k * df land inside [lo, hi).
+            let firstBin = (grid.edges[i] / df).rounded(.up)
+            return firstBin * df < grid.edges[i + 1] && Int(firstBin) <= window / 2
+        }
+    }
+
     /// Shared tail: energy-average per-channel band powers (NOT sum-to-mono, which cancels
     /// out-of-phase stereo), floor, then resonance/centroid/peaks/classification.
     private static func finishAnalysis(
@@ -224,8 +258,13 @@ enum AudioFeatureExtractionEngine {
         for i in 0..<bandPower.count { bandPower[i] = max(bandPower[i], floorLin) }
         let bandsDb = bandPower.map { 10.0 * log10($0) }
 
-        let bands = zip(grid.centers, bandsDb).map { SpectralBand(centerHz: $0.0, energyDb: $0.1) }
-        let resonances = detectResonances(centers: grid.centers, db: bandsDb, config: config, grid: grid)
+        let measurable = measurableBands(grid: grid, sampleRate: sampleRate, config: config)
+        let bands = zip(grid.centers, bandsDb).enumerated().map { index, pair in
+            SpectralBand(centerHz: pair.0, energyDb: pair.1,
+                         measured: index < measurable.count ? measurable[index] : true)
+        }
+        let resonances = detectResonances(
+            centers: grid.centers, db: bandsDb, measurable: measurable, config: config, grid: grid)
         let (centroid, peaks) = centroidAndPeaks(centers: grid.centers, db: bandsDb, power: bandPower, config: config)
         let (classification, confidence) = classify(centers: grid.centers, power: bandPower, centroid: centroid, config: config)
 
@@ -706,6 +745,7 @@ enum AudioFeatureExtractionEngine {
     private static func detectResonances(
         centers: [Double],
         db: [Double],
+        measurable: [Bool],
         config: Config,
         grid: BandGrid
     ) -> [SpectralResonance] {
@@ -717,7 +757,13 @@ enum AudioFeatureExtractionEngine {
             guard db[i] > floorGate else { continue }
             let lo = max(0, i - half)
             let hi = min(centers.count - 1, i + half)
-            let baseline = median(Array(db[lo...hi]))
+            // Unmeasurable bands sit at the floor for every signal, so leaving them in the window
+            // drags the median down and inflates the prominence of everything beside them — a
+            // resonance manufactured by the grid rather than found in the audio. They are excluded
+            // from the baseline, not from the spectrum.
+            let window = (lo...hi).filter { measurable.isEmpty || ($0 < measurable.count && measurable[$0]) }
+                .map { db[$0] }
+            let baseline = median(window.isEmpty ? Array(db[lo...hi]) : window)
             let prominence = db[i] - baseline
             let leftOk = i == 0 || db[i] >= db[i - 1]
             let rightOk = i == centers.count - 1 || db[i] >= db[i + 1]

--- a/Sources/LogicProMCP/SpectralEQ/SpectralAnalysis.swift
+++ b/Sources/LogicProMCP/SpectralEQ/SpectralAnalysis.swift
@@ -3,6 +3,35 @@ import Foundation
 struct SpectralBand: Codable, Equatable, Sendable {
     let centerHz: Double
     let energyDb: Double
+
+    /// False when this band's edges enclose no FFT bin of the window it is stitched from, so its
+    /// `energyDb` is the floor sentinel and not a reading.
+    ///
+    /// Measured 2026-08-28 at 44.1 kHz with the default grid: bands at 20, 25.198 and 40 Hz report
+    /// exactly `floorDbfs` for every signal, including white noise — the log-spaced bands are ~3 Hz
+    /// wide down there and the 8192-point window resolves 5.383 Hz. `-80 dB` in that position reads
+    /// as "this region is silent", which is a false statement about the audio rather than a small
+    /// one about the grid.
+    ///
+    /// Defaults to `true` so a hand-built band in a test is a reading unless it says otherwise.
+    var measured: Bool = true
+
+    init(centerHz: Double, energyDb: Double, measured: Bool = true) {
+        self.centerHz = centerHz
+        self.energyDb = energyDb
+        self.measured = measured
+    }
+
+    /// Written by hand because Swift's synthesised `init(from:)` does NOT apply a property's
+    /// default for a missing key — it requires every non-optional key to be present. Adding
+    /// `measured` therefore broke decoding of every document written before it existed, which
+    /// `legacyResonanceArrayDecodesWithDefaults` caught on the first run.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        centerHz = try container.decode(Double.self, forKey: .centerHz)
+        energyDb = try container.decode(Double.self, forKey: .energyDb)
+        measured = try container.decodeIfPresent(Bool.self, forKey: .measured) ?? true
+    }
 }
 
 struct SpectralResonance: Codable, Equatable, Sendable {

--- a/Tests/LogicProMCPTests/AudioFeatureExtractionEngineTests.swift
+++ b/Tests/LogicProMCPTests/AudioFeatureExtractionEngineTests.swift
@@ -654,14 +654,18 @@ struct Issue300UnmeasurableBandsTests {
     }
 
     @Test("bands 0 and n-1 are not called unmeasured, because they do receive energy")
-    func edgeBandsAreNotFlagged() {
+    func edgeBandsAreNotFlagged() throws {
         let grid = AudioFeatureExtractionEngine.makeGrid()
         let mask = AudioFeatureExtractionEngine.measurableBands(grid: grid, sampleRate: 44_100)
         // `bandIndex(forFrequency:)` sends everything below the first edge into band 0 and
         // everything above the last into band n-1. They are measured — of the wrong range. Calling
         // them unmeasured would paper over that separate defect with this one's vocabulary.
-        #expect(mask.first == true)
-        #expect(mask.last == true)
+        // Bound with `try #require`: these are `Bool?`, and comparing an optional against a boolean
+        // literal is always-pass on this toolchain — the dead-assertion shape the guard rejects.
+        let firstBand = try #require(mask.first)
+        let lastBand = try #require(mask.last)
+        #expect(firstBand, "band 0 was called unmeasured, but it receives every bin below edges[1]")
+        #expect(lastBand, "the top band was called unmeasured at a rate where it does receive bins")
     }
 
     @Test("a finer window measures bands the default one cannot")

--- a/Tests/LogicProMCPTests/AudioFeatureExtractionEngineTests.swift
+++ b/Tests/LogicProMCPTests/AudioFeatureExtractionEngineTests.swift
@@ -630,3 +630,70 @@ private final class ChunkFeeder {
         return block
     }
 }
+
+/// #300 — a band whose edges enclose no FFT bin does not report the floor as a reading.
+///
+/// Measured 2026-08-28 at 44.1 kHz with the default grid: the bands at 25.198 and 40 Hz come back
+/// at exactly `floorDbfs` for every signal tried, white noise included. The log-spaced bands are
+/// about 3 Hz wide down there and the 8192-point window resolves 5.383 Hz, so no bin lands inside
+/// them. `-80 dB` in that position reads as "this region is silent", which is a false statement
+/// about the audio rather than a small one about the grid.
+@Suite("Issue300UnmeasurableBands")
+struct Issue300UnmeasurableBandsTests {
+
+    @Test("the grid names exactly the bands it cannot measure at 44.1 kHz")
+    func maskMatchesTheMeasurement() {
+        let grid = AudioFeatureExtractionEngine.makeGrid()
+        let mask = AudioFeatureExtractionEngine.measurableBands(grid: grid, sampleRate: 44_100)
+
+        #expect(mask.count == grid.centers.count)
+        let unmeasurable = zip(grid.centers, mask).filter { !$0.1 }.map { ($0.0 * 1000).rounded() / 1000 }
+        // Derived from the code and confirmed against the live analyser's output, not asserted from
+        // one side only: `analyze_spectrum` reports `measured: false` for these two and no others.
+        #expect(unmeasurable == [25.198, 40.0], "got \(unmeasurable)")
+    }
+
+    @Test("bands 0 and n-1 are not called unmeasured, because they do receive energy")
+    func edgeBandsAreNotFlagged() {
+        let grid = AudioFeatureExtractionEngine.makeGrid()
+        let mask = AudioFeatureExtractionEngine.measurableBands(grid: grid, sampleRate: 44_100)
+        // `bandIndex(forFrequency:)` sends everything below the first edge into band 0 and
+        // everything above the last into band n-1. They are measured — of the wrong range. Calling
+        // them unmeasured would paper over that separate defect with this one's vocabulary.
+        #expect(mask.first == true)
+        #expect(mask.last == true)
+    }
+
+    @Test("a finer window measures bands the default one cannot")
+    func theMaskFollowsTheWindow() {
+        // The negative control for the mask: it has to depend on resolution, or it is just a
+        // hard-coded pair of frequencies.
+        //
+        // Counted BELOW 100 Hz, and the first version of this case did not, which is why it failed:
+        // a quarter sample rate gives the same window four times the low-frequency resolution AND
+        // drops Nyquist to 5512 Hz, so every band above that becomes unmeasurable and the total
+        // goes UP (9 against 2). The mask is right about both ends; the assertion was only looking
+        // at one and calling the sum a resolution.
+        let grid = AudioFeatureExtractionEngine.makeGrid()
+        func unmeasurableBelow100Hz(_ rate: Double) -> Int {
+            zip(grid.centers, AudioFeatureExtractionEngine.measurableBands(grid: grid, sampleRate: rate))
+                .filter { $0.0 < 100 && !$0.1 }.count
+        }
+        #expect(unmeasurableBelow100Hz(44_100) == 2)
+        #expect(unmeasurableBelow100Hz(11_025) < unmeasurableBelow100Hz(44_100),
+                "four times the low-frequency resolution measured no more bands")
+
+        // And the other end, so the Nyquist half is asserted rather than merely explained.
+        //
+        // Keyed on the LOWER EDGE, not the centre. A band whose centre sits above Nyquist can still
+        // enclose a bin when its lower edge is below it — that band straddles Nyquist and is
+        // genuinely measurable. Filtering by centre called it a defect, which is the third time
+        // this control has been sharper than its first phrasing.
+        let nyquist = 11_025.0 / 2
+        let mask11k = AudioFeatureExtractionEngine.measurableBands(grid: grid, sampleRate: 11_025)
+        let whollyAbove = (0..<grid.centers.count).filter { grid.edges[$0] > nyquist }
+        #expect(!whollyAbove.isEmpty)
+        #expect(whollyAbove.allSatisfy { !mask11k[$0] },
+                "a band whose lower edge is above Nyquist was called measurable")
+    }
+}


### PR DESCRIPTION
Measured at 44.1 kHz with the default grid: the bands at **25.198 and 40 Hz** come back at exactly `floorDbfs` for every signal tried, white noise included. The log-spaced bands are about 3 Hz wide down there and the 8192-point window resolves 5.383 Hz, so no bin lands inside them.

`-80 dB` in that position reads as *"this region is silent"*, which is a false statement about the audio rather than a small one about the grid.

## What this changes

`SpectralBand` carries `measured`. The mask is derived from the grid and the sample rate rather than counted at runtime — the LF/HF splice is deterministic, so which window a band is stitched from is known in advance.

Those bands are also excluded from the **resonance baseline**. Sitting at the floor for every signal, they drag the median of any window containing them down and inflate the prominence of everything beside them.

## What that did — and did not — fix

Measured on generated signals:

```
pink noise, recommended cut at 20 Hz     -9.9 dB -> -9.4 dB
injected 250 Hz resonance                still found at 254 Hz
white noise                              still recommends nothing
```

So the dead bands *were* inflating the 20 Hz recommendation, and they are **not what causes it**. The dominant cause is the other artifact on #300 and it is **not fixed here**: band 0 collects everything below the first edge, so its energy is the sum of all sub-18.9 Hz content rather than the 20 Hz band's. Pink noise genuinely has that content, band 0 sums it, and the cut follows.

Saying so rather than letting a 0.5 dB move read as a resolved artifact.

## Three control failures, each of which sharpened the claim

```
a quarter sample rate has MORE unmeasurable bands, not fewer — four times the
low-frequency resolution, and Nyquist down at 5512 Hz taking the whole top

the top band was marked measurable unconditionally, and it receives nothing
when Nyquist is below its lower edge                        <- a real code defect

a band whose CENTRE is above Nyquist can still enclose a bin if its lower edge
is below it — the assertion, not the code, was wrong that time
```

## Backward compatibility

`init(from:)` is hand-written because Swift's synthesised decoder does not apply a property default for a missing key. Adding the field broke decoding of every document written before it, which `legacyResonanceArrayDecodesWithDefaults` caught on the first run.

## The evidence is about this change

The gate demands live evidence for any `Sources/` change but cannot tell whether that evidence is *about* the change — this branch's harness covers selectors, and running it would have satisfied the binding check while saying nothing about the spectral grid. So the analyser is driven through the same binary the gate hashes, and the counterexample is the pre-change output: the same bands, every one claiming to be a reading.

```
public-surface preflight   PASS
ship gate                  PASS
live evidence @ 2a9b8808   ok — 12 checks, 12 passed, 7 counterexamples, 0 unrejected
```

## Noted, not fixed here

`_worktree_head` counts a tree dirty only for modifications under `Sources/` and `Tests/`, which is correct for its stated subject (what was compiled). It does mean a **harness edited after its evidence run still counts as covered** by the coverage rule. Narrower than it sounds and out of scope for this branch; recording it rather than widening the change.

Advances #300. Does not close it — the band-0 accumulator and the constant `confidence` are still open, and the promotion decision is still the owner's.
