### PR TITLE
feat(#290): the English control bar, and the false drift capturing it exposed

### DIFF
--- a/Sources/LogicProMCP/SelectorAtlas/AtlasDiff.swift
+++ b/Sources/LogicProMCP/SelectorAtlas/AtlasDiff.swift
@@ -28,6 +28,44 @@ enum AtlasDiff {
         ]
     }
 
+    /// Which container a selector addresses, so it is not scored outside it.
+    ///
+    /// A selector is written for a scope, and production supplies that scope at the call site:
+    /// `findTrackArmButton` searches a TRACK HEADER, so the control bar's global Record button is
+    /// never in its candidate set. #628 established the same thing for Solo — "Solo matches TWENTY
+    /// checkboxes, one in the Control Bar and nineteen track buttons; scoping to the bar makes it
+    /// unique."
+    ///
+    /// `confidences` scores across a whole document, so without this it asks a selector a question
+    /// it was not written for. Measured 2026-08-30 the moment an English control-bar baseline
+    /// existed: the arm toggle matches `Record` by prefix and the transport's Record button carries
+    /// exactly that description, so diffing the two locales' control bars reported
+    /// `trackHeaderArmToggle changed` — a drift in nothing, produced by scoring a track selector in
+    /// a bar. Korean hid it only because `녹음` is not a prefix of `녹음 활성화`.
+    static func scopeOf(_ id: SelectorID) -> ScopeKind {
+        switch id {
+        case .controlBar, .transportPlayButton: .controlBar
+        default: .trackHeaderRail
+        }
+    }
+
+    enum ScopeKind: Equatable, Sendable { case controlBar, trackHeaderRail }
+
+    /// The selectors a document may be scored against, from what it says its scope is.
+    ///
+    /// A `window` capture holds both, so it scores everything. A scope nothing recognises scores
+    /// nothing rather than everything — an unknown container is not a reason to ask every question.
+    static func selectors(for document: AXSnapshot.Document) -> [SemanticSelector] {
+        if document.scope == "window" { return adoptedSelectors }
+        let kind: ScopeKind? =
+            AXLocalePolicy.controlBarGroupLabel.matches(document.scope, mode: .exactStrict)
+                ? .controlBar
+                : (AXLocalePolicy.trackHeadersDescription.matches(document.scope, mode: .exactStrict)
+                    ? .trackHeaderRail : nil)
+        guard let kind else { return [] }
+        return adoptedSelectors.filter { scopeOf($0.id) == kind }
+    }
+
     /// Selectors that name ONE thing, not one-per-row.
     ///
     /// How many there should be is part of what a selector means, and coverage only asks a question
@@ -80,7 +118,7 @@ enum AtlasDiff {
     static func confidences(in document: AXSnapshot.Document) -> [SelectorID: Double] {
         let all = candidates(in: document.root)
         var out: [SelectorID: Double] = [:]
-        for selector in adoptedSelectors {
+        for selector in selectors(for: document) {
             let best = all.map { confidence(of: $0.candidate, against: selector) }.max() ?? 0
             // Absent, not zero. `drift` distinguishes "scored 0" from "not present at all", and the
             // second is what a selector that vanished from the tree looks like.

--- a/Tests/Fixtures/AX/logic-12.x-desktop-en-control-bar.json
+++ b/Tests/Fixtures/AX/logic-12.x-desktop-en-control-bar.json
@@ -1,0 +1,258 @@
+{
+  "capturedFrom" : "ax",
+  "locale" : "en",
+  "logicVersion" : "12.x",
+  "root" : {
+    "children" : [
+      {
+        "children" : [
+          {
+            "children" : [
+
+            ],
+            "description" : "len:12 latin+space",
+            "help" : "len:181 latin+punct+space",
+            "role" : "AXPopUpButton"
+          },
+          {
+            "children" : [
+              {
+                "children" : [
+
+                ],
+                "description" : "bar",
+                "role" : "AXSlider",
+                "valueRange" : "4...6"
+              },
+              {
+                "children" : [
+
+                ],
+                "description" : "beat",
+                "role" : "AXSlider",
+                "valueRange" : "0...2"
+              }
+            ],
+            "description" : "len:17 latin+space",
+            "help" : "len:184 latin+punct+space",
+            "role" : "AXGroup"
+          },
+          {
+            "children" : [
+
+            ],
+            "description" : "Tempo",
+            "help" : "record click tempo play new rec val l m | len:156 latin+punct+space",
+            "role" : "AXSlider",
+            "valueRange" : "5...990"
+          },
+          {
+            "children" : [
+
+            ],
+            "help" : "len:216 latin+punct+space",
+            "role" : "AXPopUpButton"
+          },
+          {
+            "children" : [
+
+            ],
+            "description" : "len:14 latin+space",
+            "help" : "len:186 latin+punct+space",
+            "role" : "AXPopUpButton"
+          },
+          {
+            "children" : [
+
+            ],
+            "description" : "len:13 latin+space",
+            "help" : "len:142 latin+punct+space",
+            "role" : "AXPopUpButton"
+          }
+        ],
+        "description" : "len:11 latin+space",
+        "role" : "AXGroup"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "Cycle",
+        "help" : "record cycle play rec l | len:147 latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "len:17 latin+space",
+        "help" : "len:146 latin+punct+space",
+        "role" : "AXButton"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "record tempo rec m | len:20 latin+space",
+        "help" : "content record tempo mute rec l m | len:132 latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "Record",
+        "help" : "record tracks track read rec l m | len:93 latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "Play",
+        "help" : "playhead position position cycle play l m | len:130 latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "len:15 latin+space",
+        "help" : "len:92 latin+punct+space",
+        "role" : "AXButton"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "l | len:7 latin",
+        "help" : "record new rec l | len:102 latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "len:5 latin",
+        "help" : "instrument m | len:64 latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "Solo",
+        "help" : "region play solo l | len:63 latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "len:8 latin+space",
+        "help" : "length record click open play rec ch l m | len:166 latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "metronome click l m | len:15 latin+space",
+        "help" : "metronome record click tempo play rec l m | len:141 latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "Library",
+        "help" : "library preset play ch l m | len:181 latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "Inspector",
+        "help" : "inspector setting region volume track edit view pan ch l m | len:190 latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "l | len:10 latin+space",
+        "help" : "inspector window open l | len:112 latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "bar l | len:7 latin",
+        "help" : "bar ch l | len:92 latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "Smart Controls",
+        "help" : "smart controls edit ch l m | len:151 latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "Mixer",
+        "help" : "mixer track edit open ch l m | len:190 latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "edit | len:7 latin",
+        "help" : "session player audio track edit file play l | len:154 latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "edit list l | len:12 latin+space",
+        "help" : "marker event tempo edit list midi view ch l m | len:112 latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "len:9 latin+space",
+        "help" : "create track edit view | len:88 latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "Loop Browser",
+        "help" : "loop browser record loop rec l | len:78 latin+punct+space",
+        "role" : "AXCheckBox"
+      },
+      {
+        "children" : [
+
+        ],
+        "description" : "len:8 latin",
+        "help" : "setting import audio file l m | len:126 latin+punct+space",
+        "role" : "AXCheckBox"
+      }
+    ],
+    "description" : "Control Bar",
+    "help" : "len:168 latin+punct+space",
+    "role" : "AXGroup"
+  },
+  "scope" : "Control Bar"
+}

--- a/Tests/LogicProMCPTests/SelectorAtlasTests.swift
+++ b/Tests/LogicProMCPTests/SelectorAtlasTests.swift
@@ -630,6 +630,7 @@ struct Issue290SnapshotRedactionTests {
         "logic-12.x-desktop-en-track-headers.json",
         "logic-12.x-desktop-ko-window.json",
         "logic-12.x-desktop-ko-control-bar.json",
+        "logic-12.x-desktop-en-control-bar.json",
     ]
 
     static func fixtureURL(_ name: String) -> URL {
@@ -950,6 +951,58 @@ struct Issue290AtlasDiffTests {
 
         // And the rail alone still is not enough, or the union above proved nothing.
         #expect(AtlasDiff.verdict(baselines: [(rail, rail)]) == .failClosedMutation)
+    }
+
+    @Test("the control bar is covered in both languages, and the pair is not drift")
+    func theControlBarCoversBothLocales() throws {
+        // The last criterion with an environment constraint: it needed Logic's language changed to
+        // capture. `Control Bar` in English against `컨트롤 막대` in Korean — the same bar, and the
+        // English one resolves through `getControlBar` exactly as the Korean one does, because the
+        // capture uses the product's own discriminator rather than a description match.
+        let en = try load("logic-12.x-desktop-en-control-bar.json")
+        let ko = try controlBarBaseline()
+        #expect(en.scope == "Control Bar")
+        #expect(ko.scope == "컨트롤 막대")
+
+        for (name, document) in [("en", en), ("ko", ko)] {
+            let scored = try #require(AtlasDiff.confidences(in: document)[.controlBar],
+                                      "\(name) control bar scored nothing")
+            #expect(scored >= 0.6, "\(name) scored \(scored)")
+            #expect(try #require(AtlasDiff.confidences(in: document)[.transportPlayButton]) >= 0.6,
+                    "\(name) does not cover the play control")
+        }
+
+        // And diffing the two must not read as UI drift — the same trap the rail pair pins. A gate
+        // that fires on its operator's language is not measuring Logic.
+        let drifts = AtlasDiff.between(baseline: ko, current: en)
+        let moved = drifts.filter { $0.status != .stable }
+            .map { "\($0.selectorID) \($0.status)" }.joined(separator: ", ")
+        #expect(moved.isEmpty, "changing Logic's language read as drift: \(moved)")
+    }
+
+    @Test("a selector is scored only in the container it addresses")
+    func selectorsAreScoredInTheirOwnScope() throws {
+        // Production supplies the scope at the call site — `findTrackArmButton` searches a track
+        // header, so the bar's global Record button is never a candidate. `confidences` scores a
+        // whole document, so it has to be told the same thing or it asks a selector a question it
+        // was not written for.
+        let bar = try controlBarBaseline()
+        let rail = try baseline()
+        #expect(Set(AtlasDiff.selectors(for: bar).map(\.id)) == [.controlBar, .transportPlayButton])
+        #expect(!AtlasDiff.selectors(for: rail).map(\.id).contains(.controlBar))
+
+        // A window capture holds both, so it scores everything.
+        let window = try windowBaseline()
+        #expect(AtlasDiff.selectors(for: window).count == AtlasDiff.adoptedSelectors.count)
+
+        // And a scope nothing recognises scores NOTHING. Scoring everything there would put the
+        // whole set back into a container this code has never identified — the widening this
+        // filter exists to stop, arriving through the door marked "unknown".
+        let unknown = AXSnapshot.Document(
+            logicVersion: "12.x", locale: "ko", scope: "Vintage Warmer",
+            capturedFrom: "ax", root: bar.root)
+        #expect(AtlasDiff.selectors(for: unknown).isEmpty)
+        #expect(AtlasDiff.confidences(in: unknown).isEmpty)
     }
 
     @Test("the control bar losing its name stops a transport mutation")

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -50,7 +50,7 @@ open PRs 0 · v3.14.0 published · 17 open issues
 | ADR-004 | #287 | closed | |
 | ADR-005 | #288 | closed | |
 | ADR-006 | #289 | closed | shipped #674/#675, measured and closed |
-| ADR-007 | #290 | OPEN | six of seven criteria measured met; the diff is wired into `--qualify` as a `QualificationCase` (#715) and a refused one now blocks promotion. What is left is ONE fixture — an `en` control-bar baseline, which needs Logic's language changed — and a wording fix: the criterion asks for Creator baselines, and Creator left product scope on 2026-07-17 |
+| ADR-007 | #290 | OPEN | all seven criteria measured met as written for Desktop; five baselines cover both locales and leave `unmeasured []`. What is left is WORDING, not work: criterion 1 asks for Creator fixtures, and Creator left product scope on 2026-07-17 — narrowing that line closes the issue |
 | ADR-008 | #291 | OPEN | node identity cannot be the display string — needs a decision, not an attempt |
 | ADR-009 | #292 | OPEN | apply-back expansion on Wave-0 insert work; #299 and #301 consume it |
 | ADR-010 | #293 | OPEN | the collector's shape was already right; measured 2026-08-29 it reads a real note table and returns both notes. It could not START in any language but English — the Event tab was matched against the literal `"Event"` — fixed in #712. What stays closed is ADR-010's body: `assessReadback` and the public provider |
@@ -103,10 +103,11 @@ attached — not a silent deferral.
    on 2026-08-24 moved its blocker: the 49 mutating operations with a verification plan are waiting
    on a write-and-readback qualification mode that does not exist, which the #284 matrix does not
    supply. #373 covers a smaller part of it than "depends on #373" suggested.
-2. **#290** — wired. The diff runs at qualification time as a case, and a refusal rejects a
-   promotion; the attestation schema is untouched, which is why the case shape was chosen. What
-   remains is one `en` control-bar baseline and a criterion that still asks for Creator fixtures
-   after Creator left product scope.
+2. **#290** — done bar a sentence. The diff runs at qualification time as a case and a refusal
+   rejects a promotion; five baselines cover en and ko and leave no adopted selector unmeasured.
+   The English control bar earned its keep on capture, exposing a prefix match that let the
+   transport's Record button read as a track's arm toggle. What remains is criterion 1 still
+   asking for Creator fixtures after Creator left product scope.
 3. **#293 → #303** — readback before the transforms that must take their expected values from it.
    #293's collector is measured reading a live note table; what remains there is the ADR body.
 4. **#302** — re-measured. `kAXColumns` resolves 8 columns and none of them carries a name, which


### PR DESCRIPTION
The last acceptance criterion with an environment constraint. Logic quit, language set to `en`, relaunched, captured, and set back — verified by the window title returning to `프로젝트 선택` rather than assumed. Two captures of the same tree hash identically; the fixture carries no project, track or plugin name.

**Having it immediately found a real defect, which is the whole argument for capturing a second locale.**

## A drift in nothing

Diffing the two control bars reported `trackHeaderArmToggle changed`. Neither bar moved.

The arm toggle matches `Record` by **prefix** — the policy declares it as a track alias — and the transport's global Record button carries exactly that description:

```
ko   '녹음'      arm labels: 녹음 활성화 / Record Enable / Record
en   'Record'    ← prefix match
```

Korean hid it only because `녹음` is not a prefix of `녹음 활성화`. The English capture is what made it visible.

## Production is not affected, and the reason is the fix

`findTrackArmButton` searches a **track header**, so the bar's Record button is never in its candidate set. #628 established the same for Solo: it matches twenty checkboxes across the window and exactly one inside the rail. **The scope is the discriminator**, supplied at the call site.

`confidences` scored a whole document, so it asked a selector a question it was not written for. It now scores a selector only in the container it addresses:

| document scope | scored against |
|---|---|
| control bar | `.controlBar`, `.transportPlayButton` |
| track-header rail | the five per-track selectors |
| `window` | everything — it holds both |
| anything unrecognised | **nothing** |

That last row matters: putting the whole set back into an unidentified container is the widening this filter exists to stop, arriving through the door marked *unknown*.

## Mutation-tested, and the second one earned a case

```
score every selector in every scope again  ->  the false drift returns, test red
an unknown scope scores everything          ->  PASSED — no case covered it
```

The second is why `selectorsAreScoredInTheirOwnScope` asserts the unknown-scope behaviour. Scoring everything there was green until something asked.

## Live

```
live_290   13/13   live_628   21/21
--probe-atlas-diff, three pairs (rail, control bar, window)
   verdict reuseFull · moved [] · unmeasured []
```

`unmeasured []` is new: with the control bar covered, no adopted selector is left unmeasured by the committed set.

Refs #290 — this closes the fixture half of criterion 1. What remains there is wording: the criterion still asks for **Creator** baselines, and Creator left product scope on 2026-07-17.