### PR TITLE
docs(#302): E1-E5 were letters, and T4's gate is one of them

### DIFF
--- a/docs/prd/PRD-issue-302-independent-midi-event-readback.md
+++ b/docs/prd/PRD-issue-302-independent-midi-event-readback.md
@@ -32,6 +32,40 @@ A pure/CI core **cannot verify note-independence**; any positive `exactMatch` it
 ## E0 (CI, no Logic) — rejection-only + non-forgeability + no-positive-type
 Under the debug seam, build a `testFixture` and assert: all rejection cases (3a–f) + O→E-copy (4) + foreign-notes (5) yield non-matching verdicts (3e uses the seam-only corrupted-fixture maker; 3f is the PPQ guard); **plus** the type has no `.exactMatch` case (compile-level — positive match impossible); **plus** release DCE (0 seam symbols). **No positive-grant control** (removed by design — a note-identical fixture proves "the seam was called," not independence).
 
+## E1–E5 (live) — defined 2026-08-30
+
+Named in the GO lines below and nowhere else until now. A gate that exists only as a letter is a
+gate anyone can declare passed, so each is written here as something a run either did or did not
+do. The mapping is read off the two GO glosses, which agree where they overlap (E3, E5).
+
+- **E1 — a coordinate-free managed-temp export exists.** A `.mid` is produced at a path this
+  repository registered before the run, by a route that actuates no screen coordinate. Refuses on
+  an arbitrary user file: the artifact has to come from the surface under test.
+- **E2 — it round-trips.** `SMFReader.parse` of that file yields the notes the region holds. E1
+  says a file appeared; E2 says it means something.
+- **E2c — write-oracle fidelity.** The authored notes that reach the comparison are the SAME value
+  that was written, and they were sealed BEFORE the read began. Concretely: the
+  `[SMFWriter.NoteEvent]` used to build the imported `.mid` is the value bound into the proof, its
+  content binding is computed over that value, and the proof exists before the first AX read of the
+  region. A proof assembled after the read cannot satisfy this however equal its contents are —
+  temporal commitment is the property, not equality.
+- **E3 — observed acquisition completes.** The Event-List snapshot is `complete`: the number of
+  FULLY POPULATED rows equals `AXRows.count`. This is the hollow-row trap measured on
+  2026-08-10 — off-screen rows read `Status` only, so counting rows says 64 and dropping empties
+  says 32, and both are wrong. A run that verifies against an incomplete observation is comparing
+  against a subset it cannot name.
+- **E4 — manual-edit mismatch (non-tautology).** After a match, one note is changed in Logic and
+  the same comparison must return `.mismatch` naming it. Without this, a match proves the two sides
+  were computed, not that they could have disagreed — the control that makes the grant mean
+  something.
+- **E5 — region-identity negative.** A proof bound to region A, compared against an observation of
+  region B, is refused rather than matched. Guard (c) already implements this; E5 is the live
+  demonstration that the binding survives a real region swap.
+
+E4 and E5 are the two that can fail while everything looks right, and they are the reason
+`GO_write_oracle` is not simply "E2c". A run that cannot show its comparison failing has not shown
+it working.
+
 ## R2 acceptance criteria (live, later) — where the positive grant lives
 - **Named live-ingestion boundary** derives `E`'s notes from the independent source + a real temporal commitment (write-oracle: authored intent sealed before the AX read; dual-observation: distinct `C_alt` surface), making O→E structurally impossible; reintroduces `.exactMatch` and grants it only then, behind the qualified provider + public API.
 - **`GO_dual = E0 ∧ E1 ∧ E2 ∧ E3 ∧ E5`:** coordinate-free managed-temp export exists + round-trips + observed acquisition completes + region-identity negative.

--- a/docs/tickets/midi-readback-vNext/T4-record-sequence-verify-notes.md
+++ b/docs/tickets/midi-readback-vNext/T4-record-sequence-verify-notes.md
@@ -44,6 +44,25 @@ The observed side needs a readback surface, not a public operation. `EventListRe
 is one and is measured reading a real note table (#293 / #712): ten checks clean on a Korean Logic,
 both recorded notes returned, eight columns bound.
 
+### The gate this ticket must pass
+
+The PRD states it directly, and it is not the export gate:
+
+```
+GO_write_oracle = E0 ∧ E2c ∧ E3 ∧ E4 ∧ E5      (no export needed)
+```
+
+| gate | what this run has to show |
+|------|---------------------------|
+| E0 | CI, no Logic: every rejection case still refuses, an O→E copy is still not a match, and release holds 0 seam symbols |
+| E2c | the authored `[SMFWriter.NoteEvent]` bound into the proof is the value that was WRITTEN, and the proof existed before the first AX read — temporal commitment, not equality |
+| E3 | the Event-List snapshot is `complete`: fully populated rows == `AXRows.count`, not row count alone |
+| E4 | after a match, change one note in Logic and the same comparison returns `.mismatch` naming it |
+| E5 | a proof bound to region A against an observation of region B is refused |
+
+E4 and E5 are the ones that can fail while everything looks right. A run that cannot show its
+comparison failing has not shown it working.
+
 ### What actually blocks T4
 
 `IndependentExpectedSeam` is inside `#if QUALIFICATION_FAULT_SEAM`, so a release build's


### PR DESCRIPTION
## First, a correction

The previous PR reasoned its way to "T4 does not need the export gate" and presented it as analysis. **The PRD already said so**, in a line that has been there the whole time:

```
GO_write_oracle = E0 ∧ E2c ∧ E3 ∧ E4 ∧ E5      (no export needed)
```

The conclusion was right; the document had it first. What actually happened is that the STATUS execution rule and T4's acceptance criteria had **drifted from the PRD they implement** — the same shape as the four roadmap rows corrected this week, one level down.

## The gap that turned up on the way

The PRD gates R2 on `E1/E2/E2c/E3/E4/E5` and **defines only E0**. The other five exist in two GO lines as glosses — *"round-trips"*, *"observed acquisition completes"*, *"region-identity negative"* — and nowhere else.

**A gate that exists only as a letter is a gate anyone can declare passed.**

Each is now written as something a run either did or did not do. The mapping is read off the two GO lines, which agree where they overlap (E3, E5), so it is derived rather than invented.

| gate | what a run has to show |
|---|---|
| E1 | a `.mid` at a path registered before the run, produced without actuating a screen coordinate |
| E2 | `SMFReader.parse` of it yields the notes the region holds — E1 says a file appeared, E2 says it means something |
| **E2c** | the authored `[SMFWriter.NoteEvent]` bound into the proof is the value that was **written**, sealed **before** the first AX read |
| **E3** | the snapshot is `complete`: fully populated rows == `AXRows.count` |
| **E4** | after a match, change one note in Logic — the same comparison must return `.mismatch` naming it |
| **E5** | a proof bound to region A, against an observation of region B, is refused |

### Two of these can fail while everything looks right

**E4** is the reason `GO_write_oracle` is not simply "E2c". Without it, a match proves the two sides were *computed* — not that they could have **disagreed**. It is the same property this repository has been enforcing all week under a different name: a control that cannot fail is not evidence.

**E2c is temporal, not equal.** The authored notes must be the value that was written *and* must have been sealed before the read. A proof assembled afterwards cannot satisfy it however equal its contents are — which is exactly the `O→E` copy that R1's criterion 4 calls load-bearing, arriving by a slower route.

**E3** is the hollow-row trap measured on 2026-08-10: off-screen Event-List rows read `Status` only, so counting rows says 64 and dropping empties says 32, and both are wrong. A run verifying against an incomplete observation is comparing against a subset it cannot name.

## Also here

T4's ticket now carries its own GO table. A gate list that lives only in the PRD is a gate list a ticket drifts from — which is how this PR started.