### PR TITLE
fix(#300): an accumulator band is not a peak either

### DIFF
--- a/Sources/LogicProMCP/SpectralEQ/AudioFeatureExtractionEngine.swift
+++ b/Sources/LogicProMCP/SpectralEQ/AudioFeatureExtractionEngine.swift
@@ -267,7 +267,8 @@ enum AudioFeatureExtractionEngine {
         }
         let resonances = detectResonances(
             centers: grid.centers, db: bandsDb, measurable: measurable, config: config, grid: grid)
-        let (centroid, peaks) = centroidAndPeaks(centers: grid.centers, db: bandsDb, power: bandPower, config: config)
+        let (centroid, peaks) = centroidAndPeaks(
+            centers: grid.centers, db: bandsDb, power: bandPower, measurable: measurable, config: config)
         let (classification, levelConfidence) = classify(centers: grid.centers, power: bandPower, centroid: centroid, config: config)
 
         return SpectralAnalysisResult(
@@ -830,12 +831,24 @@ enum AudioFeatureExtractionEngine {
         centers: [Double],
         db: [Double],
         power: [Double],
+        measurable: [Bool],
         config: Config
     ) -> (centroid: Double?, peaks: [AudioAnalyzer.FrequencyPeak]) {
         let gate = config.floorDbfs + 3.0
+        // Same exclusion the resonance detector makes, and for the same reason. The edge bands
+        // accumulate everything outside the grid, so band 0 sits above the floor carrying the
+        // sub-18.9 Hz sum — measured: it was published in `frequency_peaks` at 20 Hz, and it
+        // biases an energy-weighted centroid downward with content the grid does not cover.
+        //
+        // Found by auditing this issue's acceptance criteria AFTER the surface was promoted, which
+        // is the wrong order: excluding accumulators from resonances and not from peaks left the
+        // same artifact reachable through a different field.
+        func usable(_ i: Int) -> Bool {
+            db[i] > gate && (measurable.isEmpty || (i < measurable.count && measurable[i]))
+        }
         var num = 0.0
         var den = 0.0
-        for i in 0..<centers.count where db[i] > gate {
+        for i in 0..<centers.count where usable(i) {
             num += centers[i] * power[i]
             den += power[i]
         }
@@ -844,7 +857,7 @@ enum AudioFeatureExtractionEngine {
         // Frequency peaks = local maxima above the floor, strongest first, top 5. magnitude
         // is the linear band power (computed, never a placeholder).
         var maxima = [(hz: Double, magnitude: Double)]()
-        for i in 0..<centers.count where db[i] > gate {
+        for i in 0..<centers.count where usable(i) {
             let leftOk = i == 0 || db[i] >= db[i - 1]
             let rightOk = i == centers.count - 1 || db[i] >= db[i + 1]
             if leftOk && rightOk { maxima.append((centers[i], power[i])) }

--- a/Tests/LogicProMCPTests/AudioFeatureExtractionEngineTests.swift
+++ b/Tests/LogicProMCPTests/AudioFeatureExtractionEngineTests.swift
@@ -704,3 +704,48 @@ struct Issue300UnmeasurableBandsTests {
                 "a band whose lower edge is above Nyquist was called measurable")
     }
 }
+
+/// #300 — the accumulator bands are excluded from peaks and the centroid too, not only from
+/// resonance candidates.
+///
+/// Found by auditing this issue's acceptance criteria AFTER the surface was promoted, which is the
+/// wrong order: `frequency_peaks` published band 0 at 20 Hz — the sub-18.9 Hz sum — while the
+/// resonance detector had already been taught to skip it. The same artifact was reachable through a
+/// different field.
+@Suite("Issue300AccumulatorsAreNotPeaks")
+struct Issue300AccumulatorsAreNotPeaksTests {
+
+    @Test("no reported peak is a band the analyser could not measure")
+    func peaksExcludeUnmeasurableBands() throws {
+        // Pink-ish: real energy below the grid, which is what fills the accumulator. A flat signal
+        // would not exercise this at all.
+        var b = [Double](repeating: 0, count: 7)
+        var samples = [Double]()
+        var state = UInt64(7)
+        for _ in 0..<(44_100 * 3) {
+            state = state &* 6_364_136_223_846_793_005 &+ 1_442_695_040_888_963_407
+            let w = Double(Int64(bitPattern: state >> 11)) / Double(Int64.max) * 1e-8
+            b[0] = 0.99886 * b[0] + w * 0.0555179
+            b[1] = 0.99332 * b[1] + w * 0.0750759
+            b[2] = 0.96900 * b[2] + w * 0.1538520
+            b[3] = 0.86650 * b[3] + w * 0.3104856
+            b[4] = 0.55000 * b[4] + w * 0.5329522
+            b[5] = -0.7616 * b[5] - w * 0.0168980
+            samples.append((b[0] + b[1] + b[2] + b[3] + b[4] + b[5] + b[6] + w * 0.5362) * 0.11)
+            b[6] = w * 0.115926
+        }
+        let peak = samples.map(abs).max() ?? 1
+        samples = samples.map { $0 / peak * 0.7 }
+
+        let result = AudioFeatureExtractionEngine.analyze(
+            channels: [samples], sampleRate: 44_100,
+            analysisRef: "peaks-1", artifactFingerprint: "x")
+
+        let unmeasurable = Set(result.bands.filter { !$0.measured }.map { $0.centerHz })
+        #expect(!unmeasurable.isEmpty, "the fixture did not produce an unmeasurable band")
+        for peak in result.frequencyPeaks {
+            #expect(!unmeasurable.contains(peak.frequencyHz),
+                    "\(peak.frequencyHz) Hz is reported as a peak and could not be measured")
+        }
+    }
+}


### PR DESCRIPTION
The resonance detector was taught to skip the edge accumulators in #694. `frequency_peaks` and the spectral centroid were not — so the same artifact stayed reachable through a different field.

Band 0 is the sub-18.9 Hz sum, and it was published as a **peak at 20 Hz**, and it biased an energy-weighted centroid downward with content the grid does not cover.

```
peaks     [20.0, 254.0, ...]  ->  [254.0, 18245.6, 28.3, 56.6, 142.5]
centroid  429.66              ->  438.03
```

## How it was found, and why that is worth saying

By auditing this issue's **acceptance criteria after the surface was promoted**. That is the wrong order, and it is the second time in this sequence that fixing an instance rather than the property left a way through: excluding accumulators from one consumer and not the others is exactly that shape.

## Test

Drives pink-ish noise, because a flat signal never fills the accumulator and the test would pass whatever the code did. Mutation-tested: dropping the exclusion puts 20 Hz back in the peak list and the assertion names it.

```
Expectation failed: !([20.0, 40.0, 25.198].contains(20.0))
```

## Acceptance-criteria audit for #300, measured

```
synthetic tone detected within tolerance      MET   injected 250 Hz -> 253.98 Hz
deterministic for the same input and policy   MET   3 runs, 1 digest
peaks and centroid are computed, not stubs    MET   and now exclude unmeasurable bands
recommendations include reason codes          MET   resonance_cut
recommendations include CONFIDENCE            NOT MET — there is no such number, see #695
low-confidence not auto-apply eligible        MET IN INTENT — the refusal is level_below_minimum
failed analysis never returns partial         MET   typed spectral_analysis_failed
2-hour stereo within memory bounds            NOT MEASURED
```

So #300 is not closed by this. Two criteria reference a confidence that does not exist, and one is unmeasured.

## Gates

```
public-surface preflight   PASS
ship gate                  PASS
live evidence @ fe796b14   ok — 13 checks, 13 passed, 8 counterexamples, 0 unrejected
```
