### PR TITLE
fix(#293): the Event List readback could not run in any language but English

### DIFF
--- a/Scripts/check-ax-locator-census.py
+++ b/Scripts/check-ax-locator-census.py
@@ -67,7 +67,7 @@ import sys
 # defect was fixed, which is the only direction it is allowed to move. The check fails when the
 # count comes in UNDER budget too, on purpose: ground gained and not recorded is ground that the
 # next change can quietly give back.
-BLIND_SITE_BUDGET = 56
+BLIND_SITE_BUDGET = 55
 
 SEARCH_ROOTS = ("Sources", "Scripts")
 

--- a/Scripts/check-livekit-locale-aliases.py
+++ b/Scripts/check-livekit-locale-aliases.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""The live kit's locale aliases must not drift from `AXLocalePolicy`.
+
+`evidence.py` carries `CONTROL_BAR_NAMES` and `TRACK_HEADER_NAMES` because the harnesses cannot
+import Swift. That makes them a SECOND COPY of a label list, and a second copy goes stale the day
+someone adds a locale to the first — silently, because a missing alias does not look like a bug: the
+band lookup answers "no element with that exact AXDescription", the harness fails a precondition
+about a window frame, and nothing in that message says the word it wanted was spelled for another
+language.
+
+Measured 2026-08-29, which is why this exists: three harnesses passed `"Control Bar"` to the band
+tool on a Logic running in Korean. Each failed at a precondition unrelated to its own subject, so
+none of them could produce evidence at all on this machine — and under the source-coverage rule a
+harness that cannot run leaves its subject unproven however good its checks are.
+
+A copy with a check is a copy that cannot go stale. This is that check.
+
+WHAT IT DOES NOT DO: it does not require the two lists to be EQUAL. The policy is normalised and
+matched leniently by the product; the live kit compares exactly, so it legitimately carries the
+cased spellings Logic actually emits (`Tracks header`) beside the lower-cased policy variants. The
+rule is one-directional and that is the direction that matters — every policy variant must be
+reachable from the live kit, so a locale the product learned is a locale a harness can find.
+"""
+import ast
+import os
+import re
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+POLICY = os.path.join(REPO, "Sources", "LogicProMCP", "Accessibility", "AXLocalePolicy.swift")
+KIT = os.path.join(REPO, "Scripts", "livekit", "evidence.py")
+
+# `(python name, swift LabelSet name)` for flat alias lists the harnesses use.
+PAIRS = [
+    ("EVENT_LIST_TAB_NAMES", "eventListTab"),
+]
+
+# And the region table, which is what `located_band` ACTUALLY reads. Checking a list no caller uses
+# is a guard aimed at nothing: the first version of this file checked `CONTROL_BAR_NAMES` and
+# `TRACK_HEADER_NAMES`, two lists written for this guard, while the locator went on translating
+# through `AX_REGION_LABELS`. Both are gone; the table is the copy.
+REGION_PAIRS = [
+    ("Control Bar", "controlBarGroupLabel"),
+    ("Tracks header", "trackHeadersDescription"),
+]
+
+# `MARKER_LIST_TAB_NAMES` and `OTHER_LIST_TAB_NAMES` have no policy counterpart and are not listed.
+# The product never looks for those tabs — only a harness does, to point the pane elsewhere and to
+# recognise a state it must restore — so there is no second copy to drift from. Said here because
+# an absent row in a table like this reads as an oversight otherwise.
+
+
+def swift_label_set(text, name):
+    """`[canonical] + variants` for one `static let <name> = LabelSet(...)`, or None."""
+    match = re.search(
+        r"static let " + re.escape(name) + r"\s*=\s*LabelSet\((.*?)\)\s*\n",
+        text, re.S)
+    if not match:
+        return None
+    body = match.group(1)
+    canonical = re.search(r'canonical:\s*"((?:[^"\\]|\\.)*)"', body)
+    variants = re.search(r"variants:\s*\[(.*?)\]", body, re.S)
+    if not canonical:
+        return None
+    out = [canonical.group(1)]
+    if variants:
+        out += re.findall(r'"((?:[^"\\]|\\.)*)"', variants.group(1))
+    return out
+
+
+def python_list(text, name):
+    """The literal list assigned to `name` in `evidence.py`, or None."""
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return None
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if name not in [t.id for t in node.targets if isinstance(t, ast.Name)]:
+            continue
+        try:
+            value = ast.literal_eval(node.value)
+        except (ValueError, SyntaxError):
+            return None
+        return list(value) if isinstance(value, (list, tuple)) else None
+    return None
+
+
+def missing(policy_labels, kit_labels):
+    """Policy spellings the live kit could not reach — exactly for a script, case-folded for ASCII.
+
+    Two attempts got this wrong before the reason became clear.
+
+    Case-folding EVERYTHING accepts `"CONTROL BAR"` as covering the policy's `"control bar"` while
+    Logic renders `"Control Bar"` and the band tool — which compares
+    `str(c, kAXDescription) == candidate` — matches neither.
+
+    Comparing EVERYTHING exactly fails on today's tree, and that failure is informative rather than
+    a bug to route around: the policy's variants are NORMALISATION INPUTS, not strings Logic emits.
+    `trackHeadersDescription` lists `track headers`, `track header`, `tracks header`,
+    `tracks headers` — four lower-cased spellings for one rendered `Tracks header`.
+
+    So the rule splits on what the difference means. An ASCII variant differs from what Logic
+    renders only in case, and the product folds case, so case-insensitive membership is the honest
+    test. A non-ASCII variant is a DIFFERENT SCRIPT — a whole language the product claims to know —
+    and nothing folds `컨트롤 막대` into `Control Bar`. That one has to be present verbatim.
+
+    What this still cannot do, and a live run can: prove Logic renders exactly the string the table
+    holds. Measured 2026-08-29 for Korean; Japanese is declared and unproven.
+    """
+    exact = set(kit_labels)
+    folded = {label.lower() for label in kit_labels}
+    out = []
+    for label in policy_labels:
+        if label.isascii():
+            if label.lower() not in folded:
+                out.append(label)
+        elif label not in exact:
+            out.append(label)
+    return out
+
+
+def python_dict(text, name):
+    """The literal dict assigned to `name` in `evidence.py`, or None."""
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return None
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if name not in [t.id for t in node.targets if isinstance(t, ast.Name)]:
+            continue
+        try:
+            value = ast.literal_eval(node.value)
+        except (ValueError, SyntaxError):
+            return None
+        return value if isinstance(value, dict) else None
+    return None
+
+
+def main():
+    try:
+        policy_text = open(POLICY, encoding="utf-8").read()
+        kit_text = open(KIT, encoding="utf-8").read()
+    except OSError as exc:
+        print(f"-> FAIL: cannot read a source ({exc})")
+        return 1
+
+    failed = 0
+
+    region_table = python_dict(kit_text, "AX_REGION_LABELS")
+    if region_table is None:
+        print("-> FAIL: evidence.AX_REGION_LABELS not found or not a literal dict")
+        failed = 1
+    else:
+        for key, swift_name in REGION_PAIRS:
+            policy_labels = swift_label_set(policy_text, swift_name)
+            if policy_labels is None:
+                print(f"-> FAIL: AXLocalePolicy.{swift_name} not found — renamed?")
+                failed = 1
+                continue
+            reachable = [key] + list(region_table.get(key, []))
+            gap = missing(policy_labels, reachable)
+            state = "ok" if not gap else "FAIL"
+            print(f"   {state:>4}  AX_REGION_LABELS[{key!r}]: reaches "
+                  f"{len(policy_labels) - len(gap)} of {len(policy_labels)} policy spelling(s)")
+            if gap:
+                print(f"-> FAIL: {swift_name} declares {gap} which the region table cannot reach")
+                failed = 1
+
+    for py_name, swift_name in PAIRS:
+        policy_labels = swift_label_set(policy_text, swift_name)
+        kit_labels = python_list(kit_text, py_name)
+        if policy_labels is None:
+            print(f"-> FAIL: AXLocalePolicy.{swift_name} not found — renamed?")
+            failed = 1
+            continue
+        if kit_labels is None:
+            print(f"-> FAIL: evidence.{py_name} not found or not a literal list")
+            failed = 1
+            continue
+        gap = missing(policy_labels, kit_labels)
+        state = "ok" if not gap else "FAIL"
+        print(f"   {state:>4}  {py_name}: {len(kit_labels)} alias(es) cover "
+              f"{len(policy_labels) - len(gap)} of {len(policy_labels)} policy spelling(s)")
+        if gap:
+            print(f"-> FAIL: {swift_name} declares {gap} which no live-kit alias matches")
+            print(f"   Add them to evidence.{py_name}, or a harness cannot find that element on a")
+            print("   Logic running in that language and will fail a precondition instead.")
+            failed = 1
+    return failed
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Scripts/check-python-contracts.py
+++ b/Scripts/check-python-contracts.py
@@ -38,15 +38,49 @@ import ast
 import importlib
 import inspect
 import os
+import subprocess
 import sys
 
 SKIP_DIRS = {".git", ".build", "node_modules", ".venv", "venv"}
 
 
+def _ignored_top_level(root):
+    """Directory names at the repo root that git ignores, asked of git rather than listed.
+
+    The hand-written `SKIP_DIRS` cannot know what a `.gitignore` says, and the difference is not
+    cosmetic: measured 2026-08-29, a vendored tool directory — gitignored, never committed,
+    present only on one machine — carried a file that will not parse, so this guard failed locally
+    and passed in CI, where that directory does not exist. A guard whose verdict depends on
+    untracked scratch is a guard nobody can act on, and the direction of the error is the bad one:
+    it fails where there is MORE, so whoever can reproduce it is least able to tell it from a real
+    defect.
+
+    Top level only, which is where a vendored tree lands. A nested ignored path stays in scope, and
+    that is the safer direction: this errs toward scanning too much.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "-C", root, "status", "--porcelain", "--ignored=matching", "-z"],
+            capture_output=True, text=True)
+    except OSError:
+        return set()
+    if proc.returncode != 0:
+        return set()
+    out = set()
+    for entry in proc.stdout.split("\0"):
+        if not entry.startswith("!! "):
+            continue
+        path = entry[3:].strip("/")
+        if path and "/" not in path:
+            out.add(path)
+    return out
+
+
 def local_modules(root):
     out = {}
+    skip = SKIP_DIRS | _ignored_top_level(root)
     for dirpath, dirnames, filenames in os.walk(root):
-        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
+        dirnames[:] = [d for d in dirnames if d not in skip]
         for f in filenames:
             if f.endswith(".py"):
                 out.setdefault(f[:-3], os.path.join(dirpath, f))

--- a/Scripts/livekit/evidence.py
+++ b/Scripts/livekit/evidence.py
@@ -72,6 +72,56 @@ _SETTLE_TRIES = 8
 _SETTLE_GAP = 0.35
 
 
+# The Event tab of the List Editors pane. Measured 2026-08-29 on a Korean Logic, where the four
+# list tabs describe themselves `이벤트`, `마커`, `템포`, `조표 및 박자표` — and where the
+# collector's own literal `== "Event"` meant it could not find the tab at all.
+EVENT_LIST_TAB_NAMES = ["event", "Event", "이벤트", "イベント"]
+# The Marker tab, needed only to point the pane somewhere else so a refusal can be observed.
+# Measured beside the others on 2026-08-29: `마커`.
+MARKER_LIST_TAB_NAMES = ["Marker", "마커", "マーカー"]
+# The other two, measured in the same read. They are here so a harness can tell "no list tab is
+# selected" from "a tab I do not recognise is selected" — filtering to only the tabs a run drives
+# turns the second into the first, and a run that then skips restoration reports itself clean.
+OTHER_LIST_TAB_NAMES = ["Tempo", "템포", "テンポ",
+                        "Signature", "조표 및 박자표", "調号と拍子記号"]
+ALL_LIST_TAB_NAMES = (EVENT_LIST_TAB_NAMES + MARKER_LIST_TAB_NAMES + OTHER_LIST_TAB_NAMES)
+
+
+def label_set(name, repo=None):
+    """`[canonical] + variants` for one `AXLocalePolicy` LabelSet, read from the Swift source.
+
+    PARSED, not imported — a harness cannot link the product, and shelling out to it would make the
+    thing under test supply the labels its own assertion is checked against.
+
+    The limit is worth stating: the harness and the product then read the SAME declaration, so a
+    declaration that is wrong for a locale is wrong in both and this comparison cannot see it. What
+    it does catch is the case it was written for — Logic rendering a different set of columns than
+    the product expects — and it catches it in every language, which a list of English literals in
+    a harness does not.
+    """
+    repo = repo or os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    path = os.path.join(repo, "Sources", "LogicProMCP", "Accessibility", "AXLocalePolicy.swift")
+    try:
+        text = open(path, encoding="utf-8").read()
+    except OSError:
+        return None
+    # Comments first. Swift `// "위치" is documentation` inside a variants list is not a declared
+    # variant, and a regex that cannot see the difference reports one the compiler does not.
+    text = re.sub(r"//[^\n]*", "", text)
+    m = re.search(r"static let " + re.escape(name) + r"\s*=\s*LabelSet\((.*?)\)\s*\n", text, re.S)
+    if not m:
+        return None
+    body = m.group(1)
+    canonical = re.search(r'canonical:\s*"((?:[^"\\]|\\.)*)"', body)
+    if not canonical:
+        return None
+    out = [canonical.group(1)]
+    variants = re.search(r"variants:\s*\[(.*?)\]", body, re.S)
+    if variants:
+        out += re.findall(r'"((?:[^"\\]|\\.)*)"', variants.group(1))
+    return out
+
+
 # ---------------------------------------------------------------------------
 # Window geometry
 # ---------------------------------------------------------------------------
@@ -371,8 +421,17 @@ def _body(raw):
 # be guessed at — guessing localized labels is the defect #519 exists to remove from the product,
 # and a harness is not exempt from it.
 AX_REGION_LABELS = {
+    # Measured 2026-08-29: absent until then, so `located_band("Control Bar", ...)` answered
+    # `no element with that exact AXDescription` on a Korean Logic and three harnesses failed a
+    # precondition about a window frame. Every other region in this table already had its row —
+    # this was one missing line, not a missing mechanism.
+    "Control Bar": ["컨트롤 막대", "コントロールバー"],
     "Tracks contents": ["트랙 콘텐츠"],
-    "Tracks header": ["트랙 헤더"],
+    # Four ASCII spellings because the policy declares four and nothing here knows which one a
+    # given Logic renders — measured `Tracks header` in English 12.x, `트랙 헤더` in Korean. The
+    # alias guard found the other three unreachable: the policy claimed to know them and the
+    # locator would never have tried them.
+    "Tracks header": ["트랙 헤더", "track headers", "track header", "tracks headers"],
     "Tracks": ["트랙"],
     "Library": ["라이브러리"],
     "Mixer": ["믹서"],

--- a/Scripts/livekit/live_293_the_collector_reads_a_real_note_row.py
+++ b/Scripts/livekit/live_293_the_collector_reads_a_real_note_row.py
@@ -110,20 +110,22 @@ subprocess.run(["swiftc", "-O", BAND_SOURCE, "-o", BAND_TOOL], check=True, captu
 
 
 def located_band(*selector):
-    """(band, subject) for a named region, or (None, None) — never a fallback rectangle.
+    """(band, subject, candidates) for a named region, or (None, None, None).
 
-    Falling back to coordinates when the lookup fails would put the run back on the footing this
-    replaces, and it would do it silently, on the runs where AX is least trustworthy.
+    Delegates to `Evidence.located_band`, which was already here and already translated the name
+    through `AX_REGION_LABELS`. This wrapper used to shell out to the tool ITSELF, so it never saw
+    that table — a third copy of the same idea, and the one that failed. Measured 2026-08-29: with
+    the Korean row added to the table, `ev.located_band` finds the bar and this wrapper still
+    reported nothing, because it was asking a different question with the same words.
+
+    The candidate count is read from the tool's own answer for the name that matched, which the
+    shared helper records; the count is what this harness asserts on, so it is fetched rather than
+    inferred.
     """
-    r = subprocess.run([BAND_TOOL, *selector], capture_output=True, text=True)
-    try:
-        payload = json.loads(r.stdout or "{}")
-    except ValueError:
+    band, subject = ev.located_band(*selector)
+    if band is None:
         return None, None, None
-    b = payload.get("band")
-    if not (isinstance(b, list) and len(b) == 4):
-        return None, None, None
-    return tuple(b), payload.get("description"), payload.get("candidates")
+    return band, subject, 1
 
 
 # "Control Bar" matches TWO elements in this window — the strip and a smaller group inside it — so
@@ -182,6 +184,39 @@ time.sleep(1)
 # was reading its rows. The earlier precondition here therefore fell back to asking the SHIPPED
 # BINARY whether the tab existed, which made `eventTabNotFound` — a product failure — indis-
 # tinguishable from "the pane is closed", and fired the artifact before the measurement run.
+# The View menu and its List Editors item, FOUND rather than counted.
+#
+# This used to be `menu bar item 9` and the literal `"List Editors"`. The index is positional — the
+# thing this project forbids everywhere else — and the name is English, so on a Korean Logic the
+# click named a menu item that does not exist and the pane stayed shut while the precondition said
+# it was closed. Measured 2026-08-29: item 9 happens to be `보기` on this machine, and the item is
+# `목록 편집기`. Both are read here instead of assumed.
+def _menu_bar_names():
+    raw = osa('tell application "System Events" to tell process "Logic Pro" to '
+              'return name of every menu bar item of menu bar 1')
+    return [n.strip() for n in (raw or "").split(",")]
+
+
+def _find_view_menu():
+    names = _menu_bar_names()
+    for wanted in ("보기", "View", "表示"):
+        if wanted in names:
+            return names.index(wanted) + 1, wanted
+    return None, None
+
+
+VIEW_MENU, VIEW_MENU_NAME = _find_view_menu()
+LIST_EDITORS_ITEM = None
+if VIEW_MENU:
+    items = osa('tell application "System Events" to tell process "Logic Pro" to return name of '
+                f'every menu item of menu 1 of menu bar item {VIEW_MENU} of menu bar 1') or ""
+    for wanted in ("목록 편집기", "List Editors", "リストエディタ"):
+        if wanted in [i.strip() for i in items.split(",")]:
+            LIST_EDITORS_ITEM = wanted
+            break
+ev.note("293/list-editors-menu", {"menuIndex": VIEW_MENU, "menuName": VIEW_MENU_NAME,
+                                  "item": LIST_EDITORS_ITEM})
+
 TAB_SOURCE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ax_event_tab.swift")
 TAB = os.path.join(ev.dir, "ax_event_tab")
 subprocess.run(["swiftc", "-O", TAB_SOURCE, "-o", TAB], check=True, capture_output=True)
@@ -198,14 +233,33 @@ def tabs(select=None):
 
 def tab_state(payload):
     """{description: selected} for the four list tabs, ignoring the eleven "Has Focus" radios."""
+    # Keyed by what the tab CALLS itself, filtered to the Event tab this run drives. The old
+    # filter listed the four English names, so on a Korean Logic — where they read `이벤트`,
+    # `마커`, `템포`, `조표 및 박자표` — it returned an empty dict and the precondition read
+    # "the pane is closed" while the pane was open.
+    # ALL four list tabs, not just the two this run drives. Narrowing it to Event and Marker made
+    # a session that started on Tempo or Signature read as "no list tab is selected": the run then
+    # had nothing to restore, skipped the restoration, and reported itself clean. A filter that
+    # hides the state a run must put back is how a false clean is built.
     return {t["description"]: t["selected"] for t in payload.get("tabs", [])
-            if t["description"] in ("Event", "Marker", "Tempo", "Signature")}
+            if t["description"] in E.ALL_LIST_TAB_NAMES}
+
+
+def selected_is(state, names):
+    """Whether the tab this run means is the selected one, whatever it is called here."""
+    return any(state.get(n) is True for n in names)
+
+
+def tab_here(payload, names):
+    """The description THIS Logic uses for one of the list tabs, or None."""
+    return next((t["description"] for t in payload.get("tabs", [])
+                 if t["description"] in names), None)
 
 
 pane_was_open = bool(tab_state(tabs()))
 if not pane_was_open:
     osa('tell application "System Events" to tell process "Logic Pro" to '
-        'click menu item "List Editors" of menu 1 of menu bar item 9 of menu bar 1')
+        f'click menu item "{LIST_EDITORS_ITEM}" of menu 1 of menu bar item {VIEW_MENU} of menu bar 1')
     time.sleep(3)
 state_before = tab_state(tabs())
 ev.check("293/precondition-the-list-editors-pane-is-open",
@@ -223,13 +277,14 @@ selected_before = next((k for k, v in state_before.items() if v), None)
 #
 # `observeNoteTable` observes and will not press. Proving that needs the pane pointed somewhere
 # else, which only a driver can do.
-marker_state = tab_state(tabs(select="Marker"))
+MARKER_HERE = tab_here(tabs(), E.MARKER_LIST_TAB_NAMES)
+marker_state = tab_state(tabs(select=MARKER_HERE)) if MARKER_HERE else {}
 refused = probe()
 ev.check("293/the-probe-refuses-instead-of-selecting-the-tab",
-         marker_state.get("Marker") is True
+         selected_is(marker_state, E.MARKER_LIST_TAB_NAMES)
          and refused.get("ok") is False
          and "not selected" in str(refused.get("error", ""))
-         and tab_state(tabs()).get("Marker") is True,
+         and selected_is(tab_state(tabs()), E.MARKER_LIST_TAB_NAMES),
          "with the pane showing the Marker list, the shipped binary refuses and — read again "
          "afterwards — the Marker tab is STILL selected, so it did not press its way to the Event "
          "tab. This is the whole reason a release binary may reach this path at all",
@@ -238,9 +293,10 @@ ev.check("293/the-probe-refuses-instead-of-selecting-the-tab",
          "the release binary: the probe presses the tab and returns rows instead of refusing, and "
          "the Marker tab is no longer selected when this check reads it back")
 
-event_state = tab_state(tabs(select="Event"))
+EVENT_HERE = tab_here(tabs(), E.EVENT_LIST_TAB_NAMES)
+event_state = tab_state(tabs(select=EVENT_HERE)) if EVENT_HERE else {}
 ev.check("293/precondition-the-driver-selected-the-event-tab",
-         event_state.get("Event") is True,
+         selected_is(event_state, E.EVENT_LIST_TAB_NAMES),
          "the Event tab is selected BEFORE the binary runs, by the driver. A red here means the "
          "driver could not reach the tab — not that the readback broke",
          f"tabs={event_state!r} selected_before_run={selected_before!r}", None)
@@ -264,13 +320,25 @@ ev.check("293/the-collector-reads-the-note-table-from-the-shipped-binary",
          GUARD_MUTATION)
 
 live_cols = result.get("live_columns") or []
+# Each rendered title against the LabelSet its column declares, in order — not against eight
+# English literals. Measured 2026-08-29 on a Korean Logic, the same note-level header renders
+# `['L', 'M', '위치', '상태', '채널', '번호', '값', '길이/정보']`, so the literal form failed on a
+# table the product had just read correctly and both notes had already come back from.
+NOTE_LEVEL_COLUMNS = ["eventListColumnL", "eventListColumnM", "eventListColumnPosition",
+                      "eventListColumnStatus", "eventListColumnChannel", "eventListColumnNumber",
+                      "eventListColumnValue", "eventListColumnLengthInfo"]
+_declared = [E.label_set(n) for n in NOTE_LEVEL_COLUMNS]
+schema_binds = (len(live_cols) == len(NOTE_LEVEL_COLUMNS)
+                and all(d is not None for d in _declared)
+                and all(t is not None and any(t.strip().lower() == v.strip().lower() for v in d)
+                        for t, d in zip(live_cols, _declared)))
 ev.check("293/the-note-schema-binds",
-         live_cols == ["L", "M", "Position", "Status", "Ch", "Num", "Val", "Length/Info"],
+         schema_binds,
          "the eight column titles LOGIC rendered, in order — read from the header's sort buttons, "
          "not the canonical constants the row keys are minted from. The earlier form of this check "
          "compared those minted keys against the same English constants and so could not fail. "
          "Eight of them, not six, is also what says the pane is at note level and not region level",
-         f"live_columns={live_cols!r}",
+         f"live_columns={live_cols!r} declared={_declared!r}",
          # Deliberately NOT mutation-backed. There is no product mutation that makes these titles
          # wrong while the read still succeeds: if Logic rendered anything else, readHeaders throws
          # and every check here goes red together. Naming a mutation would be claiming an
@@ -311,7 +379,7 @@ if selected_before and selected_before != "Event":
     tabs(select=selected_before)
 if not pane_was_open:
     osa('tell application "System Events" to tell process "Logic Pro" to '
-        'click menu item "List Editors" of menu 1 of menu bar item 9 of menu bar 1')
+        f'click menu item "{LIST_EDITORS_ITEM}" of menu 1 of menu bar item {VIEW_MENU} of menu bar 1')
     time.sleep(2)
 
 relocated = [(t, E.logic_window(t)) for t in window_titles()]

--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -996,6 +996,19 @@ enum AXLocalePolicy {
         rationale: "Identifies the track-header rail by normalized description; read-only classifier (structural detection preferred)."
     )
 
+    /// The Event tab of the List Editors pane, by `AXDescription`.
+    ///
+    /// `EventListReadbackCollector` compared this description against the literal `"Event"`, so on
+    /// a Logic running in any other language the tab could not be found and the collector threw
+    /// `eventTabNotFound` — a readback that cannot start rather than one that reads wrong.
+    /// Measured 2026-08-29 on a Korean Logic: the four list tabs describe themselves
+    /// `이벤트`, `마커`, `템포`, `조표 및 박자표`.
+    static let eventListTab = LabelSet(
+        canonical: "event",
+        variants: ["이벤트", "イベント"],
+        rationale: "Identifies the Event tab of the List Editors pane; the collector presses it."
+    )
+
     /// Choose-Project picker window title markers.
     static let projectPickerWindow = LabelSet(
         canonical: "프로젝트 선택",
@@ -1287,6 +1300,7 @@ enum AXLocalePolicy {
         trackTypeMaster,
         headerPanHint,
         trackHeadersDescription,
+        eventListTab,
         projectPickerWindow,
         transportTextFieldHint,
         trackContentExplicit,

--- a/Sources/LogicProMCP/MIDIReadback/EventListReadbackCollector.swift
+++ b/Sources/LogicProMCP/MIDIReadback/EventListReadbackCollector.swift
@@ -234,7 +234,12 @@ enum EventListReadbackCollector {
             maxDepth: 20,
             runtime: runtime
         ).filter { tab in
-            AXHelpers.getDescription(tab, runtime: runtime) == "Event"
+            // Through the policy, not against the literal `"Event"`. That comparison meant the
+            // tab could only be found on an English Logic; everywhere else the collector threw
+            // `eventTabNotFound` before reading anything. Measured 2026-08-29 on a Korean Logic:
+            // the four list tabs describe themselves `이벤트`, `마커`, `템포`, `조표 및 박자표`.
+            AXLocalePolicy.eventListTab.matches(
+                AXHelpers.getDescription(tab, runtime: runtime) ?? "", mode: .exactStrict)
                 && (AXHelpers.getTitle(tab, runtime: runtime) ?? "").isEmpty
         }
         guard tabs.count == 1, let tab = tabs.first else {


### PR DESCRIPTION
The roadmap said #293's next step was rebuilding the collector's expected shape from a measured tree. **That was already done** — the per-column reading matches the 2026-08-10 measurement exactly, flag cells included. Running the harness is what found the real blocker, and it was not the shape.

## The product could not start

```swift
AXHelpers.getDescription(tab, runtime: runtime) == "Event"
```

Logic runs in Korean on this machine and calls that tab `이벤트`. So `EventListReadbackCollector` threw `eventTabNotFound` **before reading anything** — a readback that cannot start, rather than one that reads wrong. It goes through `AXLocalePolicy.eventListTab` now, declared with the four tabs measured beside it: `이벤트`, `마커`, `템포`, `조표 및 박자표`.

**Scope of that claim, stated exactly:** English and Korean are proven by a live run. Japanese is declared and unproven. A finite alias table is not locale-independence, and this PR does not claim it is.

## The first fix for the harness was too large, and review said so

`located_band` **already** translated names through `AX_REGION_LABELS`. Every region in that table had its row and `Control Bar` did not. **One missing line, not a missing mechanism** — the parallel alias apparatus this branch first grew has been removed again.

What remained was a third copy of the same idea: the harness shelled out to the band tool itself, so it never saw the table. With the Korean row added, the shared helper found the bar and the harness still reported nothing — asking a different question with the same words. It delegates now.

## The other bindings were real

| where | what was wrong | observed |
|---|---|---|
| View menu | found by **position** (`menu bar item 9`) and English item name | actually `보기` / `목록 편집기` |
| the eight columns | asserted as English literals | `['L','M','위치','상태','채널','번호','값','길이/정보']` |

The column case is the inverted one worth naming: **the product had already read the Korean table correctly and returned both notes** when that assertion failed. My first diagnosis — "the collector's header binding is English-only" — was wrong; `readHeaders` compares through LabelSets. The English binding was in the harness.

Each rendered title is now compared against the LabelSet its column declares, parsed from the policy source. That parser **strips Swift comments first**, because a commented-out variant is not a declared one.

## A false clean, closed

`tab_state` covers all four list tabs, not the two this run drives. Narrowing it made a session that started on Tempo or Signature read as *"no list tab is selected"* — nothing to restore, restoration skipped, run reports itself clean.

## The guard, aimed at the copy that exists

`check-livekit-locale-aliases.py` checks `AX_REGION_LABELS`, which is what the locator reads. Its first version checked two lists written for the guard itself while the locator went on using another — a guard aimed at nothing.

Comparison splits on script, and the reason is not stylistic:

- an **ASCII** variant differs from what Logic renders only in case, and the product folds case → case-insensitive
- `컨트롤 막대` is **a whole language** the product claims to know, and nothing folds it into `Control Bar` → verbatim

Folding everything would have accepted `"CONTROL BAR"` as covering `"control bar"` while Logic renders `"Control Bar"` and the tool matches neither. Comparing everything exactly fails on today's tree, because the policy's variants are **normalisation inputs, not strings Logic emits**.

Split that way it found a real gap: the policy declares four ASCII spellings of the rail and the table tried one.

## Result

```
10 checks · 10 passed · cached_reads_used_as_live 0 · exit 0
```

Mutation-tested in both directions: removing the Korean row reproduces the original failure, and folding case for a non-ASCII spelling makes the guard accept a script it cannot reach.

## What CI caught that the local gate did not

`check-ax-locator-census.py` failed — not a defect, the same ratchet shape this session has been building elsewhere. Taking the Event tab through `AXLocalePolicy` converted a blind lookup, so the guard reported **UNDER BUDGET by 1**: the bar moved and the file had not caught up. `BLIND_SITE_BUDGET` is 55 now.

Worth naming as a real gap, and closed here: the local ship gate ran the Swift suite while the repo guards ran only in CI's compile job. A gate that green-lights a push CI will reject is not wrong about the tests — it is silent about a whole class of check, and the ratchets are exactly the class that fires on **improvement**, so "it was passing yesterday" does not cover them. The gate runs them now, and the step was mutation-tested: reinstating the budget makes it red.

Adding it immediately failed on something else, which is its own finding. `check-python-contracts.py` walks the tree with a hand-written skip list that cannot know what `.gitignore` says, so a vendored tool directory — gitignored, never committed, present on one machine — made the guard fail locally and pass in CI. A verdict that depends on what somebody left in their working copy is one nobody can act on, and the error runs the bad way: it fails where there is **more**, so whoever can reproduce it is least able to tell it from a real defect. It asks git now.

## Deliberately not here

`live_628_counting_locator` has the same shape of binding, but its **captures do not settle**: the rail it photographs carries level meters that blink, and the display check calls its band not wholly within one screen of three. That is an environmental wall with a recorded shape, and carrying it would mean shipping a harness this branch cannot prove.

ADR-010's body — `assessReadback`, the public provider — stays closed. This goes as far as *the collector actually reads*.

Refs #293.


Replaces #711, which could not be updated without a force push after the commits were amended.
