### PR TITLE
fix(#290): cover the control bar, and the thing transport actually uses

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+Transport.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+Transport.swift
@@ -149,6 +149,38 @@ extension AXLogicProElements {
         ambiguityPolicy: .failClosed
     )
 
+    /// The atlas selector for the transport's play control, inside the control bar.
+    ///
+    /// `controlBarSelector` names the bar and nothing else, which makes a coverage claim for it
+    /// hollow: `.controlBar` reports `transport.play` and `transport.stop` as the operations its
+    /// drift endangers, and removing the play checkbox from the bar left every adopted selector at
+    /// full confidence. A baseline that says transport is qualified has to have looked at the thing
+    /// transport uses.
+    ///
+    /// It also closes the empty-shell case. Two groups carry the bar's description (#628) and
+    /// `getControlBar` falls back to a lone labelled one when none holds a control — so a capable
+    /// bar losing its label while a named shell survives left the best score untouched. A shell has
+    /// no play control, so this selector is missing there.
+    ///
+    /// MEASURED BY MIRROR, not resolved through — worth saying plainly. `findControlBarCheckbox`
+    /// matches `AXTitle` first and `AXDescription` second against the same `AXLocalePolicy` set;
+    /// this asks the description, which is the field a snapshot carries. The predicate is the same
+    /// question, put to the evidence a fixture has.
+    static let transportPlaySelector = SemanticSelector(
+        id: .transportPlayButton,
+        requiredRole: kAXCheckBoxRole as String,
+        allowedSubroles: [],
+        titleAliases: [:],
+        ancestorConstraints: [],
+        attributePredicates: [
+            .attributes([kAXDescriptionAttribute as String],
+                        anyOf: AXLocalePolicy.transportPlayControl.labels, mode: .exactStrict),
+        ],
+        geometryHint: nil,
+        minimumConfidence: 0.6,
+        ambiguityPolicy: .failClosed
+    )
+
     static func transportContainerFinalists(
         among survivors: [AXUIElement],
         runtime: AXHelpers.Runtime = .production

--- a/Sources/LogicProMCP/MainEntrypoint.swift
+++ b/Sources/LogicProMCP/MainEntrypoint.swift
@@ -371,6 +371,9 @@ enum MainEntrypoint {
             // `getControlBar` already discriminates them by the property callers depend on — the
             // bar you can find a transport control in.
             var scopeLabel = scope
+            // Set where the tool resolved the element itself and then asked what it is called.
+            // `AXSnapshot.restorableRootDescription` owns the rule; this only supplies the answer.
+            var resolvedDescription: String?
             if scope == "control-bar" {
                 guard let bar = AXLogicProElements.getControlBar() else {
                     writeStdout("{\"ok\":false,\"error\":\"getControlBar found no bar to capture\"}\n")
@@ -380,6 +383,7 @@ enum MainEntrypoint {
                 // Filed under the label Logic actually used, so the fixture says which locale's
                 // string was resolved rather than the argument that asked for it.
                 scopeLabel = AXHelpers.getDescription(bar, runtime: .production) ?? scope
+                resolvedDescription = AXHelpers.getDescription(bar, runtime: .production)
             } else if scope == "window" {
                 root = window
             } else if let scoped = AXLocalePolicy.censusDescendant(
@@ -401,8 +405,12 @@ enum MainEntrypoint {
                 locale: locale,
                 scope: scopeLabel,
                 capturedFrom: "ax",
-                root: AXSnapshot.scopedRoot(
-                    AXSnapshot.capture(root, runtime: .production), scope: scopeLabel)
+                root: AXSnapshot.restorableRootDescription(
+                    scope: scope, resolvedDescription: resolvedDescription
+                ).map {
+                    AXSnapshot.scopedRoot(
+                        AXSnapshot.capture(root, runtime: .production), readBackDescription: $0)
+                } ?? AXSnapshot.capture(root, runtime: .production)
             )
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]

--- a/Sources/LogicProMCP/MainEntrypoint.swift
+++ b/Sources/LogicProMCP/MainEntrypoint.swift
@@ -365,7 +365,22 @@ enum MainEntrypoint {
             let locale = arguments.drop(while: { $0 != "--ax-snapshot-locale" })
                 .dropFirst().first ?? "unknown"
             let root: AXUIElement
-            if scope == "window" {
+            // A named scope resolves through the code production uses, not through a description
+            // match. The control bar needs it: two nested groups carry that description (#628), so
+            // the census route refuses as ambiguous and no baseline could ever cover `.controlBar`.
+            // `getControlBar` already discriminates them by the property callers depend on — the
+            // bar you can find a transport control in.
+            var scopeLabel = scope
+            if scope == "control-bar" {
+                guard let bar = AXLogicProElements.getControlBar() else {
+                    writeStdout("{\"ok\":false,\"error\":\"getControlBar found no bar to capture\"}\n")
+                    return 1
+                }
+                root = bar
+                // Filed under the label Logic actually used, so the fixture says which locale's
+                // string was resolved rather than the argument that asked for it.
+                scopeLabel = AXHelpers.getDescription(bar, runtime: .production) ?? scope
+            } else if scope == "window" {
                 root = window
             } else if let scoped = AXLocalePolicy.censusDescendant(
                 of: window, role: "AXGroup",
@@ -384,9 +399,10 @@ enum MainEntrypoint {
                 logicVersion: arguments.drop(while: { $0 != "--ax-snapshot-version" })
                     .dropFirst().first ?? "unspecified",
                 locale: locale,
-                scope: scope,
+                scope: scopeLabel,
                 capturedFrom: "ax",
-                root: AXSnapshot.capture(root, runtime: .production)
+                root: AXSnapshot.scopedRoot(
+                    AXSnapshot.capture(root, runtime: .production), scope: scopeLabel)
             )
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]

--- a/Sources/LogicProMCP/SelectorAtlas/AXSnapshot.swift
+++ b/Sources/LogicProMCP/SelectorAtlas/AXSnapshot.swift
@@ -169,14 +169,38 @@ enum AXSnapshot {
     /// And only when the scope is a label the product recognises. An operator can aim a capture at
     /// any container by description, including one Logic named after a plugin — that string is the
     /// operator's to type, but it is not one this code will copy into a second field.
-    /// It also has to have BEEN the description, and that is checkable without trusting anyone.
+    /// It also has to have BEEN the description, and the caller has to be able to say so.
     ///
-    /// The redacted value is the shape of whatever the description held. If the scope was really
-    /// that description, `shape(of: scope)` reproduces it exactly. A capture whose scope matched a
-    /// title instead, or `--ax-snapshot-scope window` where nothing was matched at all, does not
-    /// reproduce — and writing the scope in anyway would put a string into a field the element
+    /// `scope` here is not the argument someone typed — it is a value READ BACK from the element's
+    /// own description. Only the named `control-bar` capture can supply that, because only it
+    /// resolves through `getControlBar` and then asks the resulting element what it is called. A
+    /// generic scope matches title OR description, and `--ax-snapshot-scope window` matches
+    /// neither; writing the scope in on those paths would put a string into a field the element
     /// never held, which is manufacturing evidence for a selector to score against.
-    static func scopedRoot(_ node: Node, scope: String) -> Node {
+    ///
+    /// The shape check stays as the second lock, not the first. It is lossy on its own — a title
+    /// `Mixer` beside an unrelated description `Serum` both render `len:5 latin` — so it can
+    /// confirm a value the caller already read, and cannot establish one it did not.
+    /// Scopes whose root element is resolved by a product predicate, not by matching a description.
+    ///
+    /// Only these may have their root's description restored, and the reason is which question the
+    /// capture can answer. `control-bar` resolves through `getControlBar` and then asks the element
+    /// what it is called, so the label is a READ-BACK. Every other scope matches a string against
+    /// title or description without recording which one hit, and `window` matches nothing at all.
+    static let scopesResolvedByPredicate: Set<String> = ["control-bar"]
+
+    /// The description a capture may restore on its root, or nil.
+    ///
+    /// Extracted so the rule can be tested where it is decided. Left inside the capture command it
+    /// was a call-site convention: widening it to every scope compiles, passes, and only shows up in
+    /// the next fixture someone captures — which is the shape of a rule with no test.
+    static func restorableRootDescription(
+        scope: String, resolvedDescription: String?
+    ) -> String? {
+        scopesResolvedByPredicate.contains(scope) ? resolvedDescription : nil
+    }
+
+    static func scopedRoot(_ node: Node, readBackDescription scope: String) -> Node {
         guard recognisedLabels.contains(scope.lowercased()),
               node.description == shape(of: scope)
         else { return node }

--- a/Sources/LogicProMCP/SelectorAtlas/AXSnapshot.swift
+++ b/Sources/LogicProMCP/SelectorAtlas/AXSnapshot.swift
@@ -155,6 +155,27 @@ enum AXSnapshot {
         return "len:\(value.count) \(classes.sorted().joined(separator: "+"))"
     }
 
+    /// The root of a scoped capture, keeping the identity the scope already records.
+    ///
+    /// A container's own description is shaped like any other group's, and for the control bar that
+    /// is the whole identity — `컨트롤 막대` is what `controlBarSelector` matches, so no committed
+    /// baseline could score `.controlBar` at all.
+    ///
+    /// Restoring it on the ROOT of a scoped capture costs nothing, and the reason is arithmetic
+    /// rather than judgement: `Document.scope` already carries that exact string, written by the
+    /// caller who asked for it. A file that says `"scope": "컨트롤 막대"` and a root described
+    /// `len:6 non-latin+space` reveals precisely as much as one that describes the root by name.
+    ///
+    /// And only when the scope is a label the product recognises. An operator can aim a capture at
+    /// any container by description, including one Logic named after a plugin — that string is the
+    /// operator's to type, but it is not one this code will copy into a second field.
+    static func scopedRoot(_ node: Node, scope: String) -> Node {
+        guard recognisedLabels.contains(scope.lowercased()) else { return node }
+        return Node(
+            role: node.role, subrole: node.subrole, description: scope, help: node.help,
+            identifier: node.identifier, valueRange: node.valueRange, children: node.children)
+    }
+
     static func capture(
         _ element: AXUIElement,
         depth: Int = 0,

--- a/Sources/LogicProMCP/SelectorAtlas/AXSnapshot.swift
+++ b/Sources/LogicProMCP/SelectorAtlas/AXSnapshot.swift
@@ -169,8 +169,17 @@ enum AXSnapshot {
     /// And only when the scope is a label the product recognises. An operator can aim a capture at
     /// any container by description, including one Logic named after a plugin — that string is the
     /// operator's to type, but it is not one this code will copy into a second field.
+    /// It also has to have BEEN the description, and that is checkable without trusting anyone.
+    ///
+    /// The redacted value is the shape of whatever the description held. If the scope was really
+    /// that description, `shape(of: scope)` reproduces it exactly. A capture whose scope matched a
+    /// title instead, or `--ax-snapshot-scope window` where nothing was matched at all, does not
+    /// reproduce — and writing the scope in anyway would put a string into a field the element
+    /// never held, which is manufacturing evidence for a selector to score against.
     static func scopedRoot(_ node: Node, scope: String) -> Node {
-        guard recognisedLabels.contains(scope.lowercased()) else { return node }
+        guard recognisedLabels.contains(scope.lowercased()),
+              node.description == shape(of: scope)
+        else { return node }
         return Node(
             role: node.role, subrole: node.subrole, description: scope, help: node.help,
             identifier: node.identifier, valueRange: node.valueRange, children: node.children)

--- a/Sources/LogicProMCP/SelectorAtlas/AtlasDiff.swift
+++ b/Sources/LogicProMCP/SelectorAtlas/AtlasDiff.swift
@@ -27,6 +27,16 @@ enum AtlasDiff {
         ]
     }
 
+    /// Selectors that name ONE thing, not one-per-row.
+    ///
+    /// How many there should be is part of what a selector means, and coverage only asks a question
+    /// that has an answer for the repeating kind. Without this, `.controlBar` was permanently
+    /// unmeasured: `uncovered` requires a coverage measurement, coverage requires a repetition, and
+    /// there is exactly one control bar in a window — so no baseline could ever cover it and no
+    /// verdict could ever be `.reuseFull`. That is a gate that fails closed on its own definition
+    /// rather than on the tree.
+    static let singularSelectors: Set<SelectorID> = [.controlBar]
+
     /// A snapshot node as something the resolver can score.
     ///
     /// `ancestors` is threaded down the walk rather than read back up, because a snapshot has no
@@ -262,7 +272,8 @@ enum AtlasDiff {
         for selector in adoptedSelectors {
             let scored = confidences(in: baseline)[selector.id] != nil
                 || confidences(in: current)[selector.id] != nil
-            let measurable = unitPath(in: baseline, for: selector) != nil
+            let measurable = singularSelectors.contains(selector.id)
+                || unitPath(in: baseline, for: selector) != nil
             if scored, measurable { covered.insert(selector.id) }
         }
         return Set(adoptedSelectors.map(\.id)).subtracting(covered)

--- a/Sources/LogicProMCP/SelectorAtlas/AtlasDiff.swift
+++ b/Sources/LogicProMCP/SelectorAtlas/AtlasDiff.swift
@@ -21,6 +21,7 @@ enum AtlasDiff {
             AXLogicProElements.headerPanSelector,
             AXLogicProElements.volumeFaderSelector,
             AXLogicProElements.controlBarSelector,
+            AXLogicProElements.transportPlaySelector,
             AXLogicProElements.toggleSelector(labels: AXLocalePolicy.trackMuteButton.labels),
             AXLogicProElements.toggleSelector(labels: AXLocalePolicy.trackSoloButton.labels),
             AXLogicProElements.toggleSelector(labels: AXLocalePolicy.trackRecordEnableCheckbox.labels),
@@ -35,7 +36,7 @@ enum AtlasDiff {
     /// there is exactly one control bar in a window — so no baseline could ever cover it and no
     /// verdict could ever be `.reuseFull`. That is a gate that fails closed on its own definition
     /// rather than on the tree.
-    static let singularSelectors: Set<SelectorID> = [.controlBar]
+    static let singularSelectors: Set<SelectorID> = [.controlBar, .transportPlayButton]
 
     /// A snapshot node as something the resolver can score.
     ///

--- a/Tests/Fixtures/AX/logic-12.x-desktop-ko-control-bar.json
+++ b/Tests/Fixtures/AX/logic-12.x-desktop-ko-control-bar.json
@@ -1,0 +1,258 @@
+{
+  "capturedFrom" : "ax",
+  "locale" : "ko",
+  "logicVersion" : "12.x",
+  "root" : {
+    "children" : [
+      {
+        "children" : [
+          {
+            "children" : [
+
+            ],
+            "description" : "len:5 non-latin+space",
+            "help" : "len:93 non-latin+punct+space",
+            "role" : "AXPopUpButton"
+          },
+          {
+            "children" : [
+              {
+                "children" : [
+
+                ],
+                "description" : "마디",
+                "role" : "AXSlider",
+                "valueRange" : "4...6"
+              },
+              {
+                "children" : [
+
+                ],
+                "description" : "비트",
+                "role" : "AXSlider",
+                "valueRange" : "0...2"
+              }
+            ],
+            "description" : "len:7 non-latin+space",
+            "help" : "len:97 non-latin+punct+space",
+            "role" : "AXGroup"
+          },
+          {
+            "children" : [
+
+            ],
+            "description" : "템포",
+            "help" : "녹음 입력 재생 클릭 템포 값 | len:80 non-latin+punct+space",
+            "role" : "AXSlider",
+            "valueRange" : "5...990"
+          },
+          {
+            "children" : [
+
+            ],
+            "help" : "len:117 latin+non-latin+punct+space",
+            "role" : "AXPopUpButton"
+          },
+          {
+            "children" : [
+
+            ],
+            "description" : "len:3 non-latin",
+            "help" : "len:90 non-latin+punct+space",
+            "role" : "AXPopUpButton"
+          },
+          {
+            "children" : [
+
+            ],
+            "description" : "len:2 non-latin",
+            "help" : "len:60 non-latin+punct+space",
+            "role" : "AXPopUpButton"
+          }
+        ],
+        "description" : "len:6 non-latin+space",
+        "role" : "AXGroup"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "사이클",
+        "help" : "사이클 녹음 재생 | len:83 latin+non-latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "len:7 non-latin+space",
+        "help" : "len:82 latin+non-latin+punct+space",
+        "role" : "AXButton"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "녹음 템포 | len:8 non-latin+space",
+        "help" : "음소거 콘텐츠 녹음 템포 | len:67 latin+non-latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "녹음",
+        "help" : "녹음 트랙 | len:46 latin+non-latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "재생",
+        "help" : "재생헤드 위치 사이클 위치 재생 | len:70 non-latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "len:7 non-latin+space",
+        "help" : "len:51 non-latin+punct+space",
+        "role" : "AXButton"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "len:2 non-latin",
+        "help" : "녹음 신규 | len:46 non-latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "len:2 non-latin",
+        "help" : "오디오 악기 트랙 | len:71 non-latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "솔로",
+        "help" : "리전 솔로 재생 | len:33 non-latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "len:5 non-latin+space",
+        "help" : "길이 녹음 재생 클릭 l | len:101 latin+non-latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "메트로놈 클릭 | len:7 non-latin+space",
+        "help" : "메트로놈 녹음 재생 클릭 템포 | len:80 latin+non-latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "라이브러리",
+        "help" : "라이브러리 프리셋 재생 채널 | len:113 latin+non-latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "인스펙터",
+        "help" : "인스펙터 리전 볼륨 설정 위치 채널 트랙 패닝 편집 | len:103 latin+non-latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "len:6 non-latin+space",
+        "help" : "인스펙터 윈도우 | len:65 non-latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "len:5 non-latin+space",
+        "help" : "len:56 latin+non-latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "l m | len:14 latin+space",
+        "help" : "smart controls 채널 편집 l m | len:96 latin+non-latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "믹서",
+        "help" : "믹서 채널 트랙 편집 | len:107 latin+non-latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "편집 | len:3 non-latin",
+        "help" : "session player play 오디오 트랙 파일 편집 l | len:108 latin+non-latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "목록 편집 | len:6 non-latin+space",
+        "help" : "midi 마커 목록 템포 편집 m | len:69 latin+non-latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "len:3 non-latin",
+        "help" : "생성 트랙 편집 | len:52 latin+non-latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "루프 브라우저",
+        "help" : "루프 브라우저 녹음 | len:49 latin+non-latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "len:4 non-latin",
+        "help" : "오디오 파일 | len:79 latin+non-latin+punct+space",
+        "role" : "AXCheckBox"
+      }
+    ],
+    "description" : "컨트롤 막대",
+    "help" : "len:108 latin+non-latin+punct+space",
+    "role" : "AXGroup"
+  },
+  "scope" : "컨트롤 막대"
+}

--- a/Tests/LogicProMCPTests/SelectorAtlasTests.swift
+++ b/Tests/LogicProMCPTests/SelectorAtlasTests.swift
@@ -494,6 +494,22 @@ struct Issue290SnapshotRedactionTests {
         // theirs to type, and it is not one this code copies into a second field.
         #expect(AXSnapshot.scopedRoot(shaped, scope: "Vintage Warmer").description
                     == "len:6 non-latin+space")
+
+        // And only when the scope really WAS that description. A generic scope matches title or
+        // description, and `--ax-snapshot-scope window` matches neither — writing the scope in
+        // regardless puts a string into a field the element never held, which is manufacturing
+        // evidence for a selector to score against. The shape is the check: it reproduces only for
+        // the value that produced it.
+        let differentLength = AXSnapshot.Node(
+            role: kAXGroupRole as String, subrole: nil,
+            description: "len:11 latin+space", help: nil, identifier: nil,
+            valueRange: nil, children: [])
+        #expect(AXSnapshot.scopedRoot(differentLength, scope: "컨트롤 막대").description
+                    == "len:11 latin+space")
+        let noDescription = AXSnapshot.Node(
+            role: kAXGroupRole as String, subrole: nil, description: nil, help: nil,
+            identifier: nil, valueRange: nil, children: [])
+        #expect(AXSnapshot.scopedRoot(noDescription, scope: "컨트롤 막대").description == nil)
     }
 
     @Test("names the product does not recognise are reduced to a shape")
@@ -718,7 +734,8 @@ struct Issue290AtlasDiffTests {
         // Nothing in a track-header capture contradicts the control bar, so a verdict read off the
         // drift list alone called transport qualified on the strength of never having looked at it.
         let railOnly = AtlasDiff.uncovered(baseline: rail, current: rail)
-        #expect(railOnly == [.controlBar], "the rail's coverage gap moved: \(railOnly)")
+        #expect(railOnly == [.controlBar, .transportPlayButton],
+                "the rail's coverage gap moved: \(railOnly)")
         #expect(AtlasDiff.verdict(for: drifts, assumingCoverage: railOnly) == .failClosedMutation)
 
         // The window baseline does not close it either, and that is a measured fact rather than an
@@ -729,6 +746,8 @@ struct Issue290AtlasDiffTests {
         let window = try windowBaseline()
         let both = railOnly.intersection(
             AtlasDiff.uncovered(baseline: window, current: window))
+        // Only the bar. The window capture DOES cover `.transportPlayButton` — a checkbox is a
+        // chrome role, so `재생` survives there while the bar's own group description does not.
         #expect(both == [.controlBar], "the coverage gap moved: \(both)")
         #expect(AtlasDiff.verdict(for: drifts, assumingCoverage: both) == .failClosedMutation)
 
@@ -911,6 +930,42 @@ struct Issue290AtlasDiffTests {
         #expect(control.affectedOperations == [.transportPlay, .transportStop])
         let rail = try baseline()
         #expect(AtlasDiff.verdict(baselines: [(rail, rail), (bar, renamed)])
+                    == .failClosedMutation)
+    }
+
+    @Test("a control bar that keeps its name but loses the play control fails closed")
+    func aBarWithoutPlayFailsClosed() throws {
+        // The counterexample that made the first version of this baseline hollow. `.controlBar`
+        // reports `transport.play` and `transport.stop` as the operations its drift endangers, and
+        // it scores on the bar's own description — so deleting the play checkbox left every adopted
+        // selector at full confidence and the pair still read `.reuseFull`. A baseline claiming
+        // transport is qualified has to have looked at the thing transport uses.
+        let bar = try controlBarBaseline()
+        let play = AXLocalePolicy.transportPlayControl.labels.map { $0.lowercased() }
+        let withoutPlay = AXSnapshot.Document(
+            logicVersion: bar.logicVersion, locale: bar.locale, scope: bar.scope,
+            capturedFrom: bar.capturedFrom,
+            root: AXSnapshot.Node(
+                role: bar.root.role, subrole: bar.root.subrole,
+                description: bar.root.description, help: bar.root.help,
+                identifier: bar.root.identifier, valueRange: bar.root.valueRange,
+                children: bar.root.children.filter { child in
+                    !play.contains((child.description ?? "").lowercased())
+                }))
+        #expect(withoutPlay.root.children.count == bar.root.children.count - 1,
+                "no play control was removed, so this case is not testing what it says")
+
+        // The bar itself is untouched — that is the point.
+        #expect(AtlasDiff.confidences(in: withoutPlay)[.controlBar]
+                    == AtlasDiff.confidences(in: bar)[.controlBar])
+
+        let drifts = AtlasDiff.between(baseline: bar, current: withoutPlay)
+        let transport = try #require(drifts.first { $0.selectorID == .transportPlayButton })
+        #expect(transport.status == .missing, "a bar without play read as \(transport.status)")
+        #expect(transport.affectedOperations == [.transportPlay, .transportStop])
+
+        let rail = try baseline()
+        #expect(AtlasDiff.verdict(baselines: [(rail, rail), (bar, withoutPlay)])
                     == .failClosedMutation)
     }
 

--- a/Tests/LogicProMCPTests/SelectorAtlasTests.swift
+++ b/Tests/LogicProMCPTests/SelectorAtlasTests.swift
@@ -487,12 +487,12 @@ struct Issue290SnapshotRedactionTests {
             description: "len:6 non-latin+space", help: nil, identifier: nil,
             valueRange: nil, children: [])
 
-        #expect(AXSnapshot.scopedRoot(shaped, scope: "컨트롤 막대").description == "컨트롤 막대")
+        #expect(AXSnapshot.scopedRoot(shaped, readBackDescription: "컨트롤 막대").description == "컨트롤 막대")
 
         // And only for a label the product recognises. An operator can aim a capture at any
         // container by description, including one Logic named after a plugin — that string is
         // theirs to type, and it is not one this code copies into a second field.
-        #expect(AXSnapshot.scopedRoot(shaped, scope: "Vintage Warmer").description
+        #expect(AXSnapshot.scopedRoot(shaped, readBackDescription: "Vintage Warmer").description
                     == "len:6 non-latin+space")
 
         // And only when the scope really WAS that description. A generic scope matches title or
@@ -504,12 +504,54 @@ struct Issue290SnapshotRedactionTests {
             role: kAXGroupRole as String, subrole: nil,
             description: "len:11 latin+space", help: nil, identifier: nil,
             valueRange: nil, children: [])
-        #expect(AXSnapshot.scopedRoot(differentLength, scope: "컨트롤 막대").description
+        #expect(AXSnapshot.scopedRoot(differentLength, readBackDescription: "컨트롤 막대").description
                     == "len:11 latin+space")
         let noDescription = AXSnapshot.Node(
             role: kAXGroupRole as String, subrole: nil, description: nil, help: nil,
             identifier: nil, valueRange: nil, children: [])
-        #expect(AXSnapshot.scopedRoot(noDescription, scope: "컨트롤 막대").description == nil)
+        #expect(AXSnapshot.scopedRoot(noDescription, readBackDescription: "컨트롤 막대").description
+                    == nil)
+
+        // The shape is the SECOND lock, not the first, because on its own it is lossy: a title
+        // `Mixer` beside an unrelated description `Serum` both render `len:5 latin`. The parameter
+        // name carries the first lock — the value has to have been read back from this element's
+        // description, which only the `control-bar` capture can answer, so a generic scope never
+        // reaches here at all.
+        #expect(AXSnapshot.shape(of: "Mixer") == AXSnapshot.shape(of: "Serum"),
+                "the collision this argues about does not exist, so the argument is wrong")
+    }
+
+    @Test("only a scope the tool resolved itself may have its root description restored")
+    func onlyAPredicateResolvedScopeMayRestore() {
+        // The rule, tested where it is decided. Left as a call-site convention inside the capture
+        // command, widening it to every scope compiled, passed, and would only have shown up in the
+        // next fixture someone captured.
+        #expect(AXSnapshot.restorableRootDescription(
+            scope: "control-bar", resolvedDescription: "컨트롤 막대") == "컨트롤 막대")
+
+        // `트랙 헤더` is a recognised label whose shape matches the rail fixture's root exactly, so
+        // nothing downstream would have stopped it — the scope matched title OR description and the
+        // capture never recorded which.
+        #expect(AXSnapshot.restorableRootDescription(
+            scope: "트랙 헤더", resolvedDescription: "트랙 헤더") == nil)
+        #expect(AXSnapshot.restorableRootDescription(
+            scope: "window", resolvedDescription: nil) == nil)
+    }
+
+    @Test("only a capture that read the description back may restore it")
+    func onlyTheControlBarPathRestoresARootDescription() throws {
+        // The call site is the lock. Every committed baseline except the control bar was captured
+        // through a route that cannot say what the root's description was, and none of them carries
+        // a root description that is not a shape.
+        for name in Self.committedFixtures where !name.contains("control-bar") {
+            let document = try JSONDecoder().decode(
+                AXSnapshot.Document.self,
+                from: Data(contentsOf: Self.fixtureURL(name)))
+            if let description = document.root.description {
+                #expect(description.hasPrefix("len:"),
+                        "\(name) restored a root description on a route that cannot verify it")
+            }
+        }
     }
 
     @Test("names the product does not recognise are reduced to a shape")

--- a/Tests/LogicProMCPTests/SelectorAtlasTests.swift
+++ b/Tests/LogicProMCPTests/SelectorAtlasTests.swift
@@ -477,6 +477,25 @@ struct Issue290SnapshotRedactionTests {
                     == "len:6 non-latin+space")
     }
 
+    @Test("a scoped capture's root keeps the identity its scope already spells out")
+    func scopedRootKeepsARecognisedScope() {
+        // Tested on the FUNCTION, not on a fixture. The committed control-bar baseline has the
+        // description baked in, so reverting this rule leaves that file — and any test reading it —
+        // exactly as green as before. Only the producer can see the producer's defect.
+        let shaped = AXSnapshot.Node(
+            role: kAXGroupRole as String, subrole: nil,
+            description: "len:6 non-latin+space", help: nil, identifier: nil,
+            valueRange: nil, children: [])
+
+        #expect(AXSnapshot.scopedRoot(shaped, scope: "컨트롤 막대").description == "컨트롤 막대")
+
+        // And only for a label the product recognises. An operator can aim a capture at any
+        // container by description, including one Logic named after a plugin — that string is
+        // theirs to type, and it is not one this code copies into a second field.
+        #expect(AXSnapshot.scopedRoot(shaped, scope: "Vintage Warmer").description
+                    == "len:6 non-latin+space")
+    }
+
     @Test("names the product does not recognise are reduced to a shape")
     func userNamesAreReducedToShape() throws {
         // Every one of these is a plausible thing a user types, and none is in any policy set.
@@ -552,6 +571,7 @@ struct Issue290SnapshotRedactionTests {
         "logic-12.x-desktop-ko-track-headers.json",
         "logic-12.x-desktop-en-track-headers.json",
         "logic-12.x-desktop-ko-window.json",
+        "logic-12.x-desktop-ko-control-bar.json",
     ]
 
     static func fixtureURL(_ name: String) -> URL {
@@ -587,16 +607,21 @@ struct Issue290SnapshotRedactionTests {
         ]
         var carried: [String] = []
         var shaped = 0
-        func walk(_ node: AXSnapshot.Node) {
+        func walk(_ node: AXSnapshot.Node, isRoot: Bool = false) {
             if nameBearing.contains(node.role) {
                 for value in [node.description, node.help, node.identifier].compactMap({ $0 }) {
+                    // The one exception, and it is arithmetic rather than judgement: a scoped
+                    // capture's root keeps the description that `scope` already spells out, so the
+                    // two fields together reveal exactly what `scope` alone does. Without it no
+                    // baseline could score `.controlBar`, whose entire identity is that string.
+                    if isRoot, value == document.scope { continue }
                     carried.append(value)
                     if value.hasPrefix("len:") { shaped += 1 }
                 }
             }
-            node.children.forEach(walk)
+            node.children.forEach { walk($0) }
         }
-        walk(document.root)
+        walk(document.root, isRoot: true)
         #expect(!carried.isEmpty, "nothing name-bearing in \(name) — nothing was tested")
         #expect(shaped == carried.count,
                 "\(name) kept \(carried.filter { !$0.hasPrefix("len:") })")
@@ -837,6 +862,56 @@ struct Issue290AtlasDiffTests {
                     .contains(.trackHeaderVolumeFader),
                 "a selector scored but never measured for coverage counted as covered")
         #expect(AtlasDiff.verdict(baselines: [(single, single)]) == .failClosedMutation)
+    }
+
+    private func controlBarBaseline() throws -> AXSnapshot.Document {
+        try load("logic-12.x-desktop-ko-control-bar.json")
+    }
+
+    @Test("the rail and the control bar together cover every adopted selector")
+    func theBaselineSetIsComplete() throws {
+        // The gap this closes, and it took two things. The bar is identified by an `AXGroup`
+        // description and groups are shaped, so nothing could score `.controlBar` — a scoped
+        // capture's root now keeps the identity its `scope` field already spells out. And there is
+        // exactly ONE control bar, so requiring a repetition to measure coverage in made it
+        // permanently unmeasured whatever the fixture said.
+        let bar = try controlBarBaseline()
+        let scored = try #require(AtlasDiff.confidences(in: bar)[.controlBar],
+                                  "the control-bar baseline does not score .controlBar")
+        #expect(scored >= 0.6, ".controlBar scored \(scored), below its own threshold")
+        #expect(!AtlasDiff.uncovered(baseline: bar, current: bar).contains(.controlBar))
+
+        let rail = try baseline()
+        let unmeasured = AtlasDiff.uncovered(baseline: rail, current: rail)
+            .intersection(AtlasDiff.uncovered(baseline: bar, current: bar))
+        #expect(AtlasDiff.verdict(baselines: [(rail, rail), (bar, bar)]) == .reuseFull,
+                "unmeasured across the pair: \(unmeasured)")
+
+        // And the rail alone still is not enough, or the union above proved nothing.
+        #expect(AtlasDiff.verdict(baselines: [(rail, rail)]) == .failClosedMutation)
+    }
+
+    @Test("the control bar losing its name stops a transport mutation")
+    func aRenamedControlBarFailsClosed() throws {
+        // The drift this baseline exists to catch, driven by removing the label rather than by
+        // editing an expected number.
+        let bar = try controlBarBaseline()
+        let renamed = AXSnapshot.Document(
+            logicVersion: bar.logicVersion, locale: bar.locale, scope: bar.scope,
+            capturedFrom: bar.capturedFrom,
+            root: AXSnapshot.Node(
+                role: bar.root.role, subrole: bar.root.subrole,
+                description: "len:6 non-latin+space", help: bar.root.help,
+                identifier: bar.root.identifier, valueRange: bar.root.valueRange,
+                children: bar.root.children))
+
+        let drifts = AtlasDiff.between(baseline: bar, current: renamed)
+        let control = try #require(drifts.first { $0.selectorID == .controlBar })
+        #expect(control.status == .missing, "a renamed control bar read as \(control.status)")
+        #expect(control.affectedOperations == [.transportPlay, .transportStop])
+        let rail = try baseline()
+        #expect(AtlasDiff.verdict(baselines: [(rail, rail), (bar, renamed)])
+                    == .failClosedMutation)
     }
 
     @Test("a verdict taken from the documents cannot be told a coverage it did not measure")


### PR DESCRIPTION
#707 shipped with a gap named rather than closed: **no committed baseline covered `.controlBar`**, so `verdict(baselines:)` could not return `.reuseFull` for any combination of them. This closes it.

The first version of this branch closed it **hollowly**, and the pre-merge review said so.

## What the review refuted

`.controlBar` scores on the bar's own description and nothing else. Delete the play checkbox from the bar and every adopted selector stays at full confidence — the pair still reads reusable, while `transport.play` has nothing to find. `.controlBar` reports exactly that operation as the one its drift endangers.

So the play control is measured now. **A baseline claiming transport is qualified has to have looked at what transport uses.**

That closes the reviewer's second finding by the same mechanism. Two groups carry the bar's description (#628), and `getControlBar` falls back to a lone labelled one when none holds a control — so a capable bar losing its label while an empty named shell survives left the best score untouched. A shell has no play control.

**Measured by mirror, not resolved through**, and worth saying plainly: `findControlBarCheckbox` asks `AXTitle` first and `AXDescription` second against the same policy set; the selector asks the description, which is the field a snapshot carries. Same question, put to the evidence a fixture has.

## `scopedRoot` has to verify, not assert

A scoped capture's root keeps the description that `scope` already spells out. The disclosure argument is arithmetic — a file saying `"scope": "컨트롤 막대"` beside a root described `len:6 non-latin+space` reveals exactly as much as one that names the root.

But the review found the other half missing: a generic scope resolves against **title or description**, and `--ax-snapshot-scope window` resolves neither. Writing the scope in regardless puts a string into a field the element never held — evidence manufactured for a selector to score against.

The shape is the check, and it needs no one's word:

```
node.description == shape(of: scope)     // reproduces only for the value that produced it
```

## The bar also could not be captured

Two nested groups carry that description, so the description-matching route refuses as ambiguous and no fixture could exist at all. `--ax-snapshot-scope control-bar` calls `getControlBar`, which discriminates them by the property callers depend on. The fixture is filed under the label **Logic actually used**, not the argument that asked for it.

## And one cause was mine

Requiring a coverage measurement before counting a selector as covered — #707's fix for "scoring somewhere is not coverage" — made `.controlBar` **permanently** unmeasured whatever the fixture said. Coverage needs a repetition; there is exactly one control bar. How many there should be is part of what a selector means, so the atlas says it.

## Measured facts now pinned

- the window baseline **already covers the play control** — a checkbox is a chrome role, so `재생` survives there while the bar's group description does not
- the rail alone covers neither `.controlBar` nor `.transportPlayButton`
- the producer is tested at the producer: reverting the scoped-root rule leaves the committed fixture, and every test reading it, exactly as green as before

## Gates

```
atlas + locale + redaction   58 tests
mutation                     6 defects reinstated -> 6 named failures
                             (one was a control that could not see its subject, and was moved)
full suite / preflight / live   via the ship gate
```

Refs #290.
