### PR TITLE
feat(#290): the atlas diff decides a qualification case, behind the flag that gated nothing

### DIFF
--- a/Sources/LogicProMCP/MainEntrypoint.swift
+++ b/Sources/LogicProMCP/MainEntrypoint.swift
@@ -355,6 +355,39 @@ enum MainEntrypoint {
         //
         // Writes the document to stdout. The caller decides where it lands, because a command that
         // also chooses the path is a command that can overwrite a fixture nobody meant to replace.
+        // The live half of the ADR-007 diff, on its own, so it can be exercised without a whole
+        // qualification run. The DECISION is pure and tested offline; this is the part that needs
+        // Logic on screen, and a wiring nobody can run separately is a wiring nobody can debug.
+        //
+        // Reads `LOGIC_MCP_ATLAS_BASELINES` exactly as the qualification path does — same function,
+        // not a copy — so a green answer here is about the code that will run there.
+        if arguments.contains("--probe-atlas-diff") {
+            let pairs = AtlasCapture.pairsForThisRun()
+            let outcome = AtlasQualification.outcome(armed: true, pairs: pairs)
+            var payload: [String: Any] = ["pairs": pairs.count,
+                                          "scopes": pairs.map(\.scope)]
+            switch outcome {
+            case .notArmed:
+                payload["outcome"] = "not_armed"
+            case let .noBaselines(reason):
+                payload["outcome"] = "no_baselines"
+                payload["reason"] = reason
+            case let .diffed(verdict, drifts, unmeasured):
+                payload["outcome"] = "diffed"
+                payload["verdict"] = "\(verdict)"
+                payload["moved"] = drifts.filter { $0.status != .stable }
+                    .map { "\($0.selectorID)=\($0.status)" }
+                payload["unmeasured"] = unmeasured.map { "\($0)" }.sorted()
+            }
+            if let data = try? JSONSerialization.data(
+                withJSONObject: payload, options: [.prettyPrinted, .sortedKeys]) {
+                writeStdout(String(decoding: data, as: UTF8.self) + "\n")
+                return 0
+            }
+            writeStdout("{\"ok\":false,\"error\":\"could not encode the probe\"}\n")
+            return 1
+        }
+
         if arguments.contains("--ax-snapshot") {
             guard let window = AXLogicProElements.mainWindow() else {
                 writeStdout("{\"ok\":false,\"error\":\"no main window\"}\n")

--- a/Sources/LogicProMCP/MainEntrypoint.swift
+++ b/Sources/LogicProMCP/MainEntrypoint.swift
@@ -362,27 +362,35 @@ enum MainEntrypoint {
         // Reads `LOGIC_MCP_ATLAS_BASELINES` exactly as the qualification path does — same function,
         // not a copy — so a green answer here is about the code that will run there.
         if arguments.contains("--probe-atlas-diff") {
-            let pairs = AtlasCapture.pairsForThisRun()
-            let outcome = AtlasQualification.outcome(armed: true, pairs: pairs)
-            var payload: [String: Any] = ["pairs": pairs.count,
-                                          "scopes": pairs.map(\.scope)]
+            let captured = AtlasCapture.pairsForThisRun()
+            let outcome = AtlasQualification.outcome(
+                armed: true, pairs: captured.pairs, dropped: captured.dropped)
+            var payload: [String: Any] = ["pairs": captured.pairs.count,
+                                          "dropped": captured.dropped,
+                                          "scopes": captured.pairs.map(\.scope)]
             switch outcome {
             case .notArmed:
                 payload["outcome"] = "not_armed"
             case let .noBaselines(reason):
                 payload["outcome"] = "no_baselines"
                 payload["reason"] = reason
-            case let .diffed(verdict, drifts, unmeasured):
+            case let .diffed(verdict, drifts, unmeasured, _):
                 payload["outcome"] = "diffed"
                 payload["verdict"] = "\(verdict)"
                 payload["moved"] = drifts.filter { $0.status != .stable }
                     .map { "\($0.selectorID)=\($0.status)" }
                 payload["unmeasured"] = unmeasured.map { "\($0)" }.sorted()
             }
+            // The EXIT CODE carries the verdict, not just the JSON. A probe that answers 0 while
+            // printing `no_baselines` teaches a caller to read the text, and a caller reading text
+            // is the shape a `grep`-based gate had before it was fixed this week. Named by review.
+            let probePassed: Bool
+            if case let .diffed(verdict, _, _, _) = outcome { probePassed = verdict == .reuseFull }
+            else { probePassed = false }
             if let data = try? JSONSerialization.data(
                 withJSONObject: payload, options: [.prettyPrinted, .sortedKeys]) {
                 writeStdout(String(decoding: data, as: UTF8.self) + "\n")
-                return 0
+                return probePassed ? 0 : 1
             }
             writeStdout("{\"ok\":false,\"error\":\"could not encode the probe\"}\n")
             return 1

--- a/Sources/LogicProMCP/Qualification/PromotionGate.swift
+++ b/Sources/LogicProMCP/Qualification/PromotionGate.swift
@@ -23,6 +23,14 @@ enum PromotionRejectionReason: Equatable, Sendable {
     case releaseVersionUnparseable(expected: String, actual: String)
     case evidenceBindingMismatch(detail: String)
     case requiredOperationNotSatisfied(operationID: String)
+    /// The ADR-007 atlas diff ran and refused.
+    ///
+    /// A case of its own because this gate rejects a FAILED case only when its id equals a required
+    /// axis key, and `atlas.drift_diff` is not one — so without this the step reported a failure
+    /// that stopped nothing. Measured before merge, 2026-08-29: the case landed `.failed`,
+    /// `attestation.failed` counted it, and the release stayed promotable. A verdict nobody acts on
+    /// is the shape this whole step exists to remove.
+    case atlasDriftRefused(detail: String)
     case provenanceSignatureMissing
     case provenanceSignatureInvalid
     case trustedProvenanceKeyUnavailable
@@ -117,6 +125,14 @@ struct PromotionGate {
         for caseID in expiredWaiverIDs.sorted() {
             rejections.append(.expiredWaiver(caseID: caseID))
         }
+        // The atlas step, if it ran at all. Absent means the flag was off, which is today's
+        // pipeline and not a rejection; present-and-failed is one.
+        if let atlas = attestation.cases.first(where: { $0.id == "atlas.drift_diff" }),
+           atlas.status == .failed {
+            rejections.append(.atlasDriftRefused(
+                detail: atlas.reason ?? "the atlas diff refused without a stated reason"))
+        }
+
         for operationID in requiredOperationIDs.sorted() {
             let operationCases = attestation.cases.filter {
                 $0.id == "in-process/\(operationID)" && $0.operationID == operationID

--- a/Sources/LogicProMCP/Qualification/QualificationRunner.swift
+++ b/Sources/LogicProMCP/Qualification/QualificationRunner.swift
@@ -20,6 +20,9 @@ package struct QualificationRunner: Sendable {
         let handlerExists: @Sendable (String, String) -> Bool
         let beforeEvidenceRead: @Sendable (URL) -> Void
         let drive: @Sendable (QualificationDriveRequest) async throws -> QualificationDriveResult
+        /// Baseline/live pairs for the ADR-007 diff. Empty in a build that cannot capture, which an
+        /// ARMED run treats as a refusal rather than as agreement — see `AtlasQualification`.
+        let atlasPairs: @Sendable () -> [AtlasQualification.Pair]
 
         static let production = Runtime(
             executableURL: { try QualificationRunner.currentExecutableURL() },
@@ -37,7 +40,8 @@ package struct QualificationRunner: Sendable {
             beforeEvidenceRead: { _ in },
             drive: { request in
                 try QualificationTransport().drive(request)
-            }
+            },
+            atlasPairs: { AtlasCapture.pairsForThisRun() }
         )
     }
 
@@ -785,6 +789,23 @@ package struct QualificationRunner: Sendable {
                 }
             }
             cases.append(contentsOf: externalCases)
+        }
+
+        // ADR-007: the atlas diff, as one more case rather than a new attestation field.
+        //
+        // `runtime.atlasPairs` is injected so this decision is testable without Logic — and so the
+        // capture side, which needs a running application, cannot make the DECISION untestable.
+        // Off unless `adr007SelectorAtlas` is set: only `ko` has a control-bar baseline today, and
+        // arming it everywhere would refuse every run on a Logic speaking anything else.
+        if let atlasCase = AtlasQualification.caseFor(
+            AtlasQualification.outcome(
+                armed: FeatureFlags.adr007SelectorAtlas,
+                pairs: runtime.atlasPairs()),
+            axis: observedAxis,
+            binarySHA256: binarySHA256,
+            traceID: "atlas-drift-diff"
+        ) {
+            cases.append(atlasCase)
         }
 
         let caseManifest = QualificationCaseManifest(

--- a/Sources/LogicProMCP/Qualification/QualificationRunner.swift
+++ b/Sources/LogicProMCP/Qualification/QualificationRunner.swift
@@ -22,7 +22,7 @@ package struct QualificationRunner: Sendable {
         let drive: @Sendable (QualificationDriveRequest) async throws -> QualificationDriveResult
         /// Baseline/live pairs for the ADR-007 diff. Empty in a build that cannot capture, which an
         /// ARMED run treats as a refusal rather than as agreement — see `AtlasQualification`.
-        let atlasPairs: @Sendable () -> [AtlasQualification.Pair]
+        let atlasPairs: @Sendable () -> (pairs: [AtlasQualification.Pair], dropped: [String])
 
         static let production = Runtime(
             executableURL: { try QualificationRunner.currentExecutableURL() },
@@ -797,10 +797,17 @@ package struct QualificationRunner: Sendable {
         // capture side, which needs a running application, cannot make the DECISION untestable.
         // Off unless `adr007SelectorAtlas` is set: only `ko` has a control-bar baseline today, and
         // arming it everywhere would refuse every run on a Logic speaking anything else.
+        // The flag decides before anything is CAPTURED, not only before a case is emitted. Passing
+        // `runtime.atlasPairs()` as an argument evaluated it eagerly, so a run with the flag off
+        // still walked the AX tree — work nobody asked for, and a claim in the PR ("the flag is the
+        // only thing arming it") that the code did not keep. Named by review, 2026-08-29.
+        let atlasArmed = FeatureFlags.adr007SelectorAtlas
+        let atlasCaptured = atlasArmed ? runtime.atlasPairs() : (pairs: [], dropped: [])
         if let atlasCase = AtlasQualification.caseFor(
             AtlasQualification.outcome(
-                armed: FeatureFlags.adr007SelectorAtlas,
-                pairs: runtime.atlasPairs()),
+                armed: atlasArmed,
+                pairs: atlasCaptured.pairs,
+                dropped: atlasCaptured.dropped),
             axis: observedAxis,
             binarySHA256: binarySHA256,
             traceID: "atlas-drift-diff"
@@ -1309,6 +1316,11 @@ package struct QualificationRunner: Sendable {
             VerificationOutput.Rejection(
                 reason: "requiredCaseFailed", caseID: caseID, key: nil,
                 name: nil, expected: nil, actual: nil
+            )
+        case .atlasDriftRefused(let detail):
+            VerificationOutput.Rejection(
+                reason: "atlasDriftRefused", caseID: "atlas.drift_diff", key: nil,
+                name: nil, expected: nil, actual: detail
             )
         case .requiredCombinationNotQualified(let key):
             VerificationOutput.Rejection(

--- a/Sources/LogicProMCP/Qualification/QualificationRunner.swift
+++ b/Sources/LogicProMCP/Qualification/QualificationRunner.swift
@@ -805,6 +805,16 @@ package struct QualificationRunner: Sendable {
             binarySHA256: binarySHA256,
             traceID: "atlas-drift-diff"
         ) {
+            // AFTER the external-manifest collision check at the top of this function, so this id
+            // has to be checked here or not at all. An external manifest declaring
+            // `atlas.drift_diff` would otherwise produce two cases with one id, and every consumer
+            // that keys by id — the promotion gate, a waiver, a reader counting a failure — would
+            // see whichever it reached first. Found by review before merge, 2026-08-29.
+            guard !cases.contains(where: { $0.id == atlasCase.id }) else {
+                throw RunnerError.evidenceBindingMismatch(
+                    "case id \(atlasCase.id) is already present; the ADR-007 step cannot add a "
+                        + "second case under the same id")
+            }
             cases.append(atlasCase)
         }
 

--- a/Sources/LogicProMCP/SelectorAtlas/AtlasCapture.swift
+++ b/Sources/LogicProMCP/SelectorAtlas/AtlasCapture.swift
@@ -28,6 +28,14 @@ enum AtlasCapture {
         runtime: AXHelpers.Runtime = .production
     ) -> AXUIElement? {
         if AXLocalePolicy.controlBarGroupLabel.matches(scope, mode: .exactStrict) {
+            // NOTE, because the signature would otherwise imply more than happens: `getControlBar`
+            // resolves `mainWindow()` itself and takes its own runtime, so on THIS path the
+            // `window` and `runtime` given here are not used. `pairsForThisRun` passes
+            // `mainWindow()` too, so the two agree by construction there — but a caller handing
+            // `pairs(baselinesIn:window:)` some other window would get the control bar of the main
+            // one, silently. Naming that is cheaper than a signature nobody re-reads; closing it
+            // means teaching `getControlBar` to take a window, which is a change to a resolver
+            // several other call sites depend on. Named by review, 2026-08-29.
             return AXLogicProElements.getControlBar()
         }
         if scope == "window" { return window }

--- a/Sources/LogicProMCP/SelectorAtlas/AtlasCapture.swift
+++ b/Sources/LogicProMCP/SelectorAtlas/AtlasCapture.swift
@@ -1,0 +1,91 @@
+import ApplicationServices
+import Foundation
+
+/// Takes the live half of an atlas diff: for each committed baseline, a capture at the same scope.
+///
+/// Split from `AtlasQualification` because these two have different testability. The decision —
+/// what a verdict means for a run — is pure and every branch of it is exercised offline. This half
+/// needs Logic on screen, so a build without it produces no pairs; an ARMED run reads that as a
+/// refusal, which is the only reading that does not turn "could not look" into "nothing wrong".
+///
+/// WHERE THE BASELINES COME FROM
+/// -----------------------------
+/// `LOGIC_MCP_ATLAS_BASELINES`, a directory of `*.json` documents. Not bundled into the binary and
+/// not discovered by walking upward from the executable: a qualification run is asked to prove a
+/// release, and letting it find its own baselines by searching would let the answer depend on where
+/// somebody happened to unpack it. The operator names the directory or the run has none.
+enum AtlasCapture {
+
+    /// The scope resolution a baseline's `scope` field asks for.
+    ///
+    /// Two routes, because two kinds of scope exist and only one can be matched by description.
+    /// The control bar is resolved by `getControlBar`, which discriminates the two groups carrying
+    /// that description by the property callers depend on (#628); everything else is a container
+    /// named by an exact description, which is what the capture command already does.
+    static func resolveScope(
+        _ scope: String,
+        in window: AXUIElement,
+        runtime: AXHelpers.Runtime = .production
+    ) -> AXUIElement? {
+        if AXLocalePolicy.controlBarGroupLabel.matches(scope, mode: .exactStrict) {
+            return AXLogicProElements.getControlBar()
+        }
+        if scope == "window" { return window }
+        return AXLocalePolicy.censusDescendant(
+            of: window, role: "AXGroup",
+            matching: AXLocalePolicy.LabelSet(
+                canonical: scope, variants: [], rationale: "atlas baseline scope"),
+            mode: .exactStrict, maxDepth: 8, runtime: runtime).element
+    }
+
+    /// Every baseline in `directory`, paired with a capture taken at its own scope.
+    ///
+    /// A baseline whose scope cannot be resolved is DROPPED rather than paired with an empty
+    /// document. An empty current would diff as "every selector vanished" — true-looking and about
+    /// nothing — whereas a missing pair narrows what the run measured, which `uncovered` then
+    /// reports honestly. Losing every pair leaves an armed run with nothing, and that refuses.
+    static func pairs(
+        baselinesIn directory: URL,
+        window: AXUIElement,
+        runtime: AXHelpers.Runtime = .production
+    ) -> [AtlasQualification.Pair] {
+        let files = (try? FileManager.default.contentsOfDirectory(
+            at: directory, includingPropertiesForKeys: nil)) ?? []
+        var out: [AtlasQualification.Pair] = []
+        for url in files.sorted(by: { $0.lastPathComponent < $1.lastPathComponent })
+        where url.pathExtension.lowercased() == "json" {
+            guard let data = try? Data(contentsOf: url),
+                  let baseline = try? JSONDecoder().decode(AXSnapshot.Document.self, from: data),
+                  let root = resolveScope(baseline.scope, in: window, runtime: runtime)
+            else { continue }
+            let captured = AXSnapshot.capture(root, runtime: runtime)
+            let current = AXSnapshot.Document(
+                logicVersion: baseline.logicVersion,
+                locale: baseline.locale,
+                scope: baseline.scope,
+                capturedFrom: "ax",
+                root: AXSnapshot.restorableRootDescription(
+                    scope: "control-bar",
+                    resolvedDescription: AXLocalePolicy.controlBarGroupLabel
+                        .matches(baseline.scope, mode: .exactStrict)
+                        ? AXHelpers.getDescription(root, runtime: runtime) : nil
+                ).map { AXSnapshot.scopedRoot(captured, readBackDescription: $0) } ?? captured)
+            out.append(AtlasQualification.Pair(
+                scope: baseline.scope, baseline: baseline, current: current))
+        }
+        return out
+    }
+
+    /// Pairs for the run happening now, or none.
+    ///
+    /// None when the directory is unset, when it holds nothing readable, or when Logic is not on
+    /// screen. All three are the same fact from this function's point of view — it could not look —
+    /// and the caller is the one that decides what that means.
+    static func pairsForThisRun() -> [AtlasQualification.Pair] {
+        guard let path = ProcessInfo.processInfo.environment["LOGIC_MCP_ATLAS_BASELINES"],
+              !path.isEmpty,
+              let window = AXLogicProElements.mainWindow()
+        else { return [] }
+        return pairs(baselinesIn: URL(fileURLWithPath: path), window: window)
+    }
+}

--- a/Sources/LogicProMCP/SelectorAtlas/AtlasCapture.swift
+++ b/Sources/LogicProMCP/SelectorAtlas/AtlasCapture.swift
@@ -48,20 +48,31 @@ enum AtlasCapture {
         baselinesIn directory: URL,
         window: AXUIElement,
         runtime: AXHelpers.Runtime = .production
-    ) -> [AtlasQualification.Pair] {
+    ) -> (pairs: [AtlasQualification.Pair], dropped: [String]) {
         let files = (try? FileManager.default.contentsOfDirectory(
             at: directory, includingPropertiesForKeys: nil)) ?? []
         var out: [AtlasQualification.Pair] = []
+        // What was NOT paired, by name. Dropping is right — an empty current would diff as "every
+        // selector vanished", true-looking and about nothing — but dropping SILENTLY is not: with
+        // one baseline unreadable and the rest covering every selector, the case passed while a
+        // scope nobody could resolve went unmentioned. Named by review, 2026-08-29.
+        var dropped: [String] = []
         for url in files.sorted(by: { $0.lastPathComponent < $1.lastPathComponent })
         where url.pathExtension.lowercased() == "json" {
             guard let data = try? Data(contentsOf: url),
                   let baseline = try? JSONDecoder().decode(AXSnapshot.Document.self, from: data),
                   let root = resolveScope(baseline.scope, in: window, runtime: runtime)
-            else { continue }
+            else { dropped.append(url.lastPathComponent); continue }
             let captured = AXSnapshot.capture(root, runtime: runtime)
+            // NOT the baseline's `logicVersion` and `locale`. Copying them made the live document
+            // assert what it was compared AGAINST rather than what it is, so a `ko` baseline read
+            // on an English Logic produced a "ko" current and the pair looked matched. Nothing here
+            // can read the running version or language, so the honest value is a name that says so
+            // — a reader seeing `observed` knows to look elsewhere for the axis, which is exactly
+            // what an empty-looking `ko` would have hidden. Named by review, 2026-08-29.
             let current = AXSnapshot.Document(
-                logicVersion: baseline.logicVersion,
-                locale: baseline.locale,
+                logicVersion: "observed",
+                locale: "observed",
                 scope: baseline.scope,
                 capturedFrom: "ax",
                 root: AXSnapshot.restorableRootDescription(
@@ -73,7 +84,7 @@ enum AtlasCapture {
             out.append(AtlasQualification.Pair(
                 scope: baseline.scope, baseline: baseline, current: current))
         }
-        return out
+        return (out, dropped)
     }
 
     /// Pairs for the run happening now, or none.
@@ -81,11 +92,11 @@ enum AtlasCapture {
     /// None when the directory is unset, when it holds nothing readable, or when Logic is not on
     /// screen. All three are the same fact from this function's point of view — it could not look —
     /// and the caller is the one that decides what that means.
-    static func pairsForThisRun() -> [AtlasQualification.Pair] {
+    static func pairsForThisRun() -> (pairs: [AtlasQualification.Pair], dropped: [String]) {
         guard let path = ProcessInfo.processInfo.environment["LOGIC_MCP_ATLAS_BASELINES"],
               !path.isEmpty,
               let window = AXLogicProElements.mainWindow()
-        else { return [] }
+        else { return ([], []) }
         return pairs(baselinesIn: URL(fileURLWithPath: path), window: window)
     }
 }

--- a/Sources/LogicProMCP/SelectorAtlas/AtlasQualification.swift
+++ b/Sources/LogicProMCP/SelectorAtlas/AtlasQualification.swift
@@ -28,8 +28,10 @@ enum AtlasQualification {
         case notArmed
         /// Armed, but there is nothing to diff against. A refusal, not a pass — see `caseFor`.
         case noBaselines(reason: String)
-        /// Diffed. `unmeasured` is the adopted set no pair covered.
-        case diffed(verdict: QualificationReuse, drifts: [SelectorDrift], unmeasured: Set<SelectorID>)
+        /// Diffed. `unmeasured` is the adopted set no pair covered; `dropped` names baselines that
+        /// could not be paired at all.
+        case diffed(verdict: QualificationReuse, drifts: [SelectorDrift],
+                    unmeasured: Set<SelectorID>, dropped: [String])
     }
 
     /// A baseline and the live capture taken at the same scope.
@@ -43,7 +45,7 @@ enum AtlasQualification {
     ///
     /// `armed` is passed rather than read here so the decision has one home and the tests do not
     /// have to move an environment variable to exercise both sides.
-    static func outcome(armed: Bool, pairs: [Pair]) -> Outcome {
+    static func outcome(armed: Bool, pairs: [Pair], dropped: [String] = []) -> Outcome {
         guard armed else { return .notArmed }
         guard !pairs.isEmpty else {
             return .noBaselines(
@@ -54,10 +56,14 @@ enum AtlasQualification {
         let unmeasured = pairs
             .map { AtlasDiff.uncovered(baseline: $0.baseline, current: $0.current) }
             .reduce(Set(AtlasDiff.adoptedSelectors.map(\.id))) { $0.intersection($1) }
+        // A dropped baseline is a scope this run could not read. Even when the pairs that DID
+        // resolve cover every selector, the run measured less than it was given — and calling that
+        // full reuse is the silence this step exists to refuse.
+        let verdict = dropped.isEmpty
+            ? AtlasDiff.verdict(for: drifts, assumingCoverage: unmeasured)
+            : .failClosedMutation
         return .diffed(
-            verdict: AtlasDiff.verdict(for: drifts, assumingCoverage: unmeasured),
-            drifts: drifts,
-            unmeasured: unmeasured)
+            verdict: verdict, drifts: drifts, unmeasured: unmeasured, dropped: dropped)
     }
 
     /// The case an outcome produces, or nil when the run is not armed.
@@ -83,9 +89,10 @@ enum AtlasQualification {
         case let .noBaselines(why):
             passed = false
             reason = why
-        case let .diffed(verdict, drifts, unmeasured):
+        case let .diffed(verdict, drifts, unmeasured, dropped):
             passed = verdict == .reuseFull
-            reason = passed ? nil : describe(verdict: verdict, drifts: drifts, unmeasured: unmeasured)
+            reason = passed ? nil : describe(
+                verdict: verdict, drifts: drifts, unmeasured: unmeasured, dropped: dropped)
         }
         return QualificationCase(
             id: "atlas.drift_diff",
@@ -114,7 +121,8 @@ enum AtlasQualification {
     static func describe(
         verdict: QualificationReuse,
         drifts: [SelectorDrift],
-        unmeasured: Set<SelectorID>
+        unmeasured: Set<SelectorID>,
+        dropped: [String] = []
     ) -> String {
         var parts: [String] = ["atlas diff verdict \(verdict)"]
         let moved = drifts.filter { $0.status != .stable }
@@ -126,7 +134,11 @@ enum AtlasQualification {
         if !unmeasured.isEmpty {
             parts.append("unmeasured: " + unmeasured.map { "\($0)" }.sorted().joined(separator: ", "))
         }
-        if moved.isEmpty, unmeasured.isEmpty, drifts.isEmpty {
+        if !dropped.isEmpty {
+            parts.append("baselines that could not be read or resolved: "
+                + dropped.sorted().joined(separator: ", "))
+        }
+        if moved.isEmpty, unmeasured.isEmpty, dropped.isEmpty, drifts.isEmpty {
             parts.append("nothing was compared")
         }
         return parts.joined(separator: " — ")

--- a/Sources/LogicProMCP/SelectorAtlas/AtlasQualification.swift
+++ b/Sources/LogicProMCP/SelectorAtlas/AtlasQualification.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+/// The atlas diff as a qualification step.
+///
+/// ADR-007 asks that a new Logic version's qualification include an atlas diff. `AtlasDiff` scores
+/// baselines; this decides what a qualification run should DO with the answer, and it deliberately
+/// adds no field to the attestation: the result is a `QualificationCase` like any other, so it
+/// lands in `total`/`passed`/`failed` and in the case manifest without a schema change. A new field
+/// would have needed a schema version, and a step whose whole claim is "this refuses" should not
+/// arrive by changing what every consumer must parse.
+///
+/// WHAT DECIDES WHETHER IT RUNS
+/// ----------------------------
+/// `FeatureFlags.adr007SelectorAtlas`, which until now gated nothing — measured 2026-08-29, its
+/// only reference in the tree was a test asserting it is off, while the six adopted selectors
+/// resolve unconditionally in every build. So the flag said "off" about something that was on.
+/// It has a subject now, and it is this: the diff, not the selectors.
+///
+/// Off by default, and that is the point of putting it behind a flag rather than shipping it armed.
+/// Only `ko` has a control-bar baseline today; arming this for every run would refuse every
+/// qualification on a machine whose Logic speaks anything else — a gate failing on its operator's
+/// language rather than on Logic.
+enum AtlasQualification {
+
+    /// What a run can conclude, before it is turned into a case.
+    enum Outcome: Equatable, Sendable {
+        /// The flag is off. No case is emitted at all; today's pipeline is unchanged.
+        case notArmed
+        /// Armed, but there is nothing to diff against. A refusal, not a pass — see `caseFor`.
+        case noBaselines(reason: String)
+        /// Diffed. `unmeasured` is the adopted set no pair covered.
+        case diffed(verdict: QualificationReuse, drifts: [SelectorDrift], unmeasured: Set<SelectorID>)
+    }
+
+    /// A baseline and the live capture taken at the same scope.
+    struct Pair: Sendable {
+        let scope: String
+        let baseline: AXSnapshot.Document
+        let current: AXSnapshot.Document
+    }
+
+    /// The outcome for a set of pairs.
+    ///
+    /// `armed` is passed rather than read here so the decision has one home and the tests do not
+    /// have to move an environment variable to exercise both sides.
+    static func outcome(armed: Bool, pairs: [Pair]) -> Outcome {
+        guard armed else { return .notArmed }
+        guard !pairs.isEmpty else {
+            return .noBaselines(
+                reason: "no atlas baseline was captured, so the diff had nothing to compare — "
+                    + "an armed run with nothing to measure refuses rather than reporting clean")
+        }
+        let drifts = pairs.flatMap { AtlasDiff.between(baseline: $0.baseline, current: $0.current) }
+        let unmeasured = pairs
+            .map { AtlasDiff.uncovered(baseline: $0.baseline, current: $0.current) }
+            .reduce(Set(AtlasDiff.adoptedSelectors.map(\.id))) { $0.intersection($1) }
+        return .diffed(
+            verdict: AtlasDiff.verdict(for: drifts, assumingCoverage: unmeasured),
+            drifts: drifts,
+            unmeasured: unmeasured)
+    }
+
+    /// The case an outcome produces, or nil when the run is not armed.
+    ///
+    /// `.readOnlyOnly` fails too. The verdict's own vocabulary distinguishes "reuse everything"
+    /// from "reads only", and a qualification run is asking whether this release may be qualified
+    /// for the mutating operations the atlas guards — so anything short of full reuse is a no for
+    /// the question being asked here, whatever it may allow elsewhere.
+    /// - Parameter axis: the run's own axis, passed in rather than invented. The atlas result is
+    ///   about the variant and LOCALE this run measured — a case filed under a different axis would
+    ///   read as a claim about a Logic nobody looked at.
+    static func caseFor(
+        _ outcome: Outcome,
+        axis: QualificationAxis,
+        binarySHA256: String,
+        traceID: String
+    ) -> QualificationCase? {
+        let passed: Bool
+        let reason: String?
+        switch outcome {
+        case .notArmed:
+            return nil
+        case let .noBaselines(why):
+            passed = false
+            reason = why
+        case let .diffed(verdict, drifts, unmeasured):
+            passed = verdict == .reuseFull
+            reason = passed ? nil : describe(verdict: verdict, drifts: drifts, unmeasured: unmeasured)
+        }
+        return QualificationCase(
+            id: "atlas.drift_diff",
+            status: passed ? .passed : .failed,
+            tool: "selector_atlas",
+            command: "drift_diff",
+            traceID: traceID,
+            verified: passed,
+            evidenceFiles: [],
+            reason: reason,
+            binarySHA256: binarySHA256,
+            axis: axis,
+            operationID: "atlas.drift_diff",
+            operationRequestID: nil,
+            verificationKind: .readResponse,
+            deferral: nil,
+            readback: nil,
+            availabilityReason: nil
+        )
+    }
+
+    /// Why it failed, naming selectors rather than a count.
+    ///
+    /// A count tells a reader that something moved; the names tell them which operations are at
+    /// risk, which is the whole reason `SelectorDrift` carries `affectedOperations`.
+    static func describe(
+        verdict: QualificationReuse,
+        drifts: [SelectorDrift],
+        unmeasured: Set<SelectorID>
+    ) -> String {
+        var parts: [String] = ["atlas diff verdict \(verdict)"]
+        let moved = drifts.filter { $0.status != .stable }
+        if !moved.isEmpty {
+            parts.append("drifted: " + moved
+                .map { "\($0.selectorID)=\($0.status) (\($0.affectedOperations.map(\.rawValue).joined(separator: ",")))" }
+                .sorted().joined(separator: "; "))
+        }
+        if !unmeasured.isEmpty {
+            parts.append("unmeasured: " + unmeasured.map { "\($0)" }.sorted().joined(separator: ", "))
+        }
+        if moved.isEmpty, unmeasured.isEmpty, drifts.isEmpty {
+            parts.append("nothing was compared")
+        }
+        return parts.joined(separator: " — ")
+    }
+}

--- a/Tests/LogicProMCPTests/AtlasQualificationTests.swift
+++ b/Tests/LogicProMCPTests/AtlasQualificationTests.swift
@@ -1,0 +1,137 @@
+@preconcurrency import ApplicationServices
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+/// #290 — the atlas diff as a qualification step, which is the criterion the measurement was built
+/// for and the one this issue had left open.
+///
+/// It emits a `QualificationCase` rather than a new attestation field, so a consumer that never
+/// heard of the atlas still counts its failure. That is the whole reason the shape was chosen, and
+/// the first case below is the one that would notice if it changed.
+@Suite("Issue290AtlasQualification")
+struct AtlasQualificationTests {
+
+    private func fixture(_ name: String) throws -> AXSnapshot.Document {
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent().deletingLastPathComponent()
+            .appendingPathComponent("Fixtures/AX/\(name)")
+        return try JSONDecoder().decode(AXSnapshot.Document.self, from: Data(contentsOf: url))
+    }
+
+    private func pairs() throws -> [AtlasQualification.Pair] {
+        let rail = try fixture("logic-12.x-desktop-ko-track-headers.json")
+        let bar = try fixture("logic-12.x-desktop-ko-control-bar.json")
+        return [
+            AtlasQualification.Pair(scope: rail.scope, baseline: rail, current: rail),
+            AtlasQualification.Pair(scope: bar.scope, baseline: bar, current: bar),
+        ]
+    }
+
+    private var axis: QualificationAxis {
+        QualificationAxis(variant: .desktop, locale: .koKR, profile: .core, cache: .cold, fixture: .empty)
+    }
+
+    @Test("the flag decides whether the step exists at all")
+    func theFlagGatesTheStep() throws {
+        // Off is today's pipeline, unchanged: no case, so no count moves and no consumer sees a new
+        // id. That matters more than it sounds — only `ko` has a control-bar baseline, so arming
+        // this everywhere would refuse every qualification on a Logic speaking anything else, which
+        // is a gate failing on its operator's language rather than on Logic.
+        #expect(AtlasQualification.outcome(armed: false, pairs: try pairs()) == .notArmed)
+        #expect(AtlasQualification.caseFor(
+            .notArmed, axis: axis, binarySHA256: "abc", traceID: "t") == nil)
+
+        // On, with the committed baselines against themselves: a passing case.
+        let armed = AtlasQualification.outcome(armed: true, pairs: try pairs())
+        let emitted = try #require(AtlasQualification.caseFor(
+            armed, axis: axis, binarySHA256: "abc", traceID: "t"))
+        #expect(emitted.status == .passed, "reason: \(emitted.reason ?? "nil")")
+        #expect(emitted.verified)
+        #expect(emitted.id == "atlas.drift_diff")
+    }
+
+    @Test("an armed run with nothing to diff refuses instead of reporting clean")
+    func armedWithNoBaselinesFailsClosed() throws {
+        let outcome = AtlasQualification.outcome(armed: true, pairs: [])
+        guard case let .noBaselines(reason) = outcome else {
+            Issue.record("expected .noBaselines, got \(outcome)")
+            return
+        }
+        #expect(reason.contains("nothing to compare"))
+        let emitted = try #require(AtlasQualification.caseFor(
+            outcome, axis: axis, binarySHA256: "abc", traceID: "t"))
+        #expect(emitted.status == .failed)
+        #expect(!emitted.verified)
+    }
+
+    @Test("a selector that lost its control fails the case and names the operations at risk")
+    func driftFailsAndNamesOperations() throws {
+        // Driven by removing the label from the tree, not by editing an expected verdict. Every
+        // alias, because `fader` is one of them and stripping only `volume` leaves the selector
+        // resolving — a mutation that cannot be seen is not a control.
+        let rail = try fixture("logic-12.x-desktop-ko-track-headers.json")
+        var text = String(decoding: try JSONEncoder().encode(rail), as: UTF8.self)
+        for alias in AXLocalePolicy.sliderVolumeHint.labels {
+            text = text.replacingOccurrences(
+                of: alias, with: String(repeating: "x", count: alias.count),
+                options: .caseInsensitive)
+        }
+        let stripped = try JSONDecoder().decode(AXSnapshot.Document.self, from: Data(text.utf8))
+        let bar = try fixture("logic-12.x-desktop-ko-control-bar.json")
+
+        let outcome = AtlasQualification.outcome(armed: true, pairs: [
+            AtlasQualification.Pair(scope: rail.scope, baseline: rail, current: stripped),
+            AtlasQualification.Pair(scope: bar.scope, baseline: bar, current: bar),
+        ])
+        let emitted = try #require(AtlasQualification.caseFor(
+            outcome, axis: axis, binarySHA256: "abc", traceID: "t"))
+
+        #expect(emitted.status == .failed)
+        let reason = try #require(emitted.reason)
+        #expect(reason.contains("trackHeaderVolumeFader"),
+                "the failure did not name the selector: \(reason)")
+        #expect(reason.contains("mixer.set_volume"),
+                "the failure did not name the operation at risk: \(reason)")
+    }
+
+    @Test("the case is filed under the axis the run measured")
+    func theCaseCarriesTheRunsAxis() throws {
+        // A result about a Korean Logic filed under `en` would read as a claim about a Logic nobody
+        // looked at, and the axis is exactly what a promotion gate matches on.
+        let other = QualificationAxis(
+            variant: .desktop, locale: .enUS, profile: .core, cache: .cold, fixture: .empty)
+        let armed = AtlasQualification.outcome(armed: true, pairs: try pairs())
+        let ko = try #require(AtlasQualification.caseFor(
+            armed, axis: axis, binarySHA256: "abc", traceID: "t"))
+        let en = try #require(AtlasQualification.caseFor(
+            armed, axis: other, binarySHA256: "abc", traceID: "t"))
+        #expect(ko.axis.locale == .koKR)
+        #expect(en.axis.locale == .enUS)
+        #expect(ko.axis != en.axis)
+    }
+
+    @Test("read-only reuse is not enough for a run asking about mutations")
+    func readOnlyOnlyStillFails() throws {
+        // `policy(for:)` grants `.readOnlyOnly` to a minor drift with high confidence. This step is
+        // asking whether the release may be qualified for the mutating operations the atlas guards,
+        // so anything short of full reuse is a no HERE — stated because the verdict's own
+        // vocabulary makes `.readOnlyOnly` sound like a pass.
+        let minor = SelectorDrift(
+            selectorID: .trackHeaderPanControl, status: .minorDrift,
+            previousConfidence: 0.95, currentConfidence: 0.85,
+            changedRoles: [], affectedOperations: [.mixerSetPan])
+        // The CASE, not just the sentence. An earlier version of this asserted only what
+        // `describe` writes, so relaxing the decision to `verdict != .failClosedMutation` left it
+        // green — the control could not see the mutation it was aimed at.
+        let emitted = try #require(AtlasQualification.caseFor(
+            .diffed(verdict: .readOnlyOnly, drifts: [minor], unmeasured: []),
+            axis: axis, binarySHA256: "abc", traceID: "t"))
+        #expect(emitted.status == .failed, "readOnlyOnly was accepted as a pass")
+        #expect(!emitted.verified)
+
+        let reason = try #require(emitted.reason)
+        #expect(reason.contains("readOnlyOnly"))
+        #expect(reason.contains("mixer.set_pan"))
+    }
+}

--- a/Tests/LogicProMCPTests/AtlasQualificationTests.swift
+++ b/Tests/LogicProMCPTests/AtlasQualificationTests.swift
@@ -111,6 +111,50 @@ struct AtlasQualificationTests {
         #expect(ko.axis != en.axis)
     }
 
+    @Test("a baseline that could not be read is named, and the run refuses")
+    func aDroppedBaselineFailsClosed() throws {
+        // Dropping an unreadable baseline is right — an empty current would diff as "every selector
+        // vanished", true-looking and about nothing. Dropping it SILENTLY is not: with the
+        // remaining pairs covering every selector, the case passed while a scope nobody could
+        // resolve went unmentioned. Named by review before merge, 2026-08-29.
+        let outcome = AtlasQualification.outcome(
+            armed: true, pairs: try pairs(), dropped: ["logic-12.x-desktop-en-track-headers.json"])
+        let emitted = try #require(AtlasQualification.caseFor(
+            outcome, axis: axis, binarySHA256: "abc", traceID: "t"))
+        #expect(emitted.status == .failed, "a dropped baseline was absorbed")
+        let reason = try #require(emitted.reason)
+        #expect(reason.contains("logic-12.x-desktop-en-track-headers.json"),
+                "the dropped baseline is not named: \(reason)")
+
+        // And the same pairs with nothing dropped still pass, or this case would be asserting that
+        // the fixtures are broken rather than that dropping is caught.
+        let clean = AtlasQualification.outcome(armed: true, pairs: try pairs())
+        #expect(try #require(AtlasQualification.caseFor(
+            clean, axis: axis, binarySHA256: "abc", traceID: "t")).status == .passed)
+    }
+
+    @Test("a refused atlas diff is not promotable")
+    func aRefusedDiffBlocksPromotion() throws {
+        // The defect this closes: `PromotionGate` rejects a FAILED case only when its id equals a
+        // required axis key, and `atlas.drift_diff` is not one — so the step reported a failure
+        // that stopped nothing, which is the "gate that does not gate" shape it exists to remove.
+        let failed = try #require(AtlasQualification.caseFor(
+            .diffed(verdict: .failClosedMutation,
+                    drifts: [SelectorDrift(
+                        selectorID: .trackHeaderVolumeFader, status: .missing,
+                        previousConfidence: 1, currentConfidence: 0,
+                        changedRoles: [], affectedOperations: [.mixerSetVolume])],
+                    unmeasured: [], dropped: []),
+            axis: axis, binarySHA256: "abc", traceID: "t"))
+        #expect(failed.status == .failed)
+        #expect(failed.id == "atlas.drift_diff")
+        // The gate looks the case up by exactly this id; the rejection lives in PromotionGate and
+        // is exercised there. What this pins is the contract between them — a rename on either
+        // side leaves the gate watching a name nothing produces.
+        let failedReason = try #require(failed.reason)
+        #expect(failedReason.contains("failClosedMutation"))
+    }
+
     @Test("the case id is the one the runner refuses to duplicate")
     func theCaseIdIsStable() throws {
         // The runner checks external-manifest ids for collisions BEFORE this step appends, so the
@@ -143,7 +187,7 @@ struct AtlasQualificationTests {
         // `describe` writes, so relaxing the decision to `verdict != .failClosedMutation` left it
         // green — the control could not see the mutation it was aimed at.
         let emitted = try #require(AtlasQualification.caseFor(
-            .diffed(verdict: .readOnlyOnly, drifts: [minor], unmeasured: []),
+            .diffed(verdict: .readOnlyOnly, drifts: [minor], unmeasured: [], dropped: []),
             axis: axis, binarySHA256: "abc", traceID: "t"))
         #expect(emitted.status == .failed, "readOnlyOnly was accepted as a pass")
         #expect(!emitted.verified)

--- a/Tests/LogicProMCPTests/AtlasQualificationTests.swift
+++ b/Tests/LogicProMCPTests/AtlasQualificationTests.swift
@@ -111,6 +111,24 @@ struct AtlasQualificationTests {
         #expect(ko.axis != en.axis)
     }
 
+    @Test("the case id is the one the runner refuses to duplicate")
+    func theCaseIdIsStable() throws {
+        // The runner checks external-manifest ids for collisions BEFORE this step appends, so the
+        // guard against a second `atlas.drift_diff` lives at the append site and keys on this exact
+        // string. Pinning it here means renaming the id cannot silently make that guard watch a
+        // name nothing produces. Found by review before merge, 2026-08-29.
+        let armed = AtlasQualification.outcome(armed: true, pairs: try pairs())
+        let emitted = try #require(AtlasQualification.caseFor(
+            armed, axis: axis, binarySHA256: "abc", traceID: "t"))
+        #expect(emitted.id == "atlas.drift_diff")
+        #expect(emitted.operationID == "atlas.drift_diff")
+
+        // And it must not look like the ids the promotion gate matches on. That gate finds a
+        // required operation by `id == "in-process/<operationID>"`, so a case shaped like one would
+        // be read as satisfying an operation this step never drove.
+        #expect(!emitted.id.hasPrefix("in-process/"))
+    }
+
     @Test("read-only reuse is not enough for a run asking about mutations")
     func readOnlyOnlyStillFails() throws {
         // `policy(for:)` grants `.readOnlyOnly` to a minor drift with high confidence. This step is

--- a/Tests/LogicProMCPTests/QualificationGateTests.swift
+++ b/Tests/LogicProMCPTests/QualificationGateTests.swift
@@ -595,6 +595,46 @@ struct QualificationGateTests {
         #expect(decoded.completedAt == Date(timeIntervalSince1970: 1_060))
     }
 
+    @Test func aRefusedAtlasDiffIsNotPromotable() {
+        // Found by review before merge, 2026-08-29. This gate rejects a FAILED case only when its
+        // id equals a required axis key, and `atlas.drift_diff` is not one — so the ADR-007 step
+        // reported a failure, `attestation.failed` counted it, and the release stayed promotable.
+        // A verdict nobody acts on is the shape that step exists to remove.
+        let refused = QualificationCase(
+            id: "atlas.drift_diff", status: .failed, tool: "selector_atlas",
+            command: "drift_diff", traceID: "t", verified: false, evidenceFiles: [],
+            reason: "atlas diff verdict failClosedMutation — drifted: trackHeaderVolumeFader",
+            binarySHA256: binarySHA256,
+            axis: QualificationAxis(variant: .desktop, locale: .enUS, profile: .core,
+                                    cache: .cold, fixture: .empty),
+            operationID: "atlas.drift_diff", operationRequestID: nil,
+            verificationKind: .readResponse, deferral: nil, readback: nil,
+            availabilityReason: nil)
+
+        let decision = evaluate(cases: [refused])
+        #expect(!decision.promotable)
+        #expect(decision.rejections.contains {
+            if case .atlasDriftRefused = $0 { return true }
+            return false
+        }, "a refused atlas diff did not reject: \(decision.rejections)")
+
+        // And a PASSING one contributes no rejection of its own — otherwise this case would be
+        // asserting that the step blocks everything rather than that it blocks a refusal.
+        let clean = QualificationCase(
+            id: "atlas.drift_diff", status: .passed, tool: "selector_atlas",
+            command: "drift_diff", traceID: "t", verified: true, evidenceFiles: [],
+            reason: nil, binarySHA256: binarySHA256,
+            axis: QualificationAxis(variant: .desktop, locale: .enUS, profile: .core,
+                                    cache: .cold, fixture: .empty),
+            operationID: "atlas.drift_diff", operationRequestID: nil,
+            verificationKind: .readResponse, deferral: nil, readback: nil,
+            availabilityReason: nil)
+        #expect(!evaluate(cases: [clean]).rejections.contains {
+            if case .atlasDriftRefused = $0 { return true }
+            return false
+        })
+    }
+
     @Test func requiredCombinationKeysAreExact() {
         // Ship-scope decision (2026-07-17): desktop-only matrix. Creator
         // Studio is permanently out of product scope and never enters the

--- a/Tests/LogicProMCPTests/QualificationRunnerTests.swift
+++ b/Tests/LogicProMCPTests/QualificationRunnerTests.swift
@@ -3243,7 +3243,13 @@ struct QualificationRunnerTests {
                 handlerValidationErrors: { handlerValidationErrors },
                 handlerExists: handlerExists,
                 beforeEvidenceRead: beforeEvidenceRead,
-                drive: drive
+                drive: drive,
+                // No atlas pairs. These fixtures do not run Logic, and the ADR-007 step is off
+                // unless `adr007SelectorAtlas` is set — so it emits no case and every count below
+                // is about the same cases it was about before. Spelled rather than defaulted: a
+                // default here would let the step appear in these runs the day the flag flips,
+                // and the first sign would be an arithmetic failure in an unrelated assertion.
+                atlasPairs: { [] }
             ))
         }
 

--- a/Tests/LogicProMCPTests/QualificationRunnerTests.swift
+++ b/Tests/LogicProMCPTests/QualificationRunnerTests.swift
@@ -3249,7 +3249,7 @@ struct QualificationRunnerTests {
                 // is about the same cases it was about before. Spelled rather than defaulted: a
                 // default here would let the step appear in these runs the day the flag flips,
                 // and the first sign would be an arithmetic failure in an unrelated assertion.
-                atlasPairs: { [] }
+                atlasPairs: { (pairs: [], dropped: []) }
             ))
         }
 


### PR DESCRIPTION
ADR-007 asks that a new Logic version's qualification include an atlas diff. #707/#708 built the measurement; this is the wiring.

## Review found I had built the option I rejected

I wrote on the issue that option B — record the drift but do not block — was *"the shape this issue has spent five rounds removing"*. Then I built it by accident.

`PromotionGate` rejects a **failed** case only when its id equals a required axis key. `atlas.drift_diff` is not one, so the case landed `.failed`, `attestation.failed` counted it, and **the release stayed promotable**. Measured before merge, then closed with a rejection of its own: `atlasDriftRefused`.

The two mutations that found nothing are the useful part of that story — disabling the promotion rejection left every test green, because no test aimed at the gate. One does now, and the same mutation turns it red.

## Three more from the same pass

| finding | what was wrong |
|---|---|
| capture ran with the flag off | `runtime.atlasPairs()` was an argument, evaluated before `outcome` could look at `armed`. The flag gated case emission, not work — and this PR claimed otherwise |
| the live document copied the baseline's `locale` and `logicVersion` | so it asserted what it was compared **against**, not what it is. A `ko` baseline read on an English Logic produced a `"ko"` current and the pair looked matched. Both say `observed` now |
| a dropped baseline was silent | dropping is right — an empty current would diff as "every selector vanished", true-looking and about nothing — but with the remaining pairs covering every selector, the case **passed** while a scope nobody could resolve went unmentioned |

Also fixed before reading the review: the runner checks external-manifest case ids for collisions near the top of the function and this step appends at the bottom, so an external `atlas.drift_diff` would have produced two cases under one id. The append site checks itself now.

And the probe answered `0` while printing `no_baselines`. Its exit code carries the verdict — a caller reading text is the shape a grep-based gate had before it was fixed this week.

## It changes no schema

The result is a `QualificationCase`, not a new attestation field. A field would have needed a schema version, and a step whose whole claim is *"this refuses"* should not arrive by changing what every consumer must parse.

## The flag finally has a subject

`adr007SelectorAtlas` gated **nothing** — its only reference was a test asserting it is off, while the six adopted selectors resolve unconditionally in every build. It now gates the **diff**. Default off, and that default is measured: only `ko` has a control-bar baseline, so arming this everywhere would refuse every qualification on a Logic speaking anything else.

## Driven live

`--probe-atlas-diff` runs the capture half alone, through the same function the qualification path calls.

```
baselines set     ->  pairs 2, scopes [컨트롤 막대, 트랙 헤더], reuseFull, exit 0
baselines unset   ->  pairs 0, no_baselines,                              exit 1
volume labels stripped from the rail baseline
                  ->  failClosedMutation, moved [trackHeaderVolumeFader=changed]
```

The third says the capture is real: **the diff moves when the thing it reads changes.**

```
4008 tests · preflight ok · repo guards ok · live evidence bound to this head
```

One more thing the gates caught rather than me: `#expect(reason?.contains(…) == true)` is always-pass on this toolchain, and I wrote one. It is bound with `try #require` now, and a mutation confirms it can fail.

Refs #290.
