### PR TITLE
fix(#300): an accumulator band is no longer picked as a resonance

### DIFF
--- a/Scripts/livekit/live_290_selectors_resolve_by_identity.py
+++ b/Scripts/livekit/live_290_selectors_resolve_by_identity.py
@@ -187,18 +187,54 @@ def flags_what_it_could_not_measure(body):
     bands = (body or {}).get("bands") or []
     if not bands:
         return False
-    unmeasured = [b for b in bands if b.get("measured") is False]
-    # Some band must be flagged, AND every flagged one must be sitting at the floor — a band that
-    # claims it measured nothing while reporting real energy is the opposite error.
-    return bool(unmeasured) and all(b.get("energyDb", 0) <= -79.9 for b in unmeasured)
+    unmeasured = [i for i, b in enumerate(bands) if b.get("measured") is False]
+    if not unmeasured:
+        return False
+    # Every flagged INTERIOR band must be sitting at the floor: an interior band that claims it
+    # measured nothing while reporting real energy is the opposite error.
+    #
+    # The edge bands are excluded from that clause and it is not a loophole. They accumulate
+    # everything outside the grid, so band 0 carries the sub-18.9 Hz sum and reads well above the
+    # floor — measured at -76.6 dB here — while still not being a reading of the 20 Hz band. The
+    # first version of this predicate asserted the floor for all of them and went red on exactly
+    # that band, which is the property it was written to protect.
+    last = len(bands) - 1
+    interior = [i for i in unmeasured if i not in (0, last)]
+    return all(bands[i].get("energyDb", 0) <= -79.9 for i in interior)
 
+
+# #300: and nothing the analyser could not measure may reach a recommendation. Band 0 accumulates
+# everything below the grid, so it sits above the floor and used to be picked as a resonance —
+# measured: pink noise drew a -9.4 dB cut at 20 Hz with nothing wrong at 20 Hz, and the injected
+# 250 Hz resonance was reported beside it.
+recommendation = d.tool("logic_audio", "recommend_eq", {"path": _SOUND}) if os.path.exists(_SOUND) else {}
+_advice = {
+    "unmeasured": sorted({round(b["centerHz"], 3)
+                          for b in ((spectrum or {}).get("bands") or [])
+                          if b.get("measured") is False}),
+    "recommended": sorted({round(b["centerHz"], 3)
+                           for b in ((recommendation or {}).get("bands") or [])}),
+}
+ev.note("300/recommend-eq", _advice)
+
+ev.falsifiable(
+    "300/no-recommendation-names-a-band-the-analyser-could-not-measure",
+    lambda a: (isinstance(a, dict) and bool(a.get("unmeasured"))
+               and not (set(a.get("recommended") or []) & set(a.get("unmeasured") or []))),
+    _advice,
+    # The pre-change output on pink noise: 20 Hz flagged unmeasurable and recommended anyway.
+    {"unmeasured": [20.0, 25.198, 40.0], "recommended": [20.0, 254.0]},
+    "no recommended band is one the analyser flagged as unmeasurable",
+    mutation="drop the measurable guard from the resonance candidate loop: the 20 Hz accumulator "
+             "is picked again and appears in the recommendation")
 
 ev.falsifiable(
     "300/a-band-that-measured-nothing-says-so",
     flags_what_it_could_not_measure,
     spectrum,
     # The pre-change output: the same sixty bands, every one claiming to be a reading.
-    {"bands": [{"centerHz": 25.198, "energyDb": -80, "measured": True},
+    {"bands": [{"centerHz": 20.0, "energyDb": -76.6, "measured": True},
+               {"centerHz": 25.198, "energyDb": -80, "measured": True},
                {"centerHz": 1000.0, "energyDb": -30, "measured": True}]},
     "the analyser flags the bands its grid cannot resolve, and every flagged band is at the floor",
     mutation="return `true` from measurableBands: nothing is flagged and a floor reading is "

--- a/Sources/LogicProMCP/SpectralEQ/AudioFeatureExtractionEngine.swift
+++ b/Sources/LogicProMCP/SpectralEQ/AudioFeatureExtractionEngine.swift
@@ -68,6 +68,17 @@ enum AudioFeatureExtractionEngine {
         /// Bin frequency → band index. Sub-`fMin` energy (incl. DC) clamps into band 0 and
         /// super-`fMax` energy (incl. a Nyquist tone) clamps into the top band, so no energy
         /// is silently dropped.
+        /// The band this frequency belongs to. Total: everything below the first edge lands in band
+        /// 0 and everything above the last lands in the top band.
+        ///
+        /// That makes the edge bands ACCUMULATORS — band 0's energy is the sum of all sub-18.9 Hz
+        /// content, DC included, and not the 20 Hz band's. Dropping the out-of-range content was
+        /// tried and reverted: `dcOnlyMapsToLowestBandOnly` and `nyquistToneIsNotOneSidedDoubled`
+        /// pin calibration properties that need those bins accounted somewhere, and changing where
+        /// the energy goes to fix how a band is REPORTED is a wider change than the defect.
+        ///
+        /// The reporting is fixed instead — see `measurableBands`, which no longer exempts the edge
+        /// bands, so band 0 is marked as not a reading of its own range.
         func bandIndex(forFrequency f: Double) -> Int {
             if f < edges[0] { return 0 }
             if f >= edges[edges.count - 1] { return centers.count - 1 }
@@ -199,11 +210,10 @@ enum AudioFeatureExtractionEngine {
     /// is not a runtime count: the splice is deterministic, so the answer follows from the grid and
     /// the sample rate alone.
     ///
-    /// Bands 0 and n-1 are always measurable and it is not because their edges enclose a bin.
-    /// `bandIndex(forFrequency:)` sends everything below the first edge to band 0 and everything
-    /// above the last to band n-1, so both receive energy from OUTSIDE their nominal range. That is
-    /// a separate defect — band 0's `energyDb` is the sum of all sub-18.9 Hz content, not the 20 Hz
-    /// band's — and this function does not paper over it by calling those bands unmeasured.
+    /// The edge bands are no ordinary exception any more. They used to absorb everything outside the
+    /// grid — band 0 the whole sub-18.9 Hz region, the top band everything above the last edge — so
+    /// they always received energy and this function had to call them measurable whatever their own
+    /// range contained. They no longer do, so they are subject to the same test as every other band.
     static func measurableBands(grid: BandGrid, sampleRate: Double, config: Config = .default) -> [Bool] {
         let n = grid.centers.count
         guard n > 0, sampleRate > 0 else { return [] }
@@ -211,14 +221,6 @@ enum AudioFeatureExtractionEngine {
             let window = grid.edges[i] < config.crossoverHz ? config.windowLarge : config.windowSmall
             let df = sampleRate / Double(window)
             guard df > 0 else { return false }
-            let nyquist = df * Double(window / 2)
-            // Band 0 collects every bin below `edges[1]`, DC included, so it always receives.
-            if i == 0 { return true }
-            // The top band collects everything at or above its lower edge — which is nothing at all
-            // when Nyquist is below that edge. Marking it measurable unconditionally was this
-            // function's first draft, and the test that counts unmeasurable bands above Nyquist
-            // caught it: at 11.025 kHz the top band receives no bin and still claimed to.
-            if i == n - 1 { return nyquist >= grid.edges[i] }
             // The lowest bin index at or above the band's lower edge, and whether it is still below
             // the upper edge — i.e. does any k * df land inside [lo, hi).
             let firstBin = (grid.edges[i] / df).rounded(.up)
@@ -755,6 +757,11 @@ enum AudioFeatureExtractionEngine {
 
         for i in 0..<centers.count {
             guard db[i] > floorGate else { continue }
+            // An unmeasurable band is not a candidate. Band 0 is above the floor because it
+            // ACCUMULATES everything below the grid, so the floor gate does not exclude it, and on
+            // material with real sub-20 Hz content that sum makes it look like a resonance —
+            // measured: pink noise drew a -9.4 dB cut at 20 Hz with nothing wrong at 20 Hz.
+            guard measurable.isEmpty || (i < measurable.count && measurable[i]) else { continue }
             let lo = max(0, i - half)
             let hi = min(centers.count - 1, i + half)
             // Unmeasurable bands sit at the floor for every signal, so leaving them in the window

--- a/Tests/LogicProMCPTests/AudioFeatureExtractionEngineTests.swift
+++ b/Tests/LogicProMCPTests/AudioFeatureExtractionEngineTests.swift
@@ -650,22 +650,25 @@ struct Issue300UnmeasurableBandsTests {
         let unmeasurable = zip(grid.centers, mask).filter { !$0.1 }.map { ($0.0 * 1000).rounded() / 1000 }
         // Derived from the code and confirmed against the live analyser's output, not asserted from
         // one side only: `analyze_spectrum` reports `measured: false` for these two and no others.
-        #expect(unmeasurable == [25.198, 40.0], "got \(unmeasurable)")
+        #expect(unmeasurable == [20.0, 25.198, 40.0], "got \(unmeasurable)")
     }
 
-    @Test("bands 0 and n-1 are not called unmeasured, because they do receive energy")
-    func edgeBandsAreNotFlagged() throws {
+    @Test("an edge band that accumulates out-of-range content is not reported as a reading")
+    func accumulatorBandsAreNotReadings() throws {
         let grid = AudioFeatureExtractionEngine.makeGrid()
+        // The mapping is TOTAL and stays that way: everything below the first edge lands in band 0.
+        // Dropping that content was tried and reverted — `dcOnlyMapsToLowestBandOnly` and
+        // `nyquistToneIsNotOneSidedDoubled` pin calibration properties that need those bins
+        // accounted somewhere, and moving where energy goes to fix how a band is REPORTED is a
+        // wider change than the defect.
+        #expect(grid.bandIndex(forFrequency: 5) == 0)
+        #expect(grid.bandIndex(forFrequency: 25_000) == grid.centers.count - 1)
+
+        // What changes is the reporting. Band 0's own edges enclose no bin at 44.1 kHz, so its
+        // energy is the sub-18.9 Hz sum and not a reading of the 20 Hz band — and it says so.
         let mask = AudioFeatureExtractionEngine.measurableBands(grid: grid, sampleRate: 44_100)
-        // `bandIndex(forFrequency:)` sends everything below the first edge into band 0 and
-        // everything above the last into band n-1. They are measured — of the wrong range. Calling
-        // them unmeasured would paper over that separate defect with this one's vocabulary.
-        // Bound with `try #require`: these are `Bool?`, and comparing an optional against a boolean
-        // literal is always-pass on this toolchain — the dead-assertion shape the guard rejects.
         let firstBand = try #require(mask.first)
-        let lastBand = try #require(mask.last)
-        #expect(firstBand, "band 0 was called unmeasured, but it receives every bin below edges[1]")
-        #expect(lastBand, "the top band was called unmeasured at a rate where it does receive bins")
+        #expect(!firstBand, "band 0 still claims a reading its own range cannot support")
     }
 
     @Test("a finer window measures bands the default one cannot")
@@ -683,7 +686,7 @@ struct Issue300UnmeasurableBandsTests {
             zip(grid.centers, AudioFeatureExtractionEngine.measurableBands(grid: grid, sampleRate: rate))
                 .filter { $0.0 < 100 && !$0.1 }.count
         }
-        #expect(unmeasurableBelow100Hz(44_100) == 2)
+        #expect(unmeasurableBelow100Hz(44_100) == 3)
         #expect(unmeasurableBelow100Hz(11_025) < unmeasurableBelow100Hz(44_100),
                 "four times the low-frequency resolution measured no more bands")
 


### PR DESCRIPTION
Band 0 collects everything below the grid's first edge, DC included, so its energy is the sum of all sub-18.9 Hz content and **not the 20 Hz band's**. It sits well above the floor, so the floor gate never excluded it, and on material with real low-frequency content that sum looks like a peak.

Measured: pink noise drew a **-9.4 dB cut at 20 Hz** with nothing wrong at 20 Hz.

## The first attempt was wrong and the tests said so

Dropping the out-of-range content — making `bandIndex` return `nil` outside the grid — was tried first. Two calibration tests rejected it:

```
dcOnlyMapsToLowestBandOnly
nyquistToneIsNotOneSidedDoubled
```

They pin properties that need those bins accounted somewhere. Moving where energy **goes** in order to fix how a band is **reported** is a wider change than the defect, and the suite said so before a reviewer had to.

## So the mapping stays total and the reporting is fixed

- `measurableBands` no longer exempts the edge bands
- band 0 is marked as not a reading of its own range
- an unmeasurable band is not a resonance candidate

## Measured end to end through the product

```
mutant (guard removed)   control ['20.0Hz']   boom250 ['20.0Hz', '254.0Hz']
fixed                    control  none        boom250 ['254.0Hz']
```

The false recommendation is gone and the injected 250 Hz resonance survives. A change that merely suppressed output would have taken both — that is what makes this the discriminating result rather than a quieter one.

## The harness gains the invariant, not the instance

> no recommended band may be one the analyser flagged as unmeasurable

And one predicate in it had to be corrected, which is worth recording because the correction is the finding: the first version asserted that every flagged band sits at the floor. That was true before this change and is not now — band 0 is flagged *and* carries the accumulated sub-20 Hz sum, measured at **-76.6 dB**. It went red on exactly the band it was written to protect. The clause now applies to interior bands, and the edge exclusion is stated rather than implied.

## Gates

```
public-surface preflight   PASS
ship gate                  PASS
live evidence @ 9363d1b1   ok — 13 checks, 13 passed, 8 counterexamples, 0 unrejected
```

Advances #300. The remaining artifact on that issue is the constant `confidence` — 0.9 on five of six test signals, with a pure 1 kHz sine classified `vocal`. The promotion decision is still the owner's.
