### PR TITLE
fix: the arrange window's title was English, and I called that an environmental wall

### DIFF
--- a/Scripts/livekit/evidence.py
+++ b/Scripts/livekit/evidence.py
@@ -156,12 +156,32 @@ def _running_harness_name():
     return _safe_name(f"unidentified-harness-pid{os.getpid()}")
 
 
-def logic_window(title_contains="Tracks"):
+# The arrange window's title, in every language this repository has measured it in. Logic names it
+# after the current view, so an English Logic says `… - Tracks` and a Korean one `… - 트랙`.
+#
+# This sits beside `logic_window` because its DEFAULT was the English word, and eighteen harnesses
+# take that default. Measured 2026-08-29 on a Korean Logic: `logic_window("Tracks")` returned None,
+# so `shot` took its no-window branch and recorded `settled: false`, `region: null` and
+# `wholly_within: false` — and I read those three as a settling problem and blamed blinking level
+# meters. They were one missing translation, and the capture never happened at all.
+ARRANGE_WINDOW_TITLES = ["Tracks", "트랙", "トラック"]
+
+
+def logic_window(title_contains=None):
     """The on-screen bounds of a Logic window, via CoreGraphics rather than AX.
 
     Deliberately not an AX read: the harness must be able to see the window even when the AX tree is
     exactly what is under test. Returns None when no matching window is on screen.
+
+    `title_contains` defaults to every known spelling of the arrange window rather than to one of
+    them. A caller naming a specific window still gets exactly that.
     """
+    if title_contains is None:
+        for candidate in ARRANGE_WINDOW_TITLES:
+            found = logic_window(candidate)
+            if found:
+                return found
+        return None
     try:
         import Quartz
     except ImportError:
@@ -651,7 +671,7 @@ class Evidence:
 
     # -- capture ------------------------------------------------------------
 
-    def shot(self, tag, settle_region=None, window_title="Tracks"):
+    def shot(self, tag, settle_region=None, window_title=None):
         """Capture the Logic window, waiting until the pixels stop moving.
 
         `settle_region` is an (x, y, w, h) rectangle in window coordinates. Settling is judged on that

--- a/Scripts/livekit/live_628_counting_locator.py
+++ b/Scripts/livekit/live_628_counting_locator.py
@@ -88,6 +88,12 @@ def product_census(role, depth=None):
         return {"ok": False, "raw": (r.stdout or r.stderr)[:200]}
 
 
+def control_bar_description():
+    """The description THIS Logic uses for the control bar, read off the element that was found."""
+    band, subject = ev.located_band("Control Bar", "--min-width", "1000")
+    return subject if band else None
+
+
 def product_census_from(role, container):
     """The product's count taken from a NAMED container rather than from the window."""
     r = subprocess.run([E.BIN, "--probe-locator-census", role, "--probe-locator-from", container],
@@ -109,6 +115,11 @@ def independent_count(role, depth=None):
         return {"ok": False, "raw": (r.stdout or r.stderr)[:200]}
 
 
+# `located_band` translates the name through `AX_REGION_LABELS`, so the English spelling reaches a
+# Korean Logic's `트랙 헤더`. Before that table had the row, this returned None — and a band of None
+# means the captures below have no settle region, which reads as `captures_unsettled` and
+# `wholly_within: false` on a three-display machine. I called that an environmental wall and blamed
+# blinking level meters; measured 2026-08-29, it was this lookup and nothing else.
 RAIL, RAIL_SUBJECT = ev.located_band("Tracks header")
 ev.check("628/precondition-the-track-header-rail-was-located",
          RAIL is not None and bool(RAIL_SUBJECT),
@@ -211,7 +222,11 @@ ev.check("628/zero-matches-are-not-identified-either",
 # header; `getControlBar` searches the control bar. Deciding whether a site's candidate set has one
 # member needs the count taken from ITS root, and a count from the wrong root is a confident number
 # about a different question.
-scoped = product_census_from("AXTextField", "Tracks header")
+# The rail's description as THIS Logic renders it, read off the element the band lookup found.
+# `--probe-locator-from` matches exactly, so the English spelling resolved no container and the
+# probe reported zero candidates — which reads like a tree with nothing in it rather than like a
+# lookup that missed.
+scoped = product_census_from("AXTextField", RAIL_SUBJECT)
 ev.check("628/a-count-can-be-taken-from-a-named-container",
          scoped.get("ok") is True and scoped.get("containerCandidates") == 1
          and isinstance(scoped.get("candidates"), int),
@@ -225,7 +240,8 @@ ev.check("628/a-count-can-be-taken-from-a-named-container",
 # The container is resolved by the SAME counting rule, so an ambiguous container refuses instead of
 # picking one and reporting a confident count taken from whichever it reached first. Measured:
 # `Control Bar` matches two elements in the arrange window.
-ambiguous = product_census_from("AXCheckBox", "Control Bar")
+CONTROL_BAR_HERE = control_bar_description()
+ambiguous = product_census_from("AXCheckBox", CONTROL_BAR_HERE)
 ev.check("628/an-ambiguous-container-refuses-rather-than-choosing",
          ambiguous.get("ok") is False and ambiguous.get("containerCandidates", 0) > 1,
          "a container description matching more than one element produces a refusal naming the "

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -36,7 +36,7 @@ still list the issue rather than delete its row.
 It does not check the prose. The "waiting on" column, the order, and the state block below are still
 claims dated by the "measured" line, and only issue numbers and open/closed are mechanised.
 
-## State — measured 2026-08-29 at `4ef4d3cf`
+## State — measured 2026-08-29 at `b1e2c0ee`
 
 ```
 open PRs 0 · v3.14.0 published · 17 open issues
@@ -50,7 +50,7 @@ open PRs 0 · v3.14.0 published · 17 open issues
 | ADR-004 | #287 | closed | |
 | ADR-005 | #288 | closed | |
 | ADR-006 | #289 | closed | shipped #674/#675, measured and closed |
-| ADR-007 | #290 | OPEN | scoring fixed and six selectors adopted; the diff, four baselines and cross-locale coverage shipped in #707/#708. Waiting on a **decision**, not work: wiring the diff into `--qualify` changes the attestation schema or the release gate's behaviour, and the three options are written up on the issue |
+| ADR-007 | #290 | OPEN | six of seven criteria measured met; the diff is wired into `--qualify` as a `QualificationCase` (#715) and a refused one now blocks promotion. What is left is ONE fixture — an `en` control-bar baseline, which needs Logic's language changed — and a wording fix: the criterion asks for Creator baselines, and Creator left product scope on 2026-07-17 |
 | ADR-008 | #291 | OPEN | node identity cannot be the display string — needs a decision, not an attempt |
 | ADR-009 | #292 | OPEN | apply-back expansion on Wave-0 insert work; #299 and #301 consume it |
 | ADR-010 | #293 | OPEN | the collector's shape was already right; measured 2026-08-29 it reads a real note table and returns both notes. It could not START in any language but English — the Event tab was matched against the literal `"Event"` — fixed in #712. What stays closed is ADR-010's body: `assessReadback` and the public provider |
@@ -103,11 +103,10 @@ attached — not a silent deferral.
    on 2026-08-24 moved its blocker: the 49 mutating operations with a verification plan are waiting
    on a write-and-readback qualification mode that does not exist, which the #284 matrix does not
    supply. #373 covers a smaller part of it than "depends on #373" suggested.
-2. **#290** — the scoring decision is made and the atlas is in use. `confidence` is a ratio over
-   the evidence a selector actually requests, so a header slider with no `AXIdentifier` scores 1.0
-   on what it does expose; six selectors resolve identity through it. What remains is not code: the
-   diff runs, but nothing calls it at qualification time, and every way of wiring it touches either
-   the attestation schema or what `--qualify` refuses. That choice is on the issue as A/B/C.
+2. **#290** — wired. The diff runs at qualification time as a case, and a refusal rejects a
+   promotion; the attestation schema is untouched, which is why the case shape was chosen. What
+   remains is one `en` control-bar baseline and a criterion that still asks for Creator fixtures
+   after Creator left product scope.
 3. **#293 → #303** — readback before the transforms that must take their expected values from it.
    #293's collector is measured reading a live note table; what remains there is the ADR body.
 4. **#302** — re-measured. `kAXColumns` resolves 8 columns and none of them carries a name, which


### PR DESCRIPTION
`logic_window` defaulted to the substring `"Tracks"`. Logic names the arrange window after the current view, so a Korean Logic says `… - 트랙` and the lookup returned `None`. `shot` then took its no-window branch and recorded three things:

```
settled: false      region: null      wholly_within: false
```

Those are the symptoms of a capture that **never happened**.

## I read them as a settling problem

And wrote so — in a commit message and in a pull request — that the rail carries blinking level meters and does not fit one screen of three. That was **recalled, not measured**. The rail band is `(603, 162, 325, 1465)` against a 1050-tall window, so the clip is real; it is also irrelevant, because there was no window to clip against.

The measurement that settled it took one line: the capture record said `region: null` while the visual beside it carried a region, which cannot both be true of a rail that resolved. It resolved. The window did not.

## Eighteen harnesses take that default

On this machine none of them could capture anything, and each recorded it as an unsettled capture rather than as a missing window. The default is now every spelling of the arrange window this repository has measured; a caller naming a specific window still gets exactly that.

## `live_628` also still had English container names

Reverted out when an earlier branch was split, and never put back: the rail for `--probe-locator-from`, and the control bar for the ambiguity case. Both now read the description off the element the band lookup found.

```
before   19 of 21 checks, 2 captures that never ran
after    21 of 21, captures 2, unsettled 0, straddling 0, visual_failed 0, exit 0
```

`live_293` (10/10) and `live_290` (13/13) re-run clean at this head too — the three harnesses this touches all produce evidence.

## Also here: the #290 roadmap row

Six of seven criteria are measured met and the diff is wired (#715). What is left is one `en` control-bar fixture and a criterion that still asks for **Creator** baselines after Creator left product scope on 2026-07-17 — a wording fix, not work.

---

This is the fourth locale binding found this week and the deepest: not a harness, but the **library default** every harness inherits. It is also the second time I named a cause from memory instead of measuring it — the first was calling the collector's header binding English-only when `readHeaders` compares through LabelSets.