### PR TITLE
docs(#302): T4 is a write-oracle, so it was never behind the export gate

### DIFF
--- a/docs/tickets/midi-readback-vNext/STATUS.md
+++ b/docs/tickets/midi-readback-vNext/STATUS.md
@@ -2,7 +2,9 @@
 
 **PRD**: `docs/prd/PRD-midi-readback-vNext.md`
 **Status**: Gate harness added; live State-A proof failed in current launch context
-**Execution rule**: no implementation ticket may start until one evidence gate proves a controlled selected-region read-back path.
+**Execution rule (narrowed 2026-08-30)**: no ticket whose expected sequence must come from a
+*dual-observation* source may start until one evidence gate proves a controlled selected-region
+read-back path. **T4 is not such a ticket** — see "Two independence classes" below.
 
 ## Tickets
 
@@ -12,14 +14,57 @@
 | T1 | Logic project/package event-reader spike | Todo | Saved scratch project note equality |
 | T2 | Operator-assisted export contract | Todo | Explicit non-default profile decision + exact-path proof |
 | T3 | `logic_midi.read_selection_notes` implementation | Blocked | T0 or T1 or T2 PASS |
-| T4 | `record_sequence verify_notes` integration | Blocked | T3 PASS |
+| T4 | `record_sequence verify_notes` integration | Todo | a release-constructible `authoredIntent` proof; NOT T3 |
+
+## Two independence classes, and why T4 is not behind T3
+
+The PRD names two classes of independent expected `E`, and the code carries both:
+
+```swift
+enum IndependentExpectedRoot {
+    case authoredIntent    // write-oracle: pre-authored write intent (import / record_sequence)
+    case controlledExport  // dual-observation: a distinct Logic→notes surface
+}
+```
+
+`O` is always the Event-List AX snapshot. T0/T1/T2 exist to supply `controlledExport` — a surface
+DIFFERENT from `O` — because a comparison of `O` against `O` proves nothing.
+
+T3 and T4 do not need the same class:
+
+| ticket | where `E` comes from | needs |
+|--------|----------------------|-------|
+| T3 `read_selection_notes` | notes nobody just wrote — there is **no authored intent** | `controlledExport`, i.e. T0 or T1 or T2 |
+| T4 `record_sequence verify_notes` | the notes the caller just asked for — **authored intent exists** | nothing further; it is already in hand |
+
+`record_sequence` parses the caller's `notes` into `[SMFWriter.NoteEvent]` before it writes
+anything. That value is fixed before the read and never re-encoded from observation, which is the
+write-oracle definition verbatim.
+
+**What blocks T4 is code, not evidence.** `IndependentExpectedSeam` sits inside
+`#if QUALIFICATION_FAULT_SEAM`, so a release build's `independentPayload` is always nil. For
+`authoredIntent`, R2's "live-ingestion boundary" is not a file route — it is a release-reachable
+constructor plus the guards that already exist.
+
+### The asymmetry that makes the write-oracle worth having
+
+Suppose `SMFWriter` encodes note 60 as 61.
+
+- **dual-observation** — Logic holds 61, the export says 61, `SMFReader` reads 61. They agree.
+  **The bug is invisible.**
+- **write-oracle** — expected is the authored 60, observed is 61. **Mismatch.**
+
+A file route looks more independent because the artifact is visible. It is not more independent
+against our own encoder, which is the component both the write and a `SMFReader`-based check share.
 
 ## Dependency Graph
 
 ```text
 T0 ┐
-T1 ├─> T3 -> T4
+T1 ├─> T3          (dual-observation)
 T2 ┘
+
+T4                 (write-oracle — independent of the three above)
 ```
 
 ## Evidence Gate

--- a/docs/tickets/midi-readback-vNext/T4-record-sequence-verify-notes.md
+++ b/docs/tickets/midi-readback-vNext/T4-record-sequence-verify-notes.md
@@ -1,9 +1,9 @@
 # T4: `record_sequence verify_notes`
 
 **PRD Ref**: `PRD-midi-readback-vNext` §7
-**Priority**: P1 after T3
-**Status**: Blocked
-**Depends On**: T3
+**Priority**: P1
+**Status**: Todo
+**Depends On**: a release-constructible `authoredIntent` proof. NOT T3 — see below.
 
 ## Objective
 
@@ -12,7 +12,7 @@ Add optional note-level verification to `record_sequence` without changing the d
 ## Acceptance Criteria
 
 - [ ] `verify_notes` defaults to false and keeps current response behavior unchanged.
-- [ ] When true, `record_sequence` captures pre-state, creates/imports a region, deterministically selects the created region, exports/reads it through the T3 surface, and compares notes.
+- [ ] When true, `record_sequence` captures pre-state, creates/imports a region, deterministically selects the created region, reads it back through a readback surface, and compares against the AUTHORED notes — the `[SMFWriter.NoteEvent]` parsed from the caller's request before anything was written.
 - [ ] Selection failure returns State B before export attempt.
 - [ ] Note mismatch returns State C with expected/observed summary.
 - [ ] Previous selection/playhead restoration is attempted and reported.
@@ -25,12 +25,44 @@ Add optional note-level verification to `record_sequence` without changing the d
 - `recordSequenceVerifyNotesStateCOnMismatch`
 - `recordSequenceVerifyNotesRestoresPreviousSelectionBestEffort`
 
+## Why this is not behind T3 (2026-08-30)
+
+The AC used to say "exports/reads it through the T3 surface", and that sentence is what created
+the dependency. It named an implementation, and the implementation it named is the one blocked.
+
+What T4 needs is an expected sequence that cannot agree with the write by sharing its mistake, and
+it already has one. `record_sequence` parses the caller's `notes` into `[SMFWriter.NoteEvent]`
+BEFORE it writes anything; that value is fixed before the read and never re-encoded from
+observation, which is the PRD's write-oracle verbatim — `IndependentExpectedRoot.authoredIntent`,
+whose own comment names `record_sequence`.
+
+T3 is a different class. `read_selection_notes` returns notes nobody just wrote, so there is no
+authored intent behind them and its expected must come from a second observation surface. That is
+what T0/T1/T2 are for, and T3 still waits on them.
+
+The observed side needs a readback surface, not a public operation. `EventListReadbackCollector`
+is one and is measured reading a real note table (#293 / #712): ten checks clean on a Korean Logic,
+both recorded notes returned, eight columns bound.
+
+### What actually blocks T4
+
+`IndependentExpectedSeam` is inside `#if QUALIFICATION_FAULT_SEAM`, so a release build's
+`independentPayload` is always nil and `verifyRegion` can only answer `incompleteCannotVerify`.
+For `authoredIntent`, R2's "live-ingestion boundary" is a release-reachable constructor plus the
+guards that already exist — not a file route.
+
+That constructor is the one thing this ticket has to earn, and it has to earn it without
+reopening the hole R1 closed: an `O→E` copy must still be refused, which criterion 4 of the PRD
+calls the load-bearing strict case.
+
 ## Implementation Boundary
 
 Likely files:
 
 - `Sources/LogicProMCP/Dispatchers/TrackDispatcher+RecordSequence.swift`
-- selected-region helper from T3
+- `Sources/LogicProMCP/MIDIReadback/MIDINoteIndependentVerification.swift` (the release-reachable
+  `authoredIntent` constructor)
+- `Sources/LogicProMCP/MIDIReadback/EventListReadbackCollector.swift` as the observed surface
 - focused dispatcher tests and one live E2E case
 
 ## Manual QA Gate


### PR DESCRIPTION
The execution rule blocked **every** implementation ticket on one evidence gate: a controlled selected-region read-back path. T0, T1 and T2 all try to supply it, and all three have been stuck since 2026-07-07 when the live attempt died on Apple-events permission (`-1743`). T3 and T4 sat behind them.

I went to write a ticket and read the PRD's own independence model instead of the gate.

## Expected has two classes, and the code names both

```swift
enum IndependentExpectedRoot {
    case authoredIntent    // write-oracle: pre-authored write intent (import / record_sequence)
    case controlledExport  // dual-observation: a distinct Logic→notes surface
}
```

`O` is always the Event-List AX snapshot. T0/T1/T2 are file-shaped **because they must be a surface different from `O`** — comparing `O` against `O` proves nothing. (I had this wrong in a first comment on the issue, where I offered the Event List route as a *fourth candidate alongside them*. It is the observed side, not a candidate for the expected side. Corrected there.)

## T3 and T4 do not need the same class

| ticket | where `E` comes from | needs |
|---|---|---|
| T3 `read_selection_notes` | notes nobody just wrote — **no authored intent exists** | `controlledExport`: T0 or T1 or T2 |
| T4 `record_sequence verify_notes` | the notes the caller just asked for — **authored intent exists** | nothing further |

`record_sequence` parses the caller's `notes` into `[SMFWriter.NoteEvent]` **before it writes anything**. That value is fixed before the read and never re-encoded from observation — the write-oracle definition verbatim, and the enum's own comment points at `record_sequence` by name.

**What blocks T4 is code, not evidence.** `IndependentExpectedSeam` sits inside `#if QUALIFICATION_FAULT_SEAM`, so a release build's `independentPayload` is always nil. For this class, R2's "live-ingestion boundary" is a release-reachable constructor, not a file route.

## The asymmetry that makes the write-oracle worth having

Suppose `SMFWriter` encodes note 60 as 61.

| route | Logic holds | expected says | verdict |
|---|---|---|---|
| dual-observation | 61 | export → `SMFReader` → **61** | agree — **the bug is invisible** |
| write-oracle | 61 | authored **60** | **mismatch** |

A file route *looks* more independent because the artifact is visible. It is not more independent against **our own encoder**, which is the component a write and an `SMFReader`-based check both lean on.

## The ticket carried the dependency in one sentence

`T4-record-sequence-verify-notes.md` said:

> exports/reads it through **the T3 surface**

That names an implementation rather than a property, and the implementation it names is the blocked one — so the ticket inherited a wait it did not need. It now says what T4 actually requires: read it back through *a readback surface* and compare against the **authored** notes.

The observed side needs a surface, not a public operation. `EventListReadbackCollector` is one, measured reading a real note table (#293 / #712) — ten checks clean on a Korean Logic, both recorded notes returned, eight columns bound.

The ticket also now names what **does** block T4 (a release-reachable `authoredIntent` constructor, since the seam is debug-only) and the constraint that constructor has to respect: an `O→E` copy must still be refused, which the PRD calls the load-bearing strict case. Opening this must not reopen what R1 closed.

## What this changes

The execution rule now names the class it governs rather than every ticket, and the dependency graph splits:

```
T0 ┐
T1 ├─> T3          (dual-observation)
T2 ┘

T4                 (write-oracle — independent of the three above)
```

T3 is untouched and still waits. A gate nothing can pass had been holding a ticket that never needed it.

**To reverse this, one claim has to fall:** that authored intent is not a write-oracle. The enum comment says it is.
