### PR TITLE
feat: a Sources change now obliges the harness that claims it

### DIFF
--- a/Scripts/check-falsifiable-adoption.py
+++ b/Scripts/check-falsifiable-adoption.py
@@ -27,9 +27,9 @@ can distinguish the observation from one stated alternative, and no more; whethe
 is the one that matters is the author's claim and a reviewer's job. Said here because a guard named
 "adoption" invites being read as "quality".
 """
+import ast
 import glob
 import os
-import re
 import sys
 
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -37,7 +37,28 @@ REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # The measured floor. Raise it when a harness converts; never lower it to make a branch pass.
 FLOOR = 1
 
-CALL = re.compile(r"\bfalsifiable\s*\(")
+def _calls_falsifiable(text):
+    """Whether the source contains an actual CALL to `falsifiable`, not a mention of the word.
+
+    Parsed, because a regex counts `# falsifiable(` in a comment and a `"falsifiable("` in a
+    string. Found by review, 2026-08-29, reproduced: a harness whose only occurrence was a comment
+    held the floor and passed CI, and the test that was supposed to catch it wrote the word without
+    the parenthesis — so the control could not see the defect it was aimed at.
+
+    A file that will not parse claims nothing. It cannot be run either, so it cannot be an adopter.
+    """
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return False
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+        if name == "falsifiable":
+            return True
+    return False
 
 
 def adoption(paths=None):
@@ -53,7 +74,7 @@ def adoption(paths=None):
             # Unreadable is not adopted. Counting it either way would let a permissions accident
             # move the number, and this number is the whole point of the guard.
             continue
-        if CALL.search(text):
+        if _calls_falsifiable(text):
             adopters.append(os.path.basename(path))
     return adopters, len(files)
 

--- a/Scripts/check-falsifiable-adoption.py
+++ b/Scripts/check-falsifiable-adoption.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""The strongest affordance a live harness has must not decay, and the gap must be a number.
+
+`evidence.falsifiable()` hands the predicate to the framework, which runs it twice: once on what
+the run observed, once on a counterexample the author had to write down. The check passes only when
+the first is accepted AND the second rejected, and the author cannot supply the second result.
+It is the only thing in the live kit that can notice a condition which could not have failed.
+
+`is_clean` counts `checks_with_a_counterexample` and deliberately does not require it:
+
+    Requiring every harness to HAVE one is the clause with teeth, and it is left
+    counted-but-unenforced ... thirty-odd harnesses predate the affordance, and turning the whole
+    live suite red in one step invites someone to delete the clause instead of converting the
+    call sites. Enforce it when the count reaches the harness count, not before.
+
+That reasoning is right and it left the number to nobody. Measured 2026-08-29: **1 of 35**. A
+comment saying "enforce it later" has no way to notice going backwards, and no way to say how far
+"later" is.
+
+So this guard does the smaller thing that is mechanical rather than the larger one that is a
+promise: the count may rise and may not fall. Raising FLOOR is a reviewed edit in this file, which
+is where a ratchet's teeth are — a number that can be lowered by whoever is inconvenienced is a
+suggestion.
+
+It does not check that a counterexample is a GOOD one. `falsifiable` establishes that a predicate
+can distinguish the observation from one stated alternative, and no more; whether that alternative
+is the one that matters is the author's claim and a reviewer's job. Said here because a guard named
+"adoption" invites being read as "quality".
+"""
+import glob
+import os
+import re
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# The measured floor. Raise it when a harness converts; never lower it to make a branch pass.
+FLOOR = 1
+
+CALL = re.compile(r"\bfalsifiable\s*\(")
+
+
+def adoption(paths=None):
+    """`(adopters, total)` — harnesses calling `falsifiable(`, and how many there are."""
+    files = paths if paths is not None else sorted(
+        glob.glob(os.path.join(REPO, "Scripts", "livekit", "live_*.py")))
+    adopters = []
+    for path in files:
+        try:
+            with open(path, encoding="utf-8") as fh:
+                text = fh.read()
+        except OSError:
+            # Unreadable is not adopted. Counting it either way would let a permissions accident
+            # move the number, and this number is the whole point of the guard.
+            continue
+        if CALL.search(text):
+            adopters.append(os.path.basename(path))
+    return adopters, len(files)
+
+
+def main():
+    adopters, total = adoption()
+    if total == 0:
+        print("-> FAIL: no live harnesses found — an empty set satisfies any floor")
+        return 1
+
+    print(f"   falsifiable() adoption: {len(adopters)} of {total} harnesses (floor {FLOOR})")
+    for name in adopters:
+        print(f"     uses it  {name}")
+
+    if len(adopters) < FLOOR:
+        print(f"-> FAIL: adoption fell to {len(adopters)}, below the recorded floor {FLOOR}")
+        print("   A harness lost its counterexample, or one was deleted. Restore it, or raise the")
+        print("   question in review — do not lower FLOOR to make this pass.")
+        return 1
+
+    if len(adopters) > FLOOR:
+        print(f"-> FAIL: adoption is {len(adopters)} but FLOOR is still {FLOOR}")
+        print(f"   Raise FLOOR to {len(adopters)} in this file. A ratchet that does not tighten")
+        print("   when it can is a counter, and the next regression falls back to the old number.")
+        return 1
+
+    remaining = total - len(adopters)
+    if remaining:
+        print(f"   {remaining} harness(es) have no counterexample. `is_clean` will enforce")
+        print(f"   checks_with_a_counterexample > 0 when this reaches {total}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Scripts/livekit/harness_evidence_coverage.py
+++ b/Scripts/livekit/harness_evidence_coverage.py
@@ -242,6 +242,24 @@ def main(argv):
     required |= by_sources
 
     if not required:
+        # A livekit change that obliges no particular harness still has to point at a clean run.
+        # Without this, editing `evidence.py` — which DEFINES `is_clean` — reached the gate and
+        # then returned here before any document was judged by it: the branch could change what
+        # passing means, run any harness, produce red records, and be asked nothing. The binding
+        # step checks artifact metadata, not records.
+        touched_kit = [p for p in paths
+                       if p.startswith("Scripts/livekit/") and p.endswith(".py")
+                       and not os.path.basename(p).startswith("test_")]
+        if touched_kit:
+            present = documents_present(os.path.join(root, head))
+            clean = [stem for stem, path in present.items()
+                     if E.is_clean(E.summarize((_read_json(path) or {}).get("records")))]
+            print(f"   livekit changed ({len(touched_kit)} file(s)) and obliges no single harness;"
+                  f" {len(clean)} of {len(present)} document(s) at this head are clean")
+            if not clean:
+                print("-> COVERAGE FAIL: a change to the live kit must point at a clean run,"
+                      " and none of the documents at this head is one")
+                return 1
         if unproven:
             print(f"n/a — no harness claims the {len(unproven)} changed Sources/ path(s):")
             for path in unproven[:8]:

--- a/Scripts/livekit/harness_evidence_coverage.py
+++ b/Scripts/livekit/harness_evidence_coverage.py
@@ -196,8 +196,8 @@ def _read_json(path):
         return None
 
 
-def changed_paths(worktree, base, head="HEAD"):
-    """Paths the branch changed, excluding deletions.
+def changed_paths(worktree, base, head="HEAD", exclude_deletions=True):
+    """Paths the branch changed; deletions excluded only when the caller asks.
 
     `head` is the commit the caller is asking ABOUT, not the worktree's current one. The first
     version hard-coded `HEAD` and took the head sha only to look up an evidence directory, so a
@@ -206,12 +206,19 @@ def changed_paths(worktree, base, head="HEAD"):
     not, and the failure is a coverage verdict about the wrong commit reported as a verdict about
     this one.
 
-    `--diff-filter=d` drops deletions. A harness that no longer exists cannot be required to have
-    run, and requiring it would make deleting a harness impossible — the branch could never
-    produce the evidence, because there is nothing left to produce it.
+    `--diff-filter=d` drops deletions, and that is right for HARNESSES: one that no longer exists
+    cannot be required to have run, and requiring it would make deleting a harness impossible.
+
+    It is wrong for `Sources/`, and applying it there was a way through the whole source-coverage
+    rule — DELETE a file the atlas harness claims and the path never reached `required_by_sources`,
+    so removing covered product code needed no proof at all. Deleting code is a change to what
+    ships, and the harness that claims that area is exactly what should be run over it. Found by
+    review, 2026-08-29.
     """
-    proc = subprocess.run(
-        ["git", "diff", "--name-only", "--diff-filter=d", f"{base}...{head}"],
+    cmd = ["git", "diff", "--name-only"]
+    if exclude_deletions:
+        cmd.append("--diff-filter=d")
+    proc = subprocess.run(cmd + [f"{base}...{head}"],
         cwd=worktree, capture_output=True, text=True)
     if proc.returncode != 0:
         return None
@@ -231,6 +238,12 @@ def main(argv):
         return 2
     required = harness_stems(paths)
 
+    # Deletions INCLUDED for the source question, excluded for the harness one. See `changed_paths`.
+    all_paths = changed_paths(worktree, base, head, exclude_deletions=False)
+    if all_paths is None:
+        print(f"-> COVERAGE FAIL: could not diff {base}...HEAD in {worktree} (with deletions)")
+        return 2
+
     # What the branch's `Sources/` changes oblige, from declarations on the TRUSTED ref.
     declarations = declarations_from_ref(worktree, base)
     if declarations is None:
@@ -238,7 +251,7 @@ def main(argv):
         print("   The declarations are deliberately NOT read from the branch under test, so a")
         print("   missing ref is a refusal, not a fallback. Run: git fetch origin main")
         return 2
-    by_sources, unproven = required_by_sources(paths, declarations)
+    by_sources, unproven = required_by_sources(all_paths, declarations)
     required |= by_sources
 
     if not required:

--- a/Scripts/livekit/harness_evidence_coverage.py
+++ b/Scripts/livekit/harness_evidence_coverage.py
@@ -22,12 +22,21 @@ A harness is required to have proved itself when the branch CHANGED it:
 That is decidable from the diff, and it is exactly the case that went wrong. What is NOT decidable,
 and is not attempted here: which harnesses a `Sources/` change ought to have been proved against.
 Nothing in the tree records that mapping, and inventing one would put a guess where this check's
-whole value is that it does not guess. A branch that changes only `Sources/` therefore passes this
-check with nothing required — the existing "live evidence for this head" step is what covers it.
+whole value is that it does not guess. A branch that changes only `Sources/` used to pass this check with
+nothing required, and the ship gate's "live evidence for this head" step accepted ANY clean
+document — so changing the spectral engine and running the selector-atlas harness passed, with a
+document that was true and about something else.
 
-So this is a coverage floor, not a coverage proof. Said plainly because a check named `coverage`
-invites being read as more.
+That is closed as of 2026-08-29, and still without a guess: a harness DECLARES what it covers, in
+a `COVERS = [...]` literal in its own file, read from a trusted ref so a branch cannot rewrite its
+own obligations. A `Sources/` path some harness claims obliges that harness to have run clean. A
+path nobody claims is printed as `unproven` rather than treated as proved.
+
+So this is still a coverage floor, not a coverage proof — the unproven list is the size of the gap
+and it is reported, not enforced. Said plainly because a check named `coverage` invites being read
+as more.
 """
+import ast
 import glob
 import json
 import os
@@ -53,6 +62,95 @@ def harness_stems(changed_paths):
         if os.path.dirname(path).replace("\\", "/").endswith("Scripts/livekit"):
             stems.add(name[: -len(".py")])
     return stems
+
+
+def declared_coverage(text):
+    """The repo paths a harness DECLARES it proves, from its `COVERS = [...]` literal.
+
+    Parsed out of the source rather than imported, because importing a harness runs it — and the
+    thing being judged does not get to execute inside its own judge. `ast.literal_eval` accepts a
+    list of strings and nothing else, so a declaration cannot be computed, and a harness cannot
+    widen its own claim at read time.
+    """
+    try:
+        tree = ast.parse(text or "")
+    except SyntaxError:
+        return []
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        names = [t.id for t in node.targets if isinstance(t, ast.Name)]
+        if "COVERS" not in names:
+            continue
+        try:
+            value = ast.literal_eval(node.value)
+        except (ValueError, SyntaxError):
+            return []
+        if isinstance(value, (list, tuple)) and all(isinstance(v, str) for v in value):
+            return [v for v in value if v.strip()]
+        return []
+    return []
+
+
+def required_by_sources(changed, declarations):
+    """`(required, unproven)` — harnesses a `Sources/` change obliges, and the paths nobody claims.
+
+    THE HOLE THIS CLOSES. Until 2026-08-29 a branch that changed only `Sources/` required no
+    particular harness: the ship gate asked for *some* clean document bound to this head, and any
+    harness supplied one. Change the spectral engine, run the selector-atlas harness, pass. The
+    document was true and about something else.
+
+    The old rule declined to invent a mapping, and that was right — a guess in a gate is worse than
+    a gap. This does not guess. A harness SAYS what it covers, in its own file, reviewed like any
+    other line, and the declarations are read from a trusted ref so a branch cannot rewrite its own
+    obligations. What nobody claims is reported rather than assumed proved.
+
+    Matching is by path COMPONENT, not by string prefix. `Sources/LogicProMCP/SelectorAtlas`
+    written without its trailing slash would otherwise claim `SelectorAtlasExtras/` too — a
+    declaration silently wider than the directory it names, and the widening happens in the
+    direction that makes a harness look like it covers more.
+    """
+    required, unproven = set(), []
+    for path in changed or []:
+        if not path.startswith("Sources/"):
+            continue
+        claimants = sorted(
+            stem for stem, covers in (declarations or {}).items()
+            if any(path == prefix or path.startswith(prefix.rstrip("/") + "/")
+                   for prefix in covers)
+        )
+        if claimants:
+            required.update(claimants)
+        else:
+            unproven.append(path)
+    return required, sorted(unproven)
+
+
+def declarations_from_ref(worktree, ref):
+    """`{stem: [paths]}` read from `ref`, not from the branch under test.
+
+    Same principle the gate already applies to the rule itself: a branch that supplies its own
+    judgement is not judged. A harness the branch ADDS therefore claims nothing here — which is
+    safe, because the changed-harness rule already requires it to have run.
+    """
+    listing = subprocess.run(
+        ["git", "ls-tree", "--name-only", f"{ref}:Scripts/livekit"],
+        cwd=worktree, capture_output=True, text=True)
+    if listing.returncode != 0:
+        return None
+    out = {}
+    for name in listing.stdout.splitlines():
+        if not (name.startswith("live_") and name.endswith(".py")):
+            continue
+        blob = subprocess.run(
+            ["git", "show", f"{ref}:Scripts/livekit/{name}"],
+            cwd=worktree, capture_output=True, text=True)
+        if blob.returncode != 0:
+            return None
+        covers = declared_coverage(blob.stdout)
+        if covers:
+            out[name[: -len(".py")]] = covers
+    return out
 
 
 def documents_present(head_dir):
@@ -132,15 +230,38 @@ def main(argv):
         print(f"-> COVERAGE FAIL: could not diff {base}...HEAD in {worktree}")
         return 2
     required = harness_stems(paths)
+
+    # What the branch's `Sources/` changes oblige, from declarations on the TRUSTED ref.
+    declarations = declarations_from_ref(worktree, base)
+    if declarations is None:
+        print(f"-> COVERAGE FAIL: could not read harness declarations from {base}")
+        print("   The declarations are deliberately NOT read from the branch under test, so a")
+        print("   missing ref is a refusal, not a fallback. Run: git fetch origin main")
+        return 2
+    by_sources, unproven = required_by_sources(paths, declarations)
+    required |= by_sources
+
     if not required:
-        print("n/a — this branch changes no live harness")
+        if unproven:
+            print(f"n/a — no harness claims the {len(unproven)} changed Sources/ path(s):")
+            for path in unproven[:8]:
+                print(f"          unproven  {path}")
+            if len(unproven) > 8:
+                print(f"          unproven  … and {len(unproven) - 8} more")
+        else:
+            print("n/a — this branch changes no live harness")
         return 0
 
     head_dir = os.path.join(root, head)
     present = documents_present(head_dir)
     missing, unclean = verdict(required, present)
 
-    print(f"   harnesses changed by this branch: {len(required)}")
+    print(f"   harnesses this branch must prove: {len(required)}"
+          f" ({len(by_sources)} obliged by a Sources/ change)")
+    for path in unproven[:8]:
+        print(f"   unproven  {path}")
+    if len(unproven) > 8:
+        print(f"   unproven  … and {len(unproven) - 8} more")
     for stem in sorted(required):
         state = "missing" if stem in missing else ("UNCLEAN" if stem in unclean else "ok")
         print(f"   {state:>7}  {stem}")

--- a/Scripts/livekit/live_290_selectors_resolve_by_identity.py
+++ b/Scripts/livekit/live_290_selectors_resolve_by_identity.py
@@ -45,6 +45,19 @@ import time
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import evidence as E  # noqa: E402
 
+# What this harness proves, for `harness_evidence_coverage.py`. A branch touching any of these
+# paths must run this harness and produce a clean document; before declarations existed, ANY
+# harness's clean document satisfied ANY `Sources/` change.
+#
+# Claimed because this run drives them: the census rows come from the selector predicates in
+# `SelectorAtlas`, and the six adopted sites live in the two accessibility files below. The
+# snapshot and diff are claimed too — the same predicates decide what a baseline scores.
+COVERS = [
+    "Sources/LogicProMCP/SelectorAtlas/",
+    "Sources/LogicProMCP/Accessibility/AXLogicProElements+Mixer.swift",
+    "Sources/LogicProMCP/Accessibility/AXLogicProElements+Transport.swift",
+]
+
 WT = sys.argv[1] if len(sys.argv) > 1 else ""
 HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
 if not WT or not HEAD:

--- a/Scripts/livekit/test_harness_evidence_coverage.py
+++ b/Scripts/livekit/test_harness_evidence_coverage.py
@@ -169,6 +169,64 @@ with tempfile.TemporaryDirectory() as repo:
     failed += 0 if ok else 1
     print(f"{'ok  ' if ok else 'FAIL'} an unreadable base is None, not an empty change set")
 
+# --- declarations: which harness a Sources/ change obliges ------------------------------------
+#
+# The hole these close: before 2026-08-29 a `Sources/` change required NO particular harness, so
+# any clean document satisfied any change.
+
+DECL = {"live_atlas": ["Sources/LogicProMCP/SelectorAtlas/"],
+        "live_eq": ["Sources/LogicProMCP/SpectralEQ/"]}
+# The same claim written without its trailing slash. It must mean the same thing, or a typo
+# silently widens a harness's claim into every sibling whose name starts the same way.
+DECL_NO_SLASH = {"live_atlas": ["Sources/LogicProMCP/SelectorAtlas"]}
+
+for label, changed, want_required, want_unproven in [
+    ("a claimed path obliges its claimant",
+     ["Sources/LogicProMCP/SelectorAtlas/AtlasDiff.swift"], {"live_atlas"}, []),
+    ("a path nobody claims is unproven, not proved",
+     ["Sources/LogicProMCP/Channels/AccessibilityChannel.swift"], set(),
+     ["Sources/LogicProMCP/Channels/AccessibilityChannel.swift"]),
+    ("two subsystems oblige two harnesses",
+     ["Sources/LogicProMCP/SelectorAtlas/A.swift", "Sources/LogicProMCP/SpectralEQ/B.swift"],
+     {"live_atlas", "live_eq"}, []),
+    ("non-Sources paths oblige nothing and are not unproven",
+     ["docs/roadmap/README.md", "Tests/X.swift"], set(), []),
+    ("a prefix must not match a sibling directory by string alone",
+     ["Sources/LogicProMCP/SelectorAtlasExtras/C.swift"], set(),
+     ["Sources/LogicProMCP/SelectorAtlasExtras/C.swift"]),
+]:
+    required, unproven = C.required_by_sources(changed, DECL)
+    ok = required == want_required and unproven == want_unproven
+    failed += 0 if ok else 1
+    print(f"{'ok  ' if ok else 'FAIL'} {label} -> required={sorted(required)} unproven={unproven}")
+
+for label, decl, changed, want_required in [
+    ("a slashless declaration still claims its own directory", DECL_NO_SLASH,
+     ["Sources/LogicProMCP/SelectorAtlas/AtlasDiff.swift"], {"live_atlas"}),
+    ("a slashless declaration does NOT claim a sibling that starts the same", DECL_NO_SLASH,
+     ["Sources/LogicProMCP/SelectorAtlasExtras/C.swift"], set()),
+    ("a declaration naming one file claims exactly it", {"live_x": ["Sources/A/B.swift"]},
+     ["Sources/A/B.swift"], {"live_x"}),
+    ("and not a file whose name extends it", {"live_x": ["Sources/A/B.swift"]},
+     ["Sources/A/B.swift.orig"], set()),
+]:
+    required, _ = C.required_by_sources(changed, decl)
+    ok = required == want_required
+    failed += 0 if ok else 1
+    print(f"{'ok  ' if ok else 'FAIL'} {label} -> {sorted(required)}")
+
+for label, text, want in [
+    ("a literal list is read", "COVERS = ['Sources/A/']\n", ["Sources/A/"]),
+    ("a computed declaration is refused", "P='Sources/'\nCOVERS = [P + 'A/']\n", []),
+    ("a non-string member voids the whole claim", "COVERS = ['Sources/A/', 3]\n", []),
+    ("no declaration is no claim", "x = 1\n", []),
+    ("a file that does not parse claims nothing", "def (\n", []),
+]:
+    got = C.declared_coverage(text)
+    ok = got == want
+    failed += 0 if ok else 1
+    print(f"{'ok  ' if ok else 'FAIL'} {label} -> {got}")
+
 print()
 print(f"FAILED ({failed} unexpected)" if failed else "all cases behaved (0 unexpected)")
 sys.exit(1 if failed else 0)

--- a/Scripts/livekit/test_harness_evidence_coverage.py
+++ b/Scripts/livekit/test_harness_evidence_coverage.py
@@ -166,6 +166,16 @@ with tempfile.TemporaryDirectory() as repo:
     failed += 0 if ok else 1
     print(f"{'ok  ' if ok else 'FAIL'} the head ARGUMENT decides, not the worktree's HEAD -> {sorted(at_mid)}")
 
+    # Deletions: excluded for the harness question, INCLUDED for the source one. Applying the
+    # filter to `Sources/` was a way through the whole source-coverage rule — delete a file the
+    # atlas harness claims and the path never reached `required_by_sources`.
+    kept = C.changed_paths(repo, base_sha, tip_sha)
+    with_dels = C.changed_paths(repo, base_sha, tip_sha, exclude_deletions=False)
+    ok = ("Scripts/livekit/live_doomed.py" not in kept
+          and "Scripts/livekit/live_doomed.py" in with_dels)
+    failed += 0 if ok else 1
+    print(f"{'ok  ' if ok else 'FAIL'} a deletion is hidden from one question and visible to the other")
+
     ok = C.changed_paths(repo, "no/such/ref", tip_sha) is None
     failed += 0 if ok else 1
     print(f"{'ok  ' if ok else 'FAIL'} an unreadable base is None, not an empty change set")

--- a/Scripts/livekit/test_harness_evidence_coverage.py
+++ b/Scripts/livekit/test_harness_evidence_coverage.py
@@ -122,6 +122,7 @@ print(f"{'ok  ' if ok else 'FAIL'} a document named `evidence` satisfies no harn
 #   2. the commit asked about is the `head` ARGUMENT, not the worktree's HEAD. The first version
 #      hard-coded HEAD and took the sha only to find an evidence directory. In a pre-push hook the
 #      two agree and it would never have shown.
+import json
 import subprocess
 
 def _git(repo, *args):
@@ -226,6 +227,63 @@ for label, text, want in [
     ok = got == want
     failed += 0 if ok else 1
     print(f"{'ok  ' if ok else 'FAIL'} {label} -> {got}")
+
+# --- a live-kit change that obliges no harness still has to point at a clean run ---------------
+#
+# The path this covers is the one editing `evidence.py` takes. It reaches the gate (the ship
+# trigger was widened) and then used to return before any document was judged — so a branch could
+# change what `is_clean` MEANS, run any harness, produce red records, and be asked nothing.
+
+with tempfile.TemporaryDirectory() as repo, tempfile.TemporaryDirectory() as evroot:
+    os.makedirs(os.path.join(repo, "Scripts", "livekit"))
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@example.invalid")
+    _git(repo, "config", "user.name", "t")
+
+    def w2(rel, text):
+        with open(os.path.join(repo, rel), "w") as fh:
+            fh.write(text)
+
+    w2("Scripts/livekit/evidence.py", "# base\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "base")
+    base2 = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    w2("Scripts/livekit/evidence.py", "# changed — is_clean now means something else\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "change the definition of passing")
+    head2 = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    headdir = os.path.join(evroot, head2)
+    os.makedirs(headdir)
+
+    def put(stem, passed):
+        # Every non-vacuity counter `is_clean` reads has to be earned, so the fixture earns them.
+        # Building it by hand rather than copying a real document keeps this case runnable with no
+        # evidence root and no Logic — and it is the same predicate either way, taken from the
+        # trusted module rather than restated here.
+        doc = {"name": stem, "records": [
+            {"kind": "check", "tag": "t", "passed": passed, "mutation_claimed": True},
+            {"kind": "capture", "tag": "c", "settled": True,
+             "display": {"wholly_within": True}},
+            {"kind": "visual", "tag": "v", "passed": True, "subject": "a named thing"},
+            {"kind": "recording", "tag": "r"},
+            {"kind": "operation", "tag": "o"},
+        ]}
+        with open(os.path.join(headdir, f"{stem}.evidence.json"), "w") as fh:
+            json.dump(doc, fh)
+
+    put("live_unrelated", False)
+    rc = C.main(["x", repo, head2, evroot, base2])
+    ok = rc == 1
+    failed += 0 if ok else 1
+    print(f"{'ok  ' if ok else 'FAIL'} a live-kit change with no clean document is refused -> rc={rc}")
+
+    put("live_unrelated", True)
+    rc = C.main(["x", repo, head2, evroot, base2])
+    ok = rc == 0
+    failed += 0 if ok else 1
+    print(f"{'ok  ' if ok else 'FAIL'} ...and is allowed once one document is clean -> rc={rc}")
 
 print()
 print(f"FAILED ({failed} unexpected)" if failed else "all cases behaved (0 unexpected)")

--- a/Scripts/test_falsifiable_adoption.py
+++ b/Scripts/test_falsifiable_adoption.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Cases for `check-falsifiable-adoption.py`, the ratchet on the live kit's counterexamples.
+
+A ratchet has to bite in BOTH directions or it is a counter with an opinion: falling below the
+floor is a regression, and rising above it without raising the floor leaves the next regression
+free to fall back to the old number. Both are asserted here.
+
+Written against `adoption()` with an explicit file list, so the cases do not depend on how many
+harnesses the repository happens to contain today — that number is exactly what the guard exists
+to track, and a test that reads it too would move with it.
+"""
+import importlib.util
+import os
+import sys
+import tempfile
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+spec = importlib.util.spec_from_file_location(
+    "adoption_guard", os.path.join(REPO, "Scripts", "check-falsifiable-adoption.py"))
+G = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(G)
+
+failed = 0
+tmp = tempfile.mkdtemp()
+
+
+def harness(name, body):
+    path = os.path.join(tmp, name)
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(body)
+    return path
+
+
+for label, files, want in [
+    ("a harness that calls it counts",
+     [harness("live_a.py", "E.falsifiable(tag, p, obs, cx, exp)\n")], 1),
+    ("a harness that does not, does not",
+     [harness("live_b.py", "E.check(tag, True, 'x', 'y')\n")], 0),
+    ("a mention in prose is not a call",
+     [harness("live_c.py", "# see falsifiable in evidence.py, it is the strong one\n")], 0),
+    ("whitespace before the paren still counts",
+     [harness("live_d.py", "E.falsifiable (tag, p, obs, cx, exp)\n")], 1),
+    ("a longer name is not this one",
+     [harness("live_e.py", "unfalsifiable(x)\n")], 0),
+    ("two adopters count as two",
+     [harness("live_f.py", "falsifiable(\n"), harness("live_g.py", "falsifiable(\n")], 2),
+    ("an unreadable file is not adopted",
+     [os.path.join(tmp, "live_missing.py")], 0),
+]:
+    adopters, total = G.adoption(files)
+    ok = len(adopters) == want and total == len(files)
+    failed += 0 if ok else 1
+    print(f"{'ok  ' if ok else 'FAIL'} {label} -> {len(adopters)} of {total}")
+
+# The floor is a constant in the guard, not a value read from the tree — a number the tree can
+# move is not a floor.
+ok = isinstance(G.FLOOR, int) and G.FLOOR >= 1
+failed += 0 if ok else 1
+print(f"{'ok  ' if ok else 'FAIL'} the floor is a reviewed constant -> FLOOR={G.FLOOR!r}")
+
+# And it matches what the repository actually has. If this fails the guard itself fails, which is
+# the point: raising the floor is the reviewed edit that records progress.
+adopters, total = G.adoption()
+ok = len(adopters) == G.FLOOR
+failed += 0 if ok else 1
+print(f"{'ok  ' if ok else 'FAIL'} the floor equals live adoption -> "
+      f"{len(adopters)} adopters of {total}, FLOOR={G.FLOOR}")
+
+print()
+print(f"FAILED ({failed} unexpected)" if failed else "all cases behaved (0 unexpected)")
+sys.exit(1 if failed else 0)

--- a/Scripts/test_falsifiable_adoption.py
+++ b/Scripts/test_falsifiable_adoption.py
@@ -38,12 +38,26 @@ for label, files, want in [
      [harness("live_b.py", "E.check(tag, True, 'x', 'y')\n")], 0),
     ("a mention in prose is not a call",
      [harness("live_c.py", "# see falsifiable in evidence.py, it is the strong one\n")], 0),
+    # The case the prose one could not see. A regex matched `falsifiable(` wherever it appeared,
+    # so a harness whose only occurrence was a COMMENT held the floor and passed CI — and this
+    # test's first version wrote the word without the parenthesis, which the regex also rejected.
+    # The control agreed with the defect.
+    ("a commented-out call is not a call",
+     [harness("live_h.py", "# E.falsifiable(tag, p, obs, cx, exp)\nE.check(1)\n")], 0),
+    ("the word inside a string is not a call",
+     [harness("live_i.py", "msg = 'use falsifiable(...) instead'\n")], 0),
+    ("a call reached through the module still counts",
+     [harness("live_j.py", "import evidence\nevidence.falsifiable(1)\n")], 1),
+    ("a call nested inside a function body counts",
+     [harness("live_k.py", "def run():\n    if x:\n        E.falsifiable(1)\n")], 1),
+    ("a file that will not parse is not an adopter",
+     [harness("live_l.py", "def (\n E.falsifiable(1)\n")], 0),
     ("whitespace before the paren still counts",
      [harness("live_d.py", "E.falsifiable (tag, p, obs, cx, exp)\n")], 1),
     ("a longer name is not this one",
      [harness("live_e.py", "unfalsifiable(x)\n")], 0),
     ("two adopters count as two",
-     [harness("live_f.py", "falsifiable(\n"), harness("live_g.py", "falsifiable(\n")], 2),
+     [harness("live_f.py", "falsifiable(1)\n"), harness("live_g.py", "E.falsifiable(1)\n")], 2),
     ("an unreadable file is not adopted",
      [os.path.join(tmp, "live_missing.py")], 0),
 ]:


### PR DESCRIPTION
The live gate was weak in a way its own file admitted:

> A branch that changes only `Sources/` therefore passes this check with nothing required.

And the remaining step asked for **some** clean document bound to this head. Any harness supplied one. **Change the spectral engine, run the selector-atlas harness, pass** — with a document that was true and about something else.

## It does not guess

The old rule declined to invent a mapping and that was right: a guess in a gate is worse than a gap. A harness now **declares** what it covers, in a `COVERS = [...]` literal in its own file.

Three properties make the declaration binding rather than decorative:

- **read from a trusted ref** — a branch that supplies its own obligations is not obliged
- **parsed, never imported** — importing a harness runs it, and the thing being judged does not execute inside its own judge. A computed list (`COVERS = [P + "A/"]`) is refused rather than evaluated
- **matched by path component** — `…/SelectorAtlas` written without its trailing slash would otherwise claim `SelectorAtlasExtras/` too, and that widening runs in the direction that makes a harness look like it covers more

What nobody claims is printed as `unproven` rather than assumed proved. Measured on the atlas work that just merged: four changed `Sources/` paths oblige the atlas harness, and `MainEntrypoint.swift` is claimed by nothing.

## A live-kit change must point at a clean run

Editing `evidence.py` reached the gate — that is what widening the ship trigger achieved — and then returned before any document was judged, because no harness was obliged. A branch could change what `is_clean` **means**, run any harness, produce red records, and be asked nothing. It now has to point at a document the **trusted** `is_clean` accepts.

## The review found a surface I had just added

The ship wrapper greps stdout for `LIVE GATE PASS` and ignores the child's exit code. The new diagnostic prints the paths a branch changed — so **`Sources/LIVE GATE PASS.swift` made the wrapper report success while the gate exited 1.** Reproduced, then fixed: the exit code decides, and the string is anchored to a whole line so a path cannot supply it. The string is still required, because a gate that crashed before reaching a verdict also exits non-zero.

## Companion tightenings in the operator scripts

Outside this repo, so listed here rather than diffed:

| hole | measured | now |
|---|---|---|
| `worktree_clean` recorded, never read | 1 mention in `evidence.py`, **0** in the gate | enforced; an absent field is a refusal too |
| the gate trusted the document about the tree | — | it runs `git status` itself, at verdict time |
| `evidence.py` exempt from the live trigger | trigger was `live_*.py` only | whole livekit, minus its offline `test_*.py` |
| `LPM_GATE_RULE_REF=HEAD` | reinstated "a branch edits its own judge" | remote-tracking refs only, and never HEAD |
| `LPM_BASE=HEAD` | every diff empty ⇒ nothing required | refused |

Each was mutation-tested. `worktree_clean=False` and the absent field are both refused; a dirty `Sources/` at gate time is refused; the injection is reproduced against the old logic and rejected by the new; `HEAD`, a local branch and `LPM_BASE=HEAD` are each refused while `origin/main` still passes.

## A second review pass found three more, all mine

| new bypass | reproduced | now |
|---|---|---|
| `--diff-filter=d` applied to `Sources/` too | **deleting** a file the atlas harness claims obliged nothing | deletions filtered for harnesses only — deleting covered code is a change to what ships |
| the ratchet counted a regex match | `# falsifiable(` in a comment held the floor and passed CI | parsed; real `ast.Call` nodes only |
| an annotated tag pointing at HEAD | `rev-parse tag` = `e14d983c`, `tag^{commit}` = `22e67f09` = HEAD | both gates compare `^{commit}` |

The middle one is worth naming for its shape rather than its size: the test meant to catch a commented-out call wrote the word **without the parenthesis**, which the regex also rejected — so the control agreed with the defect. Five cases replace it, including a call through the module and one nested in a function body.

## Left open, and said rather than implied

- **A binary built from a dirty tree and then reverted** still hashes correctly with a true `worktree_clean`. Closing it needs the gate to rebuild and compare. That is a deliberate act, not an accident, and this round is aimed at accidents.
- **`falsifiable()` adoption is 1 of 35.** `is_clean` counts `checks_with_a_counterexample` and does not require it, for a good reason — turning 34 harnesses red in one step invites deleting the clause. So the number gets a ratchet instead: it may rise and may not fall, and it also fails when it rises without `FLOOR` being raised, because a ratchet that does not tighten when it can is a counter.

### The size of the gap, measured rather than described

```
Swift sources          213
claimed by a harness     8
unproven               205
```

That is the honest state, and it is not something to close by writing declarations from memory —
the whole value of the mechanism is that a harness says what it proves, and a guess put there
would be the invented mapping the old rule was right to refuse. The number grows as harnesses are
touched, and it is printed on every run so it cannot quietly stop growing.

```
37 offline cases in the coverage rule · 14 in the adoption guard
full suite 3999 · preflight ok · live evidence bound to this head
```
