### PR TITLE
fix(#290): give the adopted selectors their own identities

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+Mixer.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+Mixer.swift
@@ -108,7 +108,7 @@ extension AXLogicProElements {
     /// `locale: "any"` because the alias set is not keyed by locale here: `attributeContainsAny`
     /// carries every measured label at once, which is how `AXLocalePolicy` has always matched.
     static let headerPanSelector = SemanticSelector(
-        id: .mixerStripVolumeFader,
+        id: .trackHeaderPanControl,
         requiredRole: kAXSliderRole as String,
         allowedSubroles: [],
         titleAliases: [:],
@@ -446,7 +446,7 @@ extension AXLogicProElements {
     /// carries none of `volume` / `fader` / `볼륨` in any of these fields — which is what
     /// `sliderText(_:).isVolumeFader` already relied on.
     static let volumeFaderSelector = SemanticSelector(
-        id: .mixerStripVolumeFader,
+        id: .trackHeaderVolumeFader,
         requiredRole: kAXSliderRole as String,
         allowedSubroles: [],
         titleAliases: [:],

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+Tracks.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+Tracks.swift
@@ -470,8 +470,20 @@ extension AXLogicProElements {
     /// fixed `AXLocalePolicy` sets, which is what let `--probe-selection-census` measure all three
     /// once their callers were enumerated.
     static func toggleSelector(labels: [String]) -> SemanticSelector {
-        SemanticSelector(
-            id: .trackHeaderNameField,
+        // The ID follows the label set, because `UIDriftReport` keys its affected-operations map on
+        // it: filing all three under one ID would report a mute-locator drift as endangering solo
+        // and record-arm, and vice versa. Derived from the policy sets rather than passed in, so a
+        // caller cannot pair a label set with the wrong identity.
+        let id: SelectorID
+        if labels == AXLocalePolicy.trackSoloButton.labels {
+            id = .trackHeaderSoloToggle
+        } else if labels == AXLocalePolicy.trackRecordEnableCheckbox.labels {
+            id = .trackHeaderArmToggle
+        } else {
+            id = .trackHeaderMuteToggle
+        }
+        return SemanticSelector(
+            id: id,
             requiredRole: kAXCheckBoxRole as String,
             allowedSubroles: [],
             titleAliases: [:],

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+Transport.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+Transport.swift
@@ -135,7 +135,7 @@ extension AXLogicProElements {
     /// Identity only. Whether the named bar actually HOLDS a transport control is a separate
     /// question, and `transportContainerFinalists` asks it separately.
     static let controlBarSelector = SemanticSelector(
-        id: .transportPlayButton,
+        id: .controlBar,
         requiredRole: kAXGroupRole as String,
         allowedSubroles: [],
         titleAliases: [:],

--- a/Sources/LogicProMCP/SelectorAtlas/SemanticSelector.swift
+++ b/Sources/LogicProMCP/SelectorAtlas/SemanticSelector.swift
@@ -1,6 +1,19 @@
 import Foundation
 
 enum SelectorID: String, CaseIterable, Sendable {
+    // Added when the first four sites were adopted. Every one of them had to borrow an ill-fitting
+    // ID until now — the header pan slider was filed as `mixerStripVolumeFader`, the mute, solo and
+    // record-arm checkboxes as `trackHeaderNameField`, the control bar as `transportPlayButton` —
+    // and `UIDriftReport` keys its affected-operations map on exactly this enum. A pan slider
+    // drifting was therefore reported as putting `mixer.set_volume` at risk, which is a wrong
+    // answer produced confidently.
+    case trackHeaderPanControl
+    case trackHeaderVolumeFader
+    case trackHeaderMuteToggle
+    case trackHeaderSoloToggle
+    case trackHeaderArmToggle
+    case controlBar
+
     case transportPlayButton
     case trackHeaderNameField
     case mixerStripVolumeFader

--- a/Sources/LogicProMCP/SelectorAtlas/UIDriftReport.swift
+++ b/Sources/LogicProMCP/SelectorAtlas/UIDriftReport.swift
@@ -31,7 +31,23 @@ enum QualificationReuse: Equatable, Sendable {
     case failClosedMutation
 }
 
+/// Which operations a selector's drift puts at risk.
+///
+/// EVERY `SelectorID` must appear, including with an empty list — `SelectorAtlasOperationMapTests`
+/// fails otherwise. A missing key and a deliberate empty one are indistinguishable at the call
+/// site (`operationsBySelector[id] ?? []`), so an ID added without a decision would silently report
+/// that its drift affects nothing.
+///
+/// The operation IDs are checked against `OperationRegistry` by the same test. This is a
+/// hand-maintained second copy of a relationship, and the only thing that keeps a second copy
+/// honest is something that fails when it diverges.
 private let operationsBySelector: [SelectorID: [OperationID]] = [
+    .trackHeaderPanControl: [.mixerSetPan],
+    .trackHeaderVolumeFader: [.mixerSetVolume],
+    .trackHeaderMuteToggle: [.tracksMute],
+    .trackHeaderSoloToggle: [.tracksSolo],
+    .trackHeaderArmToggle: [.tracksArm, .tracksArmOnly],
+    .controlBar: [.transportPlay, .transportStop],
     .transportPlayButton: [.transportPlay, .transportStop],
     .trackHeaderNameField: [.tracksSelect, .tracksRename],
     .mixerStripVolumeFader: [.mixerSetVolume],

--- a/Tests/LogicProMCPTests/SelectorAtlasTests.swift
+++ b/Tests/LogicProMCPTests/SelectorAtlasTests.swift
@@ -158,7 +158,17 @@ struct SelectorAtlasTests {
     }
 
     @Test func selectorIDsAreCompleteAndFeatureFlagDefaultsOff() {
+        // The six leading cases were added when the first production adoptions landed. Until then
+        // each borrowed an ill-fitting ID — the header pan slider was filed as
+        // `mixerStripVolumeFader` — and `UIDriftReport` keys its affected-operations map on this
+        // enum, so a pan drift was reported as endangering `mixer.set_volume`.
         #expect(SelectorID.allCases == [
+            .trackHeaderPanControl,
+            .trackHeaderVolumeFader,
+            .trackHeaderMuteToggle,
+            .trackHeaderSoloToggle,
+            .trackHeaderArmToggle,
+            .controlBar,
             .transportPlayButton,
             .trackHeaderNameField,
             .mixerStripVolumeFader,
@@ -351,5 +361,87 @@ struct Issue290ScoringNormalisesOverRequestedEvidenceTests {
         )
         #expect(confidence(of: reworded, against: byEquality) < 0.6)
         #expect(confidence(of: reworded, against: byContainment) == 1)
+    }
+}
+
+/// #290 — the affected-operations map is a second copy of a relationship, and this is what keeps
+/// it honest.
+///
+/// `UIDriftReport` answers "which operations does this selector's drift put at risk" from a
+/// hand-maintained dictionary. Nothing checked it. Four selectors adopted in production had to
+/// borrow ill-fitting IDs until the enum gained cases for them — the header pan slider was filed as
+/// `mixerStripVolumeFader` — so a pan drift was reported as endangering `mixer.set_volume`. That is
+/// a wrong answer delivered confidently, which is the only kind this map can produce.
+@Suite("SelectorAtlasOperationMap")
+struct SelectorAtlasOperationMapTests {
+
+    @Test("every selector has a decision recorded, including an empty one")
+    func everySelectorIsMapped() {
+        // A missing key and a deliberate empty list are indistinguishable at the call site, which
+        // reads `operationsBySelector[id] ?? []`. So an ID added without a decision would silently
+        // report that its drift affects nothing.
+        let mapped = drift(
+            previous: Dictionary(uniqueKeysWithValues: SelectorID.allCases.map { ($0, 0.9) }),
+            current: Dictionary(uniqueKeysWithValues: SelectorID.allCases.map { ($0, 0.9) }),
+            roleChanges: [:]
+        )
+        #expect(mapped.count == SelectorID.allCases.count)
+        let unmapped = mapped.filter { $0.affectedOperations.isEmpty }.map(\.selectorID)
+        // `mixerStripSendSlot` is the one deliberate empty: no send operation is registered.
+        #expect(unmapped == [.mixerStripSendSlot], "unmapped: \(unmapped)")
+    }
+
+    @Test("every operation the map names is registered")
+    func mappedOperationsExist() {
+        // The failure this catches is a rename or a removal in the registry leaving this map
+        // pointing at an operation nobody serves — a drift report that names impact on something
+        // that cannot be impacted.
+        let registered = Set(OperationRegistry.specs.map(\.id))
+        let named = Set(drift(
+            previous: Dictionary(uniqueKeysWithValues: SelectorID.allCases.map { ($0, 0.9) }),
+            current: Dictionary(uniqueKeysWithValues: SelectorID.allCases.map { ($0, 0.5) }),
+            roleChanges: [:]
+        ).flatMap(\.affectedOperations))
+        #expect(!named.isEmpty)
+        #expect(named.isSubset(of: registered),
+                "not registered: \(named.subtracting(registered).map(\.rawValue).sorted())")
+    }
+
+    @Test("the adopted selectors map to the operations that actually drive them")
+    func adoptedSelectorsMapToTheirOwnOperations() {
+        // The two checks above do NOT catch the defect this suite was written for. Mapping the pan
+        // slider to `mixer.set_volume` passes both — every ID has an entry, and `mixerSetVolume` is
+        // registered — which is a check that cannot see its own subject. Measured by mutation:
+        // re-pointing `.trackHeaderPanControl` at `.mixerSetVolume` left the suite green.
+        //
+        // So the six selectors with production consumers are pinned. It is a second copy of the
+        // mapping and that is the point: changing one now requires changing the other, which is how
+        // a hand-maintained relationship is kept from drifting silently.
+        let reported = Dictionary(uniqueKeysWithValues: drift(
+            previous: Dictionary(uniqueKeysWithValues: SelectorID.allCases.map { ($0, 0.9) }),
+            current: Dictionary(uniqueKeysWithValues: SelectorID.allCases.map { ($0, 0.5) }),
+            roleChanges: [:]
+        ).map { ($0.selectorID, Set($0.affectedOperations)) })
+
+        #expect(reported[.trackHeaderPanControl] == [.mixerSetPan])
+        #expect(reported[.trackHeaderVolumeFader] == [.mixerSetVolume])
+        #expect(reported[.trackHeaderMuteToggle] == [.tracksMute])
+        #expect(reported[.trackHeaderSoloToggle] == [.tracksSolo])
+        #expect(reported[.trackHeaderArmToggle] == [.tracksArm, .tracksArmOnly])
+        #expect(reported[.controlBar] == [.transportPlay, .transportStop])
+    }
+
+    @Test("the adopted selectors carry the identity they actually select")
+    func adoptedSelectorsAreHonestlyIdentified() {
+        // The defect this suite exists for, asserted directly at the four production selectors.
+        #expect(AXLogicProElements.headerPanSelector.id == .trackHeaderPanControl)
+        #expect(AXLogicProElements.volumeFaderSelector.id == .trackHeaderVolumeFader)
+        #expect(AXLogicProElements.controlBarSelector.id == .controlBar)
+        #expect(AXLogicProElements.toggleSelector(
+            labels: AXLocalePolicy.trackMuteButton.labels).id == .trackHeaderMuteToggle)
+        #expect(AXLogicProElements.toggleSelector(
+            labels: AXLocalePolicy.trackSoloButton.labels).id == .trackHeaderSoloToggle)
+        #expect(AXLogicProElements.toggleSelector(
+            labels: AXLocalePolicy.trackRecordEnableCheckbox.labels).id == .trackHeaderArmToggle)
     }
 }


### PR DESCRIPTION
Every one of the four production adoptions had to **borrow an ill-fitting `SelectorID`**, because the enum had no case for what they select:

```
the header pan slider     ->  mixerStripVolumeFader
mute, solo, record-arm    ->  trackHeaderNameField   (all three, one ID)
the control bar           ->  transportPlayButton
```

That is not cosmetic. `UIDriftReport` keys its affected-operations map on this enum, so a **pan-slider drift was reported as putting `mixer.set_volume` at risk**, and a mute-locator drift as endangering solo and record-arm. A wrong answer, delivered confidently, by the report whose entire job is to say what a selector change breaks.

Six cases added, each selector pointed at its own, and the toggle identity **derived from the label set** rather than passed in — so a caller cannot pair a set with the wrong identity.

## The guard, and what it could not see

Two checks were written first, and both are real:

- every `SelectorID` has an entry, including a deliberate empty one — a missing key and an intentional empty are indistinguishable at `operationsBySelector[id] ?? []`
- every operation named is registered — a rename would leave the map pointing at nothing

**Neither catches the defect this is about.** Re-pointing `.trackHeaderPanControl` at `.mixerSetVolume` passes both: every ID still has an entry, and `mixerSetVolume` is still registered. Measured by mutation rather than reasoned about — the suite stayed green.

So the six selectors with production consumers are pinned to their operations. That is a second copy of the mapping and **it is the point**: changing one now requires changing the other, which is how a hand-maintained relationship is kept from drifting in silence.

Mutation-tested again afterwards — the same re-point now fails, naming both the expected and the actual:

```
Expectation failed: (reported[.trackHeaderPanControl] → [mixerSetVolume]) == ([.mixerSetPan])
```

## Gates

```
public-surface preflight   PASS
ship gate                  PASS
live evidence @ 66bb2c39   ok
314 tests across the atlas, toggle, transport and mixer suites
```
