### PR TITLE
refactor(#290): give the atlas the product's match modes, and adopt the toggles

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+Mixer.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+Mixer.swift
@@ -114,7 +114,10 @@ extension AXLogicProElements {
         titleAliases: [:],
         ancestorConstraints: [AncestorConstraint(role: "AXLayoutItem")],
         attributePredicates: [
-            .attributeContainsAny(kAXHelpAttribute as String, AXLocalePolicy.sliderPanHint.labels),
+            .attributes([kAXHelpAttribute as String,
+                         kAXDescriptionAttribute as String,
+                         kAXRoleDescriptionAttribute as String],
+                        anyOf: AXLocalePolicy.sliderPanHint.labels, mode: .contains),
             .valueSignature("0...127"),
         ],
         geometryHint: nil,
@@ -449,11 +452,10 @@ extension AXLogicProElements {
         titleAliases: [:],
         ancestorConstraints: [],
         attributePredicates: [
-            .anyAttributeContainsAny(
-                [kAXHelpAttribute as String,
-                 kAXDescriptionAttribute as String,
-                 kAXRoleDescriptionAttribute as String],
-                AXLocalePolicy.sliderVolumeHint.labels),
+            .attributes([kAXHelpAttribute as String,
+                         kAXDescriptionAttribute as String,
+                         kAXRoleDescriptionAttribute as String],
+                        anyOf: AXLocalePolicy.sliderVolumeHint.labels, mode: .contains),
         ],
         geometryHint: nil,
         minimumConfidence: 0.6,

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+Tracks.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+Tracks.swift
@@ -449,12 +449,40 @@ extension AXLogicProElements {
         labels: [String],
         runtime: AXHelpers.Runtime = .production
     ) -> [AXUIElement] {
-        checkboxes.filter { cb in
-            guard let desc = AXHelpers.getDescription(cb, runtime: runtime) else { return false }
-            // Exact match preserves the historical arm locator semantics;
-            // prefix match tolerates trailing state suffixes some builds append.
-            return labels.contains(desc) || labels.contains { !$0.isEmpty && desc.hasPrefix($0) }
+        // Third atlas adoption. The predicate is unchanged in MEANING — `.prefix` in
+        // `AXLocalePolicy.MatchMode` is exact-or-prefix, which is what the two clauses here spelled
+        // out: exact preserves the historical arm locator semantics, prefix tolerates the trailing
+        // state suffixes some Logic builds append to a checkbox description.
+        //
+        // Expressing it as a selector is what changes. `failClosed` means the caller can refuse an
+        // ambiguous set instead of taking `.first`, and the rule now lives where the drift report
+        // and the census can both read it.
+        let selector = toggleSelector(labels: labels)
+        return checkboxes.filter { checkbox in
+            let candidate = AXResolvableCandidate.make(from: checkbox, runtime: runtime)
+            return resolve(selector, in: [candidate], locale: "any") == .exact(index: 0)
         }
+    }
+
+    /// The atlas selector for a track-header toggle, built for a caller's label set.
+    ///
+    /// Parameterised because the site is: mute, solo and record-arm are the same locator with three
+    /// fixed `AXLocalePolicy` sets, which is what let `--probe-selection-census` measure all three
+    /// once their callers were enumerated.
+    static func toggleSelector(labels: [String]) -> SemanticSelector {
+        SemanticSelector(
+            id: .trackHeaderNameField,
+            requiredRole: kAXCheckBoxRole as String,
+            allowedSubroles: [],
+            titleAliases: [:],
+            ancestorConstraints: [],
+            attributePredicates: [
+                .attributes([kAXDescriptionAttribute as String], anyOf: labels, mode: .prefix),
+            ],
+            geometryHint: nil,
+            minimumConfidence: 0.6,
+            ambiguityPolicy: .failClosed
+        )
     }
 
     static func findTrackToggleControl(

--- a/Sources/LogicProMCP/MainEntrypoint.swift
+++ b/Sources/LogicProMCP/MainEntrypoint.swift
@@ -430,7 +430,10 @@ enum MainEntrypoint {
                     ("AXLogicProElements.findTrackArmButton",
                      AXLocalePolicy.trackRecordEnableCheckbox.labels),
                 ] {
-                    record(site, boxes.count,
+                    // Still the product's own predicate — `trackToggleCandidates` resolves through
+                    // the selector atlas now, and this calls it rather than a copy, which is the
+                    // rule this census has enforced on itself since it was written.
+                    record(site + " (atlas)", boxes.count,
                            AXLogicProElements.trackToggleCandidates(
                                among: boxes, labels: labels, runtime: ax).count)
                 }

--- a/Sources/LogicProMCP/SelectorAtlas/SelectorResolver.swift
+++ b/Sources/LogicProMCP/SelectorAtlas/SelectorResolver.swift
@@ -70,15 +70,12 @@ private func supportsSchema(
         switch predicate {
         case let .axIdentifier(value), let .valueSignature(value):
             !value.isEmpty
-        case let .attribute(name, equals: value), let .attributeContains(name, value):
-            !name.isEmpty && !value.isEmpty
-        case let .anyAttributeContainsAny(names, values):
+        case let .attributes(names, anyOf: labels, mode: _):
+            // An empty attribute list can never match, an empty label list can never match, and an
+            // empty label matches everything — all three are a selector that cannot mean what it
+            // says.
             !names.isEmpty && names.allSatisfy { !$0.isEmpty }
-                && !values.isEmpty && values.allSatisfy { !$0.isEmpty }
-        case let .attributeContainsAny(name, values):
-            // An empty alternative list can never match, and an empty needle matches everything —
-            // both are a selector that cannot mean what it says.
-            !name.isEmpty && !values.isEmpty && values.allSatisfy { !$0.isEmpty }
+                && !labels.isEmpty && labels.allSatisfy { !$0.isEmpty }
         }
     }
 }

--- a/Sources/LogicProMCP/SelectorAtlas/SemanticSelector.swift
+++ b/Sources/LogicProMCP/SelectorAtlas/SemanticSelector.swift
@@ -16,38 +16,24 @@ struct AncestorConstraint: Equatable, Sendable {
 
 enum AttributePredicate: Equatable, Sendable {
     case axIdentifier(String)
-    case attribute(String, equals: String)
 
-    /// Substring match on an attribute, case-insensitively.
+    /// Any of `attributes` matching any of `labels` under `mode`.
     ///
-    /// Added because equality could not express the evidence Logic actually offers. The
-    /// discriminator that identifies a track-header pan slider is the word `밸런스` inside an
-    /// `AXHelp` that reads "패닝 노브 및 밸런스 노브. 트랙 신호를 스테레오 필드에 위치하려면 수직으로
-    /// 드래그합니다." — an equality predicate there pins a whole localized sentence, so it breaks on
-    /// any wording change and cannot be written for a locale nobody has measured.
-    case attributeContains(String, String)
-
-    /// Substring match against ANY of several alternatives, case-insensitively.
+    /// One predicate with a mode, rather than one case per matching style. Four had accumulated —
+    /// equality, containment, containment-against-a-set, and containment across a set of attributes
+    /// — each added when a call site needed it, and the toggle locators would have needed a fifth
+    /// for exact-or-prefix. That is the atlas becoming a union of the ad-hoc rules it exists to
+    /// replace.
     ///
-    /// Multiple `attributeContains` predicates are ANDed, which cannot express what a locale set
-    /// is: the header pan slider is identified by `AXHelp` containing any one of
-    /// `pan` / `panning` / `패닝` / `밸런스`, and requiring all four matches nothing in any locale.
-    /// This is the atlas gaining the primitive the product already uses everywhere else —
-    /// `AXLocalePolicy.LabelSet.containsAny`.
-    case attributeContainsAny(String, [String])
-
-    /// Substring match against any of several alternatives, in ANY of several attributes.
+    /// The mode is `AXLocalePolicy.MatchMode`, which the product has always had and which already
+    /// enumerates exactly these: `.exact` trims and compares, `.exactStrict` compares verbatim,
+    /// `.prefix` tolerates the trailing state suffixes some Logic builds append to a checkbox
+    /// description, `.contains` is a substring. Reusing it means a selector and the accessor it
+    /// replaces can express the same rule, which is the whole point of adopting one over the other.
     ///
-    /// Two `attributeContainsAny` predicates are ANDed, so naming both `AXHelp` and
-    /// `AXDescription` demands the label appear in both. Measured: Logic puts a volume fader's name
-    /// in `AXDescription` on a track header and its sentence in `AXHelp`, and a synthetic fixture
-    /// carries only the description — the conjunction matched neither reliably and the existing
-    /// mixer tests caught it.
-    ///
-    /// What the product has always meant is a search across a group of fields, which is
-    /// `AXLogicProElements.elementSearchText` joining identifier, description, title and help
-    /// before a single `containsAny`. This is that, expressed as a selector.
-    case anyAttributeContainsAny([String], [String])
+    /// Multiple attributes are ORed and multiple labels are ORed — a name may live in `AXHelp` on
+    /// one control and `AXDescription` on another, which is measured, not assumed.
+    case attributes([String], anyOf: [String], mode: AXLocalePolicy.MatchMode)
 
     case valueSignature(String)
 }
@@ -118,42 +104,24 @@ func confidence(of candidate: ResolvableCandidate, against selector: SemanticSel
     evidence.append((0.20, !selector.ancestorConstraints.isEmpty,
                      matchesAncestorChain(candidate.ancestors, selector.ancestorConstraints), false))
 
-    let equals = selector.attributePredicates.compactMap { predicate -> (String, String)? in
-        guard case let .attribute(name, expected) = predicate else { return nil }
-        return (name, expected)
+    let attributeRules = selector.attributePredicates.compactMap {
+        predicate -> ([String], [String], AXLocalePolicy.MatchMode)? in
+        guard case let .attributes(names, anyOf: labels, mode: mode) = predicate else { return nil }
+        return (names, labels, mode)
     }
-    let contains = selector.attributePredicates.compactMap { predicate -> (String, String)? in
-        guard case let .attributeContains(name, expected) = predicate else { return nil }
-        return (name, expected)
-    }
-    let containsAny = selector.attributePredicates.compactMap { predicate -> (String, [String])? in
-        guard case let .attributeContainsAny(name, needles) = predicate else { return nil }
-        return (name, needles)
-    }
-    let anyOf = selector.attributePredicates.compactMap { predicate -> ([String], [String])? in
-        guard case let .anyAttributeContainsAny(names, needles) = predicate else { return nil }
-        return (names, needles)
-    }
-    func hits(_ value: String?, _ needles: [String]) -> Bool {
-        guard let value else { return false }
-        return needles.contains {
-            !$0.isEmpty && value.range(of: $0, options: [.caseInsensitive]) != nil
-        }
-    }
-    evidence.append((0.20,
-                     !equals.isEmpty || !contains.isEmpty || !containsAny.isEmpty || !anyOf.isEmpty,
-                     equals.allSatisfy { candidate.attributes[$0.0] == $0.1 }
-                         && contains.allSatisfy { name, needle in
-                             candidate.attributes[name].map {
-                                 $0.range(of: needle, options: [.caseInsensitive]) != nil
-                             } ?? false
+    evidence.append((0.20, !attributeRules.isEmpty,
+                     attributeRules.allSatisfy { names, labels, mode in
+                         let set = AXLocalePolicy.LabelSet(
+                             canonical: labels.first ?? "",
+                             variants: Array(labels.dropFirst()),
+                             rationale: "selector predicate")
+                         return names.contains { name in
+                             guard let value = candidate.attributes[name] else { return false }
+                             return mode == .contains
+                                 ? set.containsAny(in: value)
+                                 : set.matches(value, mode: mode)
                          }
-                         && containsAny.allSatisfy { name, needles in
-                             hits(candidate.attributes[name], needles)
-                         }
-                         && anyOf.allSatisfy { names, needles in
-                             names.contains { hits(candidate.attributes[$0], needles) }
-                         }, false))
+                     }, false))
 
     let aliases = selector.titleAliases.values.flatMap { $0 }
     evidence.append((0.10, !aliases.isEmpty,

--- a/Tests/LogicProMCPTests/SelectorAtlasTests.swift
+++ b/Tests/LogicProMCPTests/SelectorAtlasTests.swift
@@ -281,7 +281,7 @@ struct Issue290ScoringNormalisesOverRequestedEvidenceTests {
         // The case the budget refused at 0.40. Nothing about the element changed — the selector no
         // longer has an identifier in its denominator, because it never asked for one.
         let s = selector([
-            .attributeContains("AXHelp", "밸런스"),
+            .attributes(["AXHelp"], anyOf: ["밸런스"], mode: .contains),
             .valueSignature("0...127"),
         ])
         #expect(confidence(of: measuredPanSlider, against: s) == 1)
@@ -295,7 +295,7 @@ struct Issue290ScoringNormalisesOverRequestedEvidenceTests {
         // strongest evidence and the denominator says so.
         let s = selector([
             .axIdentifier("pan-slider"),
-            .attributeContains("AXHelp", "밸런스"),
+            .attributes(["AXHelp"], anyOf: ["밸런스"], mode: .contains),
             .valueSignature("0...127"),
         ])
         let score = confidence(of: measuredPanSlider, against: s)
@@ -335,8 +335,8 @@ struct Issue290ScoringNormalisesOverRequestedEvidenceTests {
     @Test("containment is what equality could not express")
     func containmentIsWhatWasMissing() {
         let help = "패닝 노브 및 밸런스 노브. 트랙 신호를 스테레오 필드에 위치하려면 수직으로 드래그합니다."
-        let byEquality = selector([.attribute("AXHelp", equals: help)])
-        let byContainment = selector([.attributeContains("AXHelp", "밸런스")])
+        let byEquality = selector([.attributes(["AXHelp"], anyOf: [help], mode: .exact)])
+        let byContainment = selector([.attributes(["AXHelp"], anyOf: ["밸런스"], mode: .contains)])
         #expect(confidence(of: measuredPanSlider, against: byEquality) == 1)
         #expect(confidence(of: measuredPanSlider, against: byContainment) == 1)
 


### PR DESCRIPTION
Four attribute predicates had accumulated — equality, containment, containment-against-a-set, and containment across a set of attributes — each added when a call site needed one. The track toggles would have needed a **fifth** for exact-or-prefix.

That is the atlas becoming a union of the ad-hoc rules it exists to replace.

## One predicate, carrying the product's own match modes

```swift
case attributes([String], anyOf: [String], mode: AXLocalePolicy.MatchMode)
```

`MatchMode` is not new — the product has always had it and it already enumerates exactly these:

```
.exact         trims and compares
.exactStrict   compares verbatim
.prefix        tolerates the trailing state suffixes some Logic builds append
.contains      substring
```

A selector and the accessor it replaces can now express the **same rule**, which is the point of adopting one over the other. Multiple attributes are ORed and multiple labels are ORed, because a name lives in `AXDescription` on one control and `AXHelp` on another — measured, not assumed.

## Third adoption

`trackToggleCandidates` resolves through the atlas, **unchanged in meaning**: `.prefix` *is* the exact-or-prefix pair its two clauses spelled out — exact preserves the historical arm-locator semantics, prefix tolerates the state suffixes.

What changes is that the caller can refuse an ambiguous set rather than take `.first`, and the rule lives where the census and the drift report can both read it.

## Five sites now resolve through the atlas

Measured live, every one at a single survivor and unambiguous:

```
findTrackMuteButton (atlas)       gathered 4   survivors 1   unambiguous
findTrackSoloButton (atlas)       gathered 4   survivors 1   unambiguous
findTrackArmButton  (atlas)       gathered 4   survivors 1   unambiguous
findPanControlInHeader (atlas)    gathered 2   survivors 1   unambiguous
findVolumeFader (atlas)           gathered 2   survivors 1   unambiguous
```

and driven: `mute`, `solo` and `set_volume` all return **State A**.

```
public-surface preflight   PASS
ship gate                  PASS
live evidence @ 678a9bd0   ok
```

`getTransportBar` is the last ad-hoc resolver, and #290 stays open until it is not.
