### PR TITLE
feat(#290): score selectors as a ratio over the evidence they asked for

### DIFF
--- a/Sources/LogicProMCP/SelectorAtlas/SelectorResolver.swift
+++ b/Sources/LogicProMCP/SelectorAtlas/SelectorResolver.swift
@@ -70,7 +70,7 @@ private func supportsSchema(
         switch predicate {
         case let .axIdentifier(value), let .valueSignature(value):
             !value.isEmpty
-        case let .attribute(name, equals: value):
+        case let .attribute(name, equals: value), let .attributeContains(name, value):
             !name.isEmpty && !value.isEmpty
         }
     }

--- a/Sources/LogicProMCP/SelectorAtlas/SemanticSelector.swift
+++ b/Sources/LogicProMCP/SelectorAtlas/SemanticSelector.swift
@@ -17,6 +17,16 @@ struct AncestorConstraint: Equatable, Sendable {
 enum AttributePredicate: Equatable, Sendable {
     case axIdentifier(String)
     case attribute(String, equals: String)
+
+    /// Substring match on an attribute, case-insensitively.
+    ///
+    /// Added because equality could not express the evidence Logic actually offers. The
+    /// discriminator that identifies a track-header pan slider is the word `밸런스` inside an
+    /// `AXHelp` that reads "패닝 노브 및 밸런스 노브. 트랙 신호를 스테레오 필드에 위치하려면 수직으로
+    /// 드래그합니다." — an equality predicate there pins a whole localized sentence, so it breaks on
+    /// any wording change and cannot be written for a locale nobody has measured.
+    case attributeContains(String, String)
+
     case valueSignature(String)
 }
 
@@ -44,56 +54,94 @@ struct SemanticSelector: Sendable {
     let ambiguityPolicy: AmbiguityPolicy
 }
 
+/// How much of the evidence this selector ASKED FOR the candidate actually carries.
+///
+/// The weights keep ADR-007's evidence priority — identifier, then ancestor chain and attributes,
+/// then title, then value signature, with geometry last — but they are a ratio now, not a budget.
+///
+/// The budget was the defect. It awarded 0.55 of a possible 1.0 for an exact `AXIdentifier`, so an
+/// element without one could never exceed 0.45 however much else it matched. Measured on Logic
+/// 12.x, the track-header sliders expose no `AXIdentifier` at all: a pan slider satisfying every
+/// predicate its selector named scored 0.40 and `minimumConfidence: 0.6` refused it. A model that
+/// cannot resolve the elements the product addresses is not a strict model, it is an unusable one —
+/// and lowering every threshold to 0.4 instead would leave the tiers decorative and publish a
+/// confidence nothing measures.
+///
+/// Normalising over what was requested fixes that without weakening anything: a selector that asks
+/// for an identifier and does not get one still scores low, because the identifier is in its
+/// denominator. A selector that asks for role, ancestors and an `AXHelp` substring, and gets all
+/// three, scores 1.0 — which is the truth about that selector and that element.
+///
+/// Two floors survive from the old model and one is new:
+///
+///   - a candidate whose role or subrole is wrong scores 0, before anything else is considered
+///   - geometry alone cannot exceed 0.49, which is ADR-007's acceptance criterion
+///   - role alone cannot exceed 0.49 either. Under a ratio a selector naming ONLY a role would
+///     otherwise score 1.0 for matching a role, and "it is a slider" is not an identification.
 func confidence(of candidate: ResolvableCandidate, against selector: SemanticSelector) -> Double {
     guard candidate.role == selector.requiredRole else { return 0 }
     guard selector.allowedSubroles.isEmpty
         || candidate.subrole.map(selector.allowedSubroles.contains) == true else { return 0 }
 
-    var score = 0.25
-    let identifierMatch = selector.attributePredicates.contains { predicate in
-        guard case let .axIdentifier(expected) = predicate else { return false }
-        return candidate.axIdentifier == expected
+    /// (weight, requested, satisfied, isGeometry) in ADR-007's priority order.
+    var evidence: [(weight: Double, requested: Bool, satisfied: Bool, isGeometry: Bool)] = []
+
+    let identifiers = selector.attributePredicates.compactMap { predicate -> String? in
+        guard case let .axIdentifier(value) = predicate else { return nil }
+        return value
     }
-    if identifierMatch { score += 0.55 }
+    evidence.append((0.40, !identifiers.isEmpty,
+                     candidate.axIdentifier.map(identifiers.contains) == true, false))
 
-    let ancestorMatch = !selector.ancestorConstraints.isEmpty
-        && matchesAncestorChain(candidate.ancestors, selector.ancestorConstraints)
-    if ancestorMatch { score += 0.08 }
+    evidence.append((0.20, !selector.ancestorConstraints.isEmpty,
+                     matchesAncestorChain(candidate.ancestors, selector.ancestorConstraints), false))
 
-    let attributePredicates = selector.attributePredicates.compactMap { predicate -> (String, String)? in
+    let equals = selector.attributePredicates.compactMap { predicate -> (String, String)? in
         guard case let .attribute(name, expected) = predicate else { return nil }
         return (name, expected)
     }
-    let attributeMatch = !attributePredicates.isEmpty
-        && attributePredicates.allSatisfy { candidate.attributes[$0.0] == $0.1 }
-    if attributeMatch { score += 0.05 }
+    let contains = selector.attributePredicates.compactMap { predicate -> (String, String)? in
+        guard case let .attributeContains(name, expected) = predicate else { return nil }
+        return (name, expected)
+    }
+    evidence.append((0.20, !equals.isEmpty || !contains.isEmpty,
+                     equals.allSatisfy { candidate.attributes[$0.0] == $0.1 }
+                         && contains.allSatisfy { name, needle in
+                             candidate.attributes[name].map {
+                                 $0.range(of: needle, options: [.caseInsensitive]) != nil
+                             } ?? false
+                         }, false))
 
-    let titleMatch = candidate.title.map { title in
-        selector.titleAliases.values.flatMap { $0 }.contains {
-            title.caseInsensitiveCompare($0) == .orderedSame
-        }
-    } ?? false
-    if titleMatch { score += 0.04 }
+    let aliases = selector.titleAliases.values.flatMap { $0 }
+    evidence.append((0.10, !aliases.isEmpty,
+                     candidate.title.map { title in
+                         aliases.contains { title.caseInsensitiveCompare($0) == .orderedSame }
+                     } ?? false, false))
 
     let signatures = selector.attributePredicates.compactMap { predicate -> String? in
-        guard case let .valueSignature(expected) = predicate else { return nil }
-        return expected
+        guard case let .valueSignature(value) = predicate else { return nil }
+        return value
     }
-    let valueMatch = candidate.valueSignature.map(signatures.contains) == true
-    if valueMatch { score += 0.02 }
+    evidence.append((0.08, !signatures.isEmpty,
+                     candidate.valueSignature.map(signatures.contains) == true, false))
 
-    let geometryMatch = selector.geometryHint == candidate.geometry && selector.geometryHint != nil
-    if geometryMatch { score += 0.01 }
+    evidence.append((0.02, selector.geometryHint != nil,
+                     selector.geometryHint != nil && selector.geometryHint == candidate.geometry, true))
 
-    let hasSpecificNonGeometryEvidence = identifierMatch
-        || ancestorMatch
-        || attributeMatch
-        || titleMatch
-        || valueMatch
-    if geometryMatch, !hasSpecificNonGeometryEvidence {
-        return min(score, 0.49)
-    }
-    return min(score, 1)
+    let requested = evidence.filter(\.requested)
+    // A selector that named nothing but a role has identified nothing.
+    guard !requested.isEmpty else { return 0.25 }
+
+    let denominator = requested.reduce(0) { $0 + $1.weight }
+    let numerator = requested.filter(\.satisfied).reduce(0) { $0 + $1.weight }
+    let score = denominator > 0 ? numerator / denominator : 0
+
+    // Identified by its flag, not by position. `requested` is filtered, so geometry may not be its
+    // last element — or present at all — and the first draft's `dropLast()` silently capped a
+    // selector that asked only for an identifier and got it. Its own test caught that.
+    let satisfiedBeyondGeometry = requested.contains { $0.satisfied && !$0.isGeometry }
+    if !satisfiedBeyondGeometry { return min(score, 0.49) }
+    return min(max(score, 0), 1)
 }
 
 private func matchesAncestorChain(

--- a/Tests/LogicProMCPTests/SelectorAtlasTests.swift
+++ b/Tests/LogicProMCPTests/SelectorAtlasTests.swift
@@ -230,18 +230,22 @@ struct SelectorAtlasTests {
     }
 }
 
-/// #290 — what the scoring can award an element Logic actually exposes.
+/// #290 — the scoring is a ratio over the evidence a selector ASKED FOR, not a fixed budget.
 ///
-/// The atlas is written and nothing in `Sources/` outside `SelectorAtlas/` refers to it. Before
-/// adopting it, the question is whether it CAN resolve the elements the product addresses, and the
-/// answer is arithmetic over the scoring plus one measurement.
+/// This suite recorded the defect before it recorded the fix, and the numbers below are the same
+/// measurement read the other way round.
 ///
-/// `confidence` awards 0.25 for role, then 0.55 for an exact `AXIdentifier` and crumbs for
-/// everything else. Measured 2026-08-28 on Logic 12.x: the track-header sliders expose no
-/// `AXIdentifier` at all — the attribute is absent from the element, not empty — and the pan slider
-/// has no `AXTitle` either, because its name lives in `AXHelp`.
-@Suite("Issue290AtlasScoringCeiling")
-struct Issue290AtlasScoringCeilingTests {
+/// The budget awarded 0.55 of a possible 1.0 for an exact `AXIdentifier`, so an element without one
+/// could never exceed 0.45 however much else it matched. Measured 2026-08-28 on Logic 12.x: the
+/// track-header sliders expose no `AXIdentifier` at all — the attribute is absent from the element,
+/// not empty — and the pan slider has no `AXTitle` either, because its name lives in `AXHelp`. A
+/// slider satisfying every predicate its selector named scored **0.40**, and an ordinary-looking
+/// `minimumConfidence: 0.6` refused it.
+///
+/// Lowering thresholds to 0.4 instead would have left the tiers decorative and published a
+/// confidence nothing measures — the shape removed from three other places the same day.
+@Suite("Issue290ScoringNormalisesOverRequestedEvidence")
+struct Issue290ScoringNormalisesOverRequestedEvidenceTests {
 
     /// Transcribed from the live tree, not invented: role, absent identifier, absent title, the
     /// help string that carries the name, and the value range that separates pan from volume.
@@ -258,62 +262,94 @@ struct Issue290AtlasScoringCeilingTests {
         )
     }
 
-    private func selector(minimumConfidence: Double) -> SemanticSelector {
+    private func selector(
+        _ predicates: [AttributePredicate],
+        ancestors: [AncestorConstraint] = [AncestorConstraint(role: "AXLayoutItem")],
+        geometry: GeometryHint? = nil,
+        minimumConfidence: Double = 0.6
+    ) -> SemanticSelector {
         SemanticSelector(
-            id: .mixerStripVolumeFader,
-            requiredRole: "AXSlider",
-            allowedSubroles: [],
-            titleAliases: [:],
-            ancestorConstraints: [AncestorConstraint(role: "AXLayoutItem")],
-            attributePredicates: [
-                .attribute("AXHelp", equals: "패닝 노브 및 밸런스 노브. 트랙 신호를 스테레오 필드에 위치하려면 수직으로 드래그합니다."),
-                .valueSignature("0...127"),
-            ],
-            geometryHint: nil,
-            minimumConfidence: minimumConfidence,
-            ambiguityPolicy: .failClosed
+            id: .mixerStripVolumeFader, requiredRole: "AXSlider", allowedSubroles: [],
+            titleAliases: [:], ancestorConstraints: ancestors,
+            attributePredicates: predicates, geometryHint: geometry,
+            minimumConfidence: minimumConfidence, ambiguityPolicy: .failClosed
         )
     }
 
-    @Test("an element with no AXIdentifier cannot score above the identifier tier")
-    func noIdentifierMeansALowCeiling() {
-        let score = confidence(of: measuredPanSlider, against: selector(minimumConfidence: 0))
-        // Everything this element can offer, awarded: role 0.25 + ancestor 0.08 + attribute 0.05
-        // + value signature 0.02. No identifier, no title, no geometry.
-        #expect(score > 0.39 && score < 0.41, "scored \(score)")
-        #expect(score < 0.55,
-                "the identifier tier alone is worth more than everything this element has")
+    @Test("an element with no identifier resolves when it matches what the selector asked for")
+    func normalisedOverRequestedEvidence() {
+        // The case the budget refused at 0.40. Nothing about the element changed — the selector no
+        // longer has an identifier in its denominator, because it never asked for one.
+        let s = selector([
+            .attributeContains("AXHelp", "밸런스"),
+            .valueSignature("0...127"),
+        ])
+        #expect(confidence(of: measuredPanSlider, against: s) == 1)
+        #expect(resolve(s, in: [measuredPanSlider], locale: "ko") == .exact(index: 0))
     }
 
-    @Test("a minimumConfidence above the ceiling makes the element unresolvable")
-    func aboveTheCeilingIsNotFound() {
-        // 0.6 is an ordinary-looking threshold for "resolve confidently", and it refuses an element
-        // that matched every predicate the selector named.
-        let result = resolve(selector(minimumConfidence: 0.6), in: [measuredPanSlider], locale: "ko")
-        #expect(result == .notFound)
+    @Test("asking for an identifier the element lacks still scores low")
+    func askingForAMissingIdentifierStillCosts() {
+        // The strictness that had to survive. A ratio could have made everything resolve; it does
+        // not, because a selector that names an identifier and does not get one has lost its
+        // strongest evidence and the denominator says so.
+        let s = selector([
+            .axIdentifier("pan-slider"),
+            .attributeContains("AXHelp", "밸런스"),
+            .valueSignature("0...127"),
+        ])
+        let score = confidence(of: measuredPanSlider, against: s)
+        #expect(score < 0.6, "scored \(score); a missing identifier cost nothing")
+        #expect(resolve(s, in: [measuredPanSlider], locale: "ko") == .notFound)
     }
 
-    @Test("the same element with an identifier clears it easily")
-    func withAnIdentifierItResolves() {
-        // The control: the ceiling is about the missing identifier, not about the element being a
-        // poor match. Nothing else changes.
+    @Test("an identifier still dominates when it is there")
+    func identifierStillDominates() {
+        // ADR-007's evidence priority is unchanged: the identifier is the heaviest single tier.
         let withID = ResolvableCandidate(
-            axIdentifier: "pan-slider",
-            role: measuredPanSlider.role,
-            subrole: measuredPanSlider.subrole,
-            title: measuredPanSlider.title,
-            ancestors: measuredPanSlider.ancestors,
-            attributes: measuredPanSlider.attributes,
-            valueSignature: measuredPanSlider.valueSignature,
-            geometry: measuredPanSlider.geometry
+            axIdentifier: "pan-slider", role: "AXSlider", subrole: nil, title: nil,
+            ancestors: measuredPanSlider.ancestors, attributes: [:], valueSignature: nil, geometry: nil
         )
-        var s = selector(minimumConfidence: 0.6)
-        s = SemanticSelector(
-            id: s.id, requiredRole: s.requiredRole, allowedSubroles: s.allowedSubroles,
-            titleAliases: s.titleAliases, ancestorConstraints: s.ancestorConstraints,
-            attributePredicates: s.attributePredicates + [.axIdentifier("pan-slider")],
-            geometryHint: s.geometryHint, minimumConfidence: 0.6, ambiguityPolicy: s.ambiguityPolicy
-        )
+        let s = selector([.axIdentifier("pan-slider")], ancestors: [])
         #expect(resolve(s, in: [withID], locale: "ko") == .exact(index: 0))
+    }
+
+    @Test("role alone cannot identify anything")
+    func roleAloneIsCapped() {
+        // Under a ratio a selector naming ONLY a role matches everything it asked for and would
+        // otherwise score 1.0. "It is a slider" is not an identification.
+        #expect(confidence(of: measuredPanSlider, against: selector([], ancestors: [])) <= 0.49)
+    }
+
+    @Test("geometry alone cannot produce high confidence")
+    func geometryAloneIsCapped() {
+        // ADR-007 acceptance criterion, preserved through the rewrite rather than assumed.
+        let hint = GeometryHint(x: 1, y: 2, width: 3, height: 4)
+        let positioned = ResolvableCandidate(
+            axIdentifier: nil, role: "AXSlider", subrole: nil, title: nil,
+            ancestors: [], attributes: [:], valueSignature: nil, geometry: hint
+        )
+        #expect(confidence(of: positioned, against: selector([], ancestors: [], geometry: hint)) <= 0.49)
+    }
+
+    @Test("containment is what equality could not express")
+    func containmentIsWhatWasMissing() {
+        let help = "패닝 노브 및 밸런스 노브. 트랙 신호를 스테레오 필드에 위치하려면 수직으로 드래그합니다."
+        let byEquality = selector([.attribute("AXHelp", equals: help)])
+        let byContainment = selector([.attributeContains("AXHelp", "밸런스")])
+        #expect(confidence(of: measuredPanSlider, against: byEquality) == 1)
+        #expect(confidence(of: measuredPanSlider, against: byContainment) == 1)
+
+        // The difference is what happens when the sentence changes — a Logic update, another
+        // locale. Equality breaks; containment does not. An equality predicate on a localized
+        // sentence cannot be written for a locale nobody has measured.
+        let reworded = ResolvableCandidate(
+            axIdentifier: nil, role: "AXSlider", subrole: nil, title: nil,
+            ancestors: measuredPanSlider.ancestors,
+            attributes: ["AXHelp": "밸런스 노브입니다."],
+            valueSignature: measuredPanSlider.valueSignature, geometry: nil
+        )
+        #expect(confidence(of: reworded, against: byEquality) < 0.6)
+        #expect(confidence(of: reworded, against: byContainment) == 1)
     }
 }


### PR DESCRIPTION
The budget was the defect, and #699 measured it: `confidence` awarded **0.55 of a possible 1.0** for an exact `AXIdentifier`, so an element without one could never exceed 0.45 however much else it matched. On Logic 12.x the track-header sliders expose no `AXIdentifier` at all — the attribute is absent from the element — and a pan slider satisfying **every predicate its selector named** scored 0.40, which an ordinary-looking `minimumConfidence: 0.6` refused.

A model that cannot resolve the elements the product addresses is not a strict model, it is an unusable one.

## The rejected alternative

Run every selector at `minimumConfidence <= 0.4`. That leaves the tiers decorative and publishes a confidence nothing measures — the shape removed from three other places the same day (`mutation_flips`, `levelConfidence`, the resonance `confidence`). Not adopted on purpose.

## The change

The weights keep ADR-007's evidence priority and become a **ratio: satisfied over requested**.

```
identifier        0.40
ancestor chain    0.20
attributes        0.20
title             0.10
value signature   0.08
geometry          0.02
```

A selector that asks for an identifier and does not get one still scores low, because the identifier is in its denominator. One that asks for role, ancestors and an `AXHelp` substring and gets all three scores 1.0 — which is the truth about that selector and that element.

Three floors, two carried over:

```
wrong role or subrole            0, before anything else is considered
geometry alone                   cannot exceed 0.49  (ADR-007 acceptance criterion)
role alone                       cannot exceed 0.49  (new)
```

The third is new and necessary: under a ratio, a selector naming **only** a role matches everything it asked for and would otherwise score 1.0. "It is a slider" is not an identification.

## `attributeContains`

Equality could not express the evidence Logic offers. The discriminator for a header pan slider is the word `밸런스` inside a sentence; an equality predicate pins the whole localized string, breaks on any rewording, and cannot be written for a locale nobody has measured. The test asserts exactly that difference.

## The suite that recorded the ceiling now records the fix

Same measurement read the other way round — 0.40 and `.notFound` became 1.0 and `.exact`, with the strictness cases beside it so a ratio cannot quietly make everything resolve.

Its own new case caught an implementation bug on the way: the geometry floor identified geometry **by position** in a filtered list, so a selector asking only for an identifier and getting it was capped at 0.49. It is flagged explicitly now.

## Gates

```
public-surface preflight   PASS
ship gate                  PASS
live evidence @ 4c91ecbb   ok
```

Advances #290. Does not close it — the atlas still has zero production consumers; this removes the reason it could not have any.
