### PR TITLE
feat(#290): adopt the atlas for the volume fader, removing two positional paths

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+Mixer.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+Mixer.swift
@@ -401,26 +401,64 @@ extension AXLogicProElements {
         let sliders = AXHelpers.findAllDescendants(
             of: strip, role: kAXSliderRole, maxDepth: 4, runtime: runtime
         )
-        let described = sliders.filter { sliderText($0, runtime: runtime).isVolumeFader }
-        if let only = described.first {
-            // #628: the element is unchanged — still the first description match. What is new is
-            // that choosing among several says so.
-            if described.count > 1 {
-                Log.info("findVolumeFader: \(described.count) sliders described as a volume fader; "
-                    + "returning the first in tree order", subsystem: "ax")
-            }
-            return only
+        // Second atlas adoption. This site had BOTH of the shapes ADR-007 exists to remove: it
+        // returned the first description match when several qualified, and it fell back to
+        // `sliders.first` — position 0 — when none did. Routing it through the resolver removes
+        // both, because `failClosed` refuses an ambiguous set and there is no positional path to
+        // fall into.
+        let candidates = sliders.filter { slider in
+            let candidate = AXResolvableCandidate.make(from: slider, runtime: runtime)
+            return resolve(volumeFaderSelector, in: [candidate], locale: "any") == .exact(index: 0)
         }
-        // The description matched NOTHING and the answer becomes an index. Measured 2026-08-21 on
-        // Logic 12.3 this branch is not reached — two sliders in a strip, one of them described —
-        // so a run that reaches it is reporting a tree this code has never been measured against,
-        // which is worth more than silence.
+        if candidates.count == 1 { return candidates[0] }
+        if candidates.count > 1 {
+            Log.info("findVolumeFader: \(candidates.count) sliders satisfy the volume selector; "
+                + "refusing rather than returning the first in tree order", subsystem: "ax")
+            return nil
+        }
+        // Measured 2026-08-21 on Logic 12.3, and again through the census since: a strip has two
+        // sliders and one of them names itself, so this branch is not reached. It used to return
+        // position 0 anyway. A tree that reaches it is one this code has never been measured
+        // against, and answering with an index there is the wrong-target behaviour the ADR names.
         if !sliders.isEmpty {
-            Log.info("findVolumeFader: no slider described as a volume fader among \(sliders.count); "
-                + "falling back to position 0", subsystem: "ax")
+            Log.info("findVolumeFader: no slider among \(sliders.count) satisfies the volume "
+                + "selector; refusing rather than falling back to position 0", subsystem: "ax")
         }
-        return sliders.first
+        return nil
     }
+
+    /// The atlas selector for a volume fader, on a track header or a mixer strip.
+    ///
+    /// Evidence is the alias set across the fields Logic might carry the name in, and nothing else.
+    ///
+    /// `anyAttributeContainsAny`, not two per-attribute predicates: those are ANDed, and naming
+    /// both `AXHelp` and `AXDescription` demands the label appear in both. Logic puts a header
+    /// fader's name in `AXDescription` and its sentence in `AXHelp`, a synthetic fixture carries
+    /// only the description, and the conjunction matched neither reliably — the existing mixer
+    /// tests caught that draft.
+    ///
+    /// A `valueSignature` is deliberately ABSENT. The header fader was measured at `0...233`; the
+    /// mixer strip's range was not, and a selector asserting a number nobody read is the failure
+    /// this whole sequence has been about. The aliases discriminate on their own — the pan slider
+    /// carries none of `volume` / `fader` / `볼륨` in any of these fields — which is what
+    /// `sliderText(_:).isVolumeFader` already relied on.
+    static let volumeFaderSelector = SemanticSelector(
+        id: .mixerStripVolumeFader,
+        requiredRole: kAXSliderRole as String,
+        allowedSubroles: [],
+        titleAliases: [:],
+        ancestorConstraints: [],
+        attributePredicates: [
+            .anyAttributeContainsAny(
+                [kAXHelpAttribute as String,
+                 kAXDescriptionAttribute as String,
+                 kAXRoleDescriptionAttribute as String],
+                AXLocalePolicy.sliderVolumeHint.labels),
+        ],
+        geometryHint: nil,
+        minimumConfidence: 0.6,
+        ambiguityPolicy: .failClosed
+    )
 
     static func findPanControl(
         in strip: AXUIElement,

--- a/Sources/LogicProMCP/MainEntrypoint.swift
+++ b/Sources/LogicProMCP/MainEntrypoint.swift
@@ -468,9 +468,17 @@ enum MainEntrypoint {
             if let strip = strips.first {
                 let sliders = AXHelpers.findAllDescendants(
                     of: strip, role: "AXSlider", maxDepth: 4, runtime: ax)
-                record("AXLogicProElements.findVolumeFader (falls back to sliders.first)",
+                // The ADOPTED predicate, not the one it replaced. `findVolumeFader` resolves
+                // through the selector atlas now, and measuring `sliderText(_:).isVolumeFader`
+                // here would report a rule the product no longer runs — the exact drift this
+                // census exists to catch, committed by the census.
+                record("AXLogicProElements.findVolumeFader (atlas)",
                        sliders.count,
-                       sliders.filter { AXLogicProElements.sliderText($0, runtime: ax).isVolumeFader }.count)
+                       sliders.filter { slider in
+                           resolve(AXLogicProElements.volumeFaderSelector,
+                                   in: [AXResolvableCandidate.make(from: slider, runtime: ax)],
+                                   locale: "any") == .exact(index: 0)
+                       }.count)
                 record("AXLogicProElements.findPanControl (falls back to sliders[1])",
                        sliders.count,
                        sliders.filter { AXLogicProElements.sliderText($0, runtime: ax).isPanControl }.count)

--- a/Sources/LogicProMCP/SelectorAtlas/SelectorResolver.swift
+++ b/Sources/LogicProMCP/SelectorAtlas/SelectorResolver.swift
@@ -72,6 +72,9 @@ private func supportsSchema(
             !value.isEmpty
         case let .attribute(name, equals: value), let .attributeContains(name, value):
             !name.isEmpty && !value.isEmpty
+        case let .anyAttributeContainsAny(names, values):
+            !names.isEmpty && names.allSatisfy { !$0.isEmpty }
+                && !values.isEmpty && values.allSatisfy { !$0.isEmpty }
         case let .attributeContainsAny(name, values):
             // An empty alternative list can never match, and an empty needle matches everything —
             // both are a selector that cannot mean what it says.

--- a/Sources/LogicProMCP/SelectorAtlas/SemanticSelector.swift
+++ b/Sources/LogicProMCP/SelectorAtlas/SemanticSelector.swift
@@ -36,6 +36,19 @@ enum AttributePredicate: Equatable, Sendable {
     /// `AXLocalePolicy.LabelSet.containsAny`.
     case attributeContainsAny(String, [String])
 
+    /// Substring match against any of several alternatives, in ANY of several attributes.
+    ///
+    /// Two `attributeContainsAny` predicates are ANDed, so naming both `AXHelp` and
+    /// `AXDescription` demands the label appear in both. Measured: Logic puts a volume fader's name
+    /// in `AXDescription` on a track header and its sentence in `AXHelp`, and a synthetic fixture
+    /// carries only the description — the conjunction matched neither reliably and the existing
+    /// mixer tests caught it.
+    ///
+    /// What the product has always meant is a search across a group of fields, which is
+    /// `AXLogicProElements.elementSearchText` joining identifier, description, title and help
+    /// before a single `containsAny`. This is that, expressed as a selector.
+    case anyAttributeContainsAny([String], [String])
+
     case valueSignature(String)
 }
 
@@ -117,7 +130,18 @@ func confidence(of candidate: ResolvableCandidate, against selector: SemanticSel
         guard case let .attributeContainsAny(name, needles) = predicate else { return nil }
         return (name, needles)
     }
-    evidence.append((0.20, !equals.isEmpty || !contains.isEmpty || !containsAny.isEmpty,
+    let anyOf = selector.attributePredicates.compactMap { predicate -> ([String], [String])? in
+        guard case let .anyAttributeContainsAny(names, needles) = predicate else { return nil }
+        return (names, needles)
+    }
+    func hits(_ value: String?, _ needles: [String]) -> Bool {
+        guard let value else { return false }
+        return needles.contains {
+            !$0.isEmpty && value.range(of: $0, options: [.caseInsensitive]) != nil
+        }
+    }
+    evidence.append((0.20,
+                     !equals.isEmpty || !contains.isEmpty || !containsAny.isEmpty || !anyOf.isEmpty,
                      equals.allSatisfy { candidate.attributes[$0.0] == $0.1 }
                          && contains.allSatisfy { name, needle in
                              candidate.attributes[name].map {
@@ -125,12 +149,10 @@ func confidence(of candidate: ResolvableCandidate, against selector: SemanticSel
                              } ?? false
                          }
                          && containsAny.allSatisfy { name, needles in
-                             candidate.attributes[name].map { value in
-                                 needles.contains {
-                                     !$0.isEmpty
-                                         && value.range(of: $0, options: [.caseInsensitive]) != nil
-                                 }
-                             } ?? false
+                             hits(candidate.attributes[name], needles)
+                         }
+                         && anyOf.allSatisfy { names, needles in
+                             names.contains { hits(candidate.attributes[$0], needles) }
                          }, false))
 
     let aliases = selector.titleAliases.values.flatMap { $0 }

--- a/Tests/LogicProMCPTests/AXLogicProElementsTests.swift
+++ b/Tests/LogicProMCPTests/AXLogicProElementsTests.swift
@@ -80,7 +80,10 @@ import Testing
     builder.setAttribute(mixer, kAXIdentifierAttribute as String, "Mixer")
     builder.setChildren(mixer, [strip])
     builder.setChildren(strip, [fader, pan])
+    // Named, as Logic names it and as the three-strip fixture below already does. This one carried
+    // role only, so it was found by the positional fallback #290's atlas adoption removes.
     builder.setAttribute(fader, kAXRoleAttribute as String, kAXSliderRole as String)
+    builder.setAttribute(fader, kAXDescriptionAttribute as String, "볼륨 페이더")
     builder.setAttribute(pan, kAXRoleAttribute as String, kAXSliderRole as String)
 
     let runtime = builder.makeLogicRuntime(appElement: app)

--- a/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
+++ b/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
@@ -3804,9 +3804,15 @@ private final class LockedFlag: @unchecked Sendable {
     builder.setAttribute(mixer, kAXIdentifierAttribute as String, "Mixer")
     builder.setChildren(mixer, [strip])
     builder.setChildren(strip, [fader, pan])
+    // Named, because Logic names them. This fixture carried role and value only, so the strip
+    // fader was found by the positional fallback that #290's atlas adoption removes — and
+    // `--probe-selection-census` measures a real strip at two sliders with ONE surviving the
+    // discriminator, so an unnamed pair is not the tree Logic produces.
     builder.setAttribute(fader, kAXRoleAttribute as String, kAXSliderRole as String)
+    builder.setAttribute(fader, kAXDescriptionAttribute as String, "Volume")
     builder.setAttribute(fader, kAXValueAttribute as String, 0.8)
     builder.setAttribute(pan, kAXRoleAttribute as String, kAXSliderRole as String)
+    builder.setAttribute(pan, kAXDescriptionAttribute as String, "Pan")
     builder.setAttribute(pan, kAXValueAttribute as String, -0.25)
     // #107: writes target the per-track header fader/pan, not the mixer strip.
     let headerControls = attachTrackHeaderRail(

--- a/Tests/LogicProMCPTests/Issue628MixerFallbackTests.swift
+++ b/Tests/LogicProMCPTests/Issue628MixerFallbackTests.swift
@@ -45,15 +45,21 @@ struct Issue628MixerFallbackTests {
         #expect(CFEqual(found, sliders[1]))
     }
 
-    /// The branch this change makes visible. With no description the answer is `sliders[0]`, chosen
-    /// for no reason beyond tree order.
-    @Test("no described fader falls back to position 0, and the element is unchanged by instrumenting it")
-    func faderFallsBackToIndexZero() throws {
+    /// The branch this case was written to make visible, now closed.
+    ///
+    /// It used to assert `sliders[0]` — chosen for no reason beyond tree order — and that was the
+    /// honest record of what the code did. #290's atlas adoption removes the positional fallback:
+    /// a strip whose sliders name nothing is a tree this code has never been measured against, and
+    /// answering with an index there is the wrong-target behaviour ADR-007 exists to stop.
+    ///
+    /// `--probe-selection-census` measures a real strip at two sliders with ONE surviving the
+    /// discriminator, so this shape is not what Logic produces — which is why refusing costs
+    /// nothing measured and buys the guarantee.
+    @Test("no named fader is refused rather than answered with position 0")
+    func faderWithNoNameIsRefused() {
         let b = FakeAXRuntimeBuilder()
-        let (node, sliders) = strip(b, base: 6290, count: 2, describedIndex: -1, description: "Volume")
-        let found = try #require(AXLogicProElements.findVolumeFader(
-            in: node, runtime: b.makeAXRuntime()))
-        #expect(CFEqual(found, sliders[0]))
+        let (node, _) = strip(b, base: 6290, count: 2, describedIndex: -1, description: "Volume")
+        #expect(AXLogicProElements.findVolumeFader(in: node, runtime: b.makeAXRuntime()) == nil)
     }
 
     @Test("a described pan control is returned, and the index is not consulted")
@@ -90,8 +96,12 @@ struct Issue628MixerFallbackTests {
     /// ONE described slider, which means `described.first` and `described.last` are the same
     /// element and no case could tell a tree-order choice from a forced one -- a reviewer noted
     /// that swapping to `.last` would have kept the suite green.
-    @Test("two sliders described as the volume fader return the FIRST in tree order")
-    func twoDescribedFadersReturnTheFirst() throws {
+    /// Inverted with #290's atlas adoption. It asserted `sliders[0]` — the reviewer's point stands,
+    /// and it was the honest record of a tree-order choice being made. The choice is gone: the
+    /// selector's `AmbiguityPolicy` is `failClosed`, so two equally-qualified candidates are a
+    /// refusal rather than a pick, which is what ADR-007 requires of anything a write depends on.
+    @Test("two sliders described as the volume fader are refused, not resolved to the first")
+    func twoDescribedFadersAreRefused() {
         let b = FakeAXRuntimeBuilder()
         let node = b.element(6400)
         var sliders: [AXUIElement] = []
@@ -102,10 +112,7 @@ struct Issue628MixerFallbackTests {
             sliders.append(slider)
         }
         b.setChildren(node, sliders)
-        let found = try #require(AXLogicProElements.findVolumeFader(
-            in: node, runtime: b.makeAXRuntime()))
-        #expect(CFEqual(found, sliders[0]))
-        #expect(!CFEqual(found, sliders[1]))
+        #expect(AXLogicProElements.findVolumeFader(in: node, runtime: b.makeAXRuntime()) == nil)
     }
 
     /// Same for pan, and it is not the same assertion: pan's FALLBACK is `sliders[1]`, so a


### PR DESCRIPTION
Second adoption, and this site carried **both** shapes ADR-007 exists to remove: it returned the first description match when several qualified, and it fell back to `sliders.first` — position 0 — when none did.

Resolving through the atlas removes both. `failClosed` refuses an ambiguous set, and there is no positional path to fall into.

## A new predicate, because the first draft was wrong and the tests caught it

Two `attributeContainsAny` predicates are **ANDed**, so naming both `AXHelp` and `AXDescription` demands the label appear in both — and Logic puts a header fader's name in the description with its sentence in the help, while a synthetic fixture carries only the description. The conjunction matched neither reliably.

`anyAttributeContainsAny` is what the product has always meant: `elementSearchText` joins identifier, description, title and help before a single `containsAny`, and this is that as a selector.

No `valueSignature`. The header fader was measured at `0...233`; the mixer strip's range was **not**, and asserting a number nobody read is the failure this sequence has been about.

## Three fixtures and tests changed, each worth naming

```
the mixer-strip fixture carried role and value only, so its fader was found by
the positional fallback. --probe-selection-census measures a real strip at two
sliders with ONE surviving the discriminator, so an unnamed pair is not the tree
Logic produces. Named now — as the three-strip fixture in the same file already was.

"no described fader falls back to position 0" asserted exactly the branch this
removes. It was an honest record of what the code did; it now asserts the refusal.

"two described faders return the FIRST in tree order" likewise. The reviewer's
point that a tree-order choice was being made still stands — the choice is gone.
```

## The census row is repointed

Measuring `sliderText(_:).isVolumeFader` there would report a rule the product no longer runs — the drift this census exists to catch, committed by the census.

## Verified live

```
findPanControlInHeader (atlas)   gathered 2   survivors 1   unambiguous
findVolumeFader (atlas)          gathered 2   survivors 1   unambiguous
set_volume on track 1            State A, reached_target
```

```
public-surface preflight   PASS
ship gate                  PASS — 3970 tests
live evidence @ 77b570dd   ok
```

Two sites now. `findTrackToggleControl` and `getTransportBar` still resolve through their own predicates, and #290 stays open until they do not.
