### PR TITLE
docs(#290): the roadmap said the atlas has zero consumers, and it has six

### DIFF
--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -36,10 +36,10 @@ still list the issue rather than delete its row.
 It does not check the prose. The "waiting on" column, the order, and the state block below are still
 claims dated by the "measured" line, and only issue numbers and open/closed are mechanised.
 
-## State — measured 2026-08-24 at `d02d85f4`
+## State — measured 2026-08-29 at `8959bee7`
 
 ```
-open PRs 0 · v3.14.0 published · 19 open issues
+open PRs 0 · v3.14.0 published · 17 open issues
 ```
 
 | ADR | issue | state | what it is waiting on |
@@ -50,7 +50,7 @@ open PRs 0 · v3.14.0 published · 19 open issues
 | ADR-004 | #287 | closed | |
 | ADR-005 | #288 | closed | |
 | ADR-006 | #289 | closed | shipped #674/#675, measured and closed |
-| ADR-007 | #290 | OPEN | the atlas IS written (`Sources/LogicProMCP/SelectorAtlas/`, all three pieces) and has **zero production consumers**; adoption is blocked on the scoring, which awards 0.55 of 1 for an `AXIdentifier` Logic does not expose on these elements — a fully-matching header slider scores 0.40 |
+| ADR-007 | #290 | OPEN | scoring fixed and six selectors adopted; the diff, four baselines and cross-locale coverage shipped in #707/#708. Waiting on a **decision**, not work: wiring the diff into `--qualify` changes the attestation schema or the release gate's behaviour, and the three options are written up on the issue |
 | ADR-008 | #291 | OPEN | node identity cannot be the display string — needs a decision, not an attempt |
 | ADR-009 | #292 | OPEN | apply-back expansion on Wave-0 insert work; #299 and #301 consume it |
 | ADR-010 | #293 | OPEN | provider exists (10 modules); its collector was written against a fixture shape Logic does not produce |
@@ -103,9 +103,11 @@ attached — not a silent deferral.
    on 2026-08-24 moved its blocker: the 49 mutating operations with a verification plan are waiting
    on a write-and-readback qualification mode that does not exist, which the #284 matrix does not
    supply. #373 covers a smaller part of it than "depends on #373" suggested.
-2. **#290** — not "write the atlas": it is written and unused. The next step is a decision
-   about its scoring, which cannot resolve an element with no `AXIdentifier` above 0.45 and so
-   cannot resolve the ones the product addresses. Measured, with the real function.
+2. **#290** — the scoring decision is made and the atlas is in use. `confidence` is a ratio over
+   the evidence a selector actually requests, so a header slider with no `AXIdentifier` scores 1.0
+   on what it does expose; six selectors resolve identity through it. What remains is not code: the
+   diff runs, but nothing calls it at qualification time, and every way of wiring it touches either
+   the attestation schema or what `--qualify` refuses. That choice is on the issue as A/B/C.
 3. **#293 → #303** — readback before the transforms that must take their expected values from it.
 4. **#302** — blocked on the Event List's absent `kAXColumns` until that is re-measured.
 5. **#292 → #299**. #300's promotion is done — the flag is removed, not defaulted on.


### PR DESCRIPTION
`docs/roadmap/README.md` is the source of truth for what is open and in what order, and its ADR-007 row described the state before #707 and #708.

The guard that runs in CI compares **issue numbers and open/closed only** — it says so itself. So the prose is exactly the part that goes stale unnoticed, which is what happened.

**What it claimed:** the atlas is written and unused, adoption blocked on a scoring rule that awards 0.55 for an `AXIdentifier` Logic does not expose, a fully-matching header slider scoring 0.40.

**What is true:** `confidence` is a ratio over the evidence a selector actually *requests*, so that slider scores 1.0 on what it does expose. Six selectors resolve identity through the atlas. The diff, four baselines and cross-locale coverage shipped.

The remaining item on #290 is a decision rather than work, and the row now says which: nothing calls the diff at qualification time, and every way of wiring it touches either the attestation schema or what `--qualify` refuses. The three options are written up on the issue.

State block re-measured: **17 open issues at `8959bee7`**, and `Scripts/roadmap-table-matches-github.py` agrees with GitHub across 25 rows.

Refs #290.