### PR TITLE
fix(#290): diff two atlas baselines, and close three fail-open paths

### DIFF
--- a/Sources/LogicProMCP/SelectorAtlas/AXSnapshot.swift
+++ b/Sources/LogicProMCP/SelectorAtlas/AXSnapshot.swift
@@ -68,21 +68,39 @@ enum AXSnapshot {
     /// A text field's contents are user content by nature. Exact matches are always safe — the
     /// value IS a label the product knows — but a prefix is a concession, and it belongs only where
     /// the phenomenon it concedes to actually happens.
-    static let rolesWithStateSuffixes: Set<String> = [
+    /// Roles whose text is Logic's own chrome and cannot be something a user typed.
+    ///
+    /// The line that matters is not prefix-versus-contains, it is WHICH FIELDS CAN CARRY USER
+    /// CONTENT. A track name lives in an `AXTextField`; a plugin name lives in an `AXGroup`
+    /// description — both measured on this machine. A slider's `AXHelp` ("패닝 노브 및 밸런스
+    /// 노브. …") and a checkbox's description are Logic's strings in every tree seen so far.
+    ///
+    /// Inside these roles a value keeps the recognised labels it CONTAINS, beside its shape. Outside
+    /// them only an exact match survives, because a container or a text field is where a name would
+    /// be — and `오디오 1` leaking `오디오` from a text field is what the first capture did.
+    static let rolesCarryingOnlyChrome: Set<String> = [
+        kAXSliderRole as String,
         kAXCheckBoxRole as String,
         kAXRadioButtonRole as String,
+        kAXSplitterRole as String,
+        kAXDisclosureTriangleRole as String,
     ]
 
     static func redact(_ value: String?, role: String? = nil) -> String? {
         guard let value, !value.isEmpty else { return nil }
         if recognisedLabels.contains(value.lowercased()) { return value }
-        if let role, rolesWithStateSuffixes.contains(role),
-           let prefix = recognisedLabels.first(where: {
-               value.lowercased().hasPrefix($0) && !$0.isEmpty
-           }) {
-            return "\(value.prefix(prefix.count))…"
-        }
-        return shape(of: value)
+        guard let role, rolesCarryingOnlyChrome.contains(role) else { return shape(of: value) }
+
+        // Only allowlist members are emitted, never the text around them — so a chrome string keeps
+        // enough for a `.contains` selector to be scored against this fixture, which is what a
+        // baseline is FOR. Over-redacting here is safe and useless: the pan selector scored 0.583
+        // against a fixture that had shaped its help sentence away, below its own threshold.
+        let haystack = value.lowercased()
+        let found = recognisedLabels
+            .filter { !$0.isEmpty && haystack.contains($0) }
+            .sorted { $0.count > $1.count }
+        guard !found.isEmpty else { return shape(of: value) }
+        return "\(found.prefix(4).joined(separator: " ")) | \(shape(of: value))"
     }
 
     /// `len:13 latin+space` — enough to notice a tree changed, not enough to read a name.

--- a/Sources/LogicProMCP/SelectorAtlas/AXSnapshot.swift
+++ b/Sources/LogicProMCP/SelectorAtlas/AXSnapshot.swift
@@ -127,16 +127,19 @@ enum AXSnapshot {
         return "\(found.joined(separator: " ")) | \(shape(of: value))"
     }
 
-    /// An identifier is never given the chrome concession, whatever role carries it.
+    /// An identifier is always a shape. No role earns it a concession, and neither does its content.
     ///
-    /// A `.contains` match reports the labels found INSIDE a value, which is right for a help
-    /// sentence Logic wrote and wrong for an identifier: identifiers are opaque strings, and the
-    /// ones this capture might meet are not in any policy set anyway. Measured on Logic 12.3, the
-    /// track-header elements expose no identifier at all — so the concession would only ever apply
-    /// to a value this code has never seen, which is the worst place to be generous.
+    /// The containment concession reports the labels found INSIDE a value, which is right for a help
+    /// sentence Logic wrote and wrong for an identifier. The exact-match concession is wrong here
+    /// too, for the same reason it was wrong on a text field: `Solo` is a label the product knows
+    /// AND a plausible name, and an identifier equal to it would have walked out verbatim on a
+    /// slider. Measured on Logic 12.3, the track-header elements expose no identifier at all — so
+    /// the concession would only ever apply to a value this code has never seen, which is the worst
+    /// place to be generous. Nothing is lost: an identifier the atlas could match on would be
+    /// Logic's own, and a selector that needs one is a selector this capture cannot serve anyway.
     static func redactIdentifier(_ value: String?) -> String? {
         guard let value, !value.isEmpty else { return nil }
-        return recognisedLabels.contains(value.lowercased()) ? value : shape(of: value)
+        return shape(of: value)
     }
 
     /// `len:13 latin+space` — enough to notice a tree changed, not enough to read a name.

--- a/Sources/LogicProMCP/SelectorAtlas/AXSnapshot.swift
+++ b/Sources/LogicProMCP/SelectorAtlas/AXSnapshot.swift
@@ -88,19 +88,55 @@ enum AXSnapshot {
 
     static func redact(_ value: String?, role: String? = nil) -> String? {
         guard let value, !value.isEmpty else { return nil }
-        if recognisedLabels.contains(value.lowercased()) { return value }
+        // The role gate comes FIRST, and an exact match does not get past it.
+        //
+        // It used to: `recognisedLabels.contains(value.lowercased())` returned the value verbatim
+        // before the role was considered, on the reasoning that "the value IS a label the product
+        // knows". That is a statement about the string, not about where it came from — and a track
+        // named `Solo`, `Audio` or `Region` is a user's name that happens to spell a label. `audio`
+        // is declared in two policy sets, so `Audio` in a text field would have reached the file
+        // intact. Naming the roles that can carry user text and shaping everything in them costs
+        // nothing: no adopted selector matches a text field, a group or a layout item.
         guard let role, rolesCarryingOnlyChrome.contains(role) else { return shape(of: value) }
+        if recognisedLabels.contains(value.lowercased()) { return value }
 
         // Only allowlist members are emitted, never the text around them — so a chrome string keeps
         // enough for a `.contains` selector to be scored against this fixture, which is what a
         // baseline is FOR. Over-redacting here is safe and useless: the pan selector scored 0.583
         // against a fixture that had shaped its help sentence away, below its own threshold.
+        //
+        // EVERY match, and a total order over them.
+        //
+        // This used to keep the four longest. Two things went wrong with that, and the first English
+        // capture showed the symptom: three checkboxes carrying nearly the same 193-character help
+        // sentence rendered as `mixer track play mute` and `mixer track mute play`. Whichever
+        // labels tie at four characters, only some of them fit in four slots — so which ones
+        // survive depends on the rest of the matched set, and `Set` iteration is seeded per process,
+        // so it can also depend on which process wrote the file.
+        //
+        // I did not reproduce a cross-process difference; three captures of the same tree hash
+        // identically. The claim here is narrower and enough on its own: truncation makes the output
+        // a function of more than its input, and a selector scored against a fixture can be looking
+        // for a label that the cut dropped. Keeping all of them is bounded by the allowlist, and
+        // sorting by length THEN by the label itself is a total order where length alone was not.
         let haystack = value.lowercased()
         let found = recognisedLabels
             .filter { !$0.isEmpty && haystack.contains($0) }
-            .sorted { $0.count > $1.count }
+            .sorted { ($0.count, $1) > ($1.count, $0) }
         guard !found.isEmpty else { return shape(of: value) }
-        return "\(found.prefix(4).joined(separator: " ")) | \(shape(of: value))"
+        return "\(found.joined(separator: " ")) | \(shape(of: value))"
+    }
+
+    /// An identifier is never given the chrome concession, whatever role carries it.
+    ///
+    /// A `.contains` match reports the labels found INSIDE a value, which is right for a help
+    /// sentence Logic wrote and wrong for an identifier: identifiers are opaque strings, and the
+    /// ones this capture might meet are not in any policy set anyway. Measured on Logic 12.3, the
+    /// track-header elements expose no identifier at all — so the concession would only ever apply
+    /// to a value this code has never seen, which is the worst place to be generous.
+    static func redactIdentifier(_ value: String?) -> String? {
+        guard let value, !value.isEmpty else { return nil }
+        return recognisedLabels.contains(value.lowercased()) ? value : shape(of: value)
     }
 
     /// `len:13 latin+space` — enough to notice a tree changed, not enough to read a name.
@@ -141,9 +177,7 @@ enum AXSnapshot {
             subrole: AXHelpers.getAttribute(element, kAXSubroleAttribute as String, runtime: runtime),
             description: redact(AXHelpers.getDescription(element, runtime: runtime), role: role),
             help: redact(AXHelpers.getHelp(element, runtime: runtime), role: role),
-            // Identifiers are Logic's own, never a user string — but they are redacted through the
-            // same path anyway, so nothing reaches the file by a route the allowlist does not see.
-            identifier: redact(AXHelpers.getIdentifier(element, runtime: runtime), role: role),
+            identifier: redactIdentifier(AXHelpers.getIdentifier(element, runtime: runtime)),
             valueRange: range,
             children: children
         )

--- a/Sources/LogicProMCP/SelectorAtlas/AtlasDiff.swift
+++ b/Sources/LogicProMCP/SelectorAtlas/AtlasDiff.swift
@@ -92,24 +92,19 @@ enum AtlasDiff {
         return out
     }
 
-    /// The fraction of like units in which a selector finds its control.
+    /// Where a selector's repetition lives, as an index path to the container holding the units.
     ///
-    /// This is the measurement the best-score view cannot make. `confidences` takes the maximum
+    /// Coverage is the measurement the best-score view cannot make. `confidences` takes the maximum
     /// across the tree, so a Logic update that strips the volume fader from five of six track
     /// headers leaves the maximum at 1.0 and the diff reads `.stable` — while every operation
-    /// against those five tracks fails. Coverage goes 1.0 -> 0.17 and the run stops.
-    ///
-    /// A FRACTION, not a count. Counts are not comparable between two captures of different
-    /// projects: a six-track baseline against a three-track one would report every honest
-    /// re-capture as drift.
+    /// against those five tracks fails. Coverage goes 1.0 -> 0.2 and the run stops.
     ///
     /// The unit set is chosen PER SELECTOR, as the one holding the most of its matches — and that
     /// choice is the whole difference between working and not. Taking the root's children instead
     /// picked, in a whole-window capture, the five top-level groups (inspector, library, tracks,
     /// mixer, control bar): the mixer's faders all live inside one of them, so removing four of five
-    /// left that one group still hit, coverage unchanged, and the loss read `.stable`. The repetition
-    /// is nested, and the measurement has to find it where it is rather than where the root is.
-    /// Where a selector's repetition lives, as an index path to the container holding the units.
+    /// left that one group still hit, coverage unchanged, and the loss read `.stable`. The
+    /// repetition is nested, and the measurement has to find it where it is, not where the root is.
     ///
     /// A PATH, because the unit set has to be chosen once and then read in both documents. Choosing
     /// it independently on each side is what broke the first version: strip four of five mixer
@@ -138,19 +133,55 @@ enum AtlasDiff {
         candidates(in: node).contains { confidence(of: $0.candidate, against: selector) >= 0.6 }
     }
 
-    /// The fraction of units at `path` that still find the selector's control.
+    /// The roles along a path, plus the role of the units at the end of it.
     ///
-    /// Returns nil when the path is not a container of two or more like siblings any more, which is
-    /// itself a change worth failing on rather than scoring.
-    static func coverage(
-        in document: AXSnapshot.Document, for selector: SemanticSelector, at path: [Int]
-    ) -> Double? {
+    /// An index path names a POSITION, not a thing. Read in another capture it can land on a
+    /// different container that happens to have two or more children — and if that one is fully
+    /// covered, a real loss elsewhere reads as no change at all. The role chain is the cheapest
+    /// identity a snapshot can carry, and requiring it to still hold turns "the path resolved" into
+    /// "the path resolved to the same kind of place".
+    ///
+    /// It is not a true identity and this does not pretend otherwise: two containers of the same
+    /// role at the same depth are indistinguishable here. What it removes is the accidental case —
+    /// a shifted index landing on something structurally unrelated.
+    static func pathSignature(
+        in document: AXSnapshot.Document, at path: [Int]
+    ) -> [String]? {
         var node = document.root
+        var roles = [node.role]
         for index in path {
             guard index < node.children.count else { return nil }
             node = node.children[index]
+            roles.append(node.role)
         }
-        guard node.children.count >= 2 else { return nil }
+        guard node.children.count >= 2,
+              let unitRole = node.children.first?.role,
+              node.children.allSatisfy({ $0.role == unitRole })
+        else { return nil }
+        return roles + [unitRole]
+    }
+
+    /// The fraction of units at `path` that still find the selector's control.
+    ///
+    /// Returns nil when the path no longer resolves, no longer holds two or more like siblings, or
+    /// no longer has the role chain `expecting` describes. Each of those is a change worth failing
+    /// on rather than scoring, and `between` reads a nil here as zero.
+    ///
+    /// A LIMIT worth stating: this measures how many of the units present carry the control, so it
+    /// cannot see units themselves disappearing — five strips at 5/5 becoming two strips at 2/2
+    /// reads as no change. That is deliberate. Unit count follows the project (three tracks make
+    /// three rows), so a baseline captured on one project and a run on another would report drift
+    /// on every honest comparison if the count were part of the measurement.
+    static func coverage(
+        in document: AXSnapshot.Document,
+        for selector: SemanticSelector,
+        at path: [Int],
+        expecting signature: [String]? = nil
+    ) -> Double? {
+        guard let actual = pathSignature(in: document, at: path) else { return nil }
+        if let signature, signature != actual { return nil }
+        var node = document.root
+        for index in path { node = node.children[index] }
         return Double(node.children.filter { matches(selector, in: $0) }.count)
             / Double(node.children.count)
     }
@@ -183,11 +214,14 @@ enum AtlasDiff {
         var before: [SelectorID: Double] = [:]
         var after: [SelectorID: Double] = [:]
         for selector in adoptedSelectors {
-            guard let path = unitPath(in: baseline, for: selector) else { continue }
+            guard let path = unitPath(in: baseline, for: selector),
+                  let signature = pathSignature(in: baseline, at: path) else { continue }
             before[selector.id] = coverage(in: baseline, for: selector, at: path)
-            // A path that stopped being a set of like siblings scores zero rather than nothing —
-            // the units did not go missing, the tree around them changed shape.
-            after[selector.id] = coverage(in: current, for: selector, at: path) ?? 0
+            // A path that no longer resolves, no longer holds like siblings, or now holds a
+            // different KIND of place scores zero rather than nothing — the units did not go
+            // missing, the tree around them changed shape, and that is not a reason to say stable.
+            after[selector.id] = coverage(
+                in: current, for: selector, at: path, expecting: signature) ?? 0
         }
         return drift(
             previous: confidences(in: baseline),
@@ -215,13 +249,23 @@ enum AtlasDiff {
     /// them produces no `.controlBar` row at all — and a verdict read off that list alone would call
     /// transport qualified because nothing contradicted it. The caller has to see what was not
     /// measured, which is why it is a separate return rather than a quietly dropped key.
+    /// A selector counts as covered only when BOTH measurements were possible — it scored somewhere,
+    /// and there was a repetition to read its coverage in. Scoring alone is not coverage: a capture
+    /// holding exactly one instance of every selector and no repeated sibling set anywhere produces
+    /// a full set of confidences, an empty unmeasured set, and a verdict of full reuse — while the
+    /// measurement that catches partial loss never ran once.
     static func uncovered(
         baseline: AXSnapshot.Document,
         current: AXSnapshot.Document
     ) -> Set<SelectorID> {
-        let scored = Set(confidences(in: baseline).keys)
-            .union(confidences(in: current).keys)
-        return Set(adoptedSelectors.map(\.id)).subtracting(scored)
+        var covered = Set<SelectorID>()
+        for selector in adoptedSelectors {
+            let scored = confidences(in: baseline)[selector.id] != nil
+                || confidences(in: current)[selector.id] != nil
+            let measurable = unitPath(in: baseline, for: selector) != nil
+            if scored, measurable { covered.insert(selector.id) }
+        }
+        return Set(adoptedSelectors.map(\.id)).subtracting(covered)
     }
 
     /// What a qualification run should do with a diff.
@@ -248,15 +292,17 @@ enum AtlasDiff {
         let unmeasured = baselines
             .map { uncovered(baseline: $0.baseline, current: $0.current) }
             .reduce(Set(adoptedSelectors.map(\.id))) { $0.intersection($1) }
-        return verdict(for: drifts, uncovered: unmeasured)
+        return verdict(for: drifts, assumingCoverage: unmeasured)
     }
 
-    /// - Parameter uncovered: adopted selectors this pair did not measure. Prefer
-    ///   `verdict(baselines:)`, which derives this rather than trusting it — a caller that passes
-    ///   `[]` here is making a claim, and a claim is not a measurement.
+    /// - Parameter assumingCoverage: the selectors the caller asserts were NOT measured. Named for
+    ///   what it is: an assumption. `verdict(baselines:)` derives the same value from the documents
+    ///   and is what production should call — passing `[]` here is a claim, and a claim is not a
+    ///   measurement. Kept for the cases that build drifts by hand, where there is no document to
+    ///   derive anything from.
     static func verdict(
         for drifts: [SelectorDrift],
-        uncovered: Set<SelectorID>
+        assumingCoverage uncovered: Set<SelectorID>
     ) -> QualificationReuse {
         // An empty comparison measured NOTHING, and nothing is not agreement. Two snapshots of the
         // wrong scope produce no drift rows at all, and this used to answer `.reuseFull` for them —

--- a/Sources/LogicProMCP/SelectorAtlas/AtlasDiff.swift
+++ b/Sources/LogicProMCP/SelectorAtlas/AtlasDiff.swift
@@ -78,16 +78,89 @@ enum AtlasDiff {
         return out
     }
 
+    /// The repeated units a scope is made of — one per track on a track-header rail.
+    ///
+    /// A rail is a list of rows with the same controls in each. Anything measured over the whole
+    /// tree cannot tell six rows from one, and that is the gap `coverage` closes.
+    static func repeatedUnits(in document: AXSnapshot.Document) -> [AXSnapshot.Node] {
+        let children = document.root.children
+        let modal = Dictionary(grouping: children, by: \.role)
+            .max { $0.value.count < $1.value.count }
+        guard let modal, modal.value.count >= 2 else { return [] }
+        return modal.value
+    }
+
+    /// The fraction of repeated units in which a selector finds its control.
+    ///
+    /// This is the measurement the best-score view cannot make. `confidences` takes the maximum
+    /// across the tree, so a Logic update that strips the volume fader from five of six track
+    /// headers leaves the maximum at 1.0 and the diff reads `.stable` — while every operation
+    /// against those five tracks fails. Coverage goes 1.0 -> 0.17 and the run stops.
+    ///
+    /// A FRACTION, not a count. Counts are not comparable between two captures of different
+    /// projects: the Korean baseline has six tracks and the English one three, and demanding equal
+    /// counts would report every honest re-capture as drift.
+    static func coverage(in document: AXSnapshot.Document) -> [SelectorID: Double] {
+        let units = repeatedUnits(in: document)
+        guard !units.isEmpty else { return [:] }
+        var out: [SelectorID: Double] = [:]
+        for selector in adoptedSelectors {
+            let hits = units.filter { unit in
+                candidates(in: unit).contains {
+                    confidence(of: $0.candidate, against: selector) >= 0.6
+                }
+            }
+            out[selector.id] = Double(hits.count) / Double(units.count)
+        }
+        return out
+    }
+
     /// The drift between two baselines, ready for a qualification report.
+    ///
+    /// Two measurements, because one of them cannot see a whole class of failure. The confidence
+    /// diff catches a label Logic renamed; the coverage diff catches a control Logic removed from
+    /// most rows but not all. A selector that loses coverage is reported `.changed` even when its
+    /// best score is untouched — the strength of the best evidence in the tree says nothing about
+    /// how many of the controls still carry it.
     static func between(
         baseline: AXSnapshot.Document,
         current: AXSnapshot.Document
     ) -> [SelectorDrift] {
-        drift(
+        let before = coverage(in: baseline)
+        let after = coverage(in: current)
+        return drift(
             previous: confidences(in: baseline),
             current: confidences(in: current),
             roleChanges: [:]
-        )
+        ).map { reported in
+            guard let was = before[reported.selectorID], let now = after[reported.selectorID],
+                  now < was - 0.001,
+                  reported.status == .stable || reported.status == .minorDrift
+            else { return reported }
+            return SelectorDrift(
+                selectorID: reported.selectorID,
+                status: .changed,
+                previousConfidence: reported.previousConfidence,
+                currentConfidence: reported.currentConfidence,
+                changedRoles: reported.changedRoles,
+                affectedOperations: reported.affectedOperations
+            )
+        }
+    }
+
+    /// Adopted selectors this pair of baselines says nothing about.
+    ///
+    /// Silence is not coverage. A track-header fixture contains no control bar, so diffing two of
+    /// them produces no `.controlBar` row at all — and a verdict read off that list alone would call
+    /// transport qualified because nothing contradicted it. The caller has to see what was not
+    /// measured, which is why it is a separate return rather than a quietly dropped key.
+    static func uncovered(
+        baseline: AXSnapshot.Document,
+        current: AXSnapshot.Document
+    ) -> Set<SelectorID> {
+        let scored = Set(confidences(in: baseline).keys)
+            .union(confidences(in: current).keys)
+        return Set(adoptedSelectors.map(\.id)).subtracting(scored)
     }
 
     /// What a qualification run should do with a diff.
@@ -95,7 +168,19 @@ enum AtlasDiff {
     /// `policy(for:)` already decides per selector; this is the run-level answer, and it is the
     /// worst case rather than a majority. One selector that can no longer find its control is
     /// enough to make a mutation unsafe, and averaging that away is how a gate stops being one.
-    static func verdict(for drifts: [SelectorDrift]) -> QualificationReuse {
+    /// - Parameter uncovered: adopted selectors this pair did not measure. A run that leaves any
+    ///   selector unmeasured cannot reuse a mutation qualification for it, so passing an empty set
+    ///   is a claim the caller has to be able to make. The parameter has no default for that
+    ///   reason: a default would let the honest question go unasked at the call site.
+    static func verdict(
+        for drifts: [SelectorDrift],
+        uncovered: Set<SelectorID>
+    ) -> QualificationReuse {
+        // An empty comparison measured NOTHING, and nothing is not agreement. Two snapshots of the
+        // wrong scope produce no drift rows at all, and this used to answer `.reuseFull` for them —
+        // a gate that passes hardest when it is aimed at nothing.
+        guard !drifts.isEmpty else { return .failClosedMutation }
+        if !uncovered.isEmpty { return .failClosedMutation }
         let policies = drifts.map(policy(for:))
         if policies.contains(.failClosedMutation) { return .failClosedMutation }
         if policies.contains(.readOnlyOnly) { return .readOnlyOnly }

--- a/Sources/LogicProMCP/SelectorAtlas/AtlasDiff.swift
+++ b/Sources/LogicProMCP/SelectorAtlas/AtlasDiff.swift
@@ -78,19 +78,21 @@ enum AtlasDiff {
         return out
     }
 
-    /// The repeated units a scope is made of — one per track on a track-header rail.
+    /// Every set of like siblings in the tree — each a candidate for "the thing there are many of".
     ///
-    /// A rail is a list of rows with the same controls in each. Anything measured over the whole
-    /// tree cannot tell six rows from one, and that is the gap `coverage` closes.
-    static func repeatedUnits(in document: AXSnapshot.Document) -> [AXSnapshot.Node] {
-        let children = document.root.children
-        let modal = Dictionary(grouping: children, by: \.role)
-            .max { $0.value.count < $1.value.count }
-        guard let modal, modal.value.count >= 2 else { return [] }
-        return modal.value
+    /// A container qualifies when it has two or more children and they all carry the same role: a
+    /// track-header rail's rows, a mixer's strips. The set is not chosen here, because which one is
+    /// the right unit depends on the selector being measured — see `coverage`.
+    static func siblingSets(in node: AXSnapshot.Node) -> [[AXSnapshot.Node]] {
+        var out: [[AXSnapshot.Node]] = []
+        if node.children.count >= 2, Set(node.children.map(\.role)).count == 1 {
+            out.append(node.children)
+        }
+        for child in node.children { out += siblingSets(in: child) }
+        return out
     }
 
-    /// The fraction of repeated units in which a selector finds its control.
+    /// The fraction of like units in which a selector finds its control.
     ///
     /// This is the measurement the best-score view cannot make. `confidences` takes the maximum
     /// across the tree, so a Logic update that strips the volume fader from five of six track
@@ -98,19 +100,69 @@ enum AtlasDiff {
     /// against those five tracks fails. Coverage goes 1.0 -> 0.17 and the run stops.
     ///
     /// A FRACTION, not a count. Counts are not comparable between two captures of different
-    /// projects: the Korean baseline has six tracks and the English one three, and demanding equal
-    /// counts would report every honest re-capture as drift.
-    static func coverage(in document: AXSnapshot.Document) -> [SelectorID: Double] {
-        let units = repeatedUnits(in: document)
-        guard !units.isEmpty else { return [:] }
-        var out: [SelectorID: Double] = [:]
-        for selector in adoptedSelectors {
-            let hits = units.filter { unit in
-                candidates(in: unit).contains {
-                    confidence(of: $0.candidate, against: selector) >= 0.6
+    /// projects: a six-track baseline against a three-track one would report every honest
+    /// re-capture as drift.
+    ///
+    /// The unit set is chosen PER SELECTOR, as the one holding the most of its matches — and that
+    /// choice is the whole difference between working and not. Taking the root's children instead
+    /// picked, in a whole-window capture, the five top-level groups (inspector, library, tracks,
+    /// mixer, control bar): the mixer's faders all live inside one of them, so removing four of five
+    /// left that one group still hit, coverage unchanged, and the loss read `.stable`. The repetition
+    /// is nested, and the measurement has to find it where it is rather than where the root is.
+    /// Where a selector's repetition lives, as an index path to the container holding the units.
+    ///
+    /// A PATH, because the unit set has to be chosen once and then read in both documents. Choosing
+    /// it independently on each side is what broke the first version: strip four of five mixer
+    /// faders and the five-strip set drops to one hit, so a smaller two-unit set elsewhere now has
+    /// the most matches and wins — reporting 1.0 again, from a different place. The measurement
+    /// moved to keep its own score up. The baseline names the place; the current capture is read
+    /// there and nowhere else.
+    static func unitPath(in document: AXSnapshot.Document, for selector: SemanticSelector) -> [Int]? {
+        var best: (path: [Int], hits: Int, ratio: Double)?
+        func visit(_ node: AXSnapshot.Node, _ path: [Int]) {
+            if node.children.count >= 2, Set(node.children.map(\.role)).count == 1 {
+                let hits = node.children.filter { matches(selector, in: $0) }.count
+                let ratio = Double(hits) / Double(node.children.count)
+                if hits > 0,
+                   best == nil || hits > best!.hits || (hits == best!.hits && ratio < best!.ratio) {
+                    best = (path, hits, ratio)
                 }
             }
-            out[selector.id] = Double(hits.count) / Double(units.count)
+            for (index, child) in node.children.enumerated() { visit(child, path + [index]) }
+        }
+        visit(document.root, [])
+        return best?.path
+    }
+
+    static func matches(_ selector: SemanticSelector, in node: AXSnapshot.Node) -> Bool {
+        candidates(in: node).contains { confidence(of: $0.candidate, against: selector) >= 0.6 }
+    }
+
+    /// The fraction of units at `path` that still find the selector's control.
+    ///
+    /// Returns nil when the path is not a container of two or more like siblings any more, which is
+    /// itself a change worth failing on rather than scoring.
+    static func coverage(
+        in document: AXSnapshot.Document, for selector: SemanticSelector, at path: [Int]
+    ) -> Double? {
+        var node = document.root
+        for index in path {
+            guard index < node.children.count else { return nil }
+            node = node.children[index]
+        }
+        guard node.children.count >= 2 else { return nil }
+        return Double(node.children.filter { matches(selector, in: $0) }.count)
+            / Double(node.children.count)
+    }
+
+    /// Coverage for every adopted selector, each measured where that selector's repetition is.
+    static func coverage(in document: AXSnapshot.Document) -> [SelectorID: Double] {
+        var out: [SelectorID: Double] = [:]
+        for selector in adoptedSelectors {
+            if let path = unitPath(in: document, for: selector),
+               let ratio = coverage(in: document, for: selector, at: path) {
+                out[selector.id] = ratio
+            }
         }
         return out
     }
@@ -126,8 +178,17 @@ enum AtlasDiff {
         baseline: AXSnapshot.Document,
         current: AXSnapshot.Document
     ) -> [SelectorDrift] {
-        let before = coverage(in: baseline)
-        let after = coverage(in: current)
+        // Measured at the SAME place on both sides: the baseline names where the repetition is, and
+        // the current capture is read there. See `unitPath`.
+        var before: [SelectorID: Double] = [:]
+        var after: [SelectorID: Double] = [:]
+        for selector in adoptedSelectors {
+            guard let path = unitPath(in: baseline, for: selector) else { continue }
+            before[selector.id] = coverage(in: baseline, for: selector, at: path)
+            // A path that stopped being a set of like siblings scores zero rather than nothing —
+            // the units did not go missing, the tree around them changed shape.
+            after[selector.id] = coverage(in: current, for: selector, at: path) ?? 0
+        }
         return drift(
             previous: confidences(in: baseline),
             current: confidences(in: current),
@@ -168,10 +229,31 @@ enum AtlasDiff {
     /// `policy(for:)` already decides per selector; this is the run-level answer, and it is the
     /// worst case rather than a majority. One selector that can no longer find its control is
     /// enough to make a mutation unsafe, and averaging that away is how a gate stops being one.
-    /// - Parameter uncovered: adopted selectors this pair did not measure. A run that leaves any
-    ///   selector unmeasured cannot reuse a mutation qualification for it, so passing an empty set
-    ///   is a claim the caller has to be able to make. The parameter has no default for that
-    ///   reason: a default would let the honest question go unasked at the call site.
+    /// The verdict for a qualification run, from the baselines themselves.
+    ///
+    /// THIS is the entry point a caller should use, and the reason it exists is that the other one
+    /// takes coverage as an argument — which means a caller can assert coverage it never measured.
+    /// Removing the default from that parameter made the question unavoidable; it did not make the
+    /// answer true. Here there is nothing to pass: the drifts and the unmeasured set are both
+    /// derived from the same two documents, so `.reuseFull` cannot be reached by spelling `[]`.
+    ///
+    /// - Parameter baselines: every pair to be considered. Coverage is the UNION across them,
+    ///   because one scope covering what another misses is exactly how a full baseline set is
+    ///   assembled — and a selector no pair covers is unmeasured however many pairs there are.
+    static func verdict(
+        baselines: [(baseline: AXSnapshot.Document, current: AXSnapshot.Document)]
+    ) -> QualificationReuse {
+        guard !baselines.isEmpty else { return .failClosedMutation }
+        let drifts = baselines.flatMap { between(baseline: $0.baseline, current: $0.current) }
+        let unmeasured = baselines
+            .map { uncovered(baseline: $0.baseline, current: $0.current) }
+            .reduce(Set(adoptedSelectors.map(\.id))) { $0.intersection($1) }
+        return verdict(for: drifts, uncovered: unmeasured)
+    }
+
+    /// - Parameter uncovered: adopted selectors this pair did not measure. Prefer
+    ///   `verdict(baselines:)`, which derives this rather than trusting it — a caller that passes
+    ///   `[]` here is making a claim, and a claim is not a measurement.
     static func verdict(
         for drifts: [SelectorDrift],
         uncovered: Set<SelectorID>

--- a/Sources/LogicProMCP/SelectorAtlas/AtlasDiff.swift
+++ b/Sources/LogicProMCP/SelectorAtlas/AtlasDiff.swift
@@ -1,0 +1,104 @@
+import ApplicationServices
+import Foundation
+
+/// Scores an atlas baseline against the selectors in production, and diffs two baselines.
+///
+/// This is the piece `UIDriftReport` was written without. `drift(previous:current:roleChanges:)`
+/// takes `[SelectorID: Double]` and nothing produced those numbers, so the report could not be
+/// called from anywhere — the same shape as the resolver having no adapter.
+///
+/// Both sides are snapshots, so a diff runs with no Logic on the machine. That matters for the
+/// criterion it serves: "new Logic version qualification includes atlas diff" is a step that has to
+/// run wherever qualification runs, and a step needing the application open would not.
+enum AtlasDiff {
+
+    /// Every selector the product actually resolves through, with the identity it selects.
+    ///
+    /// The adopted set, not the whole `SelectorID` enum. A selector nobody calls has no confidence
+    /// to lose, and scoring it would report drift in something that cannot break.
+    static var adoptedSelectors: [SemanticSelector] {
+        [
+            AXLogicProElements.headerPanSelector,
+            AXLogicProElements.volumeFaderSelector,
+            AXLogicProElements.controlBarSelector,
+            AXLogicProElements.toggleSelector(labels: AXLocalePolicy.trackMuteButton.labels),
+            AXLogicProElements.toggleSelector(labels: AXLocalePolicy.trackSoloButton.labels),
+            AXLogicProElements.toggleSelector(labels: AXLocalePolicy.trackRecordEnableCheckbox.labels),
+        ]
+    }
+
+    /// A snapshot node as something the resolver can score.
+    ///
+    /// `ancestors` is threaded down the walk rather than read back up, because a snapshot has no
+    /// parent links — it is a tree, and the only place the chain exists is the path taken to reach
+    /// the node.
+    static func candidates(
+        in node: AXSnapshot.Node,
+        ancestors: [String] = []
+    ) -> [(candidate: ResolvableCandidate, node: AXSnapshot.Node)] {
+        var attributes: [String: String] = [:]
+        if let description = node.description {
+            attributes[kAXDescriptionAttribute as String] = description
+        }
+        if let help = node.help {
+            attributes[kAXHelpAttribute as String] = help
+        }
+        let here = ResolvableCandidate(
+            axIdentifier: node.identifier,
+            role: node.role,
+            subrole: node.subrole,
+            title: nil,
+            ancestors: ancestors,
+            attributes: attributes,
+            valueSignature: node.valueRange,
+            geometry: nil
+        )
+        var out = [(here, node)]
+        for child in node.children {
+            out += candidates(in: child, ancestors: [node.role] + ancestors)
+        }
+        return out
+    }
+
+    /// The best score each adopted selector reaches anywhere in this baseline.
+    ///
+    /// BEST, not the resolution. A selector that matches two nodes resolves to `.ambiguous` and is a
+    /// refusal at run time — but for drift the question is "how well can this selector still see its
+    /// control", and the answer to that is the strongest evidence available. Ambiguity is a separate
+    /// failure and the report has `changedRoles` and the resolver's own policy for it.
+    static func confidences(in document: AXSnapshot.Document) -> [SelectorID: Double] {
+        let all = candidates(in: document.root)
+        var out: [SelectorID: Double] = [:]
+        for selector in adoptedSelectors {
+            let best = all.map { confidence(of: $0.candidate, against: selector) }.max() ?? 0
+            // Absent, not zero. `drift` distinguishes "scored 0" from "not present at all", and the
+            // second is what a selector that vanished from the tree looks like.
+            if best > 0 { out[selector.id] = best }
+        }
+        return out
+    }
+
+    /// The drift between two baselines, ready for a qualification report.
+    static func between(
+        baseline: AXSnapshot.Document,
+        current: AXSnapshot.Document
+    ) -> [SelectorDrift] {
+        drift(
+            previous: confidences(in: baseline),
+            current: confidences(in: current),
+            roleChanges: [:]
+        )
+    }
+
+    /// What a qualification run should do with a diff.
+    ///
+    /// `policy(for:)` already decides per selector; this is the run-level answer, and it is the
+    /// worst case rather than a majority. One selector that can no longer find its control is
+    /// enough to make a mutation unsafe, and averaging that away is how a gate stops being one.
+    static func verdict(for drifts: [SelectorDrift]) -> QualificationReuse {
+        let policies = drifts.map(policy(for:))
+        if policies.contains(.failClosedMutation) { return .failClosedMutation }
+        if policies.contains(.readOnlyOnly) { return .readOnlyOnly }
+        return .reuseFull
+    }
+}

--- a/Tests/Fixtures/AX/logic-12.x-desktop-en-track-headers.json
+++ b/Tests/Fixtures/AX/logic-12.x-desktop-en-track-headers.json
@@ -1,6 +1,6 @@
 {
   "capturedFrom" : "ax",
-  "locale" : "ko",
+  "locale" : "en",
   "logicVersion" : "12.x",
   "root" : {
     "children" : [
@@ -10,8 +10,8 @@
             "children" : [
 
             ],
-            "description" : "len:6 non-latin+space",
-            "help" : "트랙 헤더 음소거 활성화 녹음 볼륨 솔로 채널 클릭 트랙 패닝 l | len:117 latin+non-latin+punct+space",
+            "description" : "len:9 latin+space",
+            "help" : "track header record volume click track mute solo pan rec ch l m | len:210 latin+punct+space",
             "role" : "AXRadioButton",
             "valueRange" : "0...1"
           },
@@ -19,8 +19,8 @@
             "children" : [
 
             ],
-            "description" : "트랙 확대 | len:11 non-latin+punct+space",
-            "help" : "기본 설정 클릭 트랙 확대 m | len:134 latin+non-latin+punct+space",
+            "description" : "track zoom l m | len:21 latin+space",
+            "help" : "default tracks click track zoom l m | len:218 latin+punct+space",
             "role" : "AXSplitter",
             "valueRange" : "-50...50"
           },
@@ -28,7 +28,7 @@
             "children" : [
 
             ],
-            "help" : "track 트랙 | len:84 latin+non-latin+punct+space",
+            "help" : "tracks track l m | len:134 latin+punct+space",
             "role" : "AXDisclosureTriangle",
             "valueRange" : "0...127"
           },
@@ -36,8 +36,8 @@
             "children" : [
 
             ],
-            "description" : "음소거",
-            "help" : "음소거 믹서 재생 채널 트랙 | len:96 non-latin+punct+space",
+            "description" : "Mute",
+            "help" : "mixer track mute play ch l m | len:193 latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -45,8 +45,8 @@
             "children" : [
 
             ],
-            "description" : "솔로",
-            "help" : "aux 솔로 채널 출력 트랙 | len:92 latin+non-latin+punct+space",
+            "description" : "Solo",
+            "help" : "output tracks track solo aux ch l m | len:155 latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -54,8 +54,8 @@
             "children" : [
 
             ],
-            "description" : "녹음 활성화",
-            "help" : "녹음 활성화 활성화 녹음 상태 트랙 | len:101 non-latin+punct+space",
+            "description" : "Record Enable",
+            "help" : "record enable record track read rec ch l | len:193 latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -63,8 +63,8 @@
             "children" : [
 
             ],
-            "description" : "모니터링 입력 | len:7 non-latin+space",
-            "help" : "녹음 활성화 모니터링 오디오 활성화 녹음 설정 악기 입력 트랙 | len:98 non-latin+punct+space",
+            "description" : "monitor input m | len:16 latin+space",
+            "help" : "record enable instrument software monitor setting record tracks audio input track rec l m | len:187 latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -74,11 +74,11 @@
                 "children" : [
 
                 ],
-                "description" : "len:4 digit+non-latin+space",
+                "description" : "len:5 digit+latin+space",
                 "role" : "AXValueIndicator"
               }
             ],
-            "help" : "밸런스 위치 트랙 패닝 | len:51 non-latin+punct+space",
+            "help" : "position track pan l | len:84 latin+punct+space",
             "role" : "AXSlider",
             "valueRange" : "0...127"
           },
@@ -88,12 +88,12 @@
                 "children" : [
 
                 ],
-                "description" : "len:2 non-latin",
+                "description" : "len:6 latin",
                 "role" : "AXValueIndicator"
               }
             ],
-            "description" : "볼륨",
-            "help" : "aux 페이더 볼륨 설정 재생 채널 출력 트랙 | len:114 latin+non-latin+punct+space",
+            "description" : "Volume",
+            "help" : "output volume fader track play aux ch l m | len:195 latin+punct+space",
             "role" : "AXSlider",
             "valueRange" : "0...233"
           },
@@ -102,13 +102,13 @@
 
             ],
             "description" : "len:13 latin+space",
-            "help" : "len:31 non-latin+punct+space",
+            "help" : "len:46 latin+punct+space",
             "role" : "AXTextField",
             "valueRange" : "0...1"
           }
         ],
-        "description" : "len:22 digit+latin+non-latin+punct+space",
-        "help" : "len:117 latin+non-latin+punct+space",
+        "description" : "len:23 digit+latin+punct+space",
+        "help" : "len:210 latin+punct+space",
         "role" : "AXLayoutItem",
         "valueRange" : "0...1"
       },
@@ -118,8 +118,8 @@
             "children" : [
 
             ],
-            "description" : "len:6 non-latin+space",
-            "help" : "트랙 헤더 음소거 활성화 녹음 볼륨 솔로 채널 클릭 트랙 패닝 l | len:117 latin+non-latin+punct+space",
+            "description" : "len:9 latin+space",
+            "help" : "track header record volume click track mute solo pan rec ch l m | len:210 latin+punct+space",
             "role" : "AXRadioButton",
             "valueRange" : "0...1"
           },
@@ -127,8 +127,8 @@
             "children" : [
 
             ],
-            "description" : "트랙 확대 | len:11 non-latin+punct+space",
-            "help" : "기본 설정 클릭 트랙 확대 m | len:134 latin+non-latin+punct+space",
+            "description" : "track zoom l m | len:21 latin+space",
+            "help" : "default tracks click track zoom l m | len:218 latin+punct+space",
             "role" : "AXSplitter",
             "valueRange" : "-50...50"
           },
@@ -136,8 +136,8 @@
             "children" : [
 
             ],
-            "description" : "음소거",
-            "help" : "음소거 믹서 재생 채널 트랙 | len:96 non-latin+punct+space",
+            "description" : "Mute",
+            "help" : "mixer track mute play ch l m | len:193 latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -145,8 +145,8 @@
             "children" : [
 
             ],
-            "description" : "솔로",
-            "help" : "aux 솔로 채널 출력 트랙 | len:92 latin+non-latin+punct+space",
+            "description" : "Solo",
+            "help" : "output tracks track solo aux ch l m | len:155 latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -154,8 +154,8 @@
             "children" : [
 
             ],
-            "description" : "녹음 활성화",
-            "help" : "녹음 활성화 활성화 녹음 상태 트랙 | len:101 non-latin+punct+space",
+            "description" : "Record Enable",
+            "help" : "record enable record track read rec ch l | len:193 latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -163,8 +163,8 @@
             "children" : [
 
             ],
-            "description" : "모니터링 입력 | len:7 non-latin+space",
-            "help" : "녹음 활성화 모니터링 오디오 활성화 녹음 설정 악기 입력 트랙 | len:98 non-latin+punct+space",
+            "description" : "monitor input m | len:16 latin+space",
+            "help" : "record enable instrument software monitor setting record tracks audio input track rec l m | len:187 latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -174,11 +174,11 @@
                 "children" : [
 
                 ],
-                "description" : "len:4 digit+non-latin+space",
+                "description" : "len:5 digit+latin+space",
                 "role" : "AXValueIndicator"
               }
             ],
-            "help" : "밸런스 위치 트랙 패닝 | len:51 non-latin+punct+space",
+            "help" : "position track pan l | len:84 latin+punct+space",
             "role" : "AXSlider",
             "valueRange" : "0...127"
           },
@@ -188,12 +188,12 @@
                 "children" : [
 
                 ],
-                "description" : "len:2 non-latin",
+                "description" : "len:6 latin",
                 "role" : "AXValueIndicator"
               }
             ],
-            "description" : "볼륨",
-            "help" : "aux 페이더 볼륨 설정 재생 채널 출력 트랙 | len:114 latin+non-latin+punct+space",
+            "description" : "Volume",
+            "help" : "output volume fader track play aux ch l m | len:195 latin+punct+space",
             "role" : "AXSlider",
             "valueRange" : "0...233"
           },
@@ -202,13 +202,13 @@
 
             ],
             "description" : "len:7 digit+latin+space",
-            "help" : "len:31 non-latin+punct+space",
+            "help" : "len:46 latin+punct+space",
             "role" : "AXTextField",
             "valueRange" : "0...1"
           }
         ],
-        "description" : "len:17 digit+latin+non-latin+punct+space",
-        "help" : "len:117 latin+non-latin+punct+space",
+        "description" : "len:18 digit+latin+punct+space",
+        "help" : "len:210 latin+punct+space",
         "role" : "AXLayoutItem",
         "valueRange" : "0...1"
       },
@@ -218,8 +218,8 @@
             "children" : [
 
             ],
-            "description" : "len:6 non-latin+space",
-            "help" : "트랙 헤더 음소거 활성화 녹음 볼륨 솔로 채널 클릭 트랙 패닝 l | len:117 latin+non-latin+punct+space",
+            "description" : "len:9 latin+space",
+            "help" : "track header record volume click track mute solo pan rec ch l m | len:210 latin+punct+space",
             "role" : "AXRadioButton",
             "valueRange" : "0...1"
           },
@@ -227,8 +227,8 @@
             "children" : [
 
             ],
-            "description" : "트랙 확대 | len:11 non-latin+punct+space",
-            "help" : "기본 설정 클릭 트랙 확대 m | len:134 latin+non-latin+punct+space",
+            "description" : "track zoom l m | len:21 latin+space",
+            "help" : "default tracks click track zoom l m | len:218 latin+punct+space",
             "role" : "AXSplitter",
             "valueRange" : "-50...50"
           },
@@ -236,8 +236,8 @@
             "children" : [
 
             ],
-            "description" : "음소거",
-            "help" : "음소거 믹서 재생 채널 트랙 | len:96 non-latin+punct+space",
+            "description" : "Mute",
+            "help" : "mixer track mute play ch l m | len:193 latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -245,8 +245,8 @@
             "children" : [
 
             ],
-            "description" : "솔로",
-            "help" : "aux 솔로 채널 출력 트랙 | len:92 latin+non-latin+punct+space",
+            "description" : "Solo",
+            "help" : "output tracks track solo aux ch l m | len:155 latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -254,8 +254,8 @@
             "children" : [
 
             ],
-            "description" : "녹음 활성화",
-            "help" : "녹음 활성화 활성화 녹음 상태 트랙 | len:101 non-latin+punct+space",
+            "description" : "Record Enable",
+            "help" : "record enable record track read rec ch l | len:193 latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -263,8 +263,8 @@
             "children" : [
 
             ],
-            "description" : "모니터링 입력 | len:7 non-latin+space",
-            "help" : "녹음 활성화 모니터링 오디오 활성화 녹음 설정 악기 입력 트랙 | len:98 non-latin+punct+space",
+            "description" : "monitor input m | len:16 latin+space",
+            "help" : "record enable instrument software monitor setting record tracks audio input track rec l m | len:187 latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -274,11 +274,11 @@
                 "children" : [
 
                 ],
-                "description" : "len:4 digit+non-latin+space",
+                "description" : "len:5 digit+latin+space",
                 "role" : "AXValueIndicator"
               }
             ],
-            "help" : "밸런스 위치 트랙 패닝 | len:51 non-latin+punct+space",
+            "help" : "position track pan l | len:84 latin+punct+space",
             "role" : "AXSlider",
             "valueRange" : "0...127"
           },
@@ -288,12 +288,12 @@
                 "children" : [
 
                 ],
-                "description" : "len:2 non-latin",
+                "description" : "len:6 latin",
                 "role" : "AXValueIndicator"
               }
             ],
-            "description" : "볼륨",
-            "help" : "aux 페이더 볼륨 설정 재생 채널 출력 트랙 | len:114 latin+non-latin+punct+space",
+            "description" : "Volume",
+            "help" : "output volume fader track play aux ch l m | len:195 latin+punct+space",
             "role" : "AXSlider",
             "valueRange" : "0...233"
           },
@@ -302,19 +302,19 @@
 
             ],
             "description" : "len:12 latin+space",
-            "help" : "len:31 non-latin+punct+space",
+            "help" : "len:46 latin+punct+space",
             "role" : "AXTextField",
             "valueRange" : "0...1"
           }
         ],
-        "description" : "len:22 digit+latin+non-latin+punct+space",
-        "help" : "len:117 latin+non-latin+punct+space",
+        "description" : "len:23 digit+latin+punct+space",
+        "help" : "len:210 latin+punct+space",
         "role" : "AXLayoutItem",
         "valueRange" : "0...1"
       }
     ],
-    "description" : "len:5 non-latin+space",
+    "description" : "len:13 latin+space",
     "role" : "AXGroup"
   },
-  "scope" : "트랙 헤더"
+  "scope" : "Tracks header"
 }

--- a/Tests/Fixtures/AX/logic-12.x-desktop-ko-track-headers.json
+++ b/Tests/Fixtures/AX/logic-12.x-desktop-ko-track-headers.json
@@ -11,7 +11,7 @@
 
             ],
             "description" : "len:6 non-latin+space",
-            "help" : "트랙…",
+            "help" : "트랙 헤더 음소거 활성화 패닝 | len:117 latin+non-latin+punct+space",
             "role" : "AXRadioButton",
             "valueRange" : "0...1"
           },
@@ -19,8 +19,8 @@
             "children" : [
 
             ],
-            "description" : "len:11 non-latin+punct+space",
-            "help" : "len:134 latin+non-latin+punct+space",
+            "description" : "트랙 확대 | len:11 non-latin+punct+space",
+            "help" : "트랙 기본 설정 확대 | len:134 latin+non-latin+punct+space",
             "role" : "AXSplitter",
             "valueRange" : "-50...50"
           },
@@ -28,7 +28,7 @@
             "children" : [
 
             ],
-            "help" : "len:84 latin+non-latin+punct+space",
+            "help" : "track 트랙 | len:84 latin+non-latin+punct+space",
             "role" : "AXDisclosureTriangle",
             "valueRange" : "0...127"
           },
@@ -37,7 +37,7 @@
 
             ],
             "description" : "음소거",
-            "help" : "음소거…",
+            "help" : "음소거 믹서 재생 채널 | len:96 non-latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -46,7 +46,7 @@
 
             ],
             "description" : "솔로",
-            "help" : "솔로…",
+            "help" : "aux 솔로 트랙 출력 | len:92 latin+non-latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -55,7 +55,7 @@
 
             ],
             "description" : "녹음 활성화",
-            "help" : "녹음 활성화…",
+            "help" : "녹음 활성화 활성화 상태 트랙 | len:101 non-latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -63,8 +63,8 @@
             "children" : [
 
             ],
-            "description" : "입력…",
-            "help" : "입력…",
+            "description" : "모니터링 입력 | len:7 non-latin+space",
+            "help" : "녹음 활성화 모니터링 활성화 오디오 | len:98 non-latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -78,7 +78,7 @@
                 "role" : "AXValueIndicator"
               }
             ],
-            "help" : "len:51 non-latin+punct+space",
+            "help" : "밸런스 위치 패닝 트랙 | len:51 non-latin+punct+space",
             "role" : "AXSlider",
             "valueRange" : "0...127"
           },
@@ -93,7 +93,7 @@
               }
             ],
             "description" : "볼륨",
-            "help" : "len:114 latin+non-latin+punct+space",
+            "help" : "aux 페이더 재생 볼륨 | len:114 latin+non-latin+punct+space",
             "role" : "AXSlider",
             "valueRange" : "0...233"
           },
@@ -119,7 +119,7 @@
 
             ],
             "description" : "len:6 non-latin+space",
-            "help" : "트랙…",
+            "help" : "트랙 헤더 음소거 활성화 트랙 | len:117 latin+non-latin+punct+space",
             "role" : "AXRadioButton",
             "valueRange" : "0...1"
           },
@@ -127,8 +127,8 @@
             "children" : [
 
             ],
-            "description" : "len:11 non-latin+punct+space",
-            "help" : "len:134 latin+non-latin+punct+space",
+            "description" : "트랙 확대 | len:11 non-latin+punct+space",
+            "help" : "설정 기본 트랙 클릭 | len:134 latin+non-latin+punct+space",
             "role" : "AXSplitter",
             "valueRange" : "-50...50"
           },
@@ -137,7 +137,7 @@
 
             ],
             "description" : "음소거",
-            "help" : "음소거…",
+            "help" : "음소거 재생 트랙 믹서 | len:96 non-latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -146,7 +146,7 @@
 
             ],
             "description" : "솔로",
-            "help" : "솔로…",
+            "help" : "aux 솔로 트랙 출력 | len:92 latin+non-latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -155,7 +155,7 @@
 
             ],
             "description" : "녹음 활성화",
-            "help" : "녹음 활성화…",
+            "help" : "녹음 활성화 활성화 상태 트랙 | len:101 non-latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -163,8 +163,8 @@
             "children" : [
 
             ],
-            "description" : "입력…",
-            "help" : "입력…",
+            "description" : "모니터링 입력 | len:7 non-latin+space",
+            "help" : "녹음 활성화 모니터링 활성화 오디오 | len:98 non-latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -178,7 +178,7 @@
                 "role" : "AXValueIndicator"
               }
             ],
-            "help" : "len:51 non-latin+punct+space",
+            "help" : "밸런스 위치 패닝 트랙 | len:51 non-latin+punct+space",
             "role" : "AXSlider",
             "valueRange" : "0...127"
           },
@@ -193,7 +193,7 @@
               }
             ],
             "description" : "볼륨",
-            "help" : "len:114 latin+non-latin+punct+space",
+            "help" : "aux 페이더 재생 볼륨 | len:114 latin+non-latin+punct+space",
             "role" : "AXSlider",
             "valueRange" : "0...233"
           },
@@ -219,7 +219,7 @@
 
             ],
             "description" : "len:6 non-latin+space",
-            "help" : "트랙…",
+            "help" : "트랙 헤더 음소거 활성화 트랙 | len:117 latin+non-latin+punct+space",
             "role" : "AXRadioButton",
             "valueRange" : "0...1"
           },
@@ -227,8 +227,8 @@
             "children" : [
 
             ],
-            "description" : "len:11 non-latin+punct+space",
-            "help" : "len:134 latin+non-latin+punct+space",
+            "description" : "트랙 확대 | len:11 non-latin+punct+space",
+            "help" : "설정 기본 트랙 클릭 | len:134 latin+non-latin+punct+space",
             "role" : "AXSplitter",
             "valueRange" : "-50...50"
           },
@@ -237,7 +237,7 @@
 
             ],
             "description" : "음소거",
-            "help" : "음소거…",
+            "help" : "음소거 재생 트랙 믹서 | len:96 non-latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -246,7 +246,7 @@
 
             ],
             "description" : "솔로",
-            "help" : "솔로…",
+            "help" : "aux 솔로 트랙 출력 | len:92 latin+non-latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -255,7 +255,7 @@
 
             ],
             "description" : "녹음 활성화",
-            "help" : "녹음 활성화…",
+            "help" : "녹음 활성화 활성화 상태 트랙 | len:101 non-latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -263,8 +263,8 @@
             "children" : [
 
             ],
-            "description" : "입력…",
-            "help" : "입력…",
+            "description" : "모니터링 입력 | len:7 non-latin+space",
+            "help" : "녹음 활성화 모니터링 활성화 오디오 | len:98 non-latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -278,7 +278,7 @@
                 "role" : "AXValueIndicator"
               }
             ],
-            "help" : "len:51 non-latin+punct+space",
+            "help" : "밸런스 위치 패닝 트랙 | len:51 non-latin+punct+space",
             "role" : "AXSlider",
             "valueRange" : "0...127"
           },
@@ -293,7 +293,7 @@
               }
             ],
             "description" : "볼륨",
-            "help" : "len:114 latin+non-latin+punct+space",
+            "help" : "aux 페이더 재생 볼륨 | len:114 latin+non-latin+punct+space",
             "role" : "AXSlider",
             "valueRange" : "0...233"
           },
@@ -319,7 +319,7 @@
 
             ],
             "description" : "len:6 non-latin+space",
-            "help" : "트랙…",
+            "help" : "트랙 헤더 음소거 활성화 트랙 | len:117 latin+non-latin+punct+space",
             "role" : "AXRadioButton",
             "valueRange" : "0...1"
           },
@@ -327,8 +327,8 @@
             "children" : [
 
             ],
-            "description" : "len:11 non-latin+punct+space",
-            "help" : "len:134 latin+non-latin+punct+space",
+            "description" : "트랙 확대 | len:11 non-latin+punct+space",
+            "help" : "설정 기본 트랙 클릭 | len:134 latin+non-latin+punct+space",
             "role" : "AXSplitter",
             "valueRange" : "-50...50"
           },
@@ -337,7 +337,7 @@
 
             ],
             "description" : "음소거",
-            "help" : "음소거…",
+            "help" : "음소거 재생 트랙 믹서 | len:96 non-latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -346,7 +346,7 @@
 
             ],
             "description" : "솔로",
-            "help" : "솔로…",
+            "help" : "aux 솔로 트랙 출력 | len:92 latin+non-latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -355,7 +355,7 @@
 
             ],
             "description" : "녹음 활성화",
-            "help" : "녹음 활성화…",
+            "help" : "녹음 활성화 활성화 상태 트랙 | len:101 non-latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -363,8 +363,8 @@
             "children" : [
 
             ],
-            "description" : "입력…",
-            "help" : "입력…",
+            "description" : "모니터링 입력 | len:7 non-latin+space",
+            "help" : "녹음 활성화 모니터링 활성화 오디오 | len:98 non-latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -378,7 +378,7 @@
                 "role" : "AXValueIndicator"
               }
             ],
-            "help" : "len:51 non-latin+punct+space",
+            "help" : "밸런스 위치 패닝 트랙 | len:51 non-latin+punct+space",
             "role" : "AXSlider",
             "valueRange" : "0...127"
           },
@@ -393,7 +393,7 @@
               }
             ],
             "description" : "볼륨",
-            "help" : "len:114 latin+non-latin+punct+space",
+            "help" : "aux 페이더 재생 볼륨 | len:114 latin+non-latin+punct+space",
             "role" : "AXSlider",
             "valueRange" : "0...233"
           },
@@ -419,7 +419,7 @@
 
             ],
             "description" : "len:6 non-latin+space",
-            "help" : "트랙…",
+            "help" : "트랙 헤더 음소거 활성화 트랙 | len:117 latin+non-latin+punct+space",
             "role" : "AXRadioButton",
             "valueRange" : "0...1"
           },
@@ -427,8 +427,8 @@
             "children" : [
 
             ],
-            "description" : "len:11 non-latin+punct+space",
-            "help" : "len:134 latin+non-latin+punct+space",
+            "description" : "트랙 확대 | len:11 non-latin+punct+space",
+            "help" : "설정 기본 트랙 클릭 | len:134 latin+non-latin+punct+space",
             "role" : "AXSplitter",
             "valueRange" : "-50...50"
           },
@@ -437,7 +437,7 @@
 
             ],
             "description" : "음소거",
-            "help" : "음소거…",
+            "help" : "음소거 재생 트랙 믹서 | len:96 non-latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -446,7 +446,7 @@
 
             ],
             "description" : "솔로",
-            "help" : "솔로…",
+            "help" : "aux 솔로 트랙 출력 | len:92 latin+non-latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -455,7 +455,7 @@
 
             ],
             "description" : "녹음 활성화",
-            "help" : "녹음 활성화…",
+            "help" : "녹음 활성화 활성화 상태 트랙 | len:101 non-latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -463,8 +463,8 @@
             "children" : [
 
             ],
-            "description" : "입력…",
-            "help" : "입력…",
+            "description" : "모니터링 입력 | len:7 non-latin+space",
+            "help" : "녹음 활성화 모니터링 활성화 오디오 | len:98 non-latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -478,7 +478,7 @@
                 "role" : "AXValueIndicator"
               }
             ],
-            "help" : "len:51 non-latin+punct+space",
+            "help" : "밸런스 위치 패닝 트랙 | len:51 non-latin+punct+space",
             "role" : "AXSlider",
             "valueRange" : "0...127"
           },
@@ -493,7 +493,7 @@
               }
             ],
             "description" : "볼륨",
-            "help" : "len:114 latin+non-latin+punct+space",
+            "help" : "aux 페이더 재생 볼륨 | len:114 latin+non-latin+punct+space",
             "role" : "AXSlider",
             "valueRange" : "0...233"
           },
@@ -519,7 +519,7 @@
 
             ],
             "description" : "len:6 non-latin+space",
-            "help" : "트랙…",
+            "help" : "트랙 헤더 음소거 활성화 트랙 | len:117 latin+non-latin+punct+space",
             "role" : "AXRadioButton",
             "valueRange" : "0...1"
           },
@@ -527,8 +527,8 @@
             "children" : [
 
             ],
-            "description" : "len:11 non-latin+punct+space",
-            "help" : "len:134 latin+non-latin+punct+space",
+            "description" : "트랙 확대 | len:11 non-latin+punct+space",
+            "help" : "설정 기본 트랙 클릭 | len:134 latin+non-latin+punct+space",
             "role" : "AXSplitter",
             "valueRange" : "-50...50"
           },
@@ -537,7 +537,7 @@
 
             ],
             "description" : "음소거",
-            "help" : "음소거…",
+            "help" : "음소거 재생 트랙 믹서 | len:96 non-latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -546,7 +546,7 @@
 
             ],
             "description" : "솔로",
-            "help" : "솔로…",
+            "help" : "aux 솔로 트랙 출력 | len:92 latin+non-latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -555,7 +555,7 @@
 
             ],
             "description" : "녹음 활성화",
-            "help" : "녹음 활성화…",
+            "help" : "녹음 활성화 활성화 상태 트랙 | len:101 non-latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -563,8 +563,8 @@
             "children" : [
 
             ],
-            "description" : "입력…",
-            "help" : "입력…",
+            "description" : "모니터링 입력 | len:7 non-latin+space",
+            "help" : "녹음 활성화 모니터링 활성화 오디오 | len:98 non-latin+punct+space",
             "role" : "AXCheckBox",
             "valueRange" : "0...1"
           },
@@ -578,7 +578,7 @@
                 "role" : "AXValueIndicator"
               }
             ],
-            "help" : "len:51 non-latin+punct+space",
+            "help" : "밸런스 위치 패닝 트랙 | len:51 non-latin+punct+space",
             "role" : "AXSlider",
             "valueRange" : "0...127"
           },
@@ -593,7 +593,7 @@
               }
             ],
             "description" : "볼륨",
-            "help" : "len:114 latin+non-latin+punct+space",
+            "help" : "aux 페이더 재생 볼륨 | len:114 latin+non-latin+punct+space",
             "role" : "AXSlider",
             "valueRange" : "0...233"
           },

--- a/Tests/Fixtures/AX/logic-12.x-desktop-ko-window.json
+++ b/Tests/Fixtures/AX/logic-12.x-desktop-ko-window.json
@@ -1,0 +1,2566 @@
+{
+  "capturedFrom" : "ax",
+  "locale" : "ko",
+  "logicVersion" : "12.x",
+  "root" : {
+    "children" : [
+      {
+        "children" : [
+
+        ],
+        "role" : "AXButton",
+        "subrole" : "AXCloseButton"
+      },
+      {
+        "children" : [
+          {
+            "children" : [
+              {
+                "children" : [
+
+                ],
+                "role" : "AXGroup"
+              }
+            ],
+            "role" : "AXGroup"
+          }
+        ],
+        "help" : "len:24 non-latin+punct+space",
+        "role" : "AXButton",
+        "subrole" : "AXFullScreenButton"
+      },
+      {
+        "children" : [
+
+        ],
+        "role" : "AXButton",
+        "subrole" : "AXMinimizeButton"
+      },
+      {
+        "children" : [
+
+        ],
+        "role" : "AXImage"
+      },
+      {
+        "children" : [
+
+        ],
+        "role" : "AXStaticText"
+      },
+      {
+        "children" : [
+          {
+            "children" : [
+              {
+                "children" : [
+
+                ],
+                "description" : "len:5 non-latin+space",
+                "help" : "len:93 non-latin+punct+space",
+                "role" : "AXPopUpButton"
+              },
+              {
+                "children" : [
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "마디",
+                    "role" : "AXSlider",
+                    "valueRange" : "4...6"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "비트",
+                    "role" : "AXSlider",
+                    "valueRange" : "0...2"
+                  }
+                ],
+                "description" : "len:7 non-latin+space",
+                "help" : "len:97 non-latin+punct+space",
+                "role" : "AXGroup"
+              },
+              {
+                "children" : [
+
+                ],
+                "description" : "템포",
+                "help" : "녹음 입력 재생 클릭 템포 값 | len:80 non-latin+punct+space",
+                "role" : "AXSlider",
+                "valueRange" : "5...990"
+              },
+              {
+                "children" : [
+
+                ],
+                "help" : "len:117 latin+non-latin+punct+space",
+                "role" : "AXPopUpButton"
+              },
+              {
+                "children" : [
+
+                ],
+                "description" : "len:3 non-latin",
+                "help" : "len:90 non-latin+punct+space",
+                "role" : "AXPopUpButton"
+              },
+              {
+                "children" : [
+
+                ],
+                "description" : "len:2 non-latin",
+                "help" : "len:60 non-latin+punct+space",
+                "role" : "AXPopUpButton"
+              }
+            ],
+            "description" : "len:6 non-latin+space",
+            "role" : "AXGroup"
+          },
+          {
+            "children" : [
+
+            ],
+            "description" : "사이클",
+            "help" : "사이클 녹음 재생 | len:83 latin+non-latin+punct+space",
+            "role" : "AXCheckBox"
+          },
+          {
+            "children" : [
+
+            ],
+            "description" : "len:7 non-latin+space",
+            "help" : "len:82 latin+non-latin+punct+space",
+            "role" : "AXButton"
+          },
+          {
+            "children" : [
+
+            ],
+            "description" : "녹음 템포 | len:8 non-latin+space",
+            "help" : "음소거 콘텐츠 녹음 템포 | len:67 latin+non-latin+punct+space",
+            "role" : "AXCheckBox"
+          },
+          {
+            "children" : [
+
+            ],
+            "description" : "녹음",
+            "help" : "녹음 트랙 | len:46 latin+non-latin+punct+space",
+            "role" : "AXCheckBox"
+          },
+          {
+            "children" : [
+
+            ],
+            "description" : "재생",
+            "help" : "재생헤드 위치 사이클 위치 재생 | len:70 non-latin+punct+space",
+            "role" : "AXCheckBox"
+          },
+          {
+            "children" : [
+
+            ],
+            "description" : "len:7 non-latin+space",
+            "help" : "len:51 non-latin+punct+space",
+            "role" : "AXButton"
+          },
+          {
+            "children" : [
+
+            ],
+            "description" : "len:2 non-latin",
+            "help" : "녹음 신규 | len:46 non-latin+punct+space",
+            "role" : "AXCheckBox"
+          },
+          {
+            "children" : [
+
+            ],
+            "description" : "len:2 non-latin",
+            "help" : "악기 | len:31 non-latin+punct+space",
+            "role" : "AXCheckBox"
+          },
+          {
+            "children" : [
+
+            ],
+            "description" : "솔로",
+            "help" : "리전 솔로 재생 | len:33 non-latin+punct+space",
+            "role" : "AXCheckBox"
+          },
+          {
+            "children" : [
+
+            ],
+            "description" : "len:5 non-latin+space",
+            "help" : "길이 녹음 재생 클릭 l | len:101 latin+non-latin+punct+space",
+            "role" : "AXCheckBox"
+          },
+          {
+            "children" : [
+
+            ],
+            "description" : "메트로놈 클릭 | len:7 non-latin+space",
+            "help" : "메트로놈 녹음 재생 클릭 템포 | len:80 latin+non-latin+punct+space",
+            "role" : "AXCheckBox"
+          },
+          {
+            "children" : [
+
+            ],
+            "description" : "라이브러리",
+            "help" : "라이브러리 프리셋 재생 채널 | len:113 latin+non-latin+punct+space",
+            "role" : "AXCheckBox"
+          },
+          {
+            "children" : [
+
+            ],
+            "description" : "인스펙터",
+            "help" : "인스펙터 리전 볼륨 설정 위치 채널 트랙 패닝 편집 | len:103 latin+non-latin+punct+space",
+            "role" : "AXCheckBox"
+          },
+          {
+            "children" : [
+
+            ],
+            "description" : "len:6 non-latin+space",
+            "help" : "인스펙터 윈도우 | len:65 non-latin+punct+space",
+            "role" : "AXCheckBox"
+          },
+          {
+            "children" : [
+
+            ],
+            "description" : "len:5 non-latin+space",
+            "help" : "len:56 latin+non-latin+punct+space",
+            "role" : "AXCheckBox"
+          },
+          {
+            "children" : [
+
+            ],
+            "description" : "l m | len:14 latin+space",
+            "help" : "smart controls 채널 편집 l m | len:96 latin+non-latin+punct+space",
+            "role" : "AXCheckBox"
+          },
+          {
+            "children" : [
+
+            ],
+            "description" : "믹서",
+            "help" : "믹서 채널 트랙 편집 | len:107 latin+non-latin+punct+space",
+            "role" : "AXCheckBox"
+          },
+          {
+            "children" : [
+
+            ],
+            "description" : "편집 | len:3 non-latin",
+            "help" : "session player play 오디오 트랙 파일 편집 l | len:108 latin+non-latin+punct+space",
+            "role" : "AXCheckBox"
+          },
+          {
+            "children" : [
+
+            ],
+            "description" : "목록 편집 | len:6 non-latin+space",
+            "help" : "midi 마커 목록 템포 편집 m | len:69 latin+non-latin+punct+space",
+            "role" : "AXCheckBox"
+          },
+          {
+            "children" : [
+
+            ],
+            "description" : "len:3 non-latin",
+            "help" : "생성 트랙 편집 | len:52 latin+non-latin+punct+space",
+            "role" : "AXCheckBox"
+          },
+          {
+            "children" : [
+
+            ],
+            "description" : "루프 브라우저",
+            "help" : "루프 브라우저 녹음 | len:49 latin+non-latin+punct+space",
+            "role" : "AXCheckBox"
+          },
+          {
+            "children" : [
+
+            ],
+            "description" : "len:4 non-latin",
+            "help" : "오디오 파일 | len:79 latin+non-latin+punct+space",
+            "role" : "AXCheckBox"
+          }
+        ],
+        "description" : "len:6 non-latin+space",
+        "help" : "len:108 latin+non-latin+punct+space",
+        "role" : "AXGroup"
+      },
+      {
+        "children" : [
+          {
+            "children" : [
+              {
+                "children" : [
+                  {
+                    "children" : [
+                      {
+                        "children" : [
+                          {
+                            "children" : [
+
+                            ],
+                            "role" : "AXRow",
+                            "subrole" : "AXOutlineRow"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "role" : "AXRow",
+                            "subrole" : "AXOutlineRow"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "role" : "AXRow",
+                            "subrole" : "AXOutlineRow"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "role" : "AXRow",
+                            "subrole" : "AXOutlineRow"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "role" : "AXRow",
+                            "subrole" : "AXOutlineRow"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "role" : "AXRow",
+                            "subrole" : "AXOutlineRow"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "role" : "AXRow",
+                            "subrole" : "AXOutlineRow"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "role" : "AXRow",
+                            "subrole" : "AXOutlineRow"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "role" : "AXRow",
+                            "subrole" : "AXOutlineRow"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "role" : "AXRow",
+                            "subrole" : "AXOutlineRow"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "identifier" : "len:7 latin",
+                            "role" : "AXColumn"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "identifier" : "len:7 latin",
+                            "role" : "AXColumn"
+                          }
+                        ],
+                        "identifier" : "len:6 digit+latin+punct",
+                        "role" : "AXOutline"
+                      }
+                    ],
+                    "identifier" : "len:7 digit+latin+punct",
+                    "role" : "AXScrollArea"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "identifier" : "len:7 digit+latin+punct",
+                    "role" : "AXDisclosureTriangle"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "identifier" : "len:7 digit+latin+punct",
+                    "role" : "AXTextField"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "identifier" : "len:7 digit+latin+punct",
+                    "role" : "AXStaticText"
+                  }
+                ],
+                "role" : "AXGroup"
+              },
+              {
+                "children" : [
+                  {
+                    "children" : [
+                      {
+                        "children" : [
+                          {
+                            "children" : [
+
+                            ],
+                            "role" : "AXRow",
+                            "subrole" : "AXTableRow"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "role" : "AXRow",
+                            "subrole" : "AXTableRow"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "role" : "AXRow",
+                            "subrole" : "AXTableRow"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "role" : "AXRow",
+                            "subrole" : "AXTableRow"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "role" : "AXRow",
+                            "subrole" : "AXTableRow"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "identifier" : "len:7 latin",
+                            "role" : "AXColumn"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "identifier" : "len:7 latin",
+                            "role" : "AXColumn"
+                          }
+                        ],
+                        "identifier" : "len:6 digit+latin+punct",
+                        "role" : "AXTable"
+                      }
+                    ],
+                    "identifier" : "len:7 digit+latin+punct",
+                    "role" : "AXScrollArea"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "identifier" : "len:7 digit+latin+punct",
+                    "role" : "AXDisclosureTriangle"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "identifier" : "len:7 digit+latin+punct",
+                    "role" : "AXStaticText"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "identifier" : "len:7 digit+latin+punct",
+                    "role" : "AXTextField"
+                  }
+                ],
+                "role" : "AXGroup"
+              },
+              {
+                "children" : [
+                  {
+                    "children" : [
+                      {
+                        "children" : [
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:2 non-latin",
+                            "help" : "len:36 non-latin+punct+space",
+                            "role" : "AXTextField"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:3 non-latin",
+                            "help" : "len:111 latin+non-latin+punct+space",
+                            "role" : "AXButton",
+                            "subrole" : "AXSwitch"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:2 non-latin",
+                            "help" : "len:88 latin+non-latin+punct+space",
+                            "role" : "AXButton",
+                            "subrole" : "AXSwitch"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:2 non-latin",
+                            "help" : "len:101 non-latin+punct+space",
+                            "role" : "AXButton",
+                            "subrole" : "AXSwitch"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:4 non-latin",
+                            "help" : "len:98 non-latin+punct+space",
+                            "role" : "AXButton",
+                            "subrole" : "AXSwitch"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "페이더 볼륨 | len:6 non-latin+space",
+                            "help" : "aux 페이더 볼륨 설정 재생 채널 출력 트랙 | len:120 digit+latin+non-latin+punct+space",
+                            "role" : "AXSlider",
+                            "valueRange" : "0...233"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:9 non-latin+space",
+                            "help" : "len:108 digit+latin+non-latin+punct+space",
+                            "role" : "AXTextField"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:9 non-latin+space",
+                            "help" : "len:113 digit+latin+non-latin+punct+space",
+                            "role" : "AXButton"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "패닝",
+                            "help" : "밸런스 채널 패닝 | len:55 non-latin+punct+space",
+                            "role" : "AXSlider",
+                            "valueRange" : "-64...63"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:15 non-latin+punct+space",
+                            "role" : "AXGroup"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:2 non-latin",
+                            "help" : "len:74 non-latin+punct+space",
+                            "role" : "AXPopUpButton"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:13 latin+space",
+                            "help" : "len:53 non-latin+punct+space",
+                            "role" : "AXButton"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:6 non-latin+space",
+                            "help" : "len:72 latin+non-latin+punct+space",
+                            "role" : "AXButton"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:8 non-latin+space",
+                            "help" : "len:81 non-latin+punct+space",
+                            "role" : "AXButton"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:5 non-latin+space",
+                            "help" : "len:103 non-latin+punct+space",
+                            "role" : "AXButton",
+                            "subrole" : "AXSwitch"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:4 digit+non-latin+space",
+                            "help" : "len:93 non-latin+punct+space",
+                            "role" : "AXButton"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:2 latin",
+                            "help" : "len:130 latin+non-latin+punct+space",
+                            "role" : "AXButton"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:9 non-latin+space",
+                            "help" : "len:108 latin+non-latin+punct+space",
+                            "role" : "AXButton",
+                            "subrole" : "AXSwitch"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:2 non-latin",
+                            "help" : "len:62 non-latin+punct+space",
+                            "role" : "AXButton"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:17 latin+non-latin+punct+space",
+                            "help" : "len:77 non-latin+punct+space",
+                            "role" : "AXButton"
+                          }
+                        ],
+                        "description" : "len:7 digit+latin+space",
+                        "help" : "len:45 non-latin+punct+space",
+                        "role" : "AXLayoutItem"
+                      },
+                      {
+                        "children" : [
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:2 non-latin",
+                            "help" : "len:36 non-latin+punct+space",
+                            "role" : "AXTextField"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:3 non-latin",
+                            "help" : "len:111 latin+non-latin+punct+space",
+                            "role" : "AXButton",
+                            "subrole" : "AXSwitch"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:3 non-latin",
+                            "help" : "len:65 non-latin+punct+space",
+                            "role" : "AXButton",
+                            "subrole" : "AXSwitch"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "페이더 볼륨 | len:6 non-latin+space",
+                            "help" : "aux 페이더 볼륨 설정 재생 채널 출력 트랙 | len:120 digit+latin+non-latin+punct+space",
+                            "role" : "AXSlider",
+                            "valueRange" : "0...233"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:9 non-latin+space",
+                            "help" : "len:108 digit+latin+non-latin+punct+space",
+                            "role" : "AXTextField"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:9 non-latin+space",
+                            "help" : "len:113 digit+latin+non-latin+punct+space",
+                            "role" : "AXButton"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "패닝",
+                            "help" : "밸런스 채널 패닝 | len:55 non-latin+punct+space",
+                            "role" : "AXSlider",
+                            "valueRange" : "-64...63"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:15 non-latin+punct+space",
+                            "role" : "AXGroup"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:2 non-latin",
+                            "help" : "len:74 non-latin+punct+space",
+                            "role" : "AXPopUpButton"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:8 non-latin+space",
+                            "help" : "len:81 non-latin+punct+space",
+                            "role" : "AXButton"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:5 non-latin+space",
+                            "help" : "len:66 non-latin+punct+space",
+                            "role" : "AXButton",
+                            "subrole" : "AXSwitch"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:19 latin+space",
+                            "help" : "len:54 latin+non-latin+punct+space",
+                            "role" : "AXButton"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:2 latin",
+                            "help" : "len:130 latin+non-latin+punct+space",
+                            "role" : "AXButton"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:9 non-latin+space",
+                            "help" : "len:108 latin+non-latin+punct+space",
+                            "role" : "AXButton",
+                            "subrole" : "AXSwitch"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:2 non-latin",
+                            "help" : "len:62 non-latin+punct+space",
+                            "role" : "AXButton"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:17 latin+non-latin+punct+space",
+                            "help" : "len:77 non-latin+punct+space",
+                            "role" : "AXButton"
+                          }
+                        ],
+                        "description" : "len:10 latin+space",
+                        "help" : "len:163 latin+non-latin+punct+space",
+                        "role" : "AXLayoutItem"
+                      }
+                    ],
+                    "description" : "len:2 non-latin",
+                    "role" : "AXLayoutArea"
+                  }
+                ],
+                "role" : "AXGroup"
+              }
+            ],
+            "role" : "AXList"
+          }
+        ],
+        "description" : "len:4 non-latin",
+        "role" : "AXGroup"
+      },
+      {
+        "children" : [
+          {
+            "children" : [
+              {
+                "children" : [
+                  {
+                    "children" : [
+                      {
+                        "children" : [
+
+                        ],
+                        "identifier" : "len:6 digit+latin+punct",
+                        "role" : "AXStaticText"
+                      }
+                    ],
+                    "help" : "len:106 latin+non-latin+punct+space",
+                    "identifier" : "len:6 digit+latin+punct",
+                    "role" : "AXGroup"
+                  },
+                  {
+                    "children" : [
+                      {
+                        "children" : [
+
+                        ],
+                        "identifier" : "len:6 digit+latin+punct",
+                        "role" : "AXGroup"
+                      },
+                      {
+                        "children" : [
+
+                        ],
+                        "role" : "AXSplitter",
+                        "valueRange" : "0...221"
+                      },
+                      {
+                        "children" : [
+                          {
+                            "children" : [
+
+                            ],
+                            "help" : "len:66 non-latin+punct+space",
+                            "identifier" : "len:7 digit+latin+punct",
+                            "role" : "AXTextField",
+                            "subrole" : "AXSearchField"
+                          }
+                        ],
+                        "identifier" : "len:7 digit+latin+punct",
+                        "role" : "AXGroup"
+                      },
+                      {
+                        "children" : [
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:5 non-latin",
+                            "identifier" : "len:7 digit+latin+punct",
+                            "role" : "AXBrowser"
+                          }
+                        ],
+                        "identifier" : "len:7 digit+latin+punct",
+                        "role" : "AXGroup"
+                      },
+                      {
+                        "children" : [
+
+                        ],
+                        "identifier" : "len:7 digit+latin+punct",
+                        "role" : "AXGroup"
+                      }
+                    ],
+                    "identifier" : "len:6 digit+latin+punct",
+                    "role" : "AXSplitGroup"
+                  },
+                  {
+                    "children" : [
+                      {
+                        "children" : [
+
+                        ],
+                        "identifier" : "len:7 digit+latin+punct",
+                        "role" : "AXGroup"
+                      },
+                      {
+                        "children" : [
+                          {
+                            "children" : [
+
+                            ],
+                            "role" : "AXGroup"
+                          }
+                        ],
+                        "role" : "AXGroup",
+                        "subrole" : "AXHostingView"
+                      }
+                    ],
+                    "identifier" : "len:7 digit+latin+punct",
+                    "role" : "AXGroup"
+                  },
+                  {
+                    "children" : [
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "len:2 non-latin",
+                        "help" : "len:36 non-latin+punct+space",
+                        "identifier" : "len:7 digit+latin+punct",
+                        "role" : "AXPopUpButton"
+                      },
+                      {
+                        "children" : [
+
+                        ],
+                        "help" : "len:88 non-latin+punct+space",
+                        "identifier" : "len:7 digit+latin+punct",
+                        "role" : "AXButton"
+                      },
+                      {
+                        "children" : [
+
+                        ],
+                        "help" : "len:52 non-latin+punct+space",
+                        "identifier" : "len:7 digit+latin+punct",
+                        "role" : "AXButton"
+                      },
+                      {
+                        "children" : [
+
+                        ],
+                        "help" : "len:60 non-latin+punct+space",
+                        "identifier" : "len:7 digit+latin+punct",
+                        "role" : "AXButton"
+                      }
+                    ],
+                    "identifier" : "len:7 digit+latin+punct",
+                    "role" : "AXGroup"
+                  }
+                ],
+                "identifier" : "len:7 digit+latin+punct",
+                "role" : "AXGroup"
+              }
+            ],
+            "description" : "len:5 non-latin",
+            "help" : "len:106 latin+non-latin+punct+space",
+            "role" : "AXGroup"
+          }
+        ],
+        "description" : "len:5 non-latin",
+        "role" : "AXGroup"
+      },
+      {
+        "children" : [
+          {
+            "children" : [
+              {
+                "children" : [
+
+                ],
+                "description" : "len:6 non-latin+space",
+                "help" : "len:6 non-latin+space",
+                "role" : "AXButton"
+              },
+              {
+                "children" : [
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:2 non-latin",
+                    "role" : "AXMenuButton",
+                    "subrole" : "AXSegment"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:2 non-latin",
+                    "role" : "AXMenuButton",
+                    "subrole" : "AXSegment"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:2 non-latin",
+                    "role" : "AXMenuButton",
+                    "subrole" : "AXSegment"
+                  }
+                ],
+                "role" : "AXGroup"
+              },
+              {
+                "children" : [
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "loop 보기 l | len:20 latin+non-latin+punct+space",
+                    "help" : "loop 보기 l | len:20 latin+non-latin+punct+space",
+                    "role" : "AXCheckBox",
+                    "subrole" : "AXSegment"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "보기 트랙 | len:12 non-latin+punct+space",
+                    "help" : "보기 트랙 | len:12 non-latin+punct+space",
+                    "role" : "AXCheckBox",
+                    "subrole" : "AXSegment"
+                  }
+                ],
+                "role" : "AXGroup"
+              },
+              {
+                "children" : [
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "오토메이션 보기 | len:12 non-latin+punct+space",
+                    "help" : "오토메이션 보기 | len:16 latin+non-latin+punct+space",
+                    "role" : "AXCheckBox",
+                    "subrole" : "AXSegment"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "보기 l | len:11 latin+non-latin+punct+space",
+                    "help" : "보기 l | len:16 latin+non-latin+punct+space",
+                    "role" : "AXCheckBox",
+                    "subrole" : "AXSegment"
+                  }
+                ],
+                "role" : "AXGroup"
+              },
+              {
+                "children" : [
+
+                ],
+                "description" : "재생헤드 캐치",
+                "help" : "재생헤드 캐치 재생 | len:11 non-latin+punct+space",
+                "role" : "AXCheckBox"
+              },
+              {
+                "children" : [
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:16 non-latin+punct+space",
+                    "help" : "len:8 non-latin+space",
+                    "role" : "AXMenuButton",
+                    "subrole" : "AXSegment"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:20 latin+non-latin+punct+space",
+                    "help" : "len:13 latin+non-latin+punct+space",
+                    "role" : "AXMenuButton",
+                    "subrole" : "AXSegment"
+                  }
+                ],
+                "role" : "AXGroup"
+              },
+              {
+                "children" : [
+
+                ],
+                "role" : "AXStaticText"
+              },
+              {
+                "children" : [
+
+                ],
+                "role" : "AXPopUpButton"
+              },
+              {
+                "children" : [
+
+                ],
+                "role" : "AXStaticText"
+              },
+              {
+                "children" : [
+
+                ],
+                "description" : "len:6 non-latin+space",
+                "help" : "len:6 non-latin+space",
+                "role" : "AXPopUpButton"
+              },
+              {
+                "children" : [
+
+                ],
+                "description" : "확대 | len:8 non-latin+punct+space",
+                "help" : "확대 | len:8 non-latin+punct+space",
+                "role" : "AXCheckBox"
+              },
+              {
+                "children" : [
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "확대 | len:11 non-latin+punct+space",
+                    "help" : "확대 | len:11 non-latin+punct+space",
+                    "role" : "AXCheckBox",
+                    "subrole" : "AXSegment"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "확대 | len:11 non-latin+punct+space",
+                    "help" : "확대 | len:11 non-latin+punct+space",
+                    "role" : "AXCheckBox",
+                    "subrole" : "AXSegment"
+                  }
+                ],
+                "role" : "AXGroup"
+              },
+              {
+                "children" : [
+                  {
+                    "children" : [
+
+                    ],
+                    "role" : "AXValueIndicator"
+                  }
+                ],
+                "description" : "확대 | len:8 non-latin+punct+space",
+                "help" : "확대 | len:8 non-latin+punct+space",
+                "role" : "AXSlider",
+                "valueRange" : "0...1"
+              },
+              {
+                "children" : [
+                  {
+                    "children" : [
+
+                    ],
+                    "role" : "AXValueIndicator"
+                  }
+                ],
+                "description" : "확대 | len:8 non-latin+punct+space",
+                "help" : "확대 | len:8 non-latin+punct+space",
+                "role" : "AXSlider",
+                "valueRange" : "0...1"
+              }
+            ],
+            "description" : "len:2 non-latin",
+            "role" : "AXGroup"
+          },
+          {
+            "children" : [
+              {
+                "children" : [
+                  {
+                    "children" : [
+                      {
+                        "children" : [
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:11 latin+non-latin+punct+space",
+                            "help" : "len:63 non-latin+punct+space",
+                            "role" : "AXButton",
+                            "valueRange" : "0...1"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:19 latin+non-latin+punct+space",
+                            "help" : "len:80 latin+non-latin+punct+space",
+                            "role" : "AXButton",
+                            "valueRange" : "0...1"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "보기 트랙 | len:17 latin+non-latin+punct+space",
+                            "help" : "템포 트랙 | len:60 non-latin+punct+space",
+                            "role" : "AXCheckBox",
+                            "valueRange" : "0...1"
+                          }
+                        ],
+                        "description" : "len:5 non-latin+space",
+                        "role" : "AXGroup"
+                      },
+                      {
+                        "children" : [
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:9 non-latin+space",
+                            "role" : "AXLayoutArea"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "role" : "AXScrollBar"
+                          }
+                        ],
+                        "role" : "AXScrollArea"
+                      }
+                    ],
+                    "role" : "AXSplitGroup"
+                  },
+                  {
+                    "children" : [
+                      {
+                        "children" : [
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:5 non-latin+space",
+                            "role" : "AXGroup"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "role" : "AXScrollBar"
+                          }
+                        ],
+                        "role" : "AXScrollArea"
+                      },
+                      {
+                        "children" : [
+                          {
+                            "children" : [
+
+                            ],
+                            "description" : "len:6 non-latin+space",
+                            "role" : "AXGroup"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "role" : "AXScrollBar"
+                          },
+                          {
+                            "children" : [
+
+                            ],
+                            "role" : "AXScrollBar"
+                          }
+                        ],
+                        "role" : "AXScrollArea"
+                      }
+                    ],
+                    "role" : "AXSplitGroup"
+                  }
+                ],
+                "role" : "AXSplitGroup"
+              }
+            ],
+            "description" : "len:2 non-latin",
+            "role" : "AXGroup"
+          }
+        ],
+        "description" : "len:2 non-latin",
+        "role" : "AXGroup"
+      },
+      {
+        "children" : [
+          {
+            "children" : [
+              {
+                "children" : [
+
+                ],
+                "description" : "len:6 non-latin+space",
+                "help" : "len:6 non-latin+space",
+                "role" : "AXButton"
+              },
+              {
+                "children" : [
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:2 non-latin",
+                    "role" : "AXMenuButton",
+                    "subrole" : "AXSegment"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:2 non-latin",
+                    "role" : "AXMenuButton",
+                    "subrole" : "AXSegment"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:2 non-latin",
+                    "role" : "AXMenuButton",
+                    "subrole" : "AXSegment"
+                  }
+                ],
+                "role" : "AXGroup"
+              },
+              {
+                "children" : [
+
+                ],
+                "role" : "AXStaticText"
+              },
+              {
+                "children" : [
+
+                ],
+                "help" : "페이더 볼륨 센드 채널 패닝 끔 | len:68 non-latin+punct+space",
+                "role" : "AXCheckBox"
+              },
+              {
+                "children" : [
+
+                ],
+                "help" : "len:68 non-latin+punct+space",
+                "role" : "AXPopUpButton"
+              },
+              {
+                "children" : [
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:2 non-latin",
+                    "help" : "보기 트랙 | len:16 non-latin+space",
+                    "role" : "AXRadioButton",
+                    "subrole" : "AXSegment"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "트랙",
+                    "help" : "보기 채널 트랙 | len:22 non-latin+space",
+                    "role" : "AXRadioButton",
+                    "subrole" : "AXSegment"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:2 non-latin",
+                    "help" : "보기 채널 | len:12 non-latin+space",
+                    "role" : "AXRadioButton",
+                    "subrole" : "AXSegment"
+                  }
+                ],
+                "role" : "AXRadioGroup"
+              },
+              {
+                "children" : [
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "오디오",
+                    "help" : "오디오 채널 | len:13 non-latin+space",
+                    "role" : "AXCheckBox",
+                    "subrole" : "AXSegment"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "악기",
+                    "help" : "악기 채널 | len:12 non-latin+space",
+                    "role" : "AXCheckBox",
+                    "subrole" : "AXSegment"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "Aux",
+                    "help" : "aux 채널 | len:13 latin+non-latin+space",
+                    "role" : "AXCheckBox",
+                    "subrole" : "AXSegment"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:2 non-latin",
+                    "help" : "채널 | len:12 non-latin+space",
+                    "role" : "AXCheckBox",
+                    "subrole" : "AXSegment"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "입력",
+                    "help" : "입력 채널 | len:12 non-latin+space",
+                    "role" : "AXCheckBox",
+                    "subrole" : "AXSegment"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "출력",
+                    "help" : "채널 출력 | len:12 non-latin+space",
+                    "role" : "AXCheckBox",
+                    "subrole" : "AXSegment"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:7 latin+non-latin+punct",
+                    "help" : "채널 | len:17 latin+non-latin+punct+space",
+                    "role" : "AXCheckBox",
+                    "subrole" : "AXSegment"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "MIDI",
+                    "help" : "midi 채널 m | len:14 latin+non-latin+space",
+                    "role" : "AXCheckBox",
+                    "subrole" : "AXSegment"
+                  }
+                ],
+                "role" : "AXGroup"
+              },
+              {
+                "children" : [
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "채널 | len:9 non-latin+space",
+                    "help" : "채널 | len:9 non-latin+space",
+                    "role" : "AXRadioButton",
+                    "subrole" : "AXSegment"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "채널 | len:9 non-latin+space",
+                    "help" : "채널 | len:9 non-latin+space",
+                    "role" : "AXRadioButton",
+                    "subrole" : "AXSegment"
+                  }
+                ],
+                "role" : "AXRadioGroup"
+              }
+            ],
+            "description" : "len:2 non-latin",
+            "role" : "AXGroup"
+          },
+          {
+            "children" : [
+              {
+                "children" : [
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:2 non-latin",
+                    "help" : "len:36 non-latin+punct+space",
+                    "role" : "AXTextField"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "track | len:11 latin+space",
+                    "help" : "track 믹서 보기 트랙 확인 | len:84 latin+non-latin+punct+space",
+                    "role" : "AXDisclosureTriangle"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:3 non-latin",
+                    "help" : "len:111 latin+non-latin+punct+space",
+                    "role" : "AXButton",
+                    "subrole" : "AXSwitch"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:2 non-latin",
+                    "help" : "len:88 latin+non-latin+punct+space",
+                    "role" : "AXButton",
+                    "subrole" : "AXSwitch"
+                  },
+                  {
+                    "children" : [
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "len:10 latin+space",
+                        "role" : "AXValueIndicator"
+                      }
+                    ],
+                    "description" : "페이더 볼륨 | len:6 non-latin+space",
+                    "help" : "aux 페이더 볼륨 설정 재생 채널 출력 트랙 | len:120 digit+latin+non-latin+punct+space",
+                    "role" : "AXSlider",
+                    "valueRange" : "0...233"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:9 non-latin+space",
+                    "help" : "len:108 digit+latin+non-latin+punct+space",
+                    "role" : "AXTextField"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:9 non-latin+space",
+                    "help" : "len:113 digit+latin+non-latin+punct+space",
+                    "role" : "AXButton"
+                  },
+                  {
+                    "children" : [
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "len:12 latin+space",
+                        "role" : "AXStaticText"
+                      }
+                    ],
+                    "description" : "패닝",
+                    "help" : "밸런스 채널 패닝 | len:55 non-latin+punct+space",
+                    "role" : "AXSlider",
+                    "valueRange" : "-64...63"
+                  },
+                  {
+                    "children" : [
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "오토메이션",
+                        "role" : "AXCheckBox"
+                      },
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "len:2 non-latin",
+                        "role" : "AXButton"
+                      }
+                    ],
+                    "description" : "len:15 non-latin+punct+space",
+                    "role" : "AXGroup"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:2 non-latin",
+                    "help" : "len:74 non-latin+punct+space",
+                    "role" : "AXPopUpButton"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:13 latin+space",
+                    "help" : "len:53 non-latin+punct+space",
+                    "role" : "AXButton"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:6 non-latin+space",
+                    "help" : "len:72 latin+non-latin+punct+space",
+                    "role" : "AXButton"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:8 non-latin+space",
+                    "help" : "len:81 non-latin+punct+space",
+                    "role" : "AXButton"
+                  },
+                  {
+                    "children" : [
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "바이패스",
+                        "role" : "AXCheckBox"
+                      },
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "len:2 non-latin",
+                        "role" : "AXButton"
+                      },
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "len:2 non-latin",
+                        "role" : "AXButton"
+                      }
+                    ],
+                    "description" : "len:10 latin",
+                    "role" : "AXGroup"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:8 non-latin+space",
+                    "help" : "len:81 non-latin+punct+space",
+                    "role" : "AXButton"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:5 non-latin+space",
+                    "role" : "AXButton"
+                  },
+                  {
+                    "children" : [
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "바이패스",
+                        "role" : "AXCheckBox"
+                      },
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "len:2 non-latin",
+                        "role" : "AXButton"
+                      },
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "len:2 non-latin",
+                        "role" : "AXButton"
+                      }
+                    ],
+                    "description" : "len:10 latin",
+                    "role" : "AXGroup"
+                  },
+                  {
+                    "children" : [
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "바이패스",
+                        "role" : "AXCheckBox"
+                      },
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "len:2 non-latin",
+                        "role" : "AXButton"
+                      },
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "len:2 non-latin",
+                        "role" : "AXButton"
+                      }
+                    ],
+                    "description" : "len:21 latin+space",
+                    "role" : "AXGroup"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:2 latin",
+                    "help" : "len:130 latin+non-latin+punct+space",
+                    "role" : "AXButton"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:9 non-latin+space",
+                    "help" : "len:108 latin+non-latin+punct+space",
+                    "role" : "AXButton",
+                    "subrole" : "AXSwitch"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:13 latin+space",
+                    "help" : "len:62 non-latin+punct+space",
+                    "role" : "AXButton"
+                  }
+                ],
+                "description" : "len:13 latin+space",
+                "role" : "AXLayoutItem"
+              },
+              {
+                "children" : [
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:2 non-latin",
+                    "help" : "len:36 non-latin+punct+space",
+                    "role" : "AXTextField"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:3 non-latin",
+                    "help" : "len:111 latin+non-latin+punct+space",
+                    "role" : "AXButton",
+                    "subrole" : "AXSwitch"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:2 non-latin",
+                    "help" : "len:88 latin+non-latin+punct+space",
+                    "role" : "AXButton",
+                    "subrole" : "AXSwitch"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:2 non-latin",
+                    "help" : "len:101 non-latin+punct+space",
+                    "role" : "AXButton",
+                    "subrole" : "AXSwitch"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:4 non-latin",
+                    "help" : "len:98 non-latin+punct+space",
+                    "role" : "AXButton",
+                    "subrole" : "AXSwitch"
+                  },
+                  {
+                    "children" : [
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "len:10 latin+space",
+                        "role" : "AXValueIndicator"
+                      }
+                    ],
+                    "description" : "페이더 볼륨 | len:6 non-latin+space",
+                    "help" : "aux 페이더 볼륨 설정 재생 채널 출력 트랙 | len:120 digit+latin+non-latin+punct+space",
+                    "role" : "AXSlider",
+                    "valueRange" : "0...233"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:9 non-latin+space",
+                    "help" : "len:108 digit+latin+non-latin+punct+space",
+                    "role" : "AXTextField"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:9 non-latin+space",
+                    "help" : "len:113 digit+latin+non-latin+punct+space",
+                    "role" : "AXButton"
+                  },
+                  {
+                    "children" : [
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "len:12 latin+space",
+                        "role" : "AXStaticText"
+                      }
+                    ],
+                    "description" : "패닝",
+                    "help" : "밸런스 채널 패닝 | len:55 non-latin+punct+space",
+                    "role" : "AXSlider",
+                    "valueRange" : "-64...63"
+                  },
+                  {
+                    "children" : [
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "오토메이션",
+                        "role" : "AXCheckBox"
+                      },
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "len:2 non-latin",
+                        "role" : "AXButton"
+                      }
+                    ],
+                    "description" : "len:15 non-latin+punct+space",
+                    "role" : "AXGroup"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:2 non-latin",
+                    "help" : "len:74 non-latin+punct+space",
+                    "role" : "AXPopUpButton"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:13 latin+space",
+                    "help" : "len:53 non-latin+punct+space",
+                    "role" : "AXButton"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:6 non-latin+space",
+                    "help" : "len:72 latin+non-latin+punct+space",
+                    "role" : "AXButton"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:8 non-latin+space",
+                    "help" : "len:81 non-latin+punct+space",
+                    "role" : "AXButton"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:8 non-latin+space",
+                    "help" : "len:81 non-latin+punct+space",
+                    "role" : "AXButton"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:8 non-latin+space",
+                    "help" : "len:81 non-latin+punct+space",
+                    "role" : "AXButton"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:8 non-latin+space",
+                    "help" : "len:81 non-latin+punct+space",
+                    "role" : "AXButton"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:5 non-latin+space",
+                    "help" : "len:103 non-latin+punct+space",
+                    "role" : "AXButton",
+                    "subrole" : "AXSwitch"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:4 digit+non-latin+space",
+                    "help" : "len:93 non-latin+punct+space",
+                    "role" : "AXButton"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:2 latin",
+                    "help" : "len:130 latin+non-latin+punct+space",
+                    "role" : "AXButton"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:9 non-latin+space",
+                    "help" : "len:108 latin+non-latin+punct+space",
+                    "role" : "AXButton",
+                    "subrole" : "AXSwitch"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:2 non-latin",
+                    "help" : "len:62 non-latin+punct+space",
+                    "role" : "AXButton"
+                  }
+                ],
+                "description" : "len:7 digit+latin+space",
+                "role" : "AXLayoutItem"
+              },
+              {
+                "children" : [
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:2 non-latin",
+                    "help" : "len:36 non-latin+punct+space",
+                    "role" : "AXTextField"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:3 non-latin",
+                    "help" : "len:111 latin+non-latin+punct+space",
+                    "role" : "AXButton",
+                    "subrole" : "AXSwitch"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:2 non-latin",
+                    "help" : "len:88 latin+non-latin+punct+space",
+                    "role" : "AXButton",
+                    "subrole" : "AXSwitch"
+                  },
+                  {
+                    "children" : [
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "len:10 latin+space",
+                        "role" : "AXValueIndicator"
+                      }
+                    ],
+                    "description" : "페이더 볼륨 | len:6 non-latin+space",
+                    "help" : "aux 페이더 볼륨 설정 재생 채널 출력 트랙 | len:120 digit+latin+non-latin+punct+space",
+                    "role" : "AXSlider",
+                    "valueRange" : "0...233"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:9 non-latin+space",
+                    "help" : "len:108 digit+latin+non-latin+punct+space",
+                    "role" : "AXTextField"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:9 non-latin+space",
+                    "help" : "len:113 digit+latin+non-latin+punct+space",
+                    "role" : "AXButton"
+                  },
+                  {
+                    "children" : [
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "len:12 latin+space",
+                        "role" : "AXStaticText"
+                      }
+                    ],
+                    "description" : "패닝",
+                    "help" : "밸런스 채널 패닝 | len:55 non-latin+punct+space",
+                    "role" : "AXSlider",
+                    "valueRange" : "-64...63"
+                  },
+                  {
+                    "children" : [
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "오토메이션",
+                        "role" : "AXCheckBox"
+                      },
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "len:2 non-latin",
+                        "role" : "AXButton"
+                      }
+                    ],
+                    "description" : "len:15 non-latin+punct+space",
+                    "role" : "AXGroup"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:2 non-latin",
+                    "help" : "len:74 non-latin+punct+space",
+                    "role" : "AXPopUpButton"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:13 latin+space",
+                    "help" : "len:53 non-latin+punct+space",
+                    "role" : "AXButton"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:6 non-latin+space",
+                    "help" : "len:72 latin+non-latin+punct+space",
+                    "role" : "AXButton"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:8 non-latin+space",
+                    "help" : "len:81 non-latin+punct+space",
+                    "role" : "AXButton"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:5 non-latin+space",
+                    "role" : "AXButton"
+                  },
+                  {
+                    "children" : [
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "바이패스",
+                        "role" : "AXCheckBox"
+                      },
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "len:2 non-latin",
+                        "role" : "AXButton"
+                      },
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "len:2 non-latin",
+                        "role" : "AXButton"
+                      }
+                    ],
+                    "description" : "len:10 latin",
+                    "role" : "AXGroup"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:5 non-latin+space",
+                    "role" : "AXButton"
+                  },
+                  {
+                    "children" : [
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "바이패스",
+                        "role" : "AXCheckBox"
+                      },
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "len:2 non-latin",
+                        "role" : "AXButton"
+                      },
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "len:2 non-latin",
+                        "role" : "AXButton"
+                      }
+                    ],
+                    "description" : "len:10 latin",
+                    "role" : "AXGroup"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:5 non-latin+space",
+                    "role" : "AXButton"
+                  },
+                  {
+                    "children" : [
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "바이패스",
+                        "role" : "AXCheckBox"
+                      },
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "len:2 non-latin",
+                        "role" : "AXButton"
+                      },
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "len:2 non-latin",
+                        "role" : "AXButton"
+                      }
+                    ],
+                    "description" : "len:10 latin+space",
+                    "role" : "AXGroup"
+                  },
+                  {
+                    "children" : [
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "바이패스",
+                        "role" : "AXCheckBox"
+                      },
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "len:2 non-latin",
+                        "role" : "AXButton"
+                      },
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "len:2 non-latin",
+                        "role" : "AXButton"
+                      }
+                    ],
+                    "description" : "len:5 latin",
+                    "role" : "AXGroup"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:9 latin+non-latin+space",
+                    "help" : "len:56 latin+non-latin+punct+space",
+                    "role" : "AXButton"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:2 latin",
+                    "help" : "len:130 latin+non-latin+punct+space",
+                    "role" : "AXButton"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:9 non-latin+space",
+                    "help" : "len:108 latin+non-latin+punct+space",
+                    "role" : "AXButton",
+                    "subrole" : "AXSwitch"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:12 latin+space",
+                    "help" : "len:62 non-latin+punct+space",
+                    "role" : "AXButton"
+                  }
+                ],
+                "description" : "len:12 latin+space",
+                "role" : "AXLayoutItem"
+              },
+              {
+                "children" : [
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:2 non-latin",
+                    "help" : "len:36 non-latin+punct+space",
+                    "role" : "AXTextField"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:3 non-latin",
+                    "help" : "len:111 latin+non-latin+punct+space",
+                    "role" : "AXButton",
+                    "subrole" : "AXSwitch"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:3 non-latin",
+                    "help" : "len:65 non-latin+punct+space",
+                    "role" : "AXButton",
+                    "subrole" : "AXSwitch"
+                  },
+                  {
+                    "children" : [
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "len:10 latin+space",
+                        "role" : "AXValueIndicator"
+                      }
+                    ],
+                    "description" : "페이더 볼륨 | len:6 non-latin+space",
+                    "help" : "aux 페이더 볼륨 설정 재생 채널 출력 트랙 | len:120 digit+latin+non-latin+punct+space",
+                    "role" : "AXSlider",
+                    "valueRange" : "0...233"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:9 non-latin+space",
+                    "help" : "len:108 digit+latin+non-latin+punct+space",
+                    "role" : "AXTextField"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:9 non-latin+space",
+                    "help" : "len:113 digit+latin+non-latin+punct+space",
+                    "role" : "AXButton"
+                  },
+                  {
+                    "children" : [
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "len:12 latin+space",
+                        "role" : "AXStaticText"
+                      }
+                    ],
+                    "description" : "패닝",
+                    "help" : "밸런스 채널 패닝 | len:55 non-latin+punct+space",
+                    "role" : "AXSlider",
+                    "valueRange" : "-64...63"
+                  },
+                  {
+                    "children" : [
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "오토메이션",
+                        "role" : "AXCheckBox"
+                      },
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "len:2 non-latin",
+                        "role" : "AXButton"
+                      }
+                    ],
+                    "description" : "len:15 non-latin+punct+space",
+                    "role" : "AXGroup"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:2 non-latin",
+                    "help" : "len:74 non-latin+punct+space",
+                    "role" : "AXPopUpButton"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:8 non-latin+space",
+                    "help" : "len:81 non-latin+punct+space",
+                    "role" : "AXButton"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:8 non-latin+space",
+                    "help" : "len:81 non-latin+punct+space",
+                    "role" : "AXButton"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:8 non-latin+space",
+                    "help" : "len:81 non-latin+punct+space",
+                    "role" : "AXButton"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:8 non-latin+space",
+                    "help" : "len:81 non-latin+punct+space",
+                    "role" : "AXButton"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:5 non-latin+space",
+                    "help" : "len:66 non-latin+punct+space",
+                    "role" : "AXButton",
+                    "subrole" : "AXSwitch"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:19 latin+space",
+                    "help" : "len:54 latin+non-latin+punct+space",
+                    "role" : "AXButton"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:2 latin",
+                    "help" : "len:130 latin+non-latin+punct+space",
+                    "role" : "AXButton"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:9 non-latin+space",
+                    "help" : "len:108 latin+non-latin+punct+space",
+                    "role" : "AXButton",
+                    "subrole" : "AXSwitch"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:2 non-latin",
+                    "help" : "len:62 non-latin+punct+space",
+                    "role" : "AXButton"
+                  }
+                ],
+                "description" : "len:10 latin+space",
+                "role" : "AXLayoutItem"
+              },
+              {
+                "children" : [
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:2 non-latin",
+                    "help" : "len:36 non-latin+punct+space",
+                    "role" : "AXTextField"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:3 non-latin",
+                    "help" : "len:111 latin+non-latin+punct+space",
+                    "role" : "AXButton",
+                    "subrole" : "AXSwitch"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:3 latin",
+                    "help" : "len:70 non-latin+punct+space",
+                    "role" : "AXButton",
+                    "subrole" : "AXSwitch"
+                  },
+                  {
+                    "children" : [
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "len:10 latin+space",
+                        "role" : "AXValueIndicator"
+                      }
+                    ],
+                    "description" : "페이더 볼륨 | len:6 non-latin+space",
+                    "help" : "aux 페이더 볼륨 설정 재생 채널 출력 트랙 | len:120 digit+latin+non-latin+punct+space",
+                    "role" : "AXSlider",
+                    "valueRange" : "0...233"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:9 non-latin+space",
+                    "help" : "len:108 digit+latin+non-latin+punct+space",
+                    "role" : "AXTextField"
+                  },
+                  {
+                    "children" : [
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "오토메이션",
+                        "role" : "AXCheckBox"
+                      },
+                      {
+                        "children" : [
+
+                        ],
+                        "description" : "len:2 non-latin",
+                        "role" : "AXButton"
+                      }
+                    ],
+                    "description" : "len:16 non-latin+punct+space",
+                    "role" : "AXGroup"
+                  },
+                  {
+                    "children" : [
+
+                    ],
+                    "description" : "len:2 non-latin",
+                    "help" : "len:74 non-latin+punct+space",
+                    "role" : "AXPopUpButton"
+                  }
+                ],
+                "description" : "len:6 latin",
+                "role" : "AXLayoutItem"
+              }
+            ],
+            "description" : "len:2 non-latin",
+            "role" : "AXLayoutArea"
+          }
+        ],
+        "description" : "len:2 non-latin",
+        "role" : "AXGroup"
+      }
+    ],
+    "role" : "AXWindow",
+    "subrole" : "AXStandardWindow"
+  },
+  "scope" : "window"
+}

--- a/Tests/LogicProMCPTests/SelectorAtlasTests.swift
+++ b/Tests/LogicProMCPTests/SelectorAtlasTests.swift
@@ -539,6 +539,12 @@ struct Issue290SnapshotRedactionTests {
         // `user-named-thing` contains `name`, and the fixture kept it.
         let identifier = try #require(AXSnapshot.redactIdentifier("user-named-thing"))
         #expect(identifier.hasPrefix("len:"), "an identifier kept \(identifier)")
+
+        // And an identifier that IS a label exactly. Without this line the case above cannot see
+        // the concession being restored — `user-named-thing` is not an exact match either way, so
+        // the test passed with the defect back in. `Solo` is the value that separates them.
+        #expect(AXSnapshot.redactIdentifier("Solo") == "len:4 latin",
+                "an identifier equal to a label survived verbatim")
     }
 
     /// The three committed baselines, by the name they are filed under.
@@ -713,17 +719,11 @@ struct Issue290AtlasDiffTests {
         // is still a perfect match, so `confidences` is unchanged and the diff read `.stable` —
         // while `mixer.set_volume` fails on every track except one.
         let rail = try baseline()
-        let units = AtlasDiff.repeatedUnits(in: rail)
-        #expect(units.count >= 3, "the rail has \(units.count) rows — too few to lose most of them")
+        let rows = rail.root.children
+        #expect(rows.count >= 3, "the rail has \(rows.count) rows — too few to lose most of them")
 
-        let keptFirst = AXSnapshot.Document(
-            logicVersion: rail.logicVersion, locale: rail.locale, scope: rail.scope,
-            capturedFrom: rail.capturedFrom,
-            root: AXSnapshot.Node(
-                role: rail.root.role, subrole: rail.root.subrole,
-                description: rail.root.description, help: rail.root.help,
-                identifier: rail.root.identifier, valueRange: rail.root.valueRange,
-                children: [units[0]] + units.dropFirst().map(Self.withoutVolume)))
+        let keptFirst = Self.replacingRoot(
+            of: rail, with: [rows[0]] + rows.dropFirst().map(Self.withoutVolume))
 
         #expect(AtlasDiff.confidences(in: keptFirst)[.trackHeaderVolumeFader]
                     == AtlasDiff.confidences(in: rail)[.trackHeaderVolumeFader],
@@ -733,6 +733,101 @@ struct Issue290AtlasDiffTests {
         let volume = try #require(drifts.first { $0.selectorID == .trackHeaderVolumeFader })
         #expect(volume.status == .changed, "partial loss read as \(volume.status)")
         #expect(AtlasDiff.verdict(for: drifts, uncovered: []) == .failClosedMutation)
+    }
+
+    @Test("partial loss is visible when the repetition is nested, not just at the root")
+    func partialLossInsideAWindowCapture() throws {
+        // The counterexample that killed the first version of `coverage`, kept as a case because the
+        // rail is the easy shape and the window is the one that was wrong.
+        //
+        // Units used to be the ROOT's children — in a whole-window capture, five top-level groups
+        // (inspector, library, tracks, mixer, control bar). Every mixer fader lives inside one of
+        // them, so removing four of five left that group still hit, the ratio unchanged at one fifth
+        // both before and after, and the loss read `.stable` while the best score stayed 1.0.
+        let window = try windowBaseline()
+        let fader = AXLogicProElements.volumeFaderSelector
+        let path = try #require(AtlasDiff.unitPath(in: window, for: fader),
+                                "no repetition found for the fader in a whole-window capture")
+        let before = try #require(AtlasDiff.coverage(in: window, for: fader, at: path))
+        #expect(before == 1.0, "the mixer's strips do not all carry a fader: \(before)")
+
+        // Strip the volume evidence from all but the first of the deepest repeated set that holds
+        // faders — found the same way `coverage` finds it, so this mutation lands where it measures.
+        let sets = AtlasDiff.siblingSets(in: window.root)
+        let strips = try #require(sets.filter { units in
+            units.filter { Self.holdsVolume($0) }.count >= 3
+        }.min { $0.count < $1.count })
+        let stripped = Self.replacingSubtree(
+            of: window,
+            replacing: strips.dropFirst().map { ($0, Self.withoutVolume($0)) })
+
+        #expect(AtlasDiff.confidences(in: stripped)[.trackHeaderVolumeFader]
+                    == AtlasDiff.confidences(in: window)[.trackHeaderVolumeFader],
+                "the best score changed, so this case is not testing what it says")
+        // Read at the path the BASELINE named. Asking `stripped` where its own repetition is would
+        // let the measurement move: with four of five faders gone, a two-strip set elsewhere has
+        // the most matches and scores 1.0 again, from a different place.
+        let after = try #require(AtlasDiff.coverage(in: stripped, for: fader, at: path))
+        #expect(after < before, "nested partial loss left coverage at \(after)")
+
+        let drifts = AtlasDiff.between(baseline: window, current: stripped)
+        let volume = try #require(drifts.first { $0.selectorID == .trackHeaderVolumeFader })
+        #expect(volume.status == .changed, "nested partial loss read as \(volume.status)")
+    }
+
+    @Test("a verdict taken from the documents cannot be told a coverage it did not measure")
+    func documentVerdictDerivesItsOwnCoverage() throws {
+        // `verdict(for:uncovered:)` removing its default makes the question unavoidable; it does not
+        // make the answer true, and a caller can still spell `[]`. This overload has nothing to
+        // spell — both the drifts and the unmeasured set come from the same two documents.
+        let rail = try baseline()
+        let window = try windowBaseline()
+
+        // The rail alone: stable everywhere it looks, and still not reusable, because `.controlBar`
+        // is unmeasured. This is the exact call the argument-taking overload lets a caller fake.
+        #expect(AtlasDiff.verdict(baselines: [(rail, rail)]) == .failClosedMutation)
+        #expect(AtlasDiff.verdict(baselines: [(rail, rail), (window, window)])
+                    == .failClosedMutation,
+                "no committed baseline covers .controlBar, so neither should a union of them")
+
+        // And an empty run is not agreement either.
+        #expect(AtlasDiff.verdict(baselines: []) == .failClosedMutation)
+    }
+
+    private static func holdsVolume(_ node: AXSnapshot.Node) -> Bool {
+        AtlasDiff.candidates(in: node).contains {
+            confidence(of: $0.candidate, against: AXLogicProElements.volumeFaderSelector) >= 0.6
+        }
+    }
+
+    private static func replacingRoot(
+        of document: AXSnapshot.Document, with children: [AXSnapshot.Node]
+    ) -> AXSnapshot.Document {
+        AXSnapshot.Document(
+            logicVersion: document.logicVersion, locale: document.locale, scope: document.scope,
+            capturedFrom: document.capturedFrom,
+            root: AXSnapshot.Node(
+                role: document.root.role, subrole: document.root.subrole,
+                description: document.root.description, help: document.root.help,
+                identifier: document.root.identifier, valueRange: document.root.valueRange,
+                children: children))
+    }
+
+    /// Swap named subtrees wherever they appear, by value — the snapshot has no identity to key on.
+    private static func replacingSubtree(
+        of document: AXSnapshot.Document,
+        replacing pairs: [(AXSnapshot.Node, AXSnapshot.Node)]
+    ) -> AXSnapshot.Document {
+        func rewrite(_ node: AXSnapshot.Node) -> AXSnapshot.Node {
+            if let match = pairs.first(where: { $0.0 == node }) { return match.1 }
+            return AXSnapshot.Node(
+                role: node.role, subrole: node.subrole, description: node.description,
+                help: node.help, identifier: node.identifier, valueRange: node.valueRange,
+                children: node.children.map(rewrite))
+        }
+        return AXSnapshot.Document(
+            logicVersion: document.logicVersion, locale: document.locale, scope: document.scope,
+            capturedFrom: document.capturedFrom, root: rewrite(document.root))
     }
 
     /// Every volume label removed from one track row, and nothing else touched.

--- a/Tests/LogicProMCPTests/SelectorAtlasTests.swift
+++ b/Tests/LogicProMCPTests/SelectorAtlasTests.swift
@@ -524,9 +524,32 @@ struct Issue290SnapshotRedactionTests {
             .deletingLastPathComponent().deletingLastPathComponent()
             .appendingPathComponent("Fixtures/AX/logic-12.x-desktop-ko-track-headers.json")
         let text = try String(contentsOf: url, encoding: .utf8)
-        for name in ["Absolute Zero", "Absolute", "오디오", "무제", "Stereo Out"] {
+        for name in ["Absolute Zero", "Absolute", "무제", "Stereo Out"] {
             #expect(!text.contains(name), "\(name) is in the committed fixture")
         }
+
+        // `오디오` is NOT on that list, and the reason is worth stating rather than quietly
+        // dropping: it appears six times in the fixture, every one inside a checkbox's 98-character
+        // help sentence about record-enabling an audio track. That is Logic's own chrome. The
+        // criterion is "no user project/track/plugin NAMES", not "no token that also occurs in
+        // one" — and the tracks here were called `오디오 1` and `오디오 2`, which do not appear.
+        //
+        // So the structural property is asserted instead, and it is stronger than any blacklist: a
+        // name lives in a text field, and every text field in this capture is a shape.
+        let document = try JSONDecoder().decode(AXSnapshot.Document.self, from: Data(text.utf8))
+        var textFieldDescriptions: [String] = []
+        func walk(_ node: AXSnapshot.Node) {
+            if node.role == kAXTextFieldRole as String, let description = node.description {
+                textFieldDescriptions.append(description)
+            }
+            node.children.forEach(walk)
+        }
+        walk(document.root)
+        #expect(!textFieldDescriptions.isEmpty, "no text field in the capture — nothing was tested")
+        for description in textFieldDescriptions {
+            #expect(description.hasPrefix("len:"), "a text field kept \(description)")
+        }
+
         // And it is a real capture, not an empty file that trivially contains no names.
         #expect(text.contains("볼륨"))
         #expect(text.count > 5_000)
@@ -565,5 +588,82 @@ struct Issue290SnapshotRedactionTests {
         }
         // And the recognised one did survive, or the snapshot would be useless.
         #expect(encoded.contains("볼륨"))
+    }
+}
+
+/// #290 — the atlas diff, which is the last criterion with no environment constraint.
+///
+/// `UIDriftReport` takes `[SelectorID: Double]` and nothing produced those numbers, so it could not
+/// be called from anywhere — the same shape as the resolver having no adapter. `AtlasDiff` scores a
+/// baseline against the selectors actually in production, so a diff is two snapshots and needs no
+/// Logic on the machine. That matters: a qualification step that required the application open
+/// would not run where qualification runs.
+@Suite("Issue290AtlasDiff")
+struct Issue290AtlasDiffTests {
+
+    private func baseline() throws -> AXSnapshot.Document {
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent().deletingLastPathComponent()
+            .appendingPathComponent("Fixtures/AX/logic-12.x-desktop-ko-track-headers.json")
+        return try JSONDecoder().decode(AXSnapshot.Document.self, from: Data(contentsOf: url))
+    }
+
+    @Test("the committed baseline scores the selectors that resolve against it")
+    func baselineScoresAdoptedSelectors() throws {
+        // If it did not, every diff below would compare two empty dictionaries and pass while
+        // measuring nothing — the vacuous shape this suite has to avoid first.
+        let scores = AtlasDiff.confidences(in: try baseline())
+        #expect(scores[.trackHeaderPanControl] != nil, "pan scored nothing in the baseline")
+        #expect(scores[.trackHeaderVolumeFader] != nil)
+        #expect(scores[.trackHeaderMuteToggle] != nil)
+        #expect(scores[.trackHeaderSoloToggle] != nil)
+        #expect(scores[.trackHeaderArmToggle] != nil)
+        for (id, value) in scores {
+            #expect(value >= 0.6, "\(id) scored \(value), below the selectors' own threshold")
+        }
+    }
+
+    @Test("a baseline against itself is stable and reusable")
+    func identicalBaselinesAreStable() throws {
+        let doc = try baseline()
+        let drifts = AtlasDiff.between(baseline: doc, current: doc)
+        #expect(!drifts.isEmpty)
+        #expect(drifts.allSatisfy { $0.status == .stable })
+        #expect(AtlasDiff.verdict(for: drifts) == .reuseFull)
+    }
+
+    @Test("a selector that loses its control fails the run closed")
+    func aVanishedSelectorFailsClosed() throws {
+        // The failure this step exists to catch: a Logic update renames what a selector matches on,
+        // and the control stops being findable. Simulated by removing the label from the tree, not
+        // by editing the expected numbers.
+        let doc = try baseline()
+        let stripped = try JSONDecoder().decode(
+            AXSnapshot.Document.self,
+            from: Data(String(decoding: try JSONEncoder().encode(doc), as: UTF8.self)
+                .replacingOccurrences(of: "볼륨", with: "len:2 non-latin").utf8))
+
+        let drifts = AtlasDiff.between(baseline: doc, current: stripped)
+        let volume = try #require(drifts.first { $0.selectorID == .trackHeaderVolumeFader })
+        #expect(volume.status == .missing)
+        #expect(volume.affectedOperations == [.mixerSetVolume])
+        #expect(AtlasDiff.verdict(for: drifts) == .failClosedMutation,
+                "a selector that cannot find its control did not stop a mutation")
+    }
+
+    @Test("the run verdict is the worst case, not the average")
+    func verdictIsTheWorstCase() {
+        // Five stable selectors and one that vanished must not average out to reusable. That is how
+        // a gate stops being one.
+        let stable = SelectorDrift(
+            selectorID: .trackHeaderPanControl, status: .stable,
+            previousConfidence: 1, currentConfidence: 1,
+            changedRoles: [], affectedOperations: [.mixerSetPan])
+        let gone = SelectorDrift(
+            selectorID: .trackHeaderVolumeFader, status: .missing,
+            previousConfidence: 1, currentConfidence: 0,
+            changedRoles: [], affectedOperations: [.mixerSetVolume])
+        #expect(AtlasDiff.verdict(for: [stable, stable, stable, stable, stable]) == .reuseFull)
+        #expect(AtlasDiff.verdict(for: [stable, stable, stable, stable, gone]) == .failClosedMutation)
     }
 }

--- a/Tests/LogicProMCPTests/SelectorAtlasTests.swift
+++ b/Tests/LogicProMCPTests/SelectorAtlasTests.swift
@@ -456,13 +456,25 @@ struct SelectorAtlasOperationMapTests {
 @Suite("Issue290SnapshotRedaction")
 struct Issue290SnapshotRedactionTests {
 
-    @Test("a recognised label survives verbatim, including its case")
+    @Test("a recognised label survives verbatim, including its case, inside a chrome role")
     func recognisedLabelsSurvive() {
         // Verbatim and case-preserved, because selectors match `.exactStrict` — a snapshot that
         // lower-cased everything would show a tree no selector could be tested against.
-        #expect(AXSnapshot.redact("볼륨") == "볼륨")
-        #expect(AXSnapshot.redact("Control Bar") == "Control Bar")
-        #expect(AXSnapshot.redact("컨트롤 막대") == "컨트롤 막대")
+        //
+        // Inside a chrome role. These three used to be asserted with no role at all, which is the
+        // caller declining to say where the string came from — and the answer to that question can
+        // no longer be "verbatim", because a track a user named `Audio` walked out of an
+        // `AXTextField` on exactly that path.
+        #expect(AXSnapshot.redact("볼륨", role: kAXSliderRole as String) == "볼륨")
+        #expect(AXSnapshot.redact("Control Bar", role: kAXCheckBoxRole as String) == "Control Bar")
+        #expect(AXSnapshot.redact("컨트롤 막대", role: kAXSliderRole as String) == "컨트롤 막대")
+
+        // And an `AXGroup` is not a chrome role, which has a cost this suite states rather than
+        // hides: the control bar is identified BY its group description, so shaping group text
+        // means no committed baseline can score `.controlBar`. `AtlasDiff.uncovered` reports that
+        // instead of letting the verdict read the silence as agreement.
+        #expect(AXSnapshot.redact("컨트롤 막대", role: kAXGroupRole as String)
+                    == "len:6 non-latin+space")
     }
 
     @Test("names the product does not recognise are reduced to a shape")
@@ -511,48 +523,80 @@ struct Issue290SnapshotRedactionTests {
         // Without a role at all, no concession — the caller has not established the phenomenon.
         let roleless = try #require(AXSnapshot.redact("오디오 1"))
         #expect(roleless.hasPrefix("len:"))
-        // An EXACT match is safe in any role: the value IS a label the product knows.
-        #expect(AXSnapshot.redact("볼륨", role: kAXTextFieldRole as String) == "볼륨")
+
+        // An exact match is NOT safe outside a chrome role, and this case used to assert the
+        // opposite. `redact("볼륨", role: textField) == "볼륨"` encoded the reasoning that the value
+        // IS a label the product knows — which is a statement about the string and not about where
+        // it came from. `audio` is declared in two policy sets, so a track a user named `Audio`
+        // walked out of an `AXTextField` intact. The role gate now comes first.
+        #expect(AXSnapshot.redact("볼륨", role: kAXTextFieldRole as String) == "len:2 non-latin")
+        #expect(AXSnapshot.redact("Audio", role: kAXTextFieldRole as String) == "len:5 latin")
+        // And it still survives where the role says the string is Logic's own.
+        #expect(AXSnapshot.redact("볼륨", role: kAXSliderRole as String) == "볼륨")
+
+        // An identifier never gets the concession, whatever carries it. A slider is a chrome role,
+        // so before `redactIdentifier` existed this returned the labels found INSIDE the value —
+        // `user-named-thing` contains `name`, and the fixture kept it.
+        let identifier = try #require(AXSnapshot.redactIdentifier("user-named-thing"))
+        #expect(identifier.hasPrefix("len:"), "an identifier kept \(identifier)")
     }
 
-    @Test("the committed baseline carries no name from the project it was captured on")
-    func committedFixtureIsClean() throws {
-        // The criterion at the artifact, not the function. This fixture was captured on a live
-        // project whose tracks were named `Absolute Zero`, `오디오 1` and `오디오 2`, in a document
-        // called `무제 30`.
-        let url = URL(fileURLWithPath: #filePath)
+    /// The three committed baselines, by the name they are filed under.
+    static let committedFixtures = [
+        "logic-12.x-desktop-ko-track-headers.json",
+        "logic-12.x-desktop-en-track-headers.json",
+        "logic-12.x-desktop-ko-window.json",
+    ]
+
+    static func fixtureURL(_ name: String) -> URL {
+        URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent().deletingLastPathComponent()
-            .appendingPathComponent("Fixtures/AX/logic-12.x-desktop-ko-track-headers.json")
-        let text = try String(contentsOf: url, encoding: .utf8)
-        for name in ["Absolute Zero", "Absolute", "무제", "Stereo Out"] {
-            #expect(!text.contains(name), "\(name) is in the committed fixture")
+            .appendingPathComponent("Fixtures/AX/\(name)")
+    }
+
+    @Test("no committed baseline carries a name from the project it was captured on",
+          arguments: Issue290SnapshotRedactionTests.committedFixtures)
+    func committedFixtureIsClean(_ name: String) throws {
+        // The criterion at the artifact, not the function — and at EVERY artifact, because a rule
+        // that holds for the file someone remembered to check is not a rule.
+        //
+        // All three were captured on `lpm-606-warm`, whose tracks are named `Audio 1` and whose
+        // channel strip shows `Absolute Zero` and `Stereo Out`.
+        let text = try String(contentsOf: Self.fixtureURL(name), encoding: .utf8)
+        for secret in ["lpm-606-warm", "Absolute Zero", "Absolute", "Stereo Out", "Audio 1"] {
+            #expect(!text.contains(secret), "\(secret) is in \(name)")
         }
 
-        // `오디오` is NOT on that list, and the reason is worth stating rather than quietly
-        // dropping: it appears six times in the fixture, every one inside a checkbox's 98-character
-        // help sentence about record-enabling an audio track. That is Logic's own chrome. The
-        // criterion is "no user project/track/plugin NAMES", not "no token that also occurs in
-        // one" — and the tracks here were called `오디오 1` and `오디오 2`, which do not appear.
+        // A bare token is NOT on that list, and the reason is worth stating rather than quietly
+        // dropping: `오디오` and `audio` appear inside Logic's own help sentences about
+        // record-enabling an audio track. The criterion is "no user project/track/plugin NAMES",
+        // not "no token that also occurs in one".
         //
-        // So the structural property is asserted instead, and it is stronger than any blacklist: a
-        // name lives in a text field, and every text field in this capture is a shape.
+        // So the structural property is asserted too, and it is stronger than any blacklist: a name
+        // lives in a text field, a group description or a layout row, and every one of those in
+        // these captures is a shape.
         let document = try JSONDecoder().decode(AXSnapshot.Document.self, from: Data(text.utf8))
-        var textFieldDescriptions: [String] = []
+        let nameBearing: Set<String> = [
+            kAXTextFieldRole as String, kAXGroupRole as String, kAXLayoutItemRole as String,
+        ]
+        var carried: [String] = []
+        var shaped = 0
         func walk(_ node: AXSnapshot.Node) {
-            if node.role == kAXTextFieldRole as String, let description = node.description {
-                textFieldDescriptions.append(description)
+            if nameBearing.contains(node.role) {
+                for value in [node.description, node.help, node.identifier].compactMap({ $0 }) {
+                    carried.append(value)
+                    if value.hasPrefix("len:") { shaped += 1 }
+                }
             }
             node.children.forEach(walk)
         }
         walk(document.root)
-        #expect(!textFieldDescriptions.isEmpty, "no text field in the capture — nothing was tested")
-        for description in textFieldDescriptions {
-            #expect(description.hasPrefix("len:"), "a text field kept \(description)")
-        }
+        #expect(!carried.isEmpty, "nothing name-bearing in \(name) — nothing was tested")
+        #expect(shaped == carried.count,
+                "\(name) kept \(carried.filter { !$0.hasPrefix("len:") })")
 
         // And it is a real capture, not an empty file that trivially contains no names.
-        #expect(text.contains("볼륨"))
-        #expect(text.count > 5_000)
+        #expect(text.count > 5_000, "\(name) is too small to be a capture")
     }
 
     @Test("a label with a state suffix keeps its recognised prefix and loses the rest")
@@ -601,11 +645,20 @@ struct Issue290SnapshotRedactionTests {
 @Suite("Issue290AtlasDiff")
 struct Issue290AtlasDiffTests {
 
+    private func load(_ name: String) throws -> AXSnapshot.Document {
+        try JSONDecoder().decode(
+            AXSnapshot.Document.self,
+            from: Data(contentsOf: Issue290SnapshotRedactionTests.fixtureURL(name)))
+    }
+
     private func baseline() throws -> AXSnapshot.Document {
-        let url = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent().deletingLastPathComponent()
-            .appendingPathComponent("Fixtures/AX/logic-12.x-desktop-ko-track-headers.json")
-        return try JSONDecoder().decode(AXSnapshot.Document.self, from: Data(contentsOf: url))
+        try load("logic-12.x-desktop-ko-track-headers.json")
+    }
+
+    /// A track-header rail does not contain the control bar, so a pair of them leaves `.controlBar`
+    /// unmeasured. That is what `uncovered` is for, and this is the second baseline that closes it.
+    private func windowBaseline() throws -> AXSnapshot.Document {
+        try load("logic-12.x-desktop-ko-window.json")
     }
 
     @Test("the committed baseline scores the selectors that resolve against it")
@@ -623,13 +676,78 @@ struct Issue290AtlasDiffTests {
         }
     }
 
-    @Test("a baseline against itself is stable and reusable")
+    @Test("a baseline against itself is stable, and reusable only once every selector is covered")
     func identicalBaselinesAreStable() throws {
-        let doc = try baseline()
-        let drifts = AtlasDiff.between(baseline: doc, current: doc)
+        let rail = try baseline()
+        let drifts = AtlasDiff.between(baseline: rail, current: rail)
         #expect(!drifts.isEmpty)
         #expect(drifts.allSatisfy { $0.status == .stable })
-        #expect(AtlasDiff.verdict(for: drifts) == .reuseFull)
+
+        // A rail on its own does NOT earn full reuse, and this is the case that used to say it did.
+        // Nothing in a track-header capture contradicts the control bar, so a verdict read off the
+        // drift list alone called transport qualified on the strength of never having looked at it.
+        let railOnly = AtlasDiff.uncovered(baseline: rail, current: rail)
+        #expect(railOnly == [.controlBar], "the rail's coverage gap moved: \(railOnly)")
+        #expect(AtlasDiff.verdict(for: drifts, uncovered: railOnly) == .failClosedMutation)
+
+        // The window baseline does not close it either, and that is a measured fact rather than an
+        // oversight: the control bar is identified by an `AXGroup` description, groups can carry a
+        // plugin name, and the redaction shapes them. So `.controlBar` is unmeasured by every
+        // committed baseline, and until one covers it no pair of them can qualify a transport
+        // mutation. Naming the gap is the point — the previous verdict called it qualified.
+        let window = try windowBaseline()
+        let both = railOnly.intersection(
+            AtlasDiff.uncovered(baseline: window, current: window))
+        #expect(both == [.controlBar], "the coverage gap moved: \(both)")
+        #expect(AtlasDiff.verdict(for: drifts, uncovered: both) == .failClosedMutation)
+
+        // Reuse is reachable — it just takes a baseline set that covers everything, which is what
+        // the empty argument stands for here.
+        #expect(AtlasDiff.verdict(for: drifts, uncovered: []) == .reuseFull)
+    }
+
+    @Test("a selector that keeps its best score but loses most of its controls is drift")
+    func partialLossIsDrift() throws {
+        // The failure the best-score view cannot see, and the reason `coverage` exists. Logic strips
+        // the volume fader from every track header but the first: the strongest evidence in the tree
+        // is still a perfect match, so `confidences` is unchanged and the diff read `.stable` —
+        // while `mixer.set_volume` fails on every track except one.
+        let rail = try baseline()
+        let units = AtlasDiff.repeatedUnits(in: rail)
+        #expect(units.count >= 3, "the rail has \(units.count) rows — too few to lose most of them")
+
+        let keptFirst = AXSnapshot.Document(
+            logicVersion: rail.logicVersion, locale: rail.locale, scope: rail.scope,
+            capturedFrom: rail.capturedFrom,
+            root: AXSnapshot.Node(
+                role: rail.root.role, subrole: rail.root.subrole,
+                description: rail.root.description, help: rail.root.help,
+                identifier: rail.root.identifier, valueRange: rail.root.valueRange,
+                children: [units[0]] + units.dropFirst().map(Self.withoutVolume)))
+
+        #expect(AtlasDiff.confidences(in: keptFirst)[.trackHeaderVolumeFader]
+                    == AtlasDiff.confidences(in: rail)[.trackHeaderVolumeFader],
+                "the best score changed, so this case is not testing what it says")
+
+        let drifts = AtlasDiff.between(baseline: rail, current: keptFirst)
+        let volume = try #require(drifts.first { $0.selectorID == .trackHeaderVolumeFader })
+        #expect(volume.status == .changed, "partial loss read as \(volume.status)")
+        #expect(AtlasDiff.verdict(for: drifts, uncovered: []) == .failClosedMutation)
+    }
+
+    /// Every volume label removed from one track row, and nothing else touched.
+    private static func withoutVolume(_ node: AXSnapshot.Node) -> AXSnapshot.Node {
+        func strip(_ value: String?) -> String? {
+            guard let value else { return nil }
+            return AXLocalePolicy.sliderVolumeHint.labels.contains(where: {
+                value.lowercased().contains($0.lowercased())
+            }) ? "len:\(value.count) redacted" : value
+        }
+        return AXSnapshot.Node(
+            role: node.role, subrole: node.subrole,
+            description: strip(node.description), help: strip(node.help),
+            identifier: node.identifier, valueRange: node.valueRange,
+            children: node.children.map(withoutVolume))
     }
 
     @Test("a selector that loses its control fails the run closed")
@@ -647,8 +765,85 @@ struct Issue290AtlasDiffTests {
         let volume = try #require(drifts.first { $0.selectorID == .trackHeaderVolumeFader })
         #expect(volume.status == .missing)
         #expect(volume.affectedOperations == [.mixerSetVolume])
-        #expect(AtlasDiff.verdict(for: drifts) == .failClosedMutation,
+        #expect(AtlasDiff.verdict(for: drifts, uncovered: []) == .failClosedMutation,
                 "a selector that cannot find its control did not stop a mutation")
+    }
+
+    private func englishBaseline() throws -> AXSnapshot.Document {
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent().deletingLastPathComponent()
+            .appendingPathComponent("Fixtures/AX/logic-12.x-desktop-en-track-headers.json")
+        return try JSONDecoder().decode(AXSnapshot.Document.self, from: Data(contentsOf: url))
+    }
+
+    @Test("the same selectors resolve against a baseline captured in another language")
+    func selectorsResolveAcrossLocales() throws {
+        // The claim a single-locale atlas cannot make. Both fixtures are real captures from this
+        // machine — Logic quit, `defaults write com.apple.logic10 AppleLanguages -array en`,
+        // relaunched — so the two differ in Logic's own strings and in nothing else.
+        //
+        // What it caught: the rail is `트랙 헤더` in Korean and `Tracks header` in English. Not a
+        // translation of the same shape — the noun that is plural in one is singular in the other,
+        // and a selector written from the Korean alone would have looked for `track headers`.
+        let scores = AtlasDiff.confidences(in: try englishBaseline())
+        for id: SelectorID in [
+            .trackHeaderPanControl, .trackHeaderVolumeFader,
+            .trackHeaderMuteToggle, .trackHeaderSoloToggle, .trackHeaderArmToggle,
+        ] {
+            let value = try #require(scores[id], "\(id) found nothing in the English baseline")
+            #expect(value >= 0.6, "\(id) scored \(value) in English, below its own threshold")
+        }
+    }
+
+    @Test("a cross-locale diff is drift in Logic, not drift in the language")
+    func localeChangeIsNotDrift() throws {
+        // The trap this pins: diffing two locales must NOT read as a broken atlas. If it did, the
+        // qualification step would fail closed on every machine that is not the one the baseline was
+        // captured on — a gate that fires on its operator's language is not measuring Logic.
+        let drifts = AtlasDiff.between(
+            baseline: try baseline(), current: try englishBaseline())
+        #expect(!drifts.isEmpty, "nothing was compared")
+        let moved = drifts.filter { $0.status != .stable }
+            .map { "\($0.selectorID) \($0.status)" }.joined(separator: ", ")
+        #expect(AtlasDiff.verdict(for: drifts, uncovered: []) == .reuseFull,
+                "changing Logic's language read as UI drift: \(moved)")
+    }
+
+    @Test("the English baseline carries no name from the project it was captured on")
+    func englishFixtureIsClean() throws {
+        // Same criterion as the Korean fixture, and it has to be re-measured rather than inherited:
+        // this capture ran against `lpm-606-warm`, a different project with latin track names, and
+        // latin text is exactly what the shape encoding compresses least.
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent().deletingLastPathComponent()
+            .appendingPathComponent("Fixtures/AX/logic-12.x-desktop-en-track-headers.json")
+        let text = try String(contentsOf: url, encoding: .utf8)
+        #expect(!text.contains("lpm-606-warm"), "the project name is in the fixture")
+
+        let document = try JSONDecoder().decode(AXSnapshot.Document.self, from: Data(text.utf8))
+        var textFields: [String] = []
+        var layoutItems: [String] = []
+        func walk(_ node: AXSnapshot.Node) {
+            if let description = node.description {
+                if node.role == kAXTextFieldRole as String { textFields.append(description) }
+                if node.role == kAXLayoutItemRole as String { layoutItems.append(description) }
+            }
+            node.children.forEach(walk)
+        }
+        walk(document.root)
+
+        // Both places a track name reaches: the field that shows it, and the row that contains it.
+        #expect(!textFields.isEmpty, "no text field in the capture — nothing was tested")
+        #expect(!layoutItems.isEmpty, "no track row in the capture — nothing was tested")
+        for description in textFields + layoutItems {
+            #expect(description.hasPrefix("len:"), "a name-bearing element kept \(description)")
+        }
+
+        // And it is a real capture of English Logic, not an empty file that trivially holds no name.
+        for label in ["Mute", "Solo", "Volume", "Record Enable"] {
+            #expect(text.contains(label), "\(label) is missing — this is not an English capture")
+        }
+        #expect(document.locale == "en")
     }
 
     @Test("the run verdict is the worst case, not the average")
@@ -663,7 +858,7 @@ struct Issue290AtlasDiffTests {
             selectorID: .trackHeaderVolumeFader, status: .missing,
             previousConfidence: 1, currentConfidence: 0,
             changedRoles: [], affectedOperations: [.mixerSetVolume])
-        #expect(AtlasDiff.verdict(for: [stable, stable, stable, stable, stable]) == .reuseFull)
-        #expect(AtlasDiff.verdict(for: [stable, stable, stable, stable, gone]) == .failClosedMutation)
+        #expect(AtlasDiff.verdict(for: [stable, stable, stable, stable, stable], uncovered: []) == .reuseFull)
+        #expect(AtlasDiff.verdict(for: [stable, stable, stable, stable, gone], uncovered: []) == .failClosedMutation)
     }
 }

--- a/Tests/LogicProMCPTests/SelectorAtlasTests.swift
+++ b/Tests/LogicProMCPTests/SelectorAtlasTests.swift
@@ -694,7 +694,7 @@ struct Issue290AtlasDiffTests {
         // drift list alone called transport qualified on the strength of never having looked at it.
         let railOnly = AtlasDiff.uncovered(baseline: rail, current: rail)
         #expect(railOnly == [.controlBar], "the rail's coverage gap moved: \(railOnly)")
-        #expect(AtlasDiff.verdict(for: drifts, uncovered: railOnly) == .failClosedMutation)
+        #expect(AtlasDiff.verdict(for: drifts, assumingCoverage: railOnly) == .failClosedMutation)
 
         // The window baseline does not close it either, and that is a measured fact rather than an
         // oversight: the control bar is identified by an `AXGroup` description, groups can carry a
@@ -705,11 +705,11 @@ struct Issue290AtlasDiffTests {
         let both = railOnly.intersection(
             AtlasDiff.uncovered(baseline: window, current: window))
         #expect(both == [.controlBar], "the coverage gap moved: \(both)")
-        #expect(AtlasDiff.verdict(for: drifts, uncovered: both) == .failClosedMutation)
+        #expect(AtlasDiff.verdict(for: drifts, assumingCoverage: both) == .failClosedMutation)
 
         // Reuse is reachable — it just takes a baseline set that covers everything, which is what
         // the empty argument stands for here.
-        #expect(AtlasDiff.verdict(for: drifts, uncovered: []) == .reuseFull)
+        #expect(AtlasDiff.verdict(for: drifts, assumingCoverage: []) == .reuseFull)
     }
 
     @Test("a selector that keeps its best score but loses most of its controls is drift")
@@ -732,7 +732,7 @@ struct Issue290AtlasDiffTests {
         let drifts = AtlasDiff.between(baseline: rail, current: keptFirst)
         let volume = try #require(drifts.first { $0.selectorID == .trackHeaderVolumeFader })
         #expect(volume.status == .changed, "partial loss read as \(volume.status)")
-        #expect(AtlasDiff.verdict(for: drifts, uncovered: []) == .failClosedMutation)
+        #expect(AtlasDiff.verdict(for: drifts, assumingCoverage: []) == .failClosedMutation)
     }
 
     @Test("partial loss is visible when the repetition is nested, not just at the root")
@@ -773,6 +773,70 @@ struct Issue290AtlasDiffTests {
         let drifts = AtlasDiff.between(baseline: window, current: stripped)
         let volume = try #require(drifts.first { $0.selectorID == .trackHeaderVolumeFader })
         #expect(volume.status == .changed, "nested partial loss read as \(volume.status)")
+    }
+
+    @Test("a path that lands on a different kind of place is not a reading")
+    func aShiftedPathIsNotAReading() throws {
+        // An index path names a POSITION. Read in another capture it can resolve to a container
+        // that was never the one measured — and if that one is fully covered, a real loss elsewhere
+        // reads as no change. The role chain along the path is checked, so the reading is refused.
+        let window = try windowBaseline()
+        let fader = AXLogicProElements.volumeFaderSelector
+        let path = try #require(AtlasDiff.unitPath(in: window, for: fader))
+        #expect(!path.isEmpty, "the fader's repetition is at the root — nothing to shift")
+
+        // Reparent: the container the path points at is replaced by a differently-rolled one that
+        // still holds two like children. The indexes all still resolve.
+        let decoy = AXSnapshot.Node(
+            role: kAXListRole as String, subrole: nil, description: nil, help: nil,
+            identifier: nil, valueRange: nil,
+            children: (0..<2).map { _ in
+                AXSnapshot.Node(
+                    role: kAXGroupRole as String, subrole: nil, description: "볼륨", help: nil,
+                    identifier: nil, valueRange: "0...233", children: [])
+            })
+        let shifted = Self.replacing(window, at: path, with: decoy)
+
+        #expect(AtlasDiff.coverage(in: shifted, for: fader, at: path) != nil,
+                "the path stopped resolving, so this case is not testing the signature")
+        let signature = try #require(AtlasDiff.pathSignature(in: window, at: path))
+        #expect(AtlasDiff.coverage(in: shifted, for: fader, at: path, expecting: signature) == nil,
+                "a different kind of container was accepted as the same measurement")
+    }
+
+    private static func replacing(
+        _ document: AXSnapshot.Document, at path: [Int], with replacement: AXSnapshot.Node
+    ) -> AXSnapshot.Document {
+        func rewrite(_ node: AXSnapshot.Node, _ remaining: ArraySlice<Int>) -> AXSnapshot.Node {
+            guard let index = remaining.first else { return replacement }
+            var children = node.children
+            children[index] = rewrite(children[index], remaining.dropFirst())
+            return AXSnapshot.Node(
+                role: node.role, subrole: node.subrole, description: node.description,
+                help: node.help, identifier: node.identifier, valueRange: node.valueRange,
+                children: children)
+        }
+        return AXSnapshot.Document(
+            logicVersion: document.logicVersion, locale: document.locale, scope: document.scope,
+            capturedFrom: document.capturedFrom, root: rewrite(document.root, path[...]))
+    }
+
+    @Test("scoring a selector somewhere is not the same as having measured its coverage")
+    func confidenceWithoutRepetitionIsNotCoverage() throws {
+        // `uncovered` used to be "did it score anywhere", which a capture holding exactly one
+        // instance of every selector satisfies — full confidences, nothing unmeasured, full reuse,
+        // and the measurement that catches partial loss never ran once.
+        let rail = try baseline()
+        let single = Self.replacingRoot(of: rail, with: [rail.root.children[0]])
+
+        #expect(AtlasDiff.confidences(in: single)[.trackHeaderVolumeFader] != nil,
+                "the lone row does not score, so this case is not testing what it says")
+        #expect(AtlasDiff.unitPath(in: single, for: AXLogicProElements.volumeFaderSelector) == nil,
+                "one row still offered a repetition to measure")
+        #expect(AtlasDiff.uncovered(baseline: single, current: single)
+                    .contains(.trackHeaderVolumeFader),
+                "a selector scored but never measured for coverage counted as covered")
+        #expect(AtlasDiff.verdict(baselines: [(single, single)]) == .failClosedMutation)
     }
 
     @Test("a verdict taken from the documents cannot be told a coverage it did not measure")
@@ -860,7 +924,7 @@ struct Issue290AtlasDiffTests {
         let volume = try #require(drifts.first { $0.selectorID == .trackHeaderVolumeFader })
         #expect(volume.status == .missing)
         #expect(volume.affectedOperations == [.mixerSetVolume])
-        #expect(AtlasDiff.verdict(for: drifts, uncovered: []) == .failClosedMutation,
+        #expect(AtlasDiff.verdict(for: drifts, assumingCoverage: []) == .failClosedMutation,
                 "a selector that cannot find its control did not stop a mutation")
     }
 
@@ -900,7 +964,7 @@ struct Issue290AtlasDiffTests {
         #expect(!drifts.isEmpty, "nothing was compared")
         let moved = drifts.filter { $0.status != .stable }
             .map { "\($0.selectorID) \($0.status)" }.joined(separator: ", ")
-        #expect(AtlasDiff.verdict(for: drifts, uncovered: []) == .reuseFull,
+        #expect(AtlasDiff.verdict(for: drifts, assumingCoverage: []) == .reuseFull,
                 "changing Logic's language read as UI drift: \(moved)")
     }
 
@@ -953,7 +1017,7 @@ struct Issue290AtlasDiffTests {
             selectorID: .trackHeaderVolumeFader, status: .missing,
             previousConfidence: 1, currentConfidence: 0,
             changedRoles: [], affectedOperations: [.mixerSetVolume])
-        #expect(AtlasDiff.verdict(for: [stable, stable, stable, stable, stable], uncovered: []) == .reuseFull)
-        #expect(AtlasDiff.verdict(for: [stable, stable, stable, stable, gone], uncovered: []) == .failClosedMutation)
+        #expect(AtlasDiff.verdict(for: [stable, stable, stable, stable, stable], assumingCoverage: []) == .reuseFull)
+        #expect(AtlasDiff.verdict(for: [stable, stable, stable, stable, gone], assumingCoverage: []) == .failClosedMutation)
     }
 }


### PR DESCRIPTION
`UIDriftReport` takes `[SelectorID: Double]` and **nothing produced those numbers**, so it could not be called from anywhere — the same shape as the resolver having had no adapter. `AtlasDiff` scores a baseline against the selectors actually in production, so a diff is two snapshots and needs no Logic on the machine. That matters for the criterion it serves: a qualification step requiring the application open would not run where qualification runs.

**Two things this PR does not do**, stated up front because the earlier body overclaimed one of them:

- it does not wire the diff into `--qualify`; it builds the measurement and the baselines
- no committed baseline covers `.controlBar`, so `verdict(baselines:)` cannot currently return `.reuseFull` for any combination of them

## Three adversarial passes, six real fail-opens

Each round was run blind against the head, each finding was reproduced before being fixed, and every fix was mutation-tested by putting the defect back and watching the named test fail.

**Round 1.** An exact match skipped the role gate — `redact` returned any recognised label verbatim *before* looking at the role, which is a statement about the string and not about where it came from. `audio` is declared in two policy sets, so a track a user named `Audio` left an `AXTextField` intact. • Partial loss was invisible: `confidences` takes the best score in the tree, so stripping the volume fader from five of six headers left the maximum at 1.0 and the diff read `.stable`. • A verdict on an empty drift list answered `.reuseFull`, so two snapshots of the wrong scope qualified every mutation.

**Round 2 refuted two of those fixes**, and the second refutation is the interesting kind — **the measurement was moving to keep its own score up.** Units were the root's children; in a whole-window capture that is five top-level groups, and every mixer fader lives inside one of them. Choosing units independently on each side was no better: strip four of five faders and the five-strip set drops to one hit, so a two-strip set elsewhere now has the most matches and reports 1.0 **from a different place**. The baseline names the path; the current capture is read there and nowhere else. • Identifiers went from "exact match survives" to always a shape — `Solo` is a label the product knows *and* a plausible name.

**Round 3** confirmed all three controls are real and found two more. An index path names a position, so it can resolve in another capture to a container that was never the one measured; the path now carries its role chain and a reading whose chain differs is refused. • `uncovered` asked only whether a selector *scored* — a capture with one instance of each and no repetition produced full confidences, nothing unmeasured, and full reuse while the partial-loss measurement never ran.

## A limit written down rather than papered over

Coverage is a fraction of the units **present**, so it cannot see units disappearing — five strips at 5/5 becoming two at 2/2 reads as no change. Unit count follows the project, and making it part of the measurement would report drift on every honest capture of a different session.

## The redaction line moved, and scoring is what moved it

The pan selector scored **0.583** against the first fixture — below its own threshold — because scoping the prefix allowance to checkboxes had shaped a slider's help sentence away. Over-redaction is the safe direction **and it is not free**: a baseline the selector cannot be scored against is not a baseline. So the line is *which fields can carry user content*:

```
AXTextField / AXGroup / AXLayoutItem    a name lives here      -> always a shape
AXSlider / AXCheckBox help+description  Logic's own sentence   -> keeps recognised labels
AXIdentifier, any role                  opaque                 -> always a shape
```

Truncation is gone too. Keeping the four longest labels made the output a function of more than its input — the first English capture rendered near-identical help sentences as `mixer track play mute` and `mixer track mute play`.

## The English baseline

New, and it needed Logic's language changed (quit, `defaults write com.apple.logic10 AppleLanguages -array en`, relaunch, and back — verified by the window title returning to Korean, not assumed).

All five adopted selectors score **1.0** there. It caught something a single-locale atlas cannot say: the rail is `Tracks header` in English against `트랙 헤더` in Korean — **singular where the other is plural**, so a selector written from one locale alone would have looked for `track headers`.

## Gates

```
atlas + locale + redaction suites   54 tests
mutation tests                      7 defects reinstated, 7 named failures
full suite / preflight / live       via the ship gate
```

Refs #290.
