### PR TITLE
feat(#300): promote the spectral commands

### DIFF
--- a/Scripts/livekit/live_290_selectors_resolve_by_identity.py
+++ b/Scripts/livekit/live_290_selectors_resolve_by_identity.py
@@ -162,10 +162,11 @@ ev.falsifiable(
     mutation="return survivors.first from transportContainerFinalists: five survive, nothing "
              "narrows them, and the site is back to choosing by tree order")
 
-# #300: the spectral surface is flag-gated, and `E.Driver` inherits this process's environment, so
-# setting it here reaches the server it spawns. The flag gates only the spectral commands, so the
-# rest of this run is unaffected.
-os.environ["LOGIC_MCP_ADR012_SPECTRAL_EQ"] = "1"
+# #300: the spectral surface was flag-gated and this used to set the flag before building the
+# driver. It is promoted now, and the flag is REMOVED rather than defaulted on — so the variable is
+# set to "0" here instead. A run that still answered `command_not_exposed` under it would mean the
+# guard survived with a flipped default, which is a different thing from being gone.
+os.environ["LOGIC_MCP_ADR012_SPECTRAL_EQ"] = "0"
 
 d = E.Driver()
 time.sleep(3)

--- a/Sources/LogicProMCP/Dispatchers/AudioDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/AudioDispatcher.swift
@@ -12,7 +12,7 @@ struct AudioDispatcher: OperationTraceDispatching {
 
     static let tool = commandTool(
         name: "logic_audio",
-        description: "Read-only audio artifact analysis for post-bounce/export verification. Commands: analyze_file, analyze_spectrum, recommend_eq. Params: analyze_file -> { path: absolute audio file path, output_root?: absolute allowlist root, min_duration_seconds?: number, expected_duration_seconds?: number, max_duration_drift_seconds?: number, min_file_size_bytes?: int, max_input_file_size_bytes?: int, max_input_duration_seconds?: number, max_decoded_frames?: int, max_peak_dbfs?: number, near_silence_dbfs?: number, max_silence_ratio?: number, expected_sample_rate?: int, expected_channel_count?: int }; analyze_spectrum -> { path: absolute audio file path }; recommend_eq -> { path: absolute audio file path, minimum_level?: number }. The spectral commands require LOGIC_MCP_ADR012_SPECTRAL_EQ=1. Returns analysis/recommendation JSON and never mutates files or Logic Pro.",
+        description: "Read-only audio artifact analysis for post-bounce/export verification. Commands: analyze_file, analyze_spectrum, recommend_eq. Params: analyze_file -> { path: absolute audio file path, output_root?: absolute allowlist root, min_duration_seconds?: number, expected_duration_seconds?: number, max_duration_drift_seconds?: number, min_file_size_bytes?: int, max_input_file_size_bytes?: int, max_input_duration_seconds?: number, max_decoded_frames?: int, max_peak_dbfs?: number, near_silence_dbfs?: number, max_silence_ratio?: number, expected_sample_rate?: int, expected_channel_count?: int }; analyze_spectrum -> { path: absolute audio file path }; recommend_eq -> { path: absolute audio file path, minimum_level?: number }. analyze_spectrum returns per-band energy; a band whose edges enclose no FFT bin at the file's sample rate is marked measured:false and its energyDb is the floor sentinel, not a reading. `classification` is a coarse advisory heuristic — it reads white noise as drums and a pure tone as vocal — and `levelConfidence` is a loudness figure, not a measure of how sure that classification is. Returns analysis/recommendation JSON and never mutates files or Logic Pro.",
         commandDescription: "Audio command to execute"
     )
 
@@ -36,22 +36,20 @@ struct AudioDispatcher: OperationTraceDispatching {
                 isError: result.verification.status == .fail
             )
 
+        // Promoted 2026-08-28. What the flag was holding back was measured and fixed first: bands
+        // whose edges enclose no FFT bin no longer report the floor as a reading, the edge
+        // accumulators are no longer picked as resonances — which is what produced a recommended
+        // cut at 20 Hz on material with nothing wrong at 20 Hz — and the number called `confidence`
+        // is named `levelConfidence`, because it is a loudness gate and never said anything about
+        // the classification.
+        //
+        // What is NOT fixed and is stated in the description instead: the classifier is coarse. It
+        // reads white noise as `drums` and a pure sine as `vocal`. Advisory is what it is, so
+        // advisory is what it says.
         case "analyze_spectrum":
-            guard FeatureFlags.adr012SpectralEQ else {
-                return notExposedCommandResult(
-                    operation: "audio.analyze_spectrum",
-                    reason: "requires LOGIC_MCP_ADR012_SPECTRAL_EQ=1"
-                )
-            }
             return spectralAnalysisResult(command: command, params: params)
 
         case "recommend_eq":
-            guard FeatureFlags.adr012SpectralEQ else {
-                return notExposedCommandResult(
-                    operation: "audio.recommend_eq",
-                    reason: "requires LOGIC_MCP_ADR012_SPECTRAL_EQ=1"
-                )
-            }
             return eqRecommendationResult(command: command, params: params)
 
         default:

--- a/Sources/LogicProMCP/Dispatchers/AudioDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/AudioDispatcher.swift
@@ -12,7 +12,7 @@ struct AudioDispatcher: OperationTraceDispatching {
 
     static let tool = commandTool(
         name: "logic_audio",
-        description: "Read-only audio artifact analysis for post-bounce/export verification. Commands: analyze_file, analyze_spectrum, recommend_eq. Params: analyze_file -> { path: absolute audio file path, output_root?: absolute allowlist root, min_duration_seconds?: number, expected_duration_seconds?: number, max_duration_drift_seconds?: number, min_file_size_bytes?: int, max_input_file_size_bytes?: int, max_input_duration_seconds?: number, max_decoded_frames?: int, max_peak_dbfs?: number, near_silence_dbfs?: number, max_silence_ratio?: number, expected_sample_rate?: int, expected_channel_count?: int }; analyze_spectrum -> { path: absolute audio file path }; recommend_eq -> { path: absolute audio file path, minimum_confidence?: number }. The spectral commands require LOGIC_MCP_ADR012_SPECTRAL_EQ=1. Returns analysis/recommendation JSON and never mutates files or Logic Pro.",
+        description: "Read-only audio artifact analysis for post-bounce/export verification. Commands: analyze_file, analyze_spectrum, recommend_eq. Params: analyze_file -> { path: absolute audio file path, output_root?: absolute allowlist root, min_duration_seconds?: number, expected_duration_seconds?: number, max_duration_drift_seconds?: number, min_file_size_bytes?: int, max_input_file_size_bytes?: int, max_input_duration_seconds?: number, max_decoded_frames?: int, max_peak_dbfs?: number, near_silence_dbfs?: number, max_silence_ratio?: number, expected_sample_rate?: int, expected_channel_count?: int }; analyze_spectrum -> { path: absolute audio file path }; recommend_eq -> { path: absolute audio file path, minimum_level?: number }. The spectral commands require LOGIC_MCP_ADR012_SPECTRAL_EQ=1. Returns analysis/recommendation JSON and never mutates files or Logic Pro.",
         commandDescription: "Audio command to execute"
     )
 
@@ -87,20 +87,20 @@ struct AudioDispatcher: OperationTraceDispatching {
         case .refusal(let result):
             return result
         case .input(let input):
-            let minimumConfidence: Double
-            if params["minimum_confidence"] == nil {
-                minimumConfidence = 0.6
-            } else if let value = doubleParamOrNil(params, "minimum_confidence") {
-                minimumConfidence = value
+            let minimumLevel: Double
+            if params["minimum_level"] == nil {
+                minimumLevel = 0.6
+            } else if let value = doubleParamOrNil(params, "minimum_level") {
+                minimumLevel = value
             } else {
                 return toolInvalidParamsResult(
-                    "recommend_eq 'minimum_confidence' must be a finite number",
+                    "recommend_eq 'minimum_level' must be a finite number",
                     extras: ["operation": "audio.recommend_eq", "write_attempted": false]
                 )
             }
             do {
                 let analysis = try analyzeSpectrum(path: input.path, command: command)
-                switch recommendEQ(analysis, minimumConfidence: minimumConfidence) {
+                switch recommendEQ(analysis, minimumLevel: minimumLevel) {
                 case .recommendation(let bands):
                     return toolTextResult(encodeJSON(EQRecommendationResponse(bands: bands)))
                 case .noSafeRecommendation(let reason):

--- a/Sources/LogicProMCP/Server/OperationRegistry.swift
+++ b/Sources/LogicProMCP/Server/OperationRegistry.swift
@@ -626,7 +626,7 @@ enum OperationRegistry {
             ]
         ),
         (.audioAnalyzeSpectrum, "analyze_spectrum", Mutability.readOnly, ["path"]),
-        (.audioRecommendEQ, "recommend_eq", Mutability.readOnly, ["path", "minimum_confidence"]),
+        (.audioRecommendEQ, "recommend_eq", Mutability.readOnly, ["path", "minimum_level"]),
     ] as [(OperationID, String, Mutability, Set<String>)]).map { entry in
         OperationSpec(
             id: entry.0,

--- a/Sources/LogicProMCP/SpectralEQ/AudioFeatureExtractionEngine.swift
+++ b/Sources/LogicProMCP/SpectralEQ/AudioFeatureExtractionEngine.swift
@@ -134,7 +134,7 @@ enum AudioFeatureExtractionEngine {
                 bands: [],
                 resonances: [],
                 classification: .unknown,
-                confidence: 0,
+                levelConfidence: 0,
                 complete: false,
                 partialReason: reason,
                 artifactFingerprint: artifactFingerprint,
@@ -249,7 +249,7 @@ enum AudioFeatureExtractionEngine {
         for i in 0..<bandPower.count where !bandPower[i].isFinite {
             return SpectralAnalysisResult(
                 analysisRef: analysisRef, bands: [], resonances: [], classification: .unknown,
-                confidence: 0, complete: false, partialReason: "non_finite_input",
+                levelConfidence: 0, complete: false, partialReason: "non_finite_input",
                 artifactFingerprint: artifactFingerprint, sampleRate: sampleRate,
                 channelCount: channelCount, durationSeconds: durationSeconds, windowsAnalyzed: 0,
                 channelMode: mode, spectralCentroidHz: nil, frequencyPeaks: []
@@ -268,14 +268,14 @@ enum AudioFeatureExtractionEngine {
         let resonances = detectResonances(
             centers: grid.centers, db: bandsDb, measurable: measurable, config: config, grid: grid)
         let (centroid, peaks) = centroidAndPeaks(centers: grid.centers, db: bandsDb, power: bandPower, config: config)
-        let (classification, confidence) = classify(centers: grid.centers, power: bandPower, centroid: centroid, config: config)
+        let (classification, levelConfidence) = classify(centers: grid.centers, power: bandPower, centroid: centroid, config: config)
 
         return SpectralAnalysisResult(
             analysisRef: analysisRef,
             bands: bands,
             resonances: resonances,
             classification: classification,
-            confidence: confidence,
+            levelConfidence: levelConfidence,
             complete: true,
             partialReason: nil,
             artifactFingerprint: artifactFingerprint,
@@ -327,7 +327,7 @@ enum AudioFeatureExtractionEngine {
         if let maxBytes = policy.maximumInputFileSizeBytes, maxBytes > 0, Int64(fdInfo.st_size) > maxBytes {
             return SpectralAnalysisResult(
                 analysisRef: analysisRef, bands: [], resonances: [], classification: .unknown,
-                confidence: 0, complete: false, partialReason: "input_too_large",
+                levelConfidence: 0, complete: false, partialReason: "input_too_large",
                 artifactFingerprint: artifactFingerprint, sampleRate: 0, channelCount: 0,
                 durationSeconds: 0, windowsAnalyzed: 0, channelMode: .mono,
                 spectralCentroidHz: nil, frequencyPeaks: []
@@ -433,7 +433,7 @@ enum AudioFeatureExtractionEngine {
             let dur = sampleRate > 0 ? Double(max(frames, 0)) / sampleRate : 0
             return SpectralAnalysisResult(
                 analysisRef: analysisRef, bands: [], resonances: [], classification: .unknown,
-                confidence: 0, complete: false, partialReason: reason,
+                levelConfidence: 0, complete: false, partialReason: reason,
                 artifactFingerprint: artifactFingerprint, sampleRate: sampleRate,
                 channelCount: channelCount, durationSeconds: dur, windowsAnalyzed: 0,
                 channelMode: mode, spectralCentroidHz: nil, frequencyPeaks: []
@@ -860,8 +860,8 @@ enum AudioFeatureExtractionEngine {
         return sum
     }
 
-    /// Coarse, advisory classification + confidence (out-of-scope for this rollout beyond coarse). A
-    /// near-silent signal is `unknown` with ~0 confidence, which the recommendation layer
+    /// Coarse, advisory classification plus a LEVEL figure (out-of-scope for this rollout beyond
+    /// coarse). A near-silent signal is `unknown` with ~0 level, which the recommendation layer
     /// fails closed on. Confidence is capped below 1 — the classifier is coarse and must
     /// not over-claim certainty.
     private static func classify(
@@ -873,7 +873,7 @@ enum AudioFeatureExtractionEngine {
         let total = power.reduce(0, +)
         guard total > 0, let centroid else { return (.unknown, 0) }
         let overallDb = 10.0 * log10(total)
-        // Level gate: below ~-60 dBFS overall → 0 confidence (silence); ~-20 dBFS → 1.
+        // Level gate: below ~-60 dBFS overall → 0 (silence); ~-20 dBFS → 1.
         let level = min(max((overallDb + 60.0) / 40.0, 0.0), 1.0)
         guard level > 0 else { return (.unknown, 0) }
 
@@ -891,9 +891,11 @@ enum AudioFeatureExtractionEngine {
         } else {
             classification = .fullMix
         }
-        // Cap confidence: coarse heuristic, never claim full certainty.
-        let confidence = min(0.9, level)
-        return (classification, confidence)
+        // Capped at 0.9. The cap is the only part of this number that was ever about the
+        // classifier — a reminder never to claim full certainty — and capping a LOUDNESS figure
+        // does not make it one. The name says what it is now; the cap is kept so the published
+        // range does not change.
+        return (classification, min(0.9, level))
     }
 
 }

--- a/Sources/LogicProMCP/SpectralEQ/EQRecommendationEngine.swift
+++ b/Sources/LogicProMCP/SpectralEQ/EQRecommendationEngine.swift
@@ -20,13 +20,15 @@ enum EQRecommendationOutcome: Equatable, Sendable {
 
 func recommendEQ(
     _ analysis: SpectralAnalysisResult,
-    minimumConfidence: Double = 0.6
+    minimumLevel: Double = 0.6
 ) -> EQRecommendationOutcome {
     guard analysis.complete else {
         return .noSafeRecommendation(reason: "analysis_incomplete")
     }
-    guard analysis.confidence >= minimumConfidence else {
-        return .noSafeRecommendation(reason: "confidence_below_minimum")
+    // A LOUDNESS gate, named as one. It refuses to recommend EQ for near-silence, which is
+    // sensible; what it never was is a measure of how sure the classifier is.
+    guard analysis.levelConfidence >= minimumLevel else {
+        return .noSafeRecommendation(reason: "level_below_minimum")
     }
     guard analysis.classification != .unknown else {
         return .noSafeRecommendation(reason: "source_classification_unknown")

--- a/Sources/LogicProMCP/SpectralEQ/SpectralAnalysis.swift
+++ b/Sources/LogicProMCP/SpectralEQ/SpectralAnalysis.swift
@@ -109,14 +109,25 @@ struct SpectralAnalysisResult: Codable, Equatable, Sendable {
     let spectralCentroidHz: Double?
     let frequencyPeaks: [AudioAnalyzer.FrequencyPeak]
     let classification: SourceClassification
-    let confidence: Double
+    /// How loud the material is, normalised — NOT how sure the classifier is.
+    ///
+    /// Measured 2026-08-28: it comes out of `classify` as `min(0.9, (overallDb + 60) / 40)`, a
+    /// level gate and nothing else, so every signal above about -20 dBFS scores exactly 0.9
+    /// whatever it is. Five of six test signals did, including a pure 1 kHz sine the classifier
+    /// called `vocal`. Named `confidence` it is a claim about the classification that the number
+    /// cannot support; named this, it is a true statement and the gate it drives — do not
+    /// recommend EQ for near-silence — is a reasonable one.
+    ///
+    /// There is no classification-certainty figure on this type. That is the honest state: adding
+    /// one would mean inventing a metric, and the classifier itself is documented as coarse.
+    let levelConfidence: Double
 
     init(
         analysisRef: String,
         bands: [SpectralBand],
         resonances: [SpectralResonance],
         classification: SourceClassification,
-        confidence: Double,
+        levelConfidence: Double,
         complete: Bool,
         partialReason: String?,
         artifactFingerprint: String = "",
@@ -140,19 +151,31 @@ struct SpectralAnalysisResult: Codable, Equatable, Sendable {
         self.spectralCentroidHz = spectralCentroidHz
         self.frequencyPeaks = frequencyPeaks
         self.classification = classification
-        self.confidence = confidence.isFinite ? min(max(confidence, 0), 1) : 0
+        self.levelConfidence = levelConfidence.isFinite ? min(max(levelConfidence, 0), 1) : 0
         self.complete = complete
         self.partialReason = complete ? nil : partialReason
     }
 
+    /// Accepts the legacy `confidence` key as well as `levelConfidence`.
+    ///
+    /// The field was renamed because the number is a loudness gate and the old name claimed it was
+    /// a statement about the classification. Encoding writes the new name only; decoding takes
+    /// either, because analyses stored by a build running with the flag on carry the old one and a
+    /// rename is not a reason to stop being able to read them.
+    private enum LegacyKeys: String, CodingKey { case confidence }
+
     init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
+        let legacy = try decoder.container(keyedBy: LegacyKeys.self)
+        let level = try values.decodeIfPresent(Double.self, forKey: .levelConfidence)
+            ?? legacy.decodeIfPresent(Double.self, forKey: .confidence)
+            ?? 0
         self.init(
             analysisRef: try values.decode(String.self, forKey: .analysisRef),
             bands: try values.decode([SpectralBand].self, forKey: .bands),
             resonances: try values.decode([SpectralResonance].self, forKey: .resonances),
             classification: try values.decode(SourceClassification.self, forKey: .classification),
-            confidence: try values.decode(Double.self, forKey: .confidence),
+            levelConfidence: level,
             complete: try values.decode(Bool.self, forKey: .complete),
             partialReason: try values.decodeIfPresent(String.self, forKey: .partialReason),
             // New rollout-1 fields decode leniently so legacy skeleton fixtures still round-trip;

--- a/Sources/LogicProMCP/Utilities/FeatureFlags.swift
+++ b/Sources/LogicProMCP/Utilities/FeatureFlags.swift
@@ -6,7 +6,6 @@ enum FeatureFlags: Sendable {
     @TaskLocal static var adr003StrictParamsOverride: Bool?
     @TaskLocal static var adr004MutationSagaOverride: Bool?
     @TaskLocal static var adr005OperationTraceOverride: Bool?
-    @TaskLocal static var adr012SpectralEQOverride: Bool?
     #endif
 
     /// PRD-007 Part 2 (ADR-002 #285): promoted from opt-in to DEFAULT ON, so the
@@ -108,21 +107,10 @@ enum FeatureFlags: Sendable {
         ProcessInfo.processInfo.environment["LOGIC_MCP_ADR011_COMPRESSOR_CONTROL"] == "1"
     }
 
-    static var adr012SpectralEQ: Bool {
-        #if DEBUG
-        if let adr012SpectralEQOverride { return adr012SpectralEQOverride }
-        #endif
-        return ProcessInfo.processInfo.environment["LOGIC_MCP_ADR012_SPECTRAL_EQ"] == "1"
-    }
-
-    #if DEBUG
-    static func withAdr012SpectralEQForTests<Result>(
-        _ value: Bool,
-        operation: () async throws -> Result
-    ) async rethrows -> Result {
-        try await $adr012SpectralEQOverride.withValue(value, operation: operation)
-    }
-    #endif
+    // `adr012SpectralEQ` was here until 2026-08-28. The spectral commands are promoted, and the
+    // flag is REMOVED rather than defaulted on: one nothing reads still looks like a control, and
+    // the next person to set `LOGIC_MCP_ADR012_SPECTRAL_EQ=0` would have every reason to expect it
+    // to do something.
 
     static var adr013ChannelEQ: Bool {
         ProcessInfo.processInfo.environment["LOGIC_MCP_ADR013_CHANNEL_EQ"] == "1"

--- a/Tests/LogicProMCPTests/AudioFeatureExtractionEngineTests.swift
+++ b/Tests/LogicProMCPTests/AudioFeatureExtractionEngineTests.swift
@@ -123,7 +123,7 @@ struct AudioFeatureExtractionEngineTests {
     @Test func silenceIsCompleteButLowConfidence() {
         let r = analyze([[Double](repeating: 0, count: Self.frames1s)])
         #expect(r.complete)
-        #expect(r.confidence < 0.6)
+        #expect(r.levelConfidence < 0.6)
         guard case .noSafeRecommendation = recommendEQ(r) else {
             Issue.record("silence must yield no_safe_recommendation")
             return
@@ -267,7 +267,7 @@ struct AudioFeatureExtractionEngineTests {
         let outcome = recommendEQ(
             SpectralAnalysisResult(
                 analysisRef: "a", bands: [], resonances: [SpectralResonance(hz: 800, gainDb: 4, q: 3)],
-                classification: .vocal, confidence: 0.9, complete: true, partialReason: nil
+                classification: .vocal, levelConfidence: 0.9, complete: true, partialReason: nil
             )
         )
         guard case .recommendation(let bands) = outcome else {
@@ -577,7 +577,7 @@ struct AudioFeatureExtractionEngineTests {
             analysisRef: "rt-1",
             bands: [SpectralBand(centerHz: 1_000, energyDb: -3)],
             resonances: [SpectralResonance(hz: 5_120, gainDb: 9, q: 12, resolutionLimited: true)],
-            classification: .drums, confidence: 0.7, complete: true, partialReason: nil,
+            classification: .drums, levelConfidence: 0.7, complete: true, partialReason: nil,
             artifactFingerprint: "fp", sampleRate: 48_000, channelCount: 2, durationSeconds: 1.0,
             windowsAnalyzed: 42, channelMode: .stereoEnergyAverage,
             spectralCentroidHz: 1_234.5, frequencyPeaks: [AudioAnalyzer.FrequencyPeak(frequencyHz: 5_120, magnitude: 0.5)]

--- a/Tests/LogicProMCPTests/EQRecommendationTests.swift
+++ b/Tests/LogicProMCPTests/EQRecommendationTests.swift
@@ -124,20 +124,6 @@ struct EQRecommendationTests {
         #expect(analysis(levelConfidence: 1.1).levelConfidence == 1)
     }
 
-    @Test func adr012FeatureFlagDefaultsToFalse() {
-        let key = "LOGIC_MCP_ADR012_SPECTRAL_EQ"
-        let previous = ProcessInfo.processInfo.environment[key]
-        unsetenv(key)
-        defer {
-            if let previous {
-                setenv(key, previous, 1)
-            } else {
-                unsetenv(key)
-            }
-        }
-
-        #expect(!FeatureFlags.adr012SpectralEQ)
-    }
 
     private func analysis(
         bands: [SpectralBand] = [],

--- a/Tests/LogicProMCPTests/EQRecommendationTests.swift
+++ b/Tests/LogicProMCPTests/EQRecommendationTests.swift
@@ -5,7 +5,7 @@ import Testing
 @Suite("ADR-012 spectral EQ recommendations")
 struct EQRecommendationTests {
     @Test func lowConfidenceReturnsNoSafeRecommendation() {
-        expectNoSafeRecommendation(recommendEQ(analysis(confidence: 0.59)))
+        expectNoSafeRecommendation(recommendEQ(analysis(levelConfidence: 0.59)))
     }
 
     @Test func unknownSourceReturnsNoSafeRecommendation() {
@@ -120,8 +120,8 @@ struct EQRecommendationTests {
     }
 
     @Test func confidenceStaysWithinUnitInterval() {
-        #expect(analysis(confidence: -0.1).confidence == 0)
-        #expect(analysis(confidence: 1.1).confidence == 1)
+        #expect(analysis(levelConfidence: -0.1).levelConfidence == 0)
+        #expect(analysis(levelConfidence: 1.1).levelConfidence == 1)
     }
 
     @Test func adr012FeatureFlagDefaultsToFalse() {
@@ -143,7 +143,7 @@ struct EQRecommendationTests {
         bands: [SpectralBand] = [],
         resonances: [SpectralResonance] = [],
         classification: SourceClassification = .vocal,
-        confidence: Double = 0.9,
+        levelConfidence: Double = 0.9,
         complete: Bool = true,
         partialReason: String? = nil
     ) -> SpectralAnalysisResult {
@@ -152,7 +152,7 @@ struct EQRecommendationTests {
             bands: bands,
             resonances: resonances,
             classification: classification,
-            confidence: confidence,
+            levelConfidence: levelConfidence,
             complete: complete,
             partialReason: partialReason
         )

--- a/Tests/LogicProMCPTests/Issue300SpectralExposureTests.swift
+++ b/Tests/LogicProMCPTests/Issue300SpectralExposureTests.swift
@@ -5,68 +5,65 @@ import Testing
 
 @Suite("#300 ADR-012 spectral command exposure")
 struct Issue300SpectralExposureTests {
-    @Test("flag off refuses both registered spectral commands with the not-exposed envelope")
-    func flagOffRefusesSpectralCommands() async throws {
-        try await FeatureFlags.withAdr012SpectralEQForTests(false) {
-            for command in ["analyze_spectrum", "recommend_eq"] {
-                let result = AudioDispatcher.handle(
-                    command: command,
-                    params: ["path": .string("/tmp/issue300.wav")]
-                )
-                let body = try #require(sharedJSONObject(sharedToolText(result)))
-                let isError = try #require(result.isError)
-                #expect(isError)
-                #expect(body["state"] as? String == "C")
-                #expect(body["error"] as? String == "command_not_exposed")
-                let notExposed = try #require(body["not_exposed"] as? Bool)
-                #expect(notExposed)
-                let supported = try #require(body["supported"] as? Bool)
-                #expect(!supported)
-                #expect(body["operation"] as? String == "audio.\(command)")
-                #expect(body["write_attempted"] == nil)
-            }
+    @Test("the spectral commands are exposed, and setting the retired flag off does not hide them")
+    func spectralCommandsAreExposed() async throws {
+        // The inverse of what this case used to assert. It pinned the gate as the contract: with
+        // `LOGIC_MCP_ADR012_SPECTRAL_EQ` unset the commands answered `command_not_exposed`.
+        //
+        // Promoted 2026-08-28, and the flag is gone rather than defaulted on — a flag nothing reads
+        // is a trap for whoever sets it next. Setting the environment variable to `0` is the
+        // strongest available check that it was removed rather than merely flipped: if the guard
+        // were still there and only its default had changed, this would refuse.
+        setenv("LOGIC_MCP_ADR012_SPECTRAL_EQ", "0", 1)
+        defer { unsetenv("LOGIC_MCP_ADR012_SPECTRAL_EQ") }
+
+        for command in ["analyze_spectrum", "recommend_eq"] {
+            let result = AudioDispatcher.handle(
+                command: command,
+                params: ["path": .string("/tmp/issue300.wav")]
+            )
+            let body = try #require(sharedJSONObject(sharedToolText(result)))
+            #expect(body["error"] as? String != "command_not_exposed",
+                    "\(command) is still gated")
+            #expect(body["not_exposed"] == nil)
         }
     }
 
     @Test("flag on refuses an empty path before spectral analysis")
-    func emptyPathIsRefusedBeforeAnalysis() async throws {
-        try await FeatureFlags.withAdr012SpectralEQForTests(true) {
-            for command in ["analyze_spectrum", "recommend_eq"] {
-                let result = AudioDispatcher.handle(command: command, params: ["path": .string(" ")])
-                let body = try #require(sharedJSONObject(sharedToolText(result)))
-                let isError = try #require(result.isError)
-                #expect(isError)
-                #expect(body["state"] as? String == "C")
-                #expect(body["error"] as? String == "invalid_params")
-                #expect(body["analysis_error"] == nil)
-                let writeAttempted = try #require(body["write_attempted"] as? Bool)
-                #expect(!writeAttempted)
-            }
+    func emptyPathIsRefusedBeforeAnalysis() throws {
+        for command in ["analyze_spectrum", "recommend_eq"] {
+            let result = AudioDispatcher.handle(command: command, params: ["path": .string(" ")])
+            let body = try #require(sharedJSONObject(sharedToolText(result)))
+            let isError = try #require(result.isError)
+            #expect(isError)
+            #expect(body["state"] as? String == "C")
+            #expect(body["error"] as? String == "invalid_params")
+            #expect(body["analysis_error"] == nil)
+            let writeAttempted = try #require(body["write_attempted"] as? Bool)
+            #expect(!writeAttempted)
         }
     }
 
     @Test("flag on returns typed failures for a nonexistent input")
-    func nonexistentPathReturnsTypedFailure() async throws {
+    func nonexistentPathReturnsTypedFailure() throws {
         let nonexistent = FileManager.default.temporaryDirectory
             .appendingPathComponent("issue300-missing-\(UUID().uuidString).wav").path
 
-        try await FeatureFlags.withAdr012SpectralEQForTests(true) {
-            for command in ["analyze_spectrum", "recommend_eq"] {
-                let result = AudioDispatcher.handle(command: command, params: ["path": .string(nonexistent)])
-                let body = try #require(sharedJSONObject(sharedToolText(result)))
-                let isError = try #require(result.isError)
-                #expect(isError)
-                #expect(body["state"] as? String == "C")
-                #expect(body["error"] as? String == "spectral_analysis_failed")
-                #expect(body["analysis_error"] as? String == "missing_file")
-                let success = try #require(body["success"] as? Bool)
-                #expect(!success)
-            }
+        for command in ["analyze_spectrum", "recommend_eq"] {
+            let result = AudioDispatcher.handle(command: command, params: ["path": .string(nonexistent)])
+            let body = try #require(sharedJSONObject(sharedToolText(result)))
+            let isError = try #require(result.isError)
+            #expect(isError)
+            #expect(body["state"] as? String == "C")
+            #expect(body["error"] as? String == "spectral_analysis_failed")
+            #expect(body["analysis_error"] as? String == "missing_file")
+            let success = try #require(body["success"] as? Bool)
+            #expect(!success)
         }
     }
 
     @Test("recommend_eq returns a band for a temporary resonant WAV")
-    func recommendEQReturnsBandForPureToneWAV() async throws {
+    func recommendEQReturnsBandForPureToneWAV() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("issue300-spectrum-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -75,18 +72,16 @@ struct Issue300SpectralExposureTests {
         let fileURL = directory.appendingPathComponent("resonance.wav")
         try writePureToneWAV(at: fileURL, frequency: 5_001.953_125)
 
-        try await FeatureFlags.withAdr012SpectralEQForTests(true) {
-            let result = AudioDispatcher.handle(command: "recommend_eq", params: ["path": .string(fileURL.path)])
-            let body = try #require(sharedJSONObject(sharedToolText(result)))
-            let isError = try #require(result.isError)
-            #expect(!isError)
-            let bands = try #require(body["bands"] as? [[String: Any]])
-            #expect(!bands.isEmpty)
-            let firstBand = try #require(bands.first)
-            let centerHz = try #require(firstBand["centerHz"] as? Double)
-            #expect(centerHz > 0)
-            #expect(firstBand["reason"] as? String == "resonance_cut")
-        }
+        let result = AudioDispatcher.handle(command: "recommend_eq", params: ["path": .string(fileURL.path)])
+        let body = try #require(sharedJSONObject(sharedToolText(result)))
+        let isError = try #require(result.isError)
+        #expect(!isError)
+        let bands = try #require(body["bands"] as? [[String: Any]])
+        #expect(!bands.isEmpty)
+        let firstBand = try #require(bands.first)
+        let centerHz = try #require(firstBand["centerHz"] as? Double)
+        #expect(centerHz > 0)
+        #expect(firstBand["reason"] as? String == "resonance_cut")
     }
 
     private func writePureToneWAV(at url: URL, frequency: Double) throws {

--- a/Tests/LogicProMCPTests/OperationCatalogTests.swift
+++ b/Tests/LogicProMCPTests/OperationCatalogTests.swift
@@ -134,7 +134,7 @@ struct OperationCatalogTests {
             "path",
         ],
         .audioAnalyzeSpectrum: ["path"],
-        .audioRecommendEQ: ["minimum_confidence", "path"],
+        .audioRecommendEQ: ["minimum_level", "path"],
         .systemListRecentTraces: ["limit"],
         .systemGetTrace: ["trace_id"],
         .systemClearTraces: ["confirmed"],

--- a/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
@@ -391,7 +391,7 @@ enum SemanticOracleFixtures {
                 .init(
                     .wellFormedButWrong,
                     "{\"bands\":[{\"centerHz\":5000,\"gainDb\":-36.0,\"q\":8.6,"
-                        + "\"reason\":\"resonance_cut\"}],\"reason\":\"confidence_below_minimum\"}"
+                        + "\"reason\":\"resonance_cut\"}],\"reason\":\"level_below_minimum\"}"
                 ),
                 // A cut outside the audible range the old constraint pinned.
                 .init(


### PR DESCRIPTION
`audio.analyze_spectrum` and `audio.recommend_eq` are exposed by default.

## What the flag was holding back, fixed first

The last artifact was the number called `confidence`. `classify` computes it as `min(0.9, (overallDb + 60) / 40)` — a loudness figure and nothing else. It never consults the classification it is returned beside, so every signal above about -20 dBFS scores exactly **0.9** whatever it is. Five of six test signals did, including a pure 1 kHz sine the classifier called `vocal`.

Called `confidence` that is a claim the number cannot support, and it is **load-bearing**: `recommend_eq` refuses below it, so a loudness gate was deciding whether a user got a recommendation under a name that said certainty.

Renamed through the surface — `levelConfidence` on the result, `minimum_level` as the tool parameter, `level_below_minimum` as the refusal reason. The gate is kept; refusing to recommend EQ for near-silence is sensible and was never the part that was wrong.

**Verified the new name is not the old error respelled.** Four white-noise files at descending amplitude, no normalisation:

```
0.7      level 0.9      recommends
0.02     level 0.531    level_below_minimum
0.003    level 0.126    level_below_minimum
0.0006   level 0        level_below_minimum
```

Monotonic in amplitude, and the refusal names the real cause.

## The promotion

Together with #693 and #694 the three measured artifacts are addressed:

```
unmeasurable bands reported the floor as a reading   -> marked measured:false
band 0 accumulated sub-20 Hz and drew a false cut    -> not a resonance candidate
`confidence` was a loudness gate                     -> named levelConfidence
```

## The flag is removed, not defaulted on

One that nothing reads still looks like a control, and the next person to set `LOGIC_MCP_ADR012_SPECTRAL_EQ=0` would have every reason to expect it to do something.

Verified by setting exactly that and getting sixty bands back. A guard surviving with a flipped default would refuse there — which is what the inverted exposure test now checks, and what the live harness now runs under.

## What is not fixed, and says so

The classifier is coarse: white noise reads `drums`, a pure tone reads `vocal`. That is stated in the operation description rather than left for a consumer to discover. No classification-certainty figure is added — that would mean inventing a metric.

## Not claimed

**This does not move `R-SEM`.** Both operations are still `not_qualified` in the qualification breakdown; they need an oracle and valid probe parameters, and exposure was never what was missing. The read-only shortfall did drop from eight to six in the same run — that was `plugins.get_inventory` and `project.get_regions` responding to Logic's state, not this change.

## Compatibility

Decoding accepts the legacy `confidence` key; encoding writes the new name only. The surface is unshipped, but a build running with the flag on could have stored analyses, and a rename is not a reason to stop reading them.

## Gates

```
public-surface preflight   PASS
ship gate                  PASS
live evidence @ b98961a5   ok — 13 checks, 13 passed, 8 counterexamples, 0 unrejected,
                           driven with LOGIC_MCP_ADR012_SPECTRAL_EQ=0
```
