### PR TITLE
feat(#290): adopt the atlas at its first production call site

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+Mixer.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+Mixer.swift
@@ -85,8 +85,42 @@ extension AXLogicProElements {
         // searchable text ("볼륨", "볼륨 페이더. …") carries none of `pan` / `panning` / `패닝` /
         // `밸런스`. `sliderText` also excludes send and zoom sliders, which the deleted copy did
         // not — strictly narrower, not wider.
-        sliders.filter { sliderText($0, runtime: runtime).isPanControl }
+        sliders.filter { slider in
+            let candidate = AXResolvableCandidate.make(
+                from: slider, ancestors: ["AXLayoutItem"], runtime: runtime)
+            return resolve(headerPanSelector, in: [candidate], locale: "any") == .exact(index: 0)
+        }
     }
+
+    /// The atlas selector for a track-header pan slider — the FIRST production adoption of
+    /// `SelectorAtlas`.
+    ///
+    /// The atlas had every piece and zero callers, because nothing turned an `AXUIElement` into a
+    /// `ResolvableCandidate` and because the scoring could not clear an ordinary threshold without
+    /// an `AXIdentifier` Logic does not expose here. Both are fixed, so the rules this site runs are
+    /// now the rules the atlas expresses rather than a predicate written beside it.
+    ///
+    /// The evidence is the measured evidence: `AXHelp` carrying one of `sliderPanHint`'s labels,
+    /// and the `0...127` range that separates pan from the volume fader's `0...233` and does not
+    /// depend on locale. `failClosed` is the policy — two candidates are a refusal, which is what
+    /// `findPanControlInHeader` already does and what ADR-007 requires of a mutating path.
+    ///
+    /// `locale: "any"` because the alias set is not keyed by locale here: `attributeContainsAny`
+    /// carries every measured label at once, which is how `AXLocalePolicy` has always matched.
+    static let headerPanSelector = SemanticSelector(
+        id: .mixerStripVolumeFader,
+        requiredRole: kAXSliderRole as String,
+        allowedSubroles: [],
+        titleAliases: [:],
+        ancestorConstraints: [AncestorConstraint(role: "AXLayoutItem")],
+        attributePredicates: [
+            .attributeContainsAny(kAXHelpAttribute as String, AXLocalePolicy.sliderPanHint.labels),
+            .valueSignature("0...127"),
+        ],
+        geometryHint: nil,
+        minimumConfidence: 0.6,
+        ambiguityPolicy: .failClosed
+    )
 
     /// `AXMaxValue` of a track-header pan slider, measured at 127 against the volume fader's 233.
     ///

--- a/Sources/LogicProMCP/SelectorAtlas/AXResolvableCandidate.swift
+++ b/Sources/LogicProMCP/SelectorAtlas/AXResolvableCandidate.swift
@@ -1,0 +1,78 @@
+import ApplicationServices
+import Foundation
+
+/// Builds a `ResolvableCandidate` from a live AX element.
+///
+/// This is what the atlas was missing. `SemanticSelector`, `resolve` and `UIDriftReport` were all
+/// written and none of them could be called from the product, because nothing turned an
+/// `AXUIElement` into the value type they operate on — so every accessor kept its own hand-rolled
+/// predicate and the atlas sat unused beside them.
+///
+/// What it reads, and why each one:
+///
+///   - `AXIdentifier` — the model's strongest evidence. Measured absent on Logic's track-header
+///     elements, which is why the scoring had to stop assuming it.
+///   - role and subrole — the gate; a wrong role scores zero before anything else is considered.
+///   - title, and `AXHelp`/`AXDescription` as attributes. Logic puts a control's NAME in `AXHelp`
+///     on at least the header pan slider, so an adapter that read only title and description would
+///     hand the resolver a candidate with nothing to match.
+///   - `valueSignature` as `min...max`. It is what separates a pan slider (`0...127`) from a volume
+///     fader (`0...233`) on the same header, and unlike the help text it does not depend on locale.
+///   - geometry, last and worth 0.02, because ADR-007 says geometry alone cannot identify anything.
+enum AXResolvableCandidate {
+
+    /// Attributes the adapter publishes into `ResolvableCandidate.attributes`.
+    ///
+    /// A fixed list rather than "every attribute the element has": the selector names what it wants
+    /// by key, and an open-ended dictionary would make a selector's meaning depend on which
+    /// attributes a particular Logic build happens to expose.
+    static let publishedAttributes = [
+        kAXHelpAttribute as String,
+        kAXDescriptionAttribute as String,
+        kAXRoleDescriptionAttribute as String,
+    ]
+
+    static func make(
+        from element: AXUIElement,
+        ancestors: [String] = [],
+        runtime: AXHelpers.Runtime = .production
+    ) -> ResolvableCandidate {
+        var attributes: [String: String] = [:]
+        for name in publishedAttributes {
+            if let value: String = AXHelpers.getAttribute(element, name, runtime: runtime),
+               !value.isEmpty {
+                attributes[name] = value
+            }
+        }
+
+        let minValue: Double? = AXHelpers.getAttribute(
+            element, kAXMinValueAttribute as String, runtime: runtime)
+        let maxValue: Double? = AXHelpers.getAttribute(
+            element, kAXMaxValueAttribute as String, runtime: runtime)
+        // Only when BOTH bounds read. A half-known range is not a signature, and formatting one
+        // would let a selector match on a number the element never reported.
+        var signature: String?
+        if let low = minValue, let high = maxValue {
+            signature = "\(Self.trim(low))...\(Self.trim(high))"
+        }
+
+        return ResolvableCandidate(
+            axIdentifier: AXHelpers.getIdentifier(element, runtime: runtime),
+            role: AXHelpers.getRole(element, runtime: runtime) ?? "",
+            subrole: AXHelpers.getAttribute(element, kAXSubroleAttribute as String, runtime: runtime),
+            title: AXHelpers.getTitle(element, runtime: runtime),
+            ancestors: ancestors,
+            attributes: attributes,
+            valueSignature: signature,
+            geometry: nil
+        )
+    }
+
+    /// `0...127`, not `0.0...127.0`. The signature is compared as a string, so its formatting is
+    /// part of the contract a selector writes against.
+    private static func trim(_ value: Double) -> String {
+        value == value.rounded() && abs(value) < 1e15
+            ? String(Int(value))
+            : String(value)
+    }
+}

--- a/Sources/LogicProMCP/SelectorAtlas/SelectorResolver.swift
+++ b/Sources/LogicProMCP/SelectorAtlas/SelectorResolver.swift
@@ -72,6 +72,10 @@ private func supportsSchema(
             !value.isEmpty
         case let .attribute(name, equals: value), let .attributeContains(name, value):
             !name.isEmpty && !value.isEmpty
+        case let .attributeContainsAny(name, values):
+            // An empty alternative list can never match, and an empty needle matches everything —
+            // both are a selector that cannot mean what it says.
+            !name.isEmpty && !values.isEmpty && values.allSatisfy { !$0.isEmpty }
         }
     }
 }

--- a/Sources/LogicProMCP/SelectorAtlas/SemanticSelector.swift
+++ b/Sources/LogicProMCP/SelectorAtlas/SemanticSelector.swift
@@ -27,6 +27,15 @@ enum AttributePredicate: Equatable, Sendable {
     /// any wording change and cannot be written for a locale nobody has measured.
     case attributeContains(String, String)
 
+    /// Substring match against ANY of several alternatives, case-insensitively.
+    ///
+    /// Multiple `attributeContains` predicates are ANDed, which cannot express what a locale set
+    /// is: the header pan slider is identified by `AXHelp` containing any one of
+    /// `pan` / `panning` / `패닝` / `밸런스`, and requiring all four matches nothing in any locale.
+    /// This is the atlas gaining the primitive the product already uses everywhere else —
+    /// `AXLocalePolicy.LabelSet.containsAny`.
+    case attributeContainsAny(String, [String])
+
     case valueSignature(String)
 }
 
@@ -104,11 +113,23 @@ func confidence(of candidate: ResolvableCandidate, against selector: SemanticSel
         guard case let .attributeContains(name, expected) = predicate else { return nil }
         return (name, expected)
     }
-    evidence.append((0.20, !equals.isEmpty || !contains.isEmpty,
+    let containsAny = selector.attributePredicates.compactMap { predicate -> (String, [String])? in
+        guard case let .attributeContainsAny(name, needles) = predicate else { return nil }
+        return (name, needles)
+    }
+    evidence.append((0.20, !equals.isEmpty || !contains.isEmpty || !containsAny.isEmpty,
                      equals.allSatisfy { candidate.attributes[$0.0] == $0.1 }
                          && contains.allSatisfy { name, needle in
                              candidate.attributes[name].map {
                                  $0.range(of: needle, options: [.caseInsensitive]) != nil
+                             } ?? false
+                         }
+                         && containsAny.allSatisfy { name, needles in
+                             candidate.attributes[name].map { value in
+                                 needles.contains {
+                                     !$0.isEmpty
+                                         && value.range(of: $0, options: [.caseInsensitive]) != nil
+                                 }
                              } ?? false
                          }, false))
 


### PR DESCRIPTION
The atlas had every piece and **zero callers**. Two things stopped it having any; both are fixed here, and a real accessor now runs through it.

## Missing adapter

Nothing turned an `AXUIElement` into the `ResolvableCandidate` the resolver operates on, so no call site could reach `resolve` even in principle. That is the whole reason every accessor kept its own hand-rolled predicate.

`AXResolvableCandidate.make` does it, and what it reads is what was **measured** rather than what seemed natural:

- identifier, role, subrole, title
- `AXHelp` / `AXDescription` / `AXRoleDescription` as attributes — Logic puts a control's **name** in `AXHelp` on the header pan slider, so an adapter reading only title and description would hand the resolver a candidate with nothing to match
- `valueSignature` as `min...max`, and only when **both** bounds read; a half-known range would let a selector match on a number the element never reported

## Missing vocabulary

Multiple `attributeContains` predicates are ANDed, which cannot express a locale set: the pan slider is `AXHelp` containing any **one** of `pan` / `panning` / `패닝` / `밸런스`, and requiring all four matches nothing in any locale.

`attributeContainsAny` is the atlas gaining the primitive `AXLocalePolicy.LabelSet.containsAny` has always been.

## The adoption

`headerPanSliderCandidates` now runs `resolve` against `headerPanSelector`, whose evidence is the measured evidence — the help-text alias set, and the `0...127` range that separates pan from the volume fader's `0...233` and does not depend on locale — with `failClosed`, which is what the site already did.

## Behaviour preserved, mechanism changed — verified, not assumed

```
census, findPanControlInHeader   gathered 2   survivors 1   unambiguous
set_pan on track 1               state A, reached_target, and only track 1 moved
```

The unit suite for this site passes **unchanged**, which is the point: the rules it asserts are now the rules the atlas expresses rather than a predicate written beside it.

## Scope

One site, not all of them. `findVolumeFader`, `findTrackToggleControl` and `getTransportBar` still resolve through their own predicates, and #290 stays open until they do not — but the pattern is now proven end to end instead of proposed.

```
public-surface preflight   PASS
ship gate                  PASS
live evidence @ 904de73a   ok
```
