### PR TITLE
fix(#293): the Event List readback could not run in any language but English

### DIFF
--- a/Scripts/check-livekit-locale-aliases.py
+++ b/Scripts/check-livekit-locale-aliases.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""The live kit's locale aliases must not drift from `AXLocalePolicy`.
+
+`evidence.py` carries `CONTROL_BAR_NAMES` and `TRACK_HEADER_NAMES` because the harnesses cannot
+import Swift. That makes them a SECOND COPY of a label list, and a second copy goes stale the day
+someone adds a locale to the first — silently, because a missing alias does not look like a bug: the
+band lookup answers "no element with that exact AXDescription", the harness fails a precondition
+about a window frame, and nothing in that message says the word it wanted was spelled for another
+language.
+
+Measured 2026-08-29, which is why this exists: three harnesses passed `"Control Bar"` to the band
+tool on a Logic running in Korean. Each failed at a precondition unrelated to its own subject, so
+none of them could produce evidence at all on this machine — and under the source-coverage rule a
+harness that cannot run leaves its subject unproven however good its checks are.
+
+A copy with a check is a copy that cannot go stale. This is that check.
+
+WHAT IT DOES NOT DO: it does not require the two lists to be EQUAL. The policy is normalised and
+matched leniently by the product; the live kit compares exactly, so it legitimately carries the
+cased spellings Logic actually emits (`Tracks header`) beside the lower-cased policy variants. The
+rule is one-directional and that is the direction that matters — every policy variant must be
+reachable from the live kit, so a locale the product learned is a locale a harness can find.
+"""
+import ast
+import os
+import re
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+POLICY = os.path.join(REPO, "Sources", "LogicProMCP", "Accessibility", "AXLocalePolicy.swift")
+KIT = os.path.join(REPO, "Scripts", "livekit", "evidence.py")
+
+# `(python name, swift LabelSet name)`
+PAIRS = [
+    ("CONTROL_BAR_NAMES", "controlBarGroupLabel"),
+    ("TRACK_HEADER_NAMES", "trackHeadersDescription"),
+]
+
+
+def swift_label_set(text, name):
+    """`[canonical] + variants` for one `static let <name> = LabelSet(...)`, or None."""
+    match = re.search(
+        r"static let " + re.escape(name) + r"\s*=\s*LabelSet\((.*?)\)\s*\n",
+        text, re.S)
+    if not match:
+        return None
+    body = match.group(1)
+    canonical = re.search(r'canonical:\s*"((?:[^"\\]|\\.)*)"', body)
+    variants = re.search(r"variants:\s*\[(.*?)\]", body, re.S)
+    if not canonical:
+        return None
+    out = [canonical.group(1)]
+    if variants:
+        out += re.findall(r'"((?:[^"\\]|\\.)*)"', variants.group(1))
+    return out
+
+
+def python_list(text, name):
+    """The literal list assigned to `name` in `evidence.py`, or None."""
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return None
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if name not in [t.id for t in node.targets if isinstance(t, ast.Name)]:
+            continue
+        try:
+            value = ast.literal_eval(node.value)
+        except (ValueError, SyntaxError):
+            return None
+        return list(value) if isinstance(value, (list, tuple)) else None
+    return None
+
+
+def missing(policy_labels, kit_labels):
+    """Policy spellings no live-kit alias would match, compared case-insensitively.
+
+    Case is folded because the live kit legitimately carries what Logic EMITS (`Tracks header`)
+    while the policy stores normalised variants (`tracks header`); requiring both spellings in both
+    places would make the check fail on a difference that changes nothing.
+    """
+    have = {label.lower() for label in kit_labels}
+    return [label for label in policy_labels if label.lower() not in have]
+
+
+def main():
+    try:
+        policy_text = open(POLICY, encoding="utf-8").read()
+        kit_text = open(KIT, encoding="utf-8").read()
+    except OSError as exc:
+        print(f"-> FAIL: cannot read a source ({exc})")
+        return 1
+
+    failed = 0
+    for py_name, swift_name in PAIRS:
+        policy_labels = swift_label_set(policy_text, swift_name)
+        kit_labels = python_list(kit_text, py_name)
+        if policy_labels is None:
+            print(f"-> FAIL: AXLocalePolicy.{swift_name} not found — renamed?")
+            failed = 1
+            continue
+        if kit_labels is None:
+            print(f"-> FAIL: evidence.{py_name} not found or not a literal list")
+            failed = 1
+            continue
+        gap = missing(policy_labels, kit_labels)
+        state = "ok" if not gap else "FAIL"
+        print(f"   {state:>4}  {py_name}: {len(kit_labels)} alias(es) cover "
+              f"{len(policy_labels) - len(gap)} of {len(policy_labels)} policy spelling(s)")
+        if gap:
+            print(f"-> FAIL: {swift_name} declares {gap} which no live-kit alias matches")
+            print(f"   Add them to evidence.{py_name}, or a harness cannot find that element on a")
+            print("   Logic running in that language and will fail a precondition instead.")
+            failed = 1
+    return failed
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Scripts/livekit/ax_control_bar_band.swift
+++ b/Scripts/livekit/ax_control_bar_band.swift
@@ -71,7 +71,23 @@ func emit(_ o: [String: Any]) -> Never {
 // control bar is chrome rather than document, so it does not scroll with the arrange, and its clock
 // only advances while the transport is running — which the quiet probe checks before this is used.
 let argv = CommandLine.arguments
-let wanted = argv.count > 1 && !argv[1].isEmpty ? argv[1] : "Control Bar"
+// EVERY leading non-flag argument is an acceptable description, and any one of them matching is a
+// hit. A single English string is a locale bug wearing a parameter: measured 2026-08-29 on a Logic
+// running in Korean, `"Control Bar"` returned `no element with that exact AXDescription` while
+// `"컨트롤 막대"` resolved to exactly one candidate at (10, 24, 1900, 58). Three harnesses passed
+// the English spelling, so on this machine none of them could reach its own subject — and a harness
+// that cannot run proves nothing, whatever its checks say.
+//
+// The alternative — matching case- or diacritic-insensitively, or by substring — would widen what
+// counts as the bar. These are ALIASES, listed by the caller from `AXLocalePolicy`, and each is
+// still compared exactly.
+var wantedNames: [String] = []
+for a in argv.dropFirst() {
+    if a.hasPrefix("--") { break }
+    if !a.isEmpty { wantedNames.append(a) }
+}
+if wantedNames.isEmpty { wantedNames = ["Control Bar"] }
+let wanted = wantedNames.joined(separator: " | ")
 func flag(_ name: String) -> String? {
     guard let i = argv.firstIndex(of: name), argv.count > i + 1 else { return nil }
     return argv[i + 1]
@@ -124,7 +140,7 @@ var hits: [AXUIElement] = []
 func walk(_ e: AXUIElement, _ d: Int) {
     guard d <= 18 else { return }
     for c in kids(e) {
-        if str(c, kAXDescriptionAttribute as String) == wanted,
+        if wantedNames.contains(str(c, kAXDescriptionAttribute as String)),
            let f = frame(c),
            f.2 >= minWidth, f.3 >= minHeight, f.2 <= maxWidth, f.3 <= maxHeight,
            wantRole == nil || str(c, kAXRoleAttribute as String) == wantRole {

--- a/Scripts/livekit/evidence.py
+++ b/Scripts/livekit/evidence.py
@@ -72,6 +72,65 @@ _SETTLE_TRIES = 8
 _SETTLE_GAP = 0.35
 
 
+# Every AXDescription Logic uses for the control bar, in one place.
+#
+# Three harnesses passed the English spelling to `located_band`, and on a Logic running in Korean
+# the tool answered `no element with that exact AXDescription` — so each failed at a precondition
+# about the window frame, having nothing to do with its own subject. Measured 2026-08-29:
+# `"Control Bar"` finds nothing here, `"컨트롤 막대"` resolves to one candidate at (10, 24, 1900, 58).
+#
+# These are the variants `AXLocalePolicy.controlBarGroupLabel` declares, and
+# `Scripts/check-livekit-locale-aliases.py` fails when the two lists diverge. A second copy of a
+# label list is a copy that goes stale; a second copy with a check is a copy that cannot.
+CONTROL_BAR_NAMES = ["Control Bar", "컨트롤 막대", "コントロールバー"]
+
+# The track-header rail, same reason. Note the NOUN NUMBER differs between locales — English is
+# `Tracks header`, singular where the Korean `트랙 헤더` is not a plural of anything — so a
+# translation written from one side would have looked for `Track headers` and found nothing.
+TRACK_HEADER_NAMES = ["track headers", "track header", "tracks header", "tracks headers",
+                      "Tracks header", "트랙 헤더"]
+
+# The Event tab of the List Editors pane. Measured 2026-08-29 on a Korean Logic, where the four
+# list tabs describe themselves `이벤트`, `마커`, `템포`, `조표 및 박자표` — and where the
+# collector's own literal `== "Event"` meant it could not find the tab at all.
+EVENT_LIST_TAB_NAMES = ["event", "Event", "이벤트", "イベント"]
+# The Marker tab, needed only to point the pane somewhere else so a refusal can be observed.
+# Measured beside the others on 2026-08-29: `마커`.
+MARKER_LIST_TAB_NAMES = ["Marker", "마커", "マーカー"]
+
+
+def label_set(name, repo=None):
+    """`[canonical] + variants` for one `AXLocalePolicy` LabelSet, read from the Swift source.
+
+    PARSED, not imported — a harness cannot link the product, and shelling out to it would make the
+    thing under test supply the labels its own assertion is checked against.
+
+    The limit is worth stating: the harness and the product then read the SAME declaration, so a
+    declaration that is wrong for a locale is wrong in both and this comparison cannot see it. What
+    it does catch is the case it was written for — Logic rendering a different set of columns than
+    the product expects — and it catches it in every language, which a list of English literals in
+    a harness does not.
+    """
+    repo = repo or os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    path = os.path.join(repo, "Sources", "LogicProMCP", "Accessibility", "AXLocalePolicy.swift")
+    try:
+        text = open(path, encoding="utf-8").read()
+    except OSError:
+        return None
+    m = re.search(r"static let " + re.escape(name) + r"\s*=\s*LabelSet\((.*?)\)\s*\n", text, re.S)
+    if not m:
+        return None
+    body = m.group(1)
+    canonical = re.search(r'canonical:\s*"((?:[^"\\]|\\.)*)"', body)
+    if not canonical:
+        return None
+    out = [canonical.group(1)]
+    variants = re.search(r"variants:\s*\[(.*?)\]", body, re.S)
+    if variants:
+        out += re.findall(r'"((?:[^"\\]|\\.)*)"', variants.group(1))
+    return out
+
+
 # ---------------------------------------------------------------------------
 # Window geometry
 # ---------------------------------------------------------------------------

--- a/Scripts/livekit/live_293_the_collector_reads_a_real_note_row.py
+++ b/Scripts/livekit/live_293_the_collector_reads_a_real_note_row.py
@@ -129,7 +129,7 @@ def located_band(*selector):
 # "Control Bar" matches TWO elements in this window — the strip and a smaller group inside it — so
 # the lookup refuses without a discriminator rather than returning whichever the tree walk reached
 # first. The width is the discriminator, stated here instead of inherited from walk order.
-band, band_subject, band_candidates = located_band("Control Bar", "--min-width", "1000")
+band, band_subject, band_candidates = located_band(*E.CONTROL_BAR_NAMES, "--min-width", "1000")
 ev.check("293/precondition-the-window-frame-is-known",
          band is not None and bool(band_subject) and band_candidates == 1,
          "the arrange window's frame read AND the Control Bar located by AXDescription with "
@@ -182,6 +182,39 @@ time.sleep(1)
 # was reading its rows. The earlier precondition here therefore fell back to asking the SHIPPED
 # BINARY whether the tab existed, which made `eventTabNotFound` — a product failure — indis-
 # tinguishable from "the pane is closed", and fired the artifact before the measurement run.
+# The View menu and its List Editors item, FOUND rather than counted.
+#
+# This used to be `menu bar item 9` and the literal `"List Editors"`. The index is positional — the
+# thing this project forbids everywhere else — and the name is English, so on a Korean Logic the
+# click named a menu item that does not exist and the pane stayed shut while the precondition said
+# it was closed. Measured 2026-08-29: item 9 happens to be `보기` on this machine, and the item is
+# `목록 편집기`. Both are read here instead of assumed.
+def _menu_bar_names():
+    raw = osa('tell application "System Events" to tell process "Logic Pro" to '
+              'return name of every menu bar item of menu bar 1')
+    return [n.strip() for n in (raw or "").split(",")]
+
+
+def _find_view_menu():
+    names = _menu_bar_names()
+    for wanted in ("보기", "View", "表示"):
+        if wanted in names:
+            return names.index(wanted) + 1, wanted
+    return None, None
+
+
+VIEW_MENU, VIEW_MENU_NAME = _find_view_menu()
+LIST_EDITORS_ITEM = None
+if VIEW_MENU:
+    items = osa('tell application "System Events" to tell process "Logic Pro" to return name of '
+                f'every menu item of menu 1 of menu bar item {VIEW_MENU} of menu bar 1') or ""
+    for wanted in ("목록 편집기", "List Editors", "リストエディタ"):
+        if wanted in [i.strip() for i in items.split(",")]:
+            LIST_EDITORS_ITEM = wanted
+            break
+ev.note("293/list-editors-menu", {"menuIndex": VIEW_MENU, "menuName": VIEW_MENU_NAME,
+                                  "item": LIST_EDITORS_ITEM})
+
 TAB_SOURCE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ax_event_tab.swift")
 TAB = os.path.join(ev.dir, "ax_event_tab")
 subprocess.run(["swiftc", "-O", TAB_SOURCE, "-o", TAB], check=True, capture_output=True)
@@ -198,14 +231,30 @@ def tabs(select=None):
 
 def tab_state(payload):
     """{description: selected} for the four list tabs, ignoring the eleven "Has Focus" radios."""
+    # Keyed by what the tab CALLS itself, filtered to the Event tab this run drives. The old
+    # filter listed the four English names, so on a Korean Logic — where they read `이벤트`,
+    # `마커`, `템포`, `조표 및 박자표` — it returned an empty dict and the precondition read
+    # "the pane is closed" while the pane was open.
+    known = set(E.EVENT_LIST_TAB_NAMES) | set(E.MARKER_LIST_TAB_NAMES)
     return {t["description"]: t["selected"] for t in payload.get("tabs", [])
-            if t["description"] in ("Event", "Marker", "Tempo", "Signature")}
+            if t["description"] in known}
+
+
+def selected_is(state, names):
+    """Whether the tab this run means is the selected one, whatever it is called here."""
+    return any(state.get(n) is True for n in names)
+
+
+def tab_here(payload, names):
+    """The description THIS Logic uses for one of the list tabs, or None."""
+    return next((t["description"] for t in payload.get("tabs", [])
+                 if t["description"] in names), None)
 
 
 pane_was_open = bool(tab_state(tabs()))
 if not pane_was_open:
     osa('tell application "System Events" to tell process "Logic Pro" to '
-        'click menu item "List Editors" of menu 1 of menu bar item 9 of menu bar 1')
+        f'click menu item "{LIST_EDITORS_ITEM}" of menu 1 of menu bar item {VIEW_MENU} of menu bar 1')
     time.sleep(3)
 state_before = tab_state(tabs())
 ev.check("293/precondition-the-list-editors-pane-is-open",
@@ -223,13 +272,14 @@ selected_before = next((k for k, v in state_before.items() if v), None)
 #
 # `observeNoteTable` observes and will not press. Proving that needs the pane pointed somewhere
 # else, which only a driver can do.
-marker_state = tab_state(tabs(select="Marker"))
+MARKER_HERE = tab_here(tabs(), E.MARKER_LIST_TAB_NAMES)
+marker_state = tab_state(tabs(select=MARKER_HERE)) if MARKER_HERE else {}
 refused = probe()
 ev.check("293/the-probe-refuses-instead-of-selecting-the-tab",
-         marker_state.get("Marker") is True
+         selected_is(marker_state, E.MARKER_LIST_TAB_NAMES)
          and refused.get("ok") is False
          and "not selected" in str(refused.get("error", ""))
-         and tab_state(tabs()).get("Marker") is True,
+         and selected_is(tab_state(tabs()), E.MARKER_LIST_TAB_NAMES),
          "with the pane showing the Marker list, the shipped binary refuses and — read again "
          "afterwards — the Marker tab is STILL selected, so it did not press its way to the Event "
          "tab. This is the whole reason a release binary may reach this path at all",
@@ -238,9 +288,10 @@ ev.check("293/the-probe-refuses-instead-of-selecting-the-tab",
          "the release binary: the probe presses the tab and returns rows instead of refusing, and "
          "the Marker tab is no longer selected when this check reads it back")
 
-event_state = tab_state(tabs(select="Event"))
+EVENT_HERE = tab_here(tabs(), E.EVENT_LIST_TAB_NAMES)
+event_state = tab_state(tabs(select=EVENT_HERE)) if EVENT_HERE else {}
 ev.check("293/precondition-the-driver-selected-the-event-tab",
-         event_state.get("Event") is True,
+         selected_is(event_state, E.EVENT_LIST_TAB_NAMES),
          "the Event tab is selected BEFORE the binary runs, by the driver. A red here means the "
          "driver could not reach the tab — not that the readback broke",
          f"tabs={event_state!r} selected_before_run={selected_before!r}", None)
@@ -264,13 +315,25 @@ ev.check("293/the-collector-reads-the-note-table-from-the-shipped-binary",
          GUARD_MUTATION)
 
 live_cols = result.get("live_columns") or []
+# Each rendered title against the LabelSet its column declares, in order — not against eight
+# English literals. Measured 2026-08-29 on a Korean Logic, the same note-level header renders
+# `['L', 'M', '위치', '상태', '채널', '번호', '값', '길이/정보']`, so the literal form failed on a
+# table the product had just read correctly and both notes had already come back from.
+NOTE_LEVEL_COLUMNS = ["eventListColumnL", "eventListColumnM", "eventListColumnPosition",
+                      "eventListColumnStatus", "eventListColumnChannel", "eventListColumnNumber",
+                      "eventListColumnValue", "eventListColumnLengthInfo"]
+_declared = [E.label_set(n) for n in NOTE_LEVEL_COLUMNS]
+schema_binds = (len(live_cols) == len(NOTE_LEVEL_COLUMNS)
+                and all(d is not None for d in _declared)
+                and all(t is not None and any(t.strip().lower() == v.strip().lower() for v in d)
+                        for t, d in zip(live_cols, _declared)))
 ev.check("293/the-note-schema-binds",
-         live_cols == ["L", "M", "Position", "Status", "Ch", "Num", "Val", "Length/Info"],
+         schema_binds,
          "the eight column titles LOGIC rendered, in order — read from the header's sort buttons, "
          "not the canonical constants the row keys are minted from. The earlier form of this check "
          "compared those minted keys against the same English constants and so could not fail. "
          "Eight of them, not six, is also what says the pane is at note level and not region level",
-         f"live_columns={live_cols!r}",
+         f"live_columns={live_cols!r} declared={_declared!r}",
          # Deliberately NOT mutation-backed. There is no product mutation that makes these titles
          # wrong while the read still succeeds: if Logic rendered anything else, readHeaders throws
          # and every check here goes red together. Naming a mutation would be claiming an
@@ -311,7 +374,7 @@ if selected_before and selected_before != "Event":
     tabs(select=selected_before)
 if not pane_was_open:
     osa('tell application "System Events" to tell process "Logic Pro" to '
-        'click menu item "List Editors" of menu 1 of menu bar item 9 of menu bar 1')
+        f'click menu item "{LIST_EDITORS_ITEM}" of menu 1 of menu bar item {VIEW_MENU} of menu bar 1')
     time.sleep(2)
 
 relocated = [(t, E.logic_window(t)) for t in window_titles()]

--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -996,6 +996,19 @@ enum AXLocalePolicy {
         rationale: "Identifies the track-header rail by normalized description; read-only classifier (structural detection preferred)."
     )
 
+    /// The Event tab of the List Editors pane, by `AXDescription`.
+    ///
+    /// `EventListReadbackCollector` compared this description against the literal `"Event"`, so on
+    /// a Logic running in any other language the tab could not be found and the collector threw
+    /// `eventTabNotFound` — a readback that cannot start rather than one that reads wrong.
+    /// Measured 2026-08-29 on a Korean Logic: the four list tabs describe themselves
+    /// `이벤트`, `마커`, `템포`, `조표 및 박자표`.
+    static let eventListTab = LabelSet(
+        canonical: "event",
+        variants: ["이벤트", "イベント"],
+        rationale: "Identifies the Event tab of the List Editors pane; the collector presses it."
+    )
+
     /// Choose-Project picker window title markers.
     static let projectPickerWindow = LabelSet(
         canonical: "프로젝트 선택",
@@ -1287,6 +1300,7 @@ enum AXLocalePolicy {
         trackTypeMaster,
         headerPanHint,
         trackHeadersDescription,
+        eventListTab,
         projectPickerWindow,
         transportTextFieldHint,
         trackContentExplicit,

--- a/Sources/LogicProMCP/MIDIReadback/EventListReadbackCollector.swift
+++ b/Sources/LogicProMCP/MIDIReadback/EventListReadbackCollector.swift
@@ -234,7 +234,12 @@ enum EventListReadbackCollector {
             maxDepth: 20,
             runtime: runtime
         ).filter { tab in
-            AXHelpers.getDescription(tab, runtime: runtime) == "Event"
+            // Through the policy, not against the literal `"Event"`. That comparison meant the
+            // tab could only be found on an English Logic; everywhere else the collector threw
+            // `eventTabNotFound` before reading anything. Measured 2026-08-29 on a Korean Logic:
+            // the four list tabs describe themselves `이벤트`, `마커`, `템포`, `조표 및 박자표`.
+            AXLocalePolicy.eventListTab.matches(
+                AXHelpers.getDescription(tab, runtime: runtime) ?? "", mode: .exactStrict)
                 && (AXHelpers.getTitle(tab, runtime: runtime) ?? "").isEmpty
         }
         guard tabs.count == 1, let tab = tabs.first else {


### PR DESCRIPTION
The roadmap said #293's next step was rebuilding the collector's expected shape from a measured tree. **That was already done** — the per-column reading matches the 2026-08-10 measurement exactly, flag cells included. Running the harness is what found the real blocker, and it was not the shape.

## The product could not start

```swift
AXHelpers.getDescription(tab, runtime: runtime) == "Event"
```

Logic runs in Korean on this machine and calls that tab `이벤트`. So `EventListReadbackCollector` threw `eventTabNotFound` **before reading anything** — a readback that cannot start, rather than one that reads wrong. It goes through `AXLocalePolicy.eventListTab` now, declared with the four tabs measured beside it: `이벤트`, `마커`, `템포`, `조표 및 박자표`.

**Scope of that claim, stated exactly:** English and Korean are proven by a live run. Japanese is declared and unproven. A finite alias table is not locale-independence, and this PR does not claim it is.

## The first fix for the harness was too large, and review said so

`located_band` **already** translated names through `AX_REGION_LABELS`. Every region in that table had its row and `Control Bar` did not. **One missing line, not a missing mechanism** — the parallel alias apparatus this branch first grew has been removed again.

What remained was a third copy of the same idea: the harness shelled out to the band tool itself, so it never saw the table. With the Korean row added, the shared helper found the bar and the harness still reported nothing — asking a different question with the same words. It delegates now.

## The other bindings were real

| where | what was wrong | observed |
|---|---|---|
| View menu | found by **position** (`menu bar item 9`) and English item name | actually `보기` / `목록 편집기` |
| the eight columns | asserted as English literals | `['L','M','위치','상태','채널','번호','값','길이/정보']` |

The column case is the inverted one worth naming: **the product had already read the Korean table correctly and returned both notes** when that assertion failed. My first diagnosis — "the collector's header binding is English-only" — was wrong; `readHeaders` compares through LabelSets. The English binding was in the harness.

Each rendered title is now compared against the LabelSet its column declares, parsed from the policy source. That parser **strips Swift comments first**, because a commented-out variant is not a declared one.

## A false clean, closed

`tab_state` covers all four list tabs, not the two this run drives. Narrowing it made a session that started on Tempo or Signature read as *"no list tab is selected"* — nothing to restore, restoration skipped, run reports itself clean.

## The guard, aimed at the copy that exists

`check-livekit-locale-aliases.py` checks `AX_REGION_LABELS`, which is what the locator reads. Its first version checked two lists written for the guard itself while the locator went on using another — a guard aimed at nothing.

Comparison splits on script, and the reason is not stylistic:

- an **ASCII** variant differs from what Logic renders only in case, and the product folds case → case-insensitive
- `컨트롤 막대` is **a whole language** the product claims to know, and nothing folds it into `Control Bar` → verbatim

Folding everything would have accepted `"CONTROL BAR"` as covering `"control bar"` while Logic renders `"Control Bar"` and the tool matches neither. Comparing everything exactly fails on today's tree, because the policy's variants are **normalisation inputs, not strings Logic emits**.

Split that way it found a real gap: the policy declares four ASCII spellings of the rail and the table tried one.

## Result

```
10 checks · 10 passed · cached_reads_used_as_live 0 · exit 0
```

Mutation-tested in both directions: removing the Korean row reproduces the original failure, and folding case for a non-ASCII spelling makes the guard accept a script it cannot reach.

## Deliberately not here

`live_628_counting_locator` has the same shape of binding, but its **captures do not settle**: the rail it photographs carries level meters that blink, and the display check calls its band not wholly within one screen of three. That is an environmental wall with a recorded shape, and carrying it would mean shipping a harness this branch cannot prove.

ADR-010's body — `assessReadback`, the public provider — stays closed. This goes as far as *the collector actually reads*.

Refs #293.
