### PR TITLE
test(#290): the atlas scoring cannot resolve the elements Logic exposes

### DIFF
--- a/Tests/LogicProMCPTests/SelectorAtlasTests.swift
+++ b/Tests/LogicProMCPTests/SelectorAtlasTests.swift
@@ -229,3 +229,91 @@ struct SelectorAtlasTests {
         )
     }
 }
+
+/// #290 — what the scoring can award an element Logic actually exposes.
+///
+/// The atlas is written and nothing in `Sources/` outside `SelectorAtlas/` refers to it. Before
+/// adopting it, the question is whether it CAN resolve the elements the product addresses, and the
+/// answer is arithmetic over the scoring plus one measurement.
+///
+/// `confidence` awards 0.25 for role, then 0.55 for an exact `AXIdentifier` and crumbs for
+/// everything else. Measured 2026-08-28 on Logic 12.x: the track-header sliders expose no
+/// `AXIdentifier` at all — the attribute is absent from the element, not empty — and the pan slider
+/// has no `AXTitle` either, because its name lives in `AXHelp`.
+@Suite("Issue290AtlasScoringCeiling")
+struct Issue290AtlasScoringCeilingTests {
+
+    /// Transcribed from the live tree, not invented: role, absent identifier, absent title, the
+    /// help string that carries the name, and the value range that separates pan from volume.
+    private var measuredPanSlider: ResolvableCandidate {
+        ResolvableCandidate(
+            axIdentifier: nil,
+            role: "AXSlider",
+            subrole: nil,
+            title: nil,
+            ancestors: ["AXLayoutItem", "AXGroup", "AXWindow"],
+            attributes: ["AXHelp": "패닝 노브 및 밸런스 노브. 트랙 신호를 스테레오 필드에 위치하려면 수직으로 드래그합니다."],
+            valueSignature: "0...127",
+            geometry: nil
+        )
+    }
+
+    private func selector(minimumConfidence: Double) -> SemanticSelector {
+        SemanticSelector(
+            id: .mixerStripVolumeFader,
+            requiredRole: "AXSlider",
+            allowedSubroles: [],
+            titleAliases: [:],
+            ancestorConstraints: [AncestorConstraint(role: "AXLayoutItem")],
+            attributePredicates: [
+                .attribute("AXHelp", equals: "패닝 노브 및 밸런스 노브. 트랙 신호를 스테레오 필드에 위치하려면 수직으로 드래그합니다."),
+                .valueSignature("0...127"),
+            ],
+            geometryHint: nil,
+            minimumConfidence: minimumConfidence,
+            ambiguityPolicy: .failClosed
+        )
+    }
+
+    @Test("an element with no AXIdentifier cannot score above the identifier tier")
+    func noIdentifierMeansALowCeiling() {
+        let score = confidence(of: measuredPanSlider, against: selector(minimumConfidence: 0))
+        // Everything this element can offer, awarded: role 0.25 + ancestor 0.08 + attribute 0.05
+        // + value signature 0.02. No identifier, no title, no geometry.
+        #expect(score > 0.39 && score < 0.41, "scored \(score)")
+        #expect(score < 0.55,
+                "the identifier tier alone is worth more than everything this element has")
+    }
+
+    @Test("a minimumConfidence above the ceiling makes the element unresolvable")
+    func aboveTheCeilingIsNotFound() {
+        // 0.6 is an ordinary-looking threshold for "resolve confidently", and it refuses an element
+        // that matched every predicate the selector named.
+        let result = resolve(selector(minimumConfidence: 0.6), in: [measuredPanSlider], locale: "ko")
+        #expect(result == .notFound)
+    }
+
+    @Test("the same element with an identifier clears it easily")
+    func withAnIdentifierItResolves() {
+        // The control: the ceiling is about the missing identifier, not about the element being a
+        // poor match. Nothing else changes.
+        let withID = ResolvableCandidate(
+            axIdentifier: "pan-slider",
+            role: measuredPanSlider.role,
+            subrole: measuredPanSlider.subrole,
+            title: measuredPanSlider.title,
+            ancestors: measuredPanSlider.ancestors,
+            attributes: measuredPanSlider.attributes,
+            valueSignature: measuredPanSlider.valueSignature,
+            geometry: measuredPanSlider.geometry
+        )
+        var s = selector(minimumConfidence: 0.6)
+        s = SemanticSelector(
+            id: s.id, requiredRole: s.requiredRole, allowedSubroles: s.allowedSubroles,
+            titleAliases: s.titleAliases, ancestorConstraints: s.ancestorConstraints,
+            attributePredicates: s.attributePredicates + [.axIdentifier("pan-slider")],
+            geometryHint: s.geometryHint, minimumConfidence: 0.6, ambiguityPolicy: s.ambiguityPolicy
+        )
+        #expect(resolve(s, in: [withID], locale: "ko") == .exact(index: 0))
+    }
+}

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -50,7 +50,7 @@ open PRs 0 · v3.14.0 published · 19 open issues
 | ADR-004 | #287 | closed | |
 | ADR-005 | #288 | closed | |
 | ADR-006 | #289 | closed | shipped #674/#675, measured and closed |
-| ADR-007 | #290 | OPEN | the three AX trees it must encode are measured; the atlas is not written |
+| ADR-007 | #290 | OPEN | the atlas IS written (`Sources/LogicProMCP/SelectorAtlas/`, all three pieces) and has **zero production consumers**; adoption is blocked on the scoring, which awards 0.55 of 1 for an `AXIdentifier` Logic does not expose on these elements — a fully-matching header slider scores 0.40 |
 | ADR-008 | #291 | OPEN | node identity cannot be the display string — needs a decision, not an attempt |
 | ADR-009 | #292 | OPEN | apply-back expansion on Wave-0 insert work; #299 and #301 consume it |
 | ADR-010 | #293 | OPEN | provider exists (10 modules); its collector was written against a fixture shape Logic does not produce |
@@ -103,8 +103,9 @@ attached — not a silent deferral.
    on 2026-08-24 moved its blocker: the 49 mutating operations with a verification plan are waiting
    on a write-and-readback qualification mode that does not exist, which the #284 matrix does not
    supply. #373 covers a smaller part of it than "depends on #373" suggested.
-2. **#290** — the selector atlas, because every capability below addresses Logic through AX
-   selectors and ad-hoc selectors are the measured source of wrong-target behaviour.
+2. **#290** — not "write the atlas": it is written and unused. The next step is a decision
+   about its scoring, which cannot resolve an element with no `AXIdentifier` above 0.45 and so
+   cannot resolve the ones the product addresses. Measured, with the real function.
 3. **#293 → #303** — readback before the transforms that must take their expected values from it.
 4. **#302** — blocked on the Event List's absent `kAXColumns` until that is re-measured.
 5. **#292 → #299**. #300's promotion is done — the flag is removed, not defaulted on.


### PR DESCRIPTION
The atlas is written — `SelectorAtlas/` has the selector type, the resolver and the drift report — and **nothing in `Sources/` outside that directory refers to any of it.** Before adopting it, the question is whether it *can* resolve what the product addresses.

It cannot, and the reason is in the scoring.

```
role (and subrole) match          0.25
exact AXIdentifier                0.55   <- more than half the total
ancestor chain                    0.08
attribute equality (all of them)  0.05
title exact                       0.04
value signature                   0.02
geometry                          0.01
```

Measured on Logic 12.x: the track-header sliders expose **no `AXIdentifier` at all** — the attribute is absent from the element, not empty — and the pan slider has no `AXTitle` either, because its name lives in `AXHelp`.

## Run through the real function, with measured values

```
every predicate the element can satisfy, awarded   0.40
minimumConfidence 0.6                              .notFound
the same element with an identifier added          .exact
```

`0.6` is an ordinary-looking threshold for "resolve confidently", and it refuses an element that matched **everything the selector named**. The third line is the control: the ceiling is about the missing identifier, not about the element being a poor match — nothing else changes between it and the first.

## Why this is a test and not a fix

Adoption is not wiring. Two ways out, both decisions:

1. change the scoring so the tiers reflect evidence Logic actually provides — the measured discriminators at the sites already fixed are `AXHelp` containment and `AXMaxValue`, and neither is expressible today (`.attribute` is equality only)
2. run every selector at `minimumConfidence <= 0.4`, at which point the tiers are decorative and the model publishes a confidence it is not measuring

The second is the shape this repository spent today removing from three other places. It should not be adopted here on purpose.

## Also corrected

The roadmap line for #290 said the atlas was not written. It is written, unused, and blocked on the above.

```
public-surface preflight   PASS
ship gate                  PASS
live evidence              n/a — no Sources/ or live-harness change
```