### PR TITLE
docs: two roadmap rows described walls that measurement does not find

### DIFF
--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -58,7 +58,7 @@ open PRs 0 · v3.14.0 published · 17 open issues
 | ADR-012 | #300 | closed | promoted and closed 2026-08-28; all seven acceptance criteria measured, four artifacts found and fixed on the way (#693-#697) |
 | ADR-013 | #301 | OPEN | **zero band operations registered** — no public surface; the AX plane a readback needs is not exposed |
 | ADR-014 | #302 | OPEN | R1 shipped. R2 is NOT STARTED rather than blocked: measured 2026-08-29, `kAXColumns` is present and returns 8 columns — what is absent is any title or description ON them, and the header's sort buttons carry the names the collector already binds. Next step is an R2 ticket, not another measurement |
-| ADR-015 | #303 | OPEN | behind #293 |
+| ADR-015 | #303 | OPEN | behind #293, and measured 2026-08-29 the dependency is narrower than "transforms must not read their own plan" — `TransformVerification` already refuses a proof that shares the observed pipeline. What is missing is a MAKER: `IndependentExpectedSeam` is inside `#if QUALIFICATION_FAULT_SEAM`, so in a release build `independentPayload` is always nil and no positive match is possible. The three modules exist; the gap is the live ingestion boundary in front of them |
 | ADR-016 | #304 | OPEN | implementation; no measured AX wall in front of it |
 | ADR-017 | #305 | OPEN | AU parameter view observed AX-opaque; starts with a measurement |
 | ADR-018 | #306 | OPEN | same wall as #305 |

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -36,7 +36,7 @@ still list the issue rather than delete its row.
 It does not check the prose. The "waiting on" column, the order, and the state block below are still
 claims dated by the "measured" line, and only issue numbers and open/closed are mechanised.
 
-## State — measured 2026-08-29 at `8959bee7`
+## State — measured 2026-08-29 at `4ef4d3cf`
 
 ```
 open PRs 0 · v3.14.0 published · 17 open issues
@@ -53,11 +53,11 @@ open PRs 0 · v3.14.0 published · 17 open issues
 | ADR-007 | #290 | OPEN | scoring fixed and six selectors adopted; the diff, four baselines and cross-locale coverage shipped in #707/#708. Waiting on a **decision**, not work: wiring the diff into `--qualify` changes the attestation schema or the release gate's behaviour, and the three options are written up on the issue |
 | ADR-008 | #291 | OPEN | node identity cannot be the display string — needs a decision, not an attempt |
 | ADR-009 | #292 | OPEN | apply-back expansion on Wave-0 insert work; #299 and #301 consume it |
-| ADR-010 | #293 | OPEN | provider exists (10 modules); its collector was written against a fixture shape Logic does not produce |
+| ADR-010 | #293 | OPEN | the collector's shape was already right; measured 2026-08-29 it reads a real note table and returns both notes. It could not START in any language but English — the Event tab was matched against the literal `"Event"` — fixed in #712. What stays closed is ADR-010's body: `assessReadback` and the public provider |
 | ADR-011 | #299 | OPEN | behind #292 |
 | ADR-012 | #300 | closed | promoted and closed 2026-08-28; all seven acceptance criteria measured, four artifacts found and fixed on the way (#693-#697) |
 | ADR-013 | #301 | OPEN | **zero band operations registered** — no public surface; the AX plane a readback needs is not exposed |
-| ADR-014 | #302 | OPEN | R1 shipped; R2 blocked on `columnResolveFailed` — `kAXColumns` absent on the live Event List |
+| ADR-014 | #302 | OPEN | R1 shipped. R2 is NOT STARTED rather than blocked: measured 2026-08-29, `kAXColumns` is present and returns 8 columns — what is absent is any title or description ON them, and the header's sort buttons carry the names the collector already binds. Next step is an R2 ticket, not another measurement |
 | ADR-015 | #303 | OPEN | behind #293 |
 | ADR-016 | #304 | OPEN | implementation; no measured AX wall in front of it |
 | ADR-017 | #305 | OPEN | AU parameter view observed AX-opaque; starts with a measurement |
@@ -109,7 +109,10 @@ attached — not a silent deferral.
    diff runs, but nothing calls it at qualification time, and every way of wiring it touches either
    the attestation schema or what `--qualify` refuses. That choice is on the issue as A/B/C.
 3. **#293 → #303** — readback before the transforms that must take their expected values from it.
-4. **#302** — blocked on the Event List's absent `kAXColumns` until that is re-measured.
+   #293's collector is measured reading a live note table; what remains there is the ADR body.
+4. **#302** — re-measured. `kAXColumns` resolves 8 columns and none of them carries a name, which
+   is a different fact from the one recorded; the header sort buttons supply the column map and
+   `readHeaders` already reads them. The next step is an R2 ticket.
 5. **#292 → #299**. #300's promotion is done — the flag is removed, not defaulted on.
 6. **#291, #301, #305, #306, #369, #448** — each starts with a measurement.
 7. **#373 → #284's `R-SEM`**, then **#308** closes as an index.


### PR DESCRIPTION
`docs/roadmap/README.md` is the source of truth for what is open and in what order, and its guard checks **issue numbers and open/closed only** — it says so itself. The prose is the part that goes stale unnoticed, and two rows had.

## #302 — the wall is not where it was written

The row said `kAXColumns` is absent on the live Event List. Measured 2026-08-29:

```
Event List table:  hasColumnsAttribute=true   columns=8   rows=2
  AXColumn  title=<empty>  desc=<empty>   ×8
```

The attribute is **present** and returns eight columns. What is absent is any title or description **on** them — a different fact and a different blocker. And the route around it is already in the product: `readHeaders` reads the header's sort-button titles in order, which is how the same afternoon bound all eight on a Korean Logic:

```
['L', 'M', '위치', '상태', '채널', '번호', '값', '길이/정보']
```

Neither `columnResolveFailed` nor any note-manifest code exists in the tree, so **R2 is not started rather than blocked** — the recorded wall came from an attempt that did not land here. The next step is an R2 ticket, not another measurement.

## #293 — the shape was already right

The row said the collector was written against a fixture shape Logic does not produce. Its per-column reading matches the measured tree exactly, flag cells included, and it reads a real note table and returns both notes. What stopped it was that it could not **start** in any language but English (#712).

What stays closed there is ADR-010's body: `assessReadback` and the public provider.

## #303 — the dependency is a missing maker

The row said "behind #293" and the issue said transforms must take expected notes from the independent readback provider rather than from the write plan they check. **`TransformVerification` already refuses exactly that** — a proof sharing the observed conversion pipeline, one not bound to the observed region, one whose content binding is invalid, one carrying no sealed independent provenance at all.

What is absent is anything that can **mint** the proof outside a debug build:

```swift
#if QUALIFICATION_FAULT_SEAM
enum IndependentExpectedSeam { ... }   // "a release build has no maker"
#endif

var independentPayload: (...)? {
    #if QUALIFICATION_FAULT_SEAM
    ...
    #endif
    return nil                          // release: always nil
}
```

So a release binary can only answer `stateBUnverified`. The file says it: *rejection-only*, the seam *standing in for R2's live ingestion boundary*. All three modules exist; the gap is in front of them — and it is the same gap #302's R2 is for, which the same measurement found reachable.

## Why this keeps happening

Four roadmap rows were corrected today — #290, #293, #302, #303 — and the shape is the same each time. Twice the recorded wall was already gone; twice it was real but pointed at the wrong thing. The guard is mechanical about *which* issues are open and silent about *what they are waiting on*, which is the field that decides what someone does next.

**A roadmap that names a wall nobody can find sends the next reader to measure something already measured.** That is the cost being paid, and it is why these edits are worth a PR of their own rather than a line in another one.

State block re-measured at `4ef4d3cf`; `Scripts/roadmap-table-matches-github.py` agrees with GitHub across 25 rows.
