### PR TITLE
fix: recover a modifier left held when a flagged chord is interrupted (discussion #458)

### DIFF
--- a/.commitlore-policy.json
+++ b/.commitlore-policy.json
@@ -1,0 +1,6 @@
+{
+  "mode": "auto",
+  "unattended": true,
+  "max_records_per_commit": 1,
+  "require_verified_evidence": true
+}

--- a/Scripts/check-falsifiable-adoption.py
+++ b/Scripts/check-falsifiable-adoption.py
@@ -37,7 +37,7 @@ import sys
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # The measured floor. Raise it when a harness converts; never lower it to make a branch pass.
-FLOOR = 4
+FLOOR = 5
 _FALSIFIABLE_PARAMETERS = (
     "tag", "predicate", "observation", "counterexample", "expected", "mutation", "modal_snapshot",
 )

--- a/Scripts/livekit/ax_control_bar_control_values.swift
+++ b/Scripts/livekit/ax_control_bar_control_values.swift
@@ -1,0 +1,166 @@
+// Read the AXValue of every button and checkbox below ONE named control-bar AXGroup.
+//
+//   ./ax_control_bar_control_values '["control bar", "localized control-bar name"]'
+//
+// The caller supplies the label family from AXLocalePolicy through `E.label_set`; this probe does
+// not carry a second, guessed localization table.  It refuses a missing or ambiguous group, a
+// failed AXValue read, an unnamed/duplicate control, or zero controls.  Any of those states would
+// make a `description -> AXValue` map incomplete, and an incomplete map is not evidence that no
+// transport control changed.
+import AppKit
+import ApplicationServices
+import Foundation
+
+enum ProbeError: Error, CustomStringConvertible {
+    case message(String)
+    case ax(attribute: String, code: AXError)
+
+    var description: String {
+        switch self {
+        case let .message(message): return message
+        case let .ax(attribute, code): return "AX read \(attribute) failed: \(code.rawValue)"
+        }
+    }
+}
+
+func emit(_ body: [String: Any]) -> Never {
+    let data = try! JSONSerialization.data(withJSONObject: body, options: [.sortedKeys])
+    print(String(data: data, encoding: .utf8)!)
+    exit(0)
+}
+
+func attribute(_ element: AXUIElement, _ name: String) throws -> CFTypeRef {
+    var value: CFTypeRef?
+    let result = AXUIElementCopyAttributeValue(element, name as CFString, &value)
+    guard result == .success, let value else { throw ProbeError.ax(attribute: name, code: result) }
+    return value
+}
+
+func string(_ element: AXUIElement, _ name: String) throws -> String {
+    guard let value = try attribute(element, name) as? String else {
+        throw ProbeError.message("\(name) is not a string")
+    }
+    return value
+}
+
+func children(_ element: AXUIElement) throws -> [AXUIElement] {
+    var value: CFTypeRef?
+    let result = AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &value)
+    // AX reports a leaf as `noValue`, which means zero descendants, not a failed tree read.
+    if result == .noValue { return [] }
+    guard result == .success, let value, let children = value as? [AXUIElement] else {
+        throw ProbeError.ax(attribute: kAXChildrenAttribute as String, code: result)
+    }
+    return children
+}
+
+func optionalString(_ element: AXUIElement, _ name: String) -> String? {
+    var value: CFTypeRef?
+    guard AXUIElementCopyAttributeValue(element, name as CFString, &value) == .success else {
+        return nil
+    }
+    return value as? String
+}
+
+func jsonValue(_ raw: CFTypeRef) -> Any? {
+    if let number = raw as? NSNumber { return number }
+    if let text = raw as? String { return text }
+    return nil
+}
+
+let labels: [String]
+do {
+    let raw = CommandLine.arguments.dropFirst().first ?? ""
+    guard let data = raw.data(using: .utf8),
+          let decoded = try JSONSerialization.jsonObject(with: data) as? [String] else {
+        throw ProbeError.message("expected one JSON array of control-bar labels")
+    }
+    labels = decoded.filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+    guard !labels.isEmpty else { throw ProbeError.message("control-bar label family is empty") }
+} catch {
+    emit(["ok": false, "error": String(describing: error)])
+}
+
+guard let app = NSWorkspace.shared.runningApplications.first(where: {
+    ($0.bundleIdentifier ?? "").contains("logic")
+}) else {
+    emit(["ok": false, "error": "Logic is not running"])
+}
+
+do {
+    let application = AXUIElementCreateApplication(app.processIdentifier)
+    let mainWindow = try attribute(application, kAXMainWindowAttribute as String) as! AXUIElement
+    var groups: [AXUIElement] = []
+
+    func findControlBars(_ element: AXUIElement, depth: Int = 0) throws {
+        guard depth <= 24 else { throw ProbeError.message("control-bar walk exceeded depth limit") }
+        for child in try children(element) {
+            if try string(child, kAXRoleAttribute as String) == (kAXGroupRole as String),
+               let description = optionalString(child, kAXDescriptionAttribute as String),
+               labels.contains(where: { $0.caseInsensitiveCompare(description) == .orderedSame }) {
+                groups.append(child)
+            }
+            try findControlBars(child, depth: depth + 1)
+        }
+    }
+
+    try findControlBars(mainWindow)
+
+    // Measured 2026-08-30: Logic nests a control-bar AXGroup inside another AXGroup carrying the
+    // SAME description, so a description match alone returns two. They are not two control bars —
+    // one contains the other. Keep the OUTERMOST, defined structurally as the candidate that has no
+    // other candidate above it. That is a containment test, not a choice by tree order, and if two
+    // genuinely disjoint control bars ever appear this still refuses rather than picking one.
+    var outermost: [AXUIElement] = []
+    for candidate in groups {
+        var enclosed = false
+        for other in groups where !CFEqual(candidate, other) {
+            var walker = candidate
+            var hops = 0
+            while hops < 24, let raw = try? attribute(walker, kAXParentAttribute as String),
+                  CFGetTypeID(raw) == AXUIElementGetTypeID() {
+                let parent = raw as! AXUIElement
+                if CFEqual(parent, other) { enclosed = true; break }
+                walker = parent
+                hops += 1
+            }
+            if enclosed { break }
+        }
+        if !enclosed { outermost.append(candidate) }
+    }
+    groups = outermost
+    guard groups.count == 1 else {
+        throw ProbeError.message("control-bar AXGroup candidates=\(groups.count) after removing nested ones")
+    }
+    let controlBar = groups[0]
+    let controlBarDescription = try string(controlBar, kAXDescriptionAttribute as String)
+    var values: [String: Any] = [:]
+
+    func readControls(_ element: AXUIElement, depth: Int = 0) throws {
+        guard depth <= 24 else { throw ProbeError.message("control-bar control walk exceeded depth limit") }
+        for child in try children(element) {
+            let role = try string(child, kAXRoleAttribute as String)
+            if role == (kAXCheckBoxRole as String) || role == (kAXButtonRole as String) {
+                let description = try string(child, kAXDescriptionAttribute as String)
+                guard !description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                    throw ProbeError.message("\(role) has no AXDescription")
+                }
+                guard values[description] == nil else {
+                    throw ProbeError.message("duplicate control AXDescription: \(description)")
+                }
+                guard let value = jsonValue(try attribute(child, kAXValueAttribute as String)) else {
+                    throw ProbeError.message("\(role) \(description) has a non-JSON AXValue")
+                }
+                values[description] = value
+            }
+            try readControls(child, depth: depth + 1)
+        }
+    }
+
+    try readControls(controlBar)
+    guard !values.isEmpty else { throw ProbeError.message("control bar has zero buttons and checkboxes") }
+    emit(["ok": true, "control_bar": controlBarDescription, "controls": values,
+          "control_count": values.count])
+} catch {
+    emit(["ok": false, "error": String(describing: error)])
+}

--- a/Scripts/livekit/live_458_a_stale_chord_marker_is_cleared_on_start.py
+++ b/Scripts/livekit/live_458_a_stale_chord_marker_is_cleared_on_start.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""Live proof that startup clears a stale chord marker without clearing a live owner's marker.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_458_a_stale_chord_marker_is_cleared_on_start.py <worktree> <full-40-char-head-sha>
+
+This run starts the release artifact three times.  The first start can post one real synthetic
+key-up with ZERO flags for the deliberately stale marker.  Zero flags release no modifier and press
+no key, so that event releases nothing and presses nothing on the machine running the harness.
+
+WHAT THIS DOES NOT PROVE
+------------------------
+It does not observe system modifier state, verify that macOS delivered an event, or exercise the
+chord path that writes the marker.  It proves only the startup-recovery half; the chord half remains
+covered by unit tests alone.
+"""
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+
+# What this harness proves, for `harness_evidence_coverage.py`.  `LogicProServer.start()` invokes
+# recovery, `StuckModifierRecovery` selects/removes each marker, and `AXMouseHelper` is the production
+# chord boundary that arms/disarms that same marker.  This run intentionally proves only the first two
+# halves; see the module docstring for the chord-path boundary.
+COVERS = [
+    "Sources/LogicProMCP/Accessibility/AXMouseHelper.swift",
+    "Sources/LogicProMCP/Accessibility/StuckModifierRecovery.swift",
+    "Sources/LogicProMCP/Server/LogicProServer.swift",
+]
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+checks = []
+
+
+def prove(tag, predicate, observation, counterexample, expected, mutation):
+    """Record an assertion that evaluates both the observation and a rejected state."""
+    passed = ev.falsifiable(tag, predicate, observation, counterexample, expected, mutation)
+    checks.append(passed)
+    return passed
+
+
+# These values were read from `StuckModifierRecovery.swift`, not remembered: its user-domain
+# `applicationSupportDirectory` gets `LogicProMCP` appended, and `markerURL(for:in:)` writes
+# `chord-in-flight-<pid>.json`.  `Marker` decodes these exact three JSON fields.
+MARKER_DIRECTORY = Path.home() / "Library" / "Application Support" / "LogicProMCP"
+MARKER_PREFIX = "chord-in-flight-"
+MARKER_SUFFIX = ".json"
+MARKER_KEY_CODE = 56
+MARKER_FLAGS = 1 << 17
+
+
+def marker_path(pid):
+    """The same filename construction as `StuckModifierRecovery.markerURL(for:in:)`."""
+    return MARKER_DIRECTORY / f"{MARKER_PREFIX}{pid}{MARKER_SUFFIX}"
+
+
+def marker_directory_state():
+    """Only marker files are in scope; unrelated Application Support files are never touched."""
+    try:
+        entries = list(MARKER_DIRECTORY.iterdir())
+    except FileNotFoundError:
+        return {"readable": True, "directory_exists": False, "marker_files": []}
+    except OSError as exc:
+        return {"readable": False, "directory_exists": MARKER_DIRECTORY.exists(),
+                "marker_files": None, "error": repr(exc)}
+
+    return {
+        "readable": True,
+        "directory_exists": True,
+        "marker_files": sorted(
+            entry.name for entry in entries
+            if entry.is_file() and entry.name.startswith(MARKER_PREFIX)
+            and entry.name.endswith(MARKER_SUFFIX)
+        ),
+    }
+
+
+def process_is_alive(pid):
+    """The `kill(pid, 0)` decision used by production, including its fail-safe error cases."""
+    if pid <= 0:
+        return True
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return True
+    return True
+
+
+def marker_data(pid):
+    """JSONDecoder accepts the `Marker` fields read from the Swift source above."""
+    return json.dumps({"keyCode": MARKER_KEY_CODE, "flags": MARKER_FLAGS, "pid": pid},
+                      separators=(",", ":")).encode("utf-8")
+
+
+planted = {}
+
+
+def plant(path, data):
+    """Create one harness-owned production-shaped marker without overwriting any existing file."""
+    MARKER_DIRECTORY.mkdir(parents=True, exist_ok=True)
+    with path.open("xb") as fh:
+        fh.write(data)
+    stat = path.stat()
+    planted[path] = {
+        "device": stat.st_dev,
+        "inode": stat.st_ino,
+        "sha256": hashlib.sha256(data).hexdigest(),
+    }
+    return path
+
+
+def remove_ours(path):
+    """Remove only an unchanged inode and payload this harness created; never unlink a replacement."""
+    proof = planted.get(path)
+    if proof is None:
+        return {"path": str(path), "removed": False, "why": "not planted by this harness"}
+    if not path.exists():
+        return {"path": str(path), "removed": True, "why": "already removed by the artifact"}
+    try:
+        stat = path.stat()
+        data = path.read_bytes()
+    except OSError as exc:
+        return {"path": str(path), "removed": False, "why": f"cannot re-read: {exc!r}"}
+    unchanged = (stat.st_dev == proof["device"] and stat.st_ino == proof["inode"]
+                 and hashlib.sha256(data).hexdigest() == proof["sha256"])
+    if not unchanged:
+        return {"path": str(path), "removed": False,
+                "why": "file changed or was replaced after the harness planted it"}
+    try:
+        path.unlink()
+    except OSError as exc:
+        return {"path": str(path), "removed": False, "why": repr(exc)}
+    return {"path": str(path), "removed": not path.exists(), "why": "harness-owned marker"}
+
+
+def start_release_artifact(marker):
+    """Start the release binary, then make a read-only call that records the live artifact drive."""
+    driver = E.Driver()
+    try:
+        health = driver.tool("logic_system", "health", {})
+        posted_clear, info_channel_live = driver.server_logged("posted a modifier-clear event")
+        return {
+            "server_pid": driver.proc.pid,
+            "health_responded": isinstance(health, dict) and "_transport_error" not in health,
+            "marker_exists_after_start": marker.exists(),
+            "posted_modifier_clear": posted_clear,
+            "info_log_channel_live": info_channel_live,
+        }
+    finally:
+        driver.close()
+
+
+def finish():
+    summary = ev.write()
+    print(json.dumps(summary, indent=1))
+    return 0 if E.is_clean(summary) else 1
+
+
+# A pre-existing marker could be a real interrupted chord.  Refuse instead of deleting it: every
+# subsequent deletion is guarded by `planted`, but this check is what keeps the run from even trying
+# to share a recovery directory with somebody else's state.
+# `blocking_modal` has THREE answers, and an earlier draft of this harness read them as two.
+# `None` means a completed scan found nothing — that is the clean case. A dict describes a detected
+# blocker. `E.MODAL_CANNOT_TELL` means the scan could not be completed, which is not a clean screen
+# and must refuse just as loudly as a found modal: a run measured through a blocker it could not
+# see is the failure this whole precondition exists to stop.
+modal_before = E.blocking_modal()
+no_modal = prove(
+    "458/precondition-no-blocking-modal",
+    lambda observed: observed is None,
+    modal_before,
+    {"kind": "modal_panel", "layer": 8, "w": 268, "h": 283},
+    "the modal scan completed and found no blocking panel or sheet before this run starts the "
+    "artifact; a cannot-tell answer refuses here too",
+    "leave a modal dialog or sheet open, or break the scan so it answers cannot_tell: this "
+    "precondition turns red rather than treating a blocked run as modifier recovery",
+)
+initial_state = marker_directory_state()
+empty_marker_directory = prove(
+    "458/precondition-no-marker-files-already-exist",
+    lambda observed: observed.get("readable") is True and observed.get("marker_files") == [],
+    initial_state,
+    {"readable": True, "directory_exists": True,
+     "marker_files": [f"{MARKER_PREFIX}someone-else{MARKER_SUFFIX}"]},
+    "the production marker directory is readable and has no production-shaped marker files",
+    "leave a marker from another run in the directory: this run refuses instead of removing it",
+)
+ev.note("458/initial-marker-directory-state", initial_state)
+if not (no_modal and empty_marker_directory):
+    sys.exit(finish())
+
+# A visual guard is required by the live-evidence format, but it is intentionally not the primary
+# witness.  The primary witness below is the actual marker file.  The quiet Control Bar is only a
+# narrow check that the zero-flags key-up did not make a visible UI change while this run was recorded.
+arrange_window = E.logic_window()
+window_ready = prove(
+    "458/precondition-an-arrange-window-is-visible-for-the-recording",
+    lambda observed: isinstance(observed, dict) and bool(observed.get("title")),
+    arrange_window,
+    None,
+    "a visible Logic arrange window can supply the recorded visual control",
+    "close the arrange window: the recording has no defined subject and this precondition turns red",
+)
+if not window_ready:
+    sys.exit(finish())
+
+band, band_subject = ev.located_band("Control Bar", "--min-width", "1000")
+band_ready = prove(
+    "458/precondition-the-control-bar-is-unambiguous",
+    lambda observed: isinstance(observed, dict) and observed.get("band") is not None
+    and isinstance(observed.get("subject"), str) and bool(observed["subject"].strip()),
+    {"band": band, "subject": band_subject},
+    {"band": None, "subject": None},
+    "an unambiguous Control Bar region, named by the UI, can be used for the visual control",
+    "make the Control Bar lookup ambiguous or unreadable: no anonymous rectangle is substituted",
+)
+if not band_ready:
+    sys.exit(finish())
+
+quiet_before = ev.shot("458/quiet-control-bar-before", settle_region=band,
+                       window_title=arrange_window["title"])
+time.sleep(1)
+quiet_after = ev.shot("458/quiet-control-bar-after", settle_region=band,
+                      window_title=arrange_window["title"])
+quiet = {
+    "first_settled": quiet_before.get("settled"),
+    "second_settled": quiet_after.get("settled"),
+    "first_hash": quiet_before.get("region_hash"),
+    "second_hash": quiet_after.get("region_hash"),
+}
+quiet_control = prove(
+    "458/precondition-the-visual-control-is-quiet",
+    lambda observed: (observed.get("first_settled") is True and observed.get("second_settled") is True
+                      and observed.get("first_hash") is not None
+                      and observed.get("first_hash") == observed.get("second_hash")),
+    quiet,
+    {"first_settled": True, "second_settled": True, "first_hash": "before", "second_hash": "after"},
+    "two idle captures of the Control Bar are identical, so a later visual difference is attributable",
+    "start transport playback: the control bar changes and this negative visual control turns red",
+)
+if not quiet_control:
+    sys.exit(finish())
+
+recording = ev.record_screen(seconds=45)
+visual_before = ev.shot("458/before-startup-recovery", settle_region=band,
+                        window_title=arrange_window["title"])
+visual_after = None
+cleanup = []
+
+try:
+    # An invented PID is unsound: it may name a live, unrelated process.  `/usr/bin/true` gives this
+    # run an honest PID, and waiting for it plus the same `kill(pid, 0)` probe production uses establishes
+    # that it is gone before its marker is planted.
+    child = subprocess.Popen(["/usr/bin/true"])
+    dead_pid = child.pid
+    child.wait()
+    dead_owner = {"pid": dead_pid, "is_alive_after_wait": process_is_alive(dead_pid)}
+    dead_owner_is_gone = prove(
+        "458/precondition-the-dead-marker-owner-is-really-dead",
+        lambda observed: isinstance(observed.get("pid"), int) and observed["pid"] > 0
+        and observed.get("is_alive_after_wait") is False,
+        dead_owner,
+        {"pid": dead_pid, "is_alive_after_wait": True},
+        "a PID supplied by a waited-for `/usr/bin/true` child now has no live process",
+        "reuse a live PID: the run refuses rather than asking recovery to clear a live owner's marker",
+    )
+    if not dead_owner_is_gone:
+        raise RuntimeError("the waited-for child PID was live again before its marker could be planted")
+
+    dead_marker = plant(marker_path(dead_pid), marker_data(dead_pid))
+    dead_result = start_release_artifact(dead_marker)
+    dead_result.update(dead_owner)
+    prove(
+        "458/a-marker-owned-by-a-dead-pid-is-cleared-on-artifact-start",
+        lambda observed: (observed.get("health_responded") is True
+                          and observed.get("is_alive_after_wait") is False
+                          and observed.get("marker_exists_after_start") is False),
+        dead_result,
+        {"health_responded": True, "is_alive_after_wait": False,
+         "marker_exists_after_start": True},
+        "the release artifact removes a parseable marker whose different owner is no longer live",
+        "remove `StuckModifierRecovery.recoverIfNeeded()` from `LogicProServer.start()`: the marker "
+        "remains after startup",
+    )
+    # Keep each case independent even on a broken binary.  This removes only the unchanged marker
+    # `plant` recorded above; a replacement is left in place and makes restoration fail loudly.
+    cleanup.append(remove_ours(dead_marker))
+
+    live_pid = os.getpid()
+    live_marker = plant(marker_path(live_pid), marker_data(live_pid))
+    live_result = start_release_artifact(live_marker)
+    live_result.update({"marker_pid": live_pid, "owner_is_harness": live_pid == os.getpid(),
+                        "owner_is_alive": process_is_alive(live_pid)})
+    prove(
+        "458/a-marker-owned-by-a-live-pid-survives-artifact-start",
+        lambda observed: (observed.get("health_responded") is True
+                          and observed.get("owner_is_harness") is True
+                          and observed.get("owner_is_alive") is True
+                          and observed.get("marker_exists_after_start") is True),
+        live_result,
+        {"health_responded": True, "owner_is_harness": True, "owner_is_alive": True,
+         "marker_exists_after_start": False},
+        "the release artifact keeps the marker belonging to this live Python harness process",
+        "delete every marker at startup instead of consulting `shouldRecover`: this marker is gone",
+    )
+
+    # Reuse the now-available dead filename so this is exactly `markerURL(for:in:)`'s PID shape,
+    # while its bytes make `JSONDecoder().decode(Marker.self, from:)` fail.
+    garbage_marker = plant(marker_path(dead_pid), b"not JSON")
+    garbage_result = start_release_artifact(garbage_marker)
+    prove(
+        "458/an-undecodable-production-shaped-marker-is-discarded-and-posts-nothing",
+        lambda observed: (observed.get("health_responded") is True
+                          and observed.get("marker_exists_after_start") is False
+                          and observed.get("posted_modifier_clear") is False
+                          and observed.get("info_log_channel_live") is True),
+        garbage_result,
+        {"health_responded": True, "marker_exists_after_start": False,
+         "posted_modifier_clear": True, "info_log_channel_live": True},
+        "the release artifact removes undecodable marker bytes and records no modifier-clear post",
+        "skip the decode-failure removal or attempt recovery before decoding: the marker survives or "
+        "the release artifact logs a modifier-clear post",
+    )
+except Exception as exc:  # noqa: BLE001 - cleanup and the evidence receipt must still happen
+    prove(
+        "458/the-harness-reached-all-startup-recovery-observations",
+        lambda observed: observed.get("error") is None,
+        {"error": repr(exc)},
+        {"error": "a deliberately non-empty error"},
+        "all three release-artifact startups complete without a harness error",
+        "break a marker setup or artifact startup: the exception is recorded as a failed observation",
+    )
+finally:
+    for path in list(planted):
+        cleanup.append(remove_ours(path))
+    # If this run had to create an otherwise absent directory, removing its final empty directory
+    # returns the whole directory state to the precondition.  `rmdir` cannot remove unrelated files.
+    if not initial_state.get("directory_exists"):
+        try:
+            MARKER_DIRECTORY.rmdir()
+        except OSError:
+            pass
+
+    restored_state = marker_directory_state()
+    ev.note("458/marker-cleanup", cleanup)
+    restored = prove(
+        "458/restore-the-marker-directory-is-back-to-its-precondition-state",
+        lambda observed: observed == initial_state,
+        restored_state,
+        {**initial_state, "marker_files": [f"{MARKER_PREFIX}left-behind{MARKER_SUFFIX}"]},
+        "the marker directory state now exactly matches the no-marker state observed before the run",
+        "leave a harness marker behind: the recorded directory state differs and this restore check turns red",
+    )
+    ev.restored("458/remove-only-harness-owned-markers", restored,
+                f"initial={initial_state!r} restored={restored_state!r} cleanup={cleanup!r}")
+
+    visual_after = ev.shot("458/after-startup-recovery", settle_region=band,
+                           window_title=arrange_window["title"])
+    ev.visual(
+        "458/the-zero-flags-recovery-does-not-visibly-alter-the-control-bar",
+        visual_before["file"], visual_after["file"], band, expect_change=False,
+        subject=band_subject,
+        why="the recovery's only possible input is a zero-flags key-up; it must not visibly press a "
+        "key or alter this already-proven-quiet control bar",
+    )
+    ev.stop_recording(recording)
+
+sys.exit(finish())

--- a/Scripts/livekit/live_458_a_stale_chord_marker_is_cleared_on_start.py
+++ b/Scripts/livekit/live_458_a_stale_chord_marker_is_cleared_on_start.py
@@ -68,6 +68,86 @@ MARKER_SUFFIX = ".json"
 MARKER_KEY_CODE = 56
 MARKER_FLAGS = 1 << 17
 
+# This is deliberately read from the product policy instead of spelling this host's Korean label
+# into the harness. The probe receives the entire exact-match family, so a localised run measures
+# the same control-bar identity the product uses without pretending English is universal.
+CONTROL_BAR_LABELS = E.label_set("controlBarGroupLabel")
+CONTROL_VALUES_SOURCE = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                     "ax_control_bar_control_values.swift")
+CONTROL_VALUES_TOOL = os.path.join(ev.dir, "ax_control_bar_control_values")
+control_values_build = None
+
+
+def control_bar_control_values():
+    """Read every control-bar AXCheckBox/AXButton as `AXDescription -> AXValue`, or fail closed."""
+    global control_values_build
+    if not (isinstance(CONTROL_BAR_LABELS, list) and CONTROL_BAR_LABELS
+            and all(isinstance(label, str) and label.strip() for label in CONTROL_BAR_LABELS)):
+        return {"ok": False, "error": "AXLocalePolicy.controlBarGroupLabel could not be read"}
+    if control_values_build is None:
+        control_values_build = subprocess.run(
+            ["swiftc", "-O", CONTROL_VALUES_SOURCE, "-o", CONTROL_VALUES_TOOL],
+            capture_output=True, text=True,
+        )
+    if control_values_build.returncode != 0:
+        return {
+            "ok": False,
+            "error": "the direct AX control-bar reader did not compile",
+            "stderr": (control_values_build.stderr or "")[:400],
+        }
+    result = subprocess.run([CONTROL_VALUES_TOOL, json.dumps(CONTROL_BAR_LABELS, ensure_ascii=False)],
+                            capture_output=True, text=True)
+    try:
+        read = json.loads(result.stdout or "{}")
+    except ValueError:
+        read = {"ok": False, "error": "the direct AX control-bar reader did not emit JSON",
+                "raw": (result.stdout or result.stderr)[:400]}
+    if not isinstance(read, dict):
+        read = {"ok": False, "error": "the direct AX control-bar reader emitted a non-object"}
+    read["returncode"] = result.returncode
+    return read
+
+
+def control_bar_values_are_unchanged(witness):
+    """The map is evidence only when both complete reads name a non-empty identical control set."""
+    if not isinstance(witness, dict):
+        return False
+    before = witness.get("before")
+    after = witness.get("after")
+    if not (isinstance(before, dict) and isinstance(after, dict)
+            and before.get("ok") is True and after.get("ok") is True
+            and before.get("returncode") == 0 and after.get("returncode") == 0):
+        return False
+    before_values = before.get("controls")
+    after_values = after.get("controls")
+    return (isinstance(before_values, dict) and isinstance(after_values, dict)
+            and bool(before_values) and bool(after_values)
+            and before.get("control_count") == len(before_values)
+            and after.get("control_count") == len(after_values)
+            and before_values == after_values)
+
+
+def a_real_control_value_changed(witness):
+    """Copy the raw AX observation and alter one read value, preserving the observed shape."""
+    counterexample = json.loads(json.dumps(witness, ensure_ascii=False))
+    after = counterexample.get("after") if isinstance(counterexample, dict) else None
+    values = after.get("controls") if isinstance(after, dict) else None
+    if not isinstance(values, dict) or not values:
+        return counterexample
+    description = next(iter(values))
+    value = values[description]
+    if isinstance(value, bool):
+        values[description] = not value
+    elif isinstance(value, (int, float)):
+        values[description] = value + 1
+    elif isinstance(value, str):
+        values[description] = value + " (changed)"
+    else:
+        # The direct reader only accepts JSON scalar AXValues. This is defensive: a new scalar
+        # shape must still differ in exactly one map entry rather than turn into a structural case.
+        values[description] = repr(value) + " (changed)"
+    return counterexample
+
 
 def marker_path(pid):
     """The same filename construction as `StuckModifierRecovery.markerURL(for:in:)`."""
@@ -213,9 +293,13 @@ ev.note("458/initial-marker-directory-state", initial_state)
 if not (no_modal and empty_marker_directory):
     sys.exit(finish())
 
-# A visual guard is required by the live-evidence format, but it is intentionally not the primary
-# witness.  The primary witness below is the actual marker file.  The quiet Control Bar is only a
-# narrow check that the zero-flags key-up did not make a visible UI change while this run was recorded.
+# The two captures and recording remain useful context: they show whether the control bar was idle
+# before this run.  They are not the recovery side-effect witness. Measured on the settled 10,24,
+# 1900,58 region, three idle captures were byte-identical, yet before/after recovery differed in
+# exactly 12 Retina columns (six points), window x=1065...1070, at the right edge of the LCD's
+# `박자표` / `조표` AXPopUpButton (frame 1012,63 63x23). That is a real chevron/focus-ring redraw,
+# but pixels cannot distinguish it from a pressed key, so the AX map below is the control for this
+# question. Do not reinstate a recovery `ev.visual(...)` comparison over this band.
 arrange_window = E.logic_window()
 window_ready = prove(
     "458/precondition-an-arrange-window-is-visible-for-the-recording",
@@ -259,16 +343,23 @@ quiet_control = prove(
                       and observed.get("first_hash") == observed.get("second_hash")),
     quiet,
     {"first_settled": True, "second_settled": True, "first_hash": "before", "second_hash": "after"},
-    "two idle captures of the Control Bar are identical, so a later visual difference is attributable",
-    "start transport playback: the control bar changes and this negative visual control turns red",
+    "two idle captures of the Control Bar are identical, so the recording starts from a quiescent UI",
+    "start transport playback: the transport readout genuinely moves and this idle precondition turns red",
 )
-if not quiet_control:
+# Evidence requires one visual assertion. This one is deliberately only the idle precondition: the
+# transport readout would genuinely move under playback, and it says nothing about startup recovery.
+quiet_visual = ev.visual(
+    "458/precondition-the-control-bar-is-visually-quiet-before-recovery",
+    quiet_before["file"], quiet_after["file"], band, expect_change=False, subject=band_subject,
+    why="the transport readout would move during playback; this establishes only that the retained "
+        "recording context is idle before the artifact starts",
+)
+if not (quiet_control and quiet_visual):
     sys.exit(finish())
 
 recording = ev.record_screen(seconds=45)
 visual_before = ev.shot("458/before-startup-recovery", settle_region=band,
                         window_title=arrange_window["title"])
-visual_after = None
 cleanup = []
 
 try:
@@ -292,8 +383,12 @@ try:
         raise RuntimeError("the waited-for child PID was live again before its marker could be planted")
 
     dead_marker = plant(marker_path(dead_pid), marker_data(dead_pid))
+    control_values_before = control_bar_control_values()
+    ev.note("458/control-bar-AXValues-before-startup-recovery", control_values_before)
     dead_result = start_release_artifact(dead_marker)
     dead_result.update(dead_owner)
+    control_values_after = control_bar_control_values()
+    ev.note("458/control-bar-AXValues-after-startup-recovery", control_values_after)
     prove(
         "458/a-marker-owned-by-a-dead-pid-is-cleared-on-artifact-start",
         lambda observed: (observed.get("health_responded") is True
@@ -305,6 +400,21 @@ try:
         "the release artifact removes a parseable marker whose different owner is no longer live",
         "remove `StuckModifierRecovery.recoverIfNeeded()` from `LogicProServer.start()`: the marker "
         "remains after startup",
+    )
+    control_value_observation = {"before": control_values_before, "after": control_values_after}
+    # This is a raw observation plus a same-shaped counterexample, as in #290: only one real
+    # AXValue is changed. The predicate therefore rejects a transport press because that map entry
+    # moved, not because a required field was removed or the reader was made structurally invalid.
+    prove(
+        "458/the-zero-flags-recovery-does-not-change-control-bar-controls",
+        control_bar_values_are_unchanged,
+        control_value_observation,
+        a_real_control_value_changed(control_value_observation),
+        "the recovery's only possible input is a zero-flags key-up; a key that pressed any transport "
+        "button or checkbox would change its AXDescription-to-AXValue map, which is identical before "
+        "and after the startup recovery",
+        "post a key-down or non-zero-flags event from recovery: a transport control's AXValue changes "
+        "and this map comparison turns red",
     )
     # Keep each case independent even on a broken binary.  This removes only the unchanged marker
     # `plant` recorded above; a replacement is left in place and makes restoration fail loudly.
@@ -378,15 +488,11 @@ finally:
     ev.restored("458/remove-only-harness-owned-markers", restored,
                 f"initial={initial_state!r} restored={restored_state!r} cleanup={cleanup!r}")
 
-    visual_after = ev.shot("458/after-startup-recovery", settle_region=band,
-                           window_title=arrange_window["title"])
-    ev.visual(
-        "458/the-zero-flags-recovery-does-not-visibly-alter-the-control-bar",
-        visual_before["file"], visual_after["file"], band, expect_change=False,
-        subject=band_subject,
-        why="the recovery's only possible input is a zero-flags key-up; it must not visibly press a "
-        "key or alter this already-proven-quiet control bar",
-    )
+    # Keep the pre/post captures in the evidence bundle, but intentionally do not compare them with
+    # `ev.visual`: the measured six-point LCD chevron/focus redraw is a real pixel difference that
+    # cannot answer whether recovery pressed a control. The AXValue map above is that control.
+    ev.shot("458/after-startup-recovery", settle_region=band,
+            window_title=arrange_window["title"])
     ev.stop_recording(recording)
 
 sys.exit(finish())

--- a/Sources/LogicProMCP/Accessibility/AXMouseHelper.swift
+++ b/Sources/LogicProMCP/Accessibility/AXMouseHelper.swift
@@ -109,6 +109,12 @@ enum AXMouseHelper {
                     flags: flags,
                     clearModifiersAfter: true
                 ) else { return false }
+                // Three separate posts, and a process that dies between the second and the third
+                // leaves macOS holding a modifier no physical key is holding. The marker says a
+                // chord is in flight so the next start can post the clear this run owed; see
+                // `StuckModifierRecovery` for why a marker and not a blind clear at startup.
+                StuckModifierRecovery.arm(keyCode: keyCode, flags: flags)
+                defer { StuckModifierRecovery.disarm() }
                 events.down.post(tap: .cghidEventTap)
                 events.up.post(tap: .cghidEventTap)
                 events.modifierClear?.post(tap: .cghidEventTap)

--- a/Sources/LogicProMCP/Accessibility/AXMouseHelper.swift
+++ b/Sources/LogicProMCP/Accessibility/AXMouseHelper.swift
@@ -15,11 +15,22 @@ import Foundation
 enum AXMouseHelper {
     /// Coordinates the one marker file that this process uses for flagged chords.
     ///
-    /// A nested chord deliberately keeps the outer chord's key code and flags in that file: the
-    /// nested chord's clear is not recorded. The outer clear is the one still owed after the
-    /// nested work completes; recording both would require a marker per chord and recovery that
-    /// posts several keystrokes. Keep the lock held while changing the marker so another chord
-    /// cannot post in the gap between this decision and the corresponding file operation.
+    /// The first `begin` at depth zero calls `arm` with its payload; later begins do not call it.
+    /// If arming writes a marker, that payload remains until the depth returns to zero. This
+    /// intentionally does not record several in-flight chords. One marker could contain several
+    /// records, but recovery that posts several keystrokes is a broader action than this feature's
+    /// one best-effort clear attempt.
+    ///
+    /// Overlapping calls need not end LIFO, so the retained key code can name a call that has
+    /// already ended. The recovery event has zero flags: its flags release the modifier state,
+    /// not its virtual key code. A key-up naming a stale key still carries that zero-flags clear,
+    /// while a key-up for a key nobody holds releases nothing; the stale key makes the recovery
+    /// log less accurate, not the modifier-clear attempt less correct.
+    ///
+    /// `arm` and `disarm` run under this non-recursive `NSLock` and MUST NOT call back into the
+    /// chord path; the production `StuckModifierRecovery.arm` and `.disarm` callbacks are file
+    /// operations. Holding the lock across `arm` preserves the required arm-before-first-post
+    /// ordering.
     final class ChordMarkerNesting: @unchecked Sendable {
         private let lock = NSLock()
         private var depth = 0
@@ -42,16 +53,13 @@ enum AXMouseHelper {
             lock.lock()
             defer { lock.unlock() }
 
-            // Clamped rather than `precondition`. `end` is reached only from the `defer` that
-            // follows its own `begin`, so a zero depth here would be a programmer error — but the
-            // trap costs the whole server, and this module's own rule is that a bookkeeping
-            // failure must not take the feature down with it. Disarm and log instead: an
-            // unbalanced end is a bug worth seeing, not worth crashing a user's session over.
+            // A zero depth has no marker ownership to release. Logging and returning avoids
+            // clearing a marker that another caller wrote while still leaving the imbalance
+            // visible without terminating the server.
             guard depth > 0 else {
                 Log.warn(
-                    "chord marker disarmed without a matching arm — clearing it anyway",
+                    "chord marker end without a matching begin — leaving the marker untouched",
                     subsystem: "cgEvent")
-                disarm()
                 return
             }
             depth -= 1
@@ -113,10 +121,10 @@ enum AXMouseHelper {
             return (down, up, modifierClear)
         }
 
-        /// Posts a flagged chord while a best-effort marker is present. A later start can use that
-        /// marker to attempt a clear after an interruption, but arming can fail and recovery
-        /// deliberately removes the marker before posting. Event construction stays before `arm`
-        /// so no marker is written when there is no event sequence to post.
+        /// Attempts to arm a best-effort marker before posting a flagged chord. Arming can fail,
+        /// so a marker need not exist; a later start can only use one that remains to attempt a
+        /// clear after an interruption. Event construction stays before `arm` so no marker is
+        /// attempted when there is no event sequence to post.
         @discardableResult
         static func postChord(
             keyCode: CGKeyCode,

--- a/Sources/LogicProMCP/Accessibility/AXMouseHelper.swift
+++ b/Sources/LogicProMCP/Accessibility/AXMouseHelper.swift
@@ -62,6 +62,29 @@ enum AXMouseHelper {
             return (down, up, modifierClear)
         }
 
+        /// Posts a flagged chord inside the marker lifetime that makes an interrupted clear
+        /// recoverable. Event construction stays before `arm`: if nothing can be posted, there is
+        /// no modifier state to recover and no marker to clean up.
+        @discardableResult
+        static func postChord(
+            keyCode: CGKeyCode,
+            flags: CGEventFlags,
+            arm: (CGKeyCode, CGEventFlags) -> Void,
+            disarm: () -> Void,
+            post: (CGEvent) -> Void,
+            makeEvents: (CGKeyCode, CGEventFlags) -> (down: CGEvent, up: CGEvent, modifierClear: CGEvent?)?
+        ) -> Bool {
+            guard let events = makeEvents(keyCode, flags) else { return false }
+            arm(keyCode, flags)
+            defer { disarm() }
+            post(events.down)
+            post(events.up)
+            if let modifierClear = events.modifierClear {
+                post(modifierClear)
+            }
+            return true
+        }
+
         static let production = Runtime(
             postMouseEvent: { type, point, clickCount in
                 let source = CGEventSource(stateID: .combinedSessionState)
@@ -103,22 +126,21 @@ enum AXMouseHelper {
             sleepMicros: { usleep($0) },
             postFlaggedKeyEvent: { keyCode, flags in
                 let source = CGEventSource(stateID: .combinedSessionState)
-                guard let events = keyboardEvents(
-                    source: source,
+                return postChord(
                     keyCode: keyCode,
                     flags: flags,
-                    clearModifiersAfter: true
-                ) else { return false }
-                // Three separate posts, and a process that dies between the second and the third
-                // leaves macOS holding a modifier no physical key is holding. The marker says a
-                // chord is in flight so the next start can post the clear this run owed; see
-                // `StuckModifierRecovery` for why a marker and not a blind clear at startup.
-                StuckModifierRecovery.arm(keyCode: keyCode, flags: flags)
-                defer { StuckModifierRecovery.disarm() }
-                events.down.post(tap: .cghidEventTap)
-                events.up.post(tap: .cghidEventTap)
-                events.modifierClear?.post(tap: .cghidEventTap)
-                return true
+                    arm: { StuckModifierRecovery.arm(keyCode: $0, flags: $1) },
+                    disarm: { StuckModifierRecovery.disarm() },
+                    post: { $0.post(tap: .cghidEventTap) },
+                    makeEvents: { keyCode, flags in
+                        keyboardEvents(
+                            source: source,
+                            keyCode: keyCode,
+                            flags: flags,
+                            clearModifiersAfter: true
+                        )
+                    }
+                )
             }
         )
     }

--- a/Sources/LogicProMCP/Accessibility/AXMouseHelper.swift
+++ b/Sources/LogicProMCP/Accessibility/AXMouseHelper.swift
@@ -13,6 +13,57 @@ import Foundation
 /// the double-click + keystroke sequence inside the server process
 /// eliminates the FD exhaustion path entirely.
 enum AXMouseHelper {
+    /// Coordinates the one marker file that this process uses for flagged chords.
+    ///
+    /// A nested chord deliberately keeps the outer chord's key code and flags in that file: the
+    /// nested chord's clear is not recorded. The outer clear is the one still owed after the
+    /// nested work completes; recording both would require a marker per chord and recovery that
+    /// posts several keystrokes. Keep the lock held while changing the marker so another chord
+    /// cannot post in the gap between this decision and the corresponding file operation.
+    final class ChordMarkerNesting: @unchecked Sendable {
+        private let lock = NSLock()
+        private var depth = 0
+
+        func begin(
+            keyCode: CGKeyCode,
+            flags: CGEventFlags,
+            arm: (CGKeyCode, CGEventFlags) -> Void
+        ) {
+            lock.lock()
+            defer { lock.unlock() }
+
+            if depth == 0 {
+                arm(keyCode, flags)
+            }
+            depth += 1
+        }
+
+        func end(disarm: () -> Void) {
+            lock.lock()
+            defer { lock.unlock() }
+
+            // Clamped rather than `precondition`. `end` is reached only from the `defer` that
+            // follows its own `begin`, so a zero depth here would be a programmer error — but the
+            // trap costs the whole server, and this module's own rule is that a bookkeeping
+            // failure must not take the feature down with it. Disarm and log instead: an
+            // unbalanced end is a bug worth seeing, not worth crashing a user's session over.
+            guard depth > 0 else {
+                Log.warn(
+                    "chord marker disarmed without a matching arm — clearing it anyway",
+                    subsystem: "cgEvent")
+                disarm()
+                return
+            }
+            depth -= 1
+            if depth == 0 {
+                disarm()
+            }
+        }
+    }
+
+    /// Process-wide because all `postFlaggedKeyEvent` calls use the same per-process marker path.
+    private static let chordMarkerNesting = ChordMarkerNesting()
+
     struct Runtime: @unchecked Sendable {
         let postMouseEvent: @Sendable (CGEventType, CGPoint, Int64) -> Bool
         let postKeyEvent: @Sendable (CGKeyCode) -> Bool
@@ -62,9 +113,10 @@ enum AXMouseHelper {
             return (down, up, modifierClear)
         }
 
-        /// Posts a flagged chord inside the marker lifetime that makes an interrupted clear
-        /// recoverable. Event construction stays before `arm`: if nothing can be posted, there is
-        /// no modifier state to recover and no marker to clean up.
+        /// Posts a flagged chord while a best-effort marker is present. A later start can use that
+        /// marker to attempt a clear after an interruption, but arming can fail and recovery
+        /// deliberately removes the marker before posting. Event construction stays before `arm`
+        /// so no marker is written when there is no event sequence to post.
         @discardableResult
         static func postChord(
             keyCode: CGKeyCode,
@@ -72,11 +124,12 @@ enum AXMouseHelper {
             arm: (CGKeyCode, CGEventFlags) -> Void,
             disarm: () -> Void,
             post: (CGEvent) -> Void,
-            makeEvents: (CGKeyCode, CGEventFlags) -> (down: CGEvent, up: CGEvent, modifierClear: CGEvent?)?
+            makeEvents: (CGKeyCode, CGEventFlags) -> (down: CGEvent, up: CGEvent, modifierClear: CGEvent?)?,
+            markerNesting: ChordMarkerNesting = AXMouseHelper.chordMarkerNesting
         ) -> Bool {
             guard let events = makeEvents(keyCode, flags) else { return false }
-            arm(keyCode, flags)
-            defer { disarm() }
+            markerNesting.begin(keyCode: keyCode, flags: flags, arm: arm)
+            defer { markerNesting.end(disarm: disarm) }
             post(events.down)
             post(events.up)
             if let modifierClear = events.modifierClear {

--- a/Sources/LogicProMCP/Accessibility/StuckModifierRecovery.swift
+++ b/Sources/LogicProMCP/Accessibility/StuckModifierRecovery.swift
@@ -25,21 +25,24 @@ import Foundation
 /// holding Shift, and nothing available here can tell a synthetic held flag from a physical one —
 /// `CGEventSource.flagsState` reports the combined state and cannot say who put a flag there.
 ///
-/// Each process writes its own PID-bearing marker before its chord and removes it after. Startup
-/// only clears a marker whose owner is gone, and only after removing that marker. A live process
-/// keeps its marker, so another ordinary MCP launch does not post into its in-flight chord. PID
-/// reuse is the remaining ambiguity: an unrelated process can inherit a dead marker's PID, making
-/// that marker look live. Recovery then skips it, leaving the stuck modifier in the same state as
-/// before this feature; it never posts a keystroke the user did not ask for.
+/// Each process attempts to write one PID-named marker before its outermost chord and removes it
+/// after. At startup, this code only attempts a clear after removing a parseable marker whose
+/// different PID does not currently appear live. That limits blind clears, but it does not prove a
+/// marker's provenance, its owner's lifetime, or that its modifier remains held: a PID can be
+/// reused, including across a reboot, and best-effort arming means a live process can lack its
+/// marker.
+/// A hard power loss can leave a marker but cannot leave the macOS event state held, so its
+/// surviving marker is not evidence that a clear is needed.
 ///
-/// WHAT IT DOES NOT COVER, stated rather than implied: `SIGKILL` and a hard power loss remove the
-/// process without removing the marker, which is the case this recovers; a marker that cannot be
-/// written (read-only home, sandbox) leaves the window exactly as wide as it is today, and the
-/// chord still runs — refusing to send a keystroke because a breadcrumb failed would trade a rare
-/// stuck modifier for a broken feature.
+/// Residual limitations: PID reuse; reboot-stale markers; a marker written under a different UID
+/// or home; no proof that a modifier is still held at recovery time; and no test covering the
+/// production `kill`/`errno` behavior or actual `CGEvent` delivery. A marker that cannot be
+/// written (read-only home or sandbox) leaves the posting window as it was; the chord still runs
+/// because refusing its keystroke after a breadcrumb failure would break the feature.
 enum StuckModifierRecovery {
 
-    /// What a marker records: enough to identify its owner and post the clear it owed, and no more.
+    /// Diagnostic data only: the chord's key code, flags, and PID. It records no UID, boot
+    /// identity, process start time, or proof that the clear was not already posted.
     struct Marker: Codable, Equatable, Sendable {
         let keyCode: UInt16
         /// Diagnostic only. The recovery always posts with NO flags, because the event it stands in
@@ -83,8 +86,9 @@ enum StuckModifierRecovery {
         try? JSONEncoder().encode(Marker(keyCode: UInt16(keyCode), flags: flags.rawValue, pid: pid))
     }
 
-    /// Keep every liveness uncertainty on the safe side: only a known-dead, other process is owed
-    /// a clear. Injecting the check leaves this decision testable without creating processes.
+    /// Returns true only when a different PID currently has no process. `ESRCH` establishes that
+    /// current PID state, not the original marker owner or that a clear is still needed. Injecting
+    /// the check leaves this decision testable without creating processes.
     static func shouldRecover(
         marker: Marker,
         isAlive: (Int32) -> Bool,
@@ -119,18 +123,26 @@ enum StuckModifierRecovery {
         try? data.write(to: url, options: .atomic)
     }
 
-    /// The chord finished, including its clearing event. A surviving marker must be visible in logs
-    /// because another start would otherwise mistake this completed chord for an interrupted one.
+    /// The chord finished, including its clearing event, so remove its marker. If the process dies
+    /// after the clear but before this removal, a completed marker can survive without a matching
+    /// log line and a later start cannot distinguish it from an interrupted chord.
     static func disarm(at url: URL? = defaultURL) {
         guard let url, FileManager.default.fileExists(atPath: url.path) else { return }
         _ = removeMarker(at: url)
     }
 
-    /// Post every orphaned clear a previous process owed, if any. Safe to call on every start.
+    /// Attempts a clear for each removable, parseable marker whose different PID currently has no
+    /// process. It is not proven safe on every start: a reboot-stale marker can cause a post even
+    /// though no modifier remains held.
     ///
-    /// A remove must both return normally and leave no file behind before a clear is posted. That
-    /// makes concurrent starts race safely: only the process that actually removed a marker can
-    /// recover it.
+    /// The marker is deliberately removed before posting, so a crash during posting cannot retry
+    /// the same clear on every later start. Between successful removal and the post, another writer
+    /// can recreate the file, and a kill in that window permanently loses the clear represented by
+    /// the removed marker. The latter is the deliberate trade for avoiding a crashing post loop.
+    ///
+    /// The return value contains only key codes for which the poster reports constructing an event
+    /// and calling `CGEvent.post`. A normal return from `CGEvent.post` is not proof that macOS
+    /// delivered the event.
     @discardableResult
     static func recoverIfNeeded(
         in directory: URL? = defaultDirectoryURL,
@@ -138,9 +150,10 @@ enum StuckModifierRecovery {
         isAlive: (Int32) -> Bool = processIsAlive,
         remove: (URL) throws -> Void = { try FileManager.default.removeItem(at: $0) },
         fileExists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) },
-        post: (CGKeyCode) -> Void = { keyCode in
-            guard let clear = clearEvent(for: keyCode) else { return }
+        post: (CGKeyCode) -> Bool = { keyCode in
+            guard let clear = clearEvent(for: keyCode) else { return false }
             clear.post(tap: .cghidEventTap)
+            return true
         }
     ) -> [CGKeyCode] {
         guard let directory,
@@ -160,11 +173,16 @@ enum StuckModifierRecovery {
             guard removeMarker(at: url, remove: remove, fileExists: fileExists) else { continue }
 
             let keyCode = CGKeyCode(marker.keyCode)
-            post(keyCode)
-            recovered.append(keyCode)
-            Log.info(
-                "cleared a modifier left held by an interrupted chord (key \(keyCode))",
-                subsystem: "cgEvent")
+            if post(keyCode) {
+                recovered.append(keyCode)
+                Log.info(
+                    "posted a modifier-clear event for a recovery marker (key \(keyCode)); delivery is not verified",
+                    subsystem: "cgEvent")
+            } else {
+                Log.warn(
+                    "modifier recovery marker was found, but its clear event could not be built and posted (key \(keyCode))",
+                    subsystem: "cgEvent")
+            }
         }
         return recovered
     }

--- a/Sources/LogicProMCP/Accessibility/StuckModifierRecovery.swift
+++ b/Sources/LogicProMCP/Accessibility/StuckModifierRecovery.swift
@@ -1,7 +1,8 @@
 import CoreGraphics
+import Darwin
 import Foundation
 
-/// Clears a synthetic modifier that a previous run left held, and nothing else.
+/// Clears a synthetic modifier that an interrupted process left held.
 ///
 /// WHY THIS EXISTS
 /// ---------------
@@ -24,10 +25,12 @@ import Foundation
 /// holding Shift, and nothing available here can tell a synthetic held flag from a physical one —
 /// `CGEventSource.flagsState` reports the combined state and cannot say who put a flag there.
 ///
-/// A marker written before the chord and removed after it answers exactly the question that
-/// matters: *did OUR process leave a chord unfinished?* Present means yes, and the recovery posts
-/// the same key-up the interrupted sequence would have. Absent means nothing is owed and nothing is
-/// posted. It cannot fire because of anything a user is doing.
+/// Each process writes its own PID-bearing marker before its chord and removes it after. Startup
+/// only clears a marker whose owner is gone, and only after removing that marker. A live process
+/// keeps its marker, so another ordinary MCP launch does not post into its in-flight chord. PID
+/// reuse is the remaining ambiguity: an unrelated process can inherit a dead marker's PID, making
+/// that marker look live. Recovery then skips it, leaving the stuck modifier in the same state as
+/// before this feature; it never posts a keystroke the user did not ask for.
 ///
 /// WHAT IT DOES NOT COVER, stated rather than implied: `SIGKILL` and a hard power loss remove the
 /// process without removing the marker, which is the case this recovers; a marker that cannot be
@@ -36,84 +39,178 @@ import Foundation
 /// stuck modifier for a broken feature.
 enum StuckModifierRecovery {
 
-    /// What a marker records: enough to post the clear the interrupted run owed, and no more.
+    /// What a marker records: enough to identify its owner and post the clear it owed, and no more.
     struct Marker: Codable, Equatable, Sendable {
         let keyCode: UInt16
         /// Diagnostic only. The recovery always posts with NO flags, because the event it stands in
         /// for is the flag-clearing key-up — replaying the chord's own flags would re-assert them.
         let flags: UInt64
+        let pid: Int32
     }
 
-    static var defaultURL: URL? {
+    private static let markerPrefix = "chord-in-flight-"
+    private static let markerSuffix = ".json"
+
+    static var defaultDirectoryURL: URL? {
         guard let root = FileManager.default.urls(
             for: .applicationSupportDirectory, in: .userDomainMask).first
         else { return nil }
-        return root
-            .appendingPathComponent("LogicProMCP", isDirectory: true)
-            .appendingPathComponent("chord-in-flight.json", isDirectory: false)
+        return root.appendingPathComponent("LogicProMCP", isDirectory: true)
+    }
+
+    static var defaultURL: URL? {
+        guard let directory = defaultDirectoryURL else { return nil }
+        return markerURL(for: getpid(), in: directory)
+    }
+
+    static func markerURL(for pid: Int32, in directory: URL) -> URL {
+        directory.appendingPathComponent("\(markerPrefix)\(pid)\(markerSuffix)", isDirectory: false)
     }
 
     // MARK: - Pure core
 
-    /// The key-up a recovery should post, or nil when nothing is owed.
-    ///
-    /// Separated from the filesystem so every branch is testable without one: a missing marker, a
-    /// marker that will not decode, and a good one are three different answers and each is a case
-    /// below in the tests.
+    /// The key-up a recovery should post, or nil when the marker is not trustworthy.
     static func recoveryKeyCode(from data: Data?) -> CGKeyCode? {
-        guard let data,
-              let marker = try? JSONDecoder().decode(Marker.self, from: data),
-              marker.keyCode <= UInt16(CGKeyCode.max)
-        else { return nil }
+        guard let marker = marker(from: data) else { return nil }
         return CGKeyCode(marker.keyCode)
     }
 
-    static func encode(keyCode: CGKeyCode, flags: CGEventFlags) -> Data? {
-        try? JSONEncoder().encode(Marker(keyCode: UInt16(keyCode), flags: flags.rawValue))
+    static func encode(
+        keyCode: CGKeyCode,
+        flags: CGEventFlags,
+        pid: Int32 = getpid()
+    ) -> Data? {
+        try? JSONEncoder().encode(Marker(keyCode: UInt16(keyCode), flags: flags.rawValue, pid: pid))
+    }
+
+    /// Keep every liveness uncertainty on the safe side: only a known-dead, other process is owed
+    /// a clear. Injecting the check leaves this decision testable without creating processes.
+    static func shouldRecover(
+        marker: Marker,
+        isAlive: (Int32) -> Bool,
+        selfPID: Int32
+    ) -> Bool {
+        marker.pid != selfPID && !isAlive(marker.pid)
+    }
+
+    /// Builds the final key-up without posting it, so its zero-flags contract is independently
+    /// testable and cannot drift behind the recovery tests that inject their own poster.
+    static func clearEvent(for keyCode: CGKeyCode) -> CGEvent? {
+        let source = CGEventSource(stateID: .combinedSessionState)
+        guard let clear = CGEvent(
+            keyboardEventSource: source, virtualKey: keyCode, keyDown: false)
+        else { return nil }
+        clear.flags = CGEventFlags(rawValue: 0)
+        return clear
     }
 
     // MARK: - Filesystem edges
 
     /// Record that a chord is about to be posted. Best effort by design — see the type comment.
-    static func arm(keyCode: CGKeyCode, flags: CGEventFlags, at url: URL? = defaultURL) {
-        guard let url, let data = encode(keyCode: keyCode, flags: flags) else { return }
+    static func arm(
+        keyCode: CGKeyCode,
+        flags: CGEventFlags,
+        at url: URL? = defaultURL,
+        pid: Int32 = getpid()
+    ) {
+        guard let url, let data = encode(keyCode: keyCode, flags: flags, pid: pid) else { return }
         try? FileManager.default.createDirectory(
             at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
         try? data.write(to: url, options: .atomic)
     }
 
-    /// The chord finished, including its clearing event. Nothing is owed.
+    /// The chord finished, including its clearing event. A surviving marker must be visible in logs
+    /// because another start would otherwise mistake this completed chord for an interrupted one.
     static func disarm(at url: URL? = defaultURL) {
-        guard let url else { return }
-        try? FileManager.default.removeItem(at: url)
+        guard let url, FileManager.default.fileExists(atPath: url.path) else { return }
+        _ = removeMarker(at: url)
     }
 
-    /// Post the clear a previous run owed, if it owed one. Safe to call on every start.
+    /// Post every orphaned clear a previous process owed, if any. Safe to call on every start.
     ///
-    /// The marker is removed BEFORE the post, so a crash inside `post` cannot make this loop on
-    /// every subsequent launch. Losing one recovery is better than a startup that keeps trying.
+    /// A remove must both return normally and leave no file behind before a clear is posted. That
+    /// makes concurrent starts race safely: only the process that actually removed a marker can
+    /// recover it.
     @discardableResult
     static func recoverIfNeeded(
-        at url: URL? = defaultURL,
+        in directory: URL? = defaultDirectoryURL,
+        selfPID: Int32 = getpid(),
+        isAlive: (Int32) -> Bool = processIsAlive,
+        remove: (URL) throws -> Void = { try FileManager.default.removeItem(at: $0) },
+        fileExists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) },
         post: (CGKeyCode) -> Void = { keyCode in
-            let source = CGEventSource(stateID: .combinedSessionState)
-            guard let clear = CGEvent(
-                keyboardEventSource: source, virtualKey: keyCode, keyDown: false)
-            else { return }
-            clear.flags = CGEventFlags(rawValue: 0)
+            guard let clear = clearEvent(for: keyCode) else { return }
             clear.post(tap: .cghidEventTap)
         }
-    ) -> CGKeyCode? {
-        guard let url, let data = try? Data(contentsOf: url) else { return nil }
-        guard let keyCode = recoveryKeyCode(from: data) else {
-            try? FileManager.default.removeItem(at: url)
-            return nil
+    ) -> [CGKeyCode] {
+        guard let directory,
+              let urls = try? FileManager.default.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles])
+        else { return [] }
+
+        var recovered: [CGKeyCode] = []
+        for url in urls where isMarkerURL(url) {
+            guard let marker = marker(from: try? Data(contentsOf: url)) else {
+                _ = removeMarker(at: url, remove: remove, fileExists: fileExists)
+                continue
+            }
+            guard shouldRecover(marker: marker, isAlive: isAlive, selfPID: selfPID) else { continue }
+            guard removeMarker(at: url, remove: remove, fileExists: fileExists) else { continue }
+
+            let keyCode = CGKeyCode(marker.keyCode)
+            post(keyCode)
+            recovered.append(keyCode)
+            Log.info(
+                "cleared a modifier left held by an interrupted chord (key \(keyCode))",
+                subsystem: "cgEvent")
         }
-        try? FileManager.default.removeItem(at: url)
-        post(keyCode)
-        Log.info(
-            "cleared a modifier left held by an interrupted chord (key \(keyCode))",
-            subsystem: "cgEvent")
-        return keyCode
+        return recovered
+    }
+
+    private static func marker(from data: Data?) -> Marker? {
+        guard let data,
+              let marker = try? JSONDecoder().decode(Marker.self, from: data),
+              marker.keyCode <= UInt16(CGKeyCode.max)
+        else { return nil }
+        return marker
+    }
+
+    private static func isMarkerURL(_ url: URL) -> Bool {
+        let name = url.lastPathComponent
+        return name.hasPrefix(markerPrefix) && name.hasSuffix(markerSuffix)
+    }
+
+    private static func removeMarker(
+        at url: URL,
+        remove: (URL) throws -> Void = { try FileManager.default.removeItem(at: $0) },
+        fileExists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) }
+    ) -> Bool {
+        do {
+            try remove(url)
+        } catch {
+            Log.warn("could not remove modifier recovery marker at \(url.path): \(error)", subsystem: "cgEvent")
+            return false
+        }
+        guard !fileExists(url.path) else {
+            Log.warn("modifier recovery marker remained after removal at \(url.path)", subsystem: "cgEvent")
+            return false
+        }
+        return true
+    }
+
+    private static func processIsAlive(_ pid: Int32) -> Bool {
+        // `kill(-1, 0)` has process-group semantics, so malformed marker data must never reach it.
+        guard pid > 0 else { return true }
+        guard kill(pid_t(pid), 0) != 0 else { return true }
+        switch errno {
+        case EPERM:
+            return true
+        case ESRCH:
+            return false
+        default:
+            return true
+        }
     }
 }

--- a/Sources/LogicProMCP/Accessibility/StuckModifierRecovery.swift
+++ b/Sources/LogicProMCP/Accessibility/StuckModifierRecovery.swift
@@ -1,0 +1,119 @@
+import CoreGraphics
+import Foundation
+
+/// Clears a synthetic modifier that a previous run left held, and nothing else.
+///
+/// WHY THIS EXISTS
+/// ---------------
+/// A flagged chord is three posts: key-down with flags, key-up with flags, and a key-up with NO
+/// flags whose only job is to release the modifier. `AXMouseHelper.postFlaggedKeyEvent` sends all
+/// three back to back, so the sequence is correct — but it is three separate calls, and a process
+/// that dies between the second and the third leaves macOS believing Control or Shift is held while
+/// no physical key is down.
+///
+/// That is not hypothetical. Discussion #458 reported Logic becoming hard to use after running the
+/// integration — track volume moving 0.1 dB at a time, tracks and locators not draggable — which is
+/// the signature of a held Control during mouse interaction. I could not reproduce it in normal use
+/// and still cannot; the only way I produced the state was by deliberately omitting the third event.
+/// So this does not claim to be that user's cause. It closes the window I found while looking,
+/// which was left open with only an acknowledgement.
+///
+/// WHY A MARKER AND NOT A BLIND CLEAR
+/// ----------------------------------
+/// Posting a modifier-clear at startup unconditionally would also fire while a user is genuinely
+/// holding Shift, and nothing available here can tell a synthetic held flag from a physical one —
+/// `CGEventSource.flagsState` reports the combined state and cannot say who put a flag there.
+///
+/// A marker written before the chord and removed after it answers exactly the question that
+/// matters: *did OUR process leave a chord unfinished?* Present means yes, and the recovery posts
+/// the same key-up the interrupted sequence would have. Absent means nothing is owed and nothing is
+/// posted. It cannot fire because of anything a user is doing.
+///
+/// WHAT IT DOES NOT COVER, stated rather than implied: `SIGKILL` and a hard power loss remove the
+/// process without removing the marker, which is the case this recovers; a marker that cannot be
+/// written (read-only home, sandbox) leaves the window exactly as wide as it is today, and the
+/// chord still runs — refusing to send a keystroke because a breadcrumb failed would trade a rare
+/// stuck modifier for a broken feature.
+enum StuckModifierRecovery {
+
+    /// What a marker records: enough to post the clear the interrupted run owed, and no more.
+    struct Marker: Codable, Equatable, Sendable {
+        let keyCode: UInt16
+        /// Diagnostic only. The recovery always posts with NO flags, because the event it stands in
+        /// for is the flag-clearing key-up — replaying the chord's own flags would re-assert them.
+        let flags: UInt64
+    }
+
+    static var defaultURL: URL? {
+        guard let root = FileManager.default.urls(
+            for: .applicationSupportDirectory, in: .userDomainMask).first
+        else { return nil }
+        return root
+            .appendingPathComponent("LogicProMCP", isDirectory: true)
+            .appendingPathComponent("chord-in-flight.json", isDirectory: false)
+    }
+
+    // MARK: - Pure core
+
+    /// The key-up a recovery should post, or nil when nothing is owed.
+    ///
+    /// Separated from the filesystem so every branch is testable without one: a missing marker, a
+    /// marker that will not decode, and a good one are three different answers and each is a case
+    /// below in the tests.
+    static func recoveryKeyCode(from data: Data?) -> CGKeyCode? {
+        guard let data,
+              let marker = try? JSONDecoder().decode(Marker.self, from: data),
+              marker.keyCode <= UInt16(CGKeyCode.max)
+        else { return nil }
+        return CGKeyCode(marker.keyCode)
+    }
+
+    static func encode(keyCode: CGKeyCode, flags: CGEventFlags) -> Data? {
+        try? JSONEncoder().encode(Marker(keyCode: UInt16(keyCode), flags: flags.rawValue))
+    }
+
+    // MARK: - Filesystem edges
+
+    /// Record that a chord is about to be posted. Best effort by design — see the type comment.
+    static func arm(keyCode: CGKeyCode, flags: CGEventFlags, at url: URL? = defaultURL) {
+        guard let url, let data = encode(keyCode: keyCode, flags: flags) else { return }
+        try? FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try? data.write(to: url, options: .atomic)
+    }
+
+    /// The chord finished, including its clearing event. Nothing is owed.
+    static func disarm(at url: URL? = defaultURL) {
+        guard let url else { return }
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    /// Post the clear a previous run owed, if it owed one. Safe to call on every start.
+    ///
+    /// The marker is removed BEFORE the post, so a crash inside `post` cannot make this loop on
+    /// every subsequent launch. Losing one recovery is better than a startup that keeps trying.
+    @discardableResult
+    static func recoverIfNeeded(
+        at url: URL? = defaultURL,
+        post: (CGKeyCode) -> Void = { keyCode in
+            let source = CGEventSource(stateID: .combinedSessionState)
+            guard let clear = CGEvent(
+                keyboardEventSource: source, virtualKey: keyCode, keyDown: false)
+            else { return }
+            clear.flags = CGEventFlags(rawValue: 0)
+            clear.post(tap: .cghidEventTap)
+        }
+    ) -> CGKeyCode? {
+        guard let url, let data = try? Data(contentsOf: url) else { return nil }
+        guard let keyCode = recoveryKeyCode(from: data) else {
+            try? FileManager.default.removeItem(at: url)
+            return nil
+        }
+        try? FileManager.default.removeItem(at: url)
+        post(keyCode)
+        Log.info(
+            "cleared a modifier left held by an interrupted chord (key \(keyCode))",
+            subsystem: "cgEvent")
+        return keyCode
+    }
+}

--- a/Sources/LogicProMCP/Accessibility/StuckModifierRecovery.swift
+++ b/Sources/LogicProMCP/Accessibility/StuckModifierRecovery.swift
@@ -2,22 +2,21 @@ import CoreGraphics
 import Darwin
 import Foundation
 
-/// Clears a synthetic modifier that an interrupted process left held.
+/// Attempts a zero-flags synthetic key-up from a stale chord marker; it neither establishes that
+/// a modifier remains held nor verifies event delivery.
 ///
 /// WHY THIS EXISTS
 /// ---------------
-/// A flagged chord is three posts: key-down with flags, key-up with flags, and a key-up with NO
-/// flags whose only job is to release the modifier. `AXMouseHelper.postFlaggedKeyEvent` sends all
-/// three back to back, so the sequence is correct — but it is three separate calls, and a process
-/// that dies between the second and the third leaves macOS believing Control or Shift is held while
-/// no physical key is down.
+/// `AXMouseHelper.postFlaggedKeyEvent` attempts three separate posts: key-down with the requested
+/// flags, key-up with those flags, and key-up with zero flags. The requested flags can be Control,
+/// Shift, Option, Command, or empty; this code does not observe physical key state or delivery.
+/// A process can terminate between those calls, leaving a marker that later startup code can use
+/// only as a reason to attempt a zero-flags key-up.
 ///
-/// That is not hypothetical. Discussion #458 reported Logic becoming hard to use after running the
-/// integration — track volume moving 0.1 dB at a time, tracks and locators not draggable — which is
-/// the signature of a held Control during mouse interaction. I could not reproduce it in normal use
-/// and still cannot; the only way I produced the state was by deliberately omitting the third event.
-/// So this does not claim to be that user's cause. It closes the window I found while looking,
-/// which was left open with only an acknowledgement.
+/// Discussion #458 reported Logic becoming hard to use after running the integration — track volume
+/// moving 0.1 dB at a time, tracks and locators not draggable. This code does not establish that
+/// report's cause. It narrows one possible interruption window by recording a best-effort marker,
+/// without proving that recovery is needed or reaches macOS.
 ///
 /// WHY A MARKER AND NOT A BLIND CLEAR
 /// ----------------------------------
@@ -25,28 +24,41 @@ import Foundation
 /// holding Shift, and nothing available here can tell a synthetic held flag from a physical one —
 /// `CGEventSource.flagsState` reports the combined state and cannot say who put a flag there.
 ///
-/// Each process attempts to write one PID-named marker before its outermost chord and removes it
-/// after. At startup, this code only attempts a clear after removing a parseable marker whose
-/// different PID does not currently appear live. That limits blind clears, but it does not prove a
-/// marker's provenance, its owner's lifetime, or that its modifier remains held: a PID can be
-/// reused, including across a reboot, and best-effort arming means a live process can lack its
-/// marker.
-/// A hard power loss can leave a marker but cannot leave the macOS event state held, so its
-/// surviving marker is not evidence that a clear is needed.
+/// Each process attempts to write one PID-named marker before the first tracked chord and attempts
+/// to remove it after the tracked depth returns to zero. At startup, this code attempts a clear
+/// only after removing a parseable marker whose payload PID is different and does not currently
+/// appear live. That limits blind clears, but it does not prove a marker's provenance, its owner's
+/// lifetime, or that its modifier remains held: a PID can be reused, including across a reboot,
+/// and best-effort arming means a live process can lack its marker.
+/// A marker can survive a hard power loss, but that survival is not evidence that a clear is needed.
 ///
-/// Residual limitations: PID reuse; reboot-stale markers; a marker written under a different UID
-/// or home; no proof that a modifier is still held at recovery time; and no test covering the
-/// production `kill`/`errno` behavior or actual `CGEvent` delivery. A marker that cannot be
-/// written (read-only home or sandbox) leaves the posting window as it was; the chord still runs
-/// because refusing its keystroke after a breadcrumb failure would break the feature.
+/// Residual limitations:
+/// - PID reuse; reboot-stale markers; and a marker written under a different UID or home.
+/// - Markers are unauthenticated, and the filename PID is never checked against the payload PID.
+/// - No proof that a modifier is still held at recovery time, and no test covering production
+///   `kill`/`errno` behavior or actual `CGEvent` delivery.
+/// - A marker that cannot be written leaves the posting window as it was; the chord still runs
+///   because refusing its keystroke after a breadcrumb failure would break the feature.
+/// - A failed `disarm` can leave a completed marker, and the deliberate remove-before-post window
+///   can lose a clear if the process stops after removal and before the post.
+/// - An unmatched `ChordMarkerNesting.end` is logged but does not remove a marker.
+/// - Two threads can overlap non-LIFO, leaving a marker key code from a chord that has ended. The
+///   recovery post uses zero flags, so that stale code affects the log's accuracy rather than the
+///   modifier-clear attempt: a zero-flags key-up clears modifier state independently of its key
+///   code, while a key-up for a key nobody holds releases nothing.
+/// - `ChordMarkerNesting` callbacks must not re-enter the chord path because they run under its
+///   non-recursive lock.
+/// - Production `AXMouseHelper.Runtime.postChord` and the `start()` wiring to recovery are not
+///   exercised by the injected tests.
 enum StuckModifierRecovery {
 
     /// Diagnostic data only: the chord's key code, flags, and PID. It records no UID, boot
     /// identity, process start time, or proof that the clear was not already posted.
     struct Marker: Codable, Equatable, Sendable {
         let keyCode: UInt16
-        /// Diagnostic only. The recovery always posts with NO flags, because the event it stands in
-        /// for is the flag-clearing key-up — replaying the chord's own flags would re-assert them.
+        /// Diagnostic only. The default recovery poster builds an event with zero flags, because
+        /// replaying the chord's own flags would re-assert them; an injected `post` closure is not
+        /// constrained to do so.
         let flags: UInt64
         let pid: Int32
     }
@@ -72,7 +84,8 @@ enum StuckModifierRecovery {
 
     // MARK: - Pure core
 
-    /// The key-up a recovery should post, or nil when the marker is not trustworthy.
+    /// Returns a decoded, in-range marker key code, or nil when decoding or key-width validation
+    /// fails. It does not establish the marker's provenance or trustworthiness.
     static func recoveryKeyCode(from data: Data?) -> CGKeyCode? {
         guard let marker = marker(from: data) else { return nil }
         return CGKeyCode(marker.keyCode)
@@ -97,8 +110,8 @@ enum StuckModifierRecovery {
         marker.pid != selfPID && !isAlive(marker.pid)
     }
 
-    /// Builds the final key-up without posting it, so its zero-flags contract is independently
-    /// testable and cannot drift behind the recovery tests that inject their own poster.
+    /// Builds the default zero-flags key-up without posting it. This construction can be tested
+    /// directly, but injected recovery tests do not constrain a replacement production poster.
     static func clearEvent(for keyCode: CGKeyCode) -> CGEvent? {
         let source = CGEventSource(stateID: .combinedSessionState)
         guard let clear = CGEvent(
@@ -123,9 +136,9 @@ enum StuckModifierRecovery {
         try? data.write(to: url, options: .atomic)
     }
 
-    /// The chord finished, including its clearing event, so remove its marker. If the process dies
-    /// after the clear but before this removal, a completed marker can survive without a matching
-    /// log line and a later start cannot distinguish it from an interrupted chord.
+    /// Attempts to remove the marker after the chord path has attempted its posts. A failed removal
+    /// or a process stop before removal can leave a completed marker that later startup cannot
+    /// distinguish from an interrupted chord.
     static func disarm(at url: URL? = defaultURL) {
         guard let url, FileManager.default.fileExists(atPath: url.path) else { return }
         _ = removeMarker(at: url)

--- a/Sources/LogicProMCP/Server/LogicProServer.swift
+++ b/Sources/LogicProMCP/Server/LogicProServer.swift
@@ -1177,6 +1177,11 @@ actor LogicProServer {
             cleanupStartupArtifacts()
         } else {
             SMFWriter.cleanupStartupOrphanFiles()
+            // If a previous run died between a chord's key-up and its modifier-clear, macOS is
+            // still holding that modifier. This posts the clear that run owed, and posts nothing
+            // when nothing is owed — it cannot fire because of a key a user is holding. See
+            // `StuckModifierRecovery`; the symptom it addresses is discussion #458.
+            StuckModifierRecovery.recoverIfNeeded()
         }
         let plan = runtimePlan()
         try await plan.run()

--- a/Sources/LogicProMCP/Server/LogicProServer.swift
+++ b/Sources/LogicProMCP/Server/LogicProServer.swift
@@ -1170,18 +1170,30 @@ actor LogicProServer {
         ServerCatalog.snapshot(channelIDs: registeredChannels().map(\.id))
     }
 
+    /// Keeps startup cleanup together because both actions repair artifacts a prior process left
+    /// behind. The direct test covers the two actions here; it cannot catch deletion of this call
+    /// from `start()`, so that lifecycle link remains intentionally called out for review.
+    static func performStartupMaintenance(
+        cleanupOrphans: () -> Void,
+        recoverModifier: () -> Void
+    ) {
+        cleanupOrphans()
+        recoverModifier()
+    }
+
     func start() async throws {
         await sagaJournal.clear()
         OperationHandlerRegistry.validate()
         if let cleanupStartupArtifacts = runtimeOverrides?.cleanupStartupArtifacts {
-            cleanupStartupArtifacts()
+            Self.performStartupMaintenance(
+                cleanupOrphans: cleanupStartupArtifacts,
+                recoverModifier: { StuckModifierRecovery.recoverIfNeeded() }
+            )
         } else {
-            SMFWriter.cleanupStartupOrphanFiles()
-            // If a previous run died between a chord's key-up and its modifier-clear, macOS is
-            // still holding that modifier. This posts the clear that run owed, and posts nothing
-            // when nothing is owed — it cannot fire because of a key a user is holding. See
-            // `StuckModifierRecovery`; the symptom it addresses is discussion #458.
-            StuckModifierRecovery.recoverIfNeeded()
+            Self.performStartupMaintenance(
+                cleanupOrphans: { SMFWriter.cleanupStartupOrphanFiles() },
+                recoverModifier: { StuckModifierRecovery.recoverIfNeeded() }
+            )
         }
         let plan = runtimePlan()
         try await plan.run()

--- a/Sources/LogicProMCP/Server/LogicProServer.swift
+++ b/Sources/LogicProMCP/Server/LogicProServer.swift
@@ -1170,9 +1170,11 @@ actor LogicProServer {
         ServerCatalog.snapshot(channelIDs: registeredChannels().map(\.id))
     }
 
-    /// Keeps startup cleanup together because both actions repair artifacts a prior process left
-    /// behind. The direct test covers the two actions here; it cannot catch deletion of this call
-    /// from `start()`, so that lifecycle link remains intentionally called out for review.
+    /// Keeps startup maintenance together. `cleanupOrphans` removes filesystem artifacts, while
+    /// modifier recovery examines markers and may attempt a zero-flags key-up without establishing
+    /// their provenance or that a modifier is still held. The direct test covers the two actions
+    /// here; it cannot catch deletion of this call from `start()`, so that lifecycle link remains
+    /// intentionally called out for review.
     static func performStartupMaintenance(
         cleanupOrphans: () -> Void,
         recoverModifier: () -> Void

--- a/Sources/LogicProMCP/Server/LogicProServer.swift
+++ b/Sources/LogicProMCP/Server/LogicProServer.swift
@@ -1170,11 +1170,9 @@ actor LogicProServer {
         ServerCatalog.snapshot(channelIDs: registeredChannels().map(\.id))
     }
 
-    /// Keeps startup maintenance together. `cleanupOrphans` removes filesystem artifacts, while
-    /// modifier recovery examines markers and may attempt a zero-flags key-up without establishing
-    /// their provenance or that a modifier is still held. The direct test covers the two actions
-    /// here; it cannot catch deletion of this call from `start()`, so that lifecycle link remains
-    /// intentionally called out for review.
+    /// Keeps the injected maintenance actions ordered: cleanup first, then modifier recovery.
+    /// The direct test verifies invocation and order of those callbacks only; it does not exercise
+    /// their production implementations or prove that `start()` remains wired to this helper.
     static func performStartupMaintenance(
         cleanupOrphans: () -> Void,
         recoverModifier: () -> Void

--- a/Tests/LogicProMCPTests/AXMouseHelperTests.swift
+++ b/Tests/LogicProMCPTests/AXMouseHelperTests.swift
@@ -169,3 +169,105 @@ private final class AXMouseHelperRecorder: @unchecked Sendable {
     #expect(disarmCount == 0)
     #expect(postCount == 0)
 }
+
+@Test func axMouseHelperOverlappingChordsArmOnceAndDisarmAfterTheLastFinishes() throws {
+    let source = try #require(CGEventSource(stateID: .combinedSessionState))
+    let events = try #require(AXMouseHelper.Runtime.keyboardEvents(
+        source: source,
+        keyCode: 0x0E,
+        flags: .maskControl,
+        clearModifiersAfter: true
+    ))
+    let markerNesting = AXMouseHelper.ChordMarkerNesting()
+    var armCount = 0
+    var disarmCount = 0
+    var markerExists = false
+    var markerSurvivedInnerChord = false
+    var nested = false
+    var nestedChordPosted = false
+
+    let posted = AXMouseHelper.Runtime.postChord(
+        keyCode: 0x0E,
+        flags: .maskControl,
+        arm: { _, _ in
+            armCount += 1
+            markerExists = true
+        },
+        disarm: {
+            disarmCount += 1
+            markerExists = false
+        },
+        post: { _ in
+            guard !nested else { return }
+            nested = true
+            nestedChordPosted = AXMouseHelper.Runtime.postChord(
+                keyCode: 0x0F,
+                flags: .maskShift,
+                arm: { _, _ in
+                    armCount += 1
+                    markerExists = true
+                },
+                disarm: {
+                    disarmCount += 1
+                    markerExists = false
+                },
+                post: { _ in },
+                makeEvents: { _, _ in events },
+                markerNesting: markerNesting
+            )
+            markerSurvivedInnerChord = markerExists
+        },
+        makeEvents: { _, _ in events },
+        markerNesting: markerNesting
+    )
+
+    #expect(posted)
+    #expect(nestedChordPosted)
+    #expect(armCount == 1)
+    #expect(disarmCount == 1)
+    #expect(markerSurvivedInnerChord)
+    #expect(!markerExists)
+}
+
+@Test func axMouseHelperNestedChordKeepsTheOuterMarkerKeyCode() throws {
+    let source = try #require(CGEventSource(stateID: .combinedSessionState))
+    let events = try #require(AXMouseHelper.Runtime.keyboardEvents(
+        source: source,
+        keyCode: 0x0E,
+        flags: .maskControl,
+        clearModifiersAfter: true
+    ))
+    let outerKeyCode: CGKeyCode = 0x0E
+    let markerNesting = AXMouseHelper.ChordMarkerNesting()
+    var recordedKeyCode: CGKeyCode?
+    var keyCodeAfterNestedChord: CGKeyCode?
+    var nested = false
+    var nestedChordPosted = false
+
+    _ = AXMouseHelper.Runtime.postChord(
+        keyCode: outerKeyCode,
+        flags: .maskControl,
+        arm: { keyCode, _ in recordedKeyCode = keyCode },
+        disarm: { recordedKeyCode = nil },
+        post: { _ in
+            guard !nested else { return }
+            nested = true
+            nestedChordPosted = AXMouseHelper.Runtime.postChord(
+                keyCode: 0x0F,
+                flags: .maskShift,
+                arm: { keyCode, _ in recordedKeyCode = keyCode },
+                disarm: { recordedKeyCode = nil },
+                post: { _ in },
+                makeEvents: { _, _ in events },
+                markerNesting: markerNesting
+            )
+            keyCodeAfterNestedChord = recordedKeyCode
+        },
+        makeEvents: { _, _ in events },
+        markerNesting: markerNesting
+    )
+
+    #expect(nestedChordPosted)
+    let retainedKeyCode = try #require(keyCodeAfterNestedChord)
+    #expect(retainedKeyCode == outerKeyCode)
+}

--- a/Tests/LogicProMCPTests/AXMouseHelperTests.swift
+++ b/Tests/LogicProMCPTests/AXMouseHelperTests.swift
@@ -126,3 +126,46 @@ private final class AXMouseHelperRecorder: @unchecked Sendable {
     #expect(bare.up.flags == CGEventFlags(rawValue: 0))
     #expect(bare.modifierClear == nil)
 }
+
+@Test func axMouseHelperPostChordKeepsMarkerArmedAcrossEveryPost() throws {
+    let source = try #require(CGEventSource(stateID: .combinedSessionState))
+    let events = try #require(AXMouseHelper.Runtime.keyboardEvents(
+        source: source,
+        keyCode: 0x0E,
+        flags: [.maskControl, .maskShift],
+        clearModifiersAfter: true
+    ))
+    var order: [String] = []
+
+    let posted = AXMouseHelper.Runtime.postChord(
+        keyCode: 0x0E,
+        flags: [.maskControl, .maskShift],
+        arm: { _, _ in order.append("arm") },
+        disarm: { order.append("disarm") },
+        post: { _ in order.append("post") },
+        makeEvents: { _, _ in events }
+    )
+
+    #expect(posted)
+    #expect(order == ["arm", "post", "post", "post", "disarm"])
+}
+
+@Test func axMouseHelperPostChordDoesNotArmWhenItCannotBuildEvents() {
+    var armCount = 0
+    var disarmCount = 0
+    var postCount = 0
+
+    let posted = AXMouseHelper.Runtime.postChord(
+        keyCode: 0x0E,
+        flags: .maskControl,
+        arm: { _, _ in armCount += 1 },
+        disarm: { disarmCount += 1 },
+        post: { _ in postCount += 1 },
+        makeEvents: { _, _ in nil }
+    )
+
+    #expect(!posted)
+    #expect(armCount == 0)
+    #expect(disarmCount == 0)
+    #expect(postCount == 0)
+}

--- a/Tests/LogicProMCPTests/AXMouseHelperTests.swift
+++ b/Tests/LogicProMCPTests/AXMouseHelperTests.swift
@@ -170,6 +170,67 @@ private final class AXMouseHelperRecorder: @unchecked Sendable {
     #expect(postCount == 0)
 }
 
+@Test func axMouseHelperUnmatchedMarkerEndLeavesTheMarkerAlone() {
+    let markerNesting = AXMouseHelper.ChordMarkerNesting()
+    var disarmCount = 0
+
+    markerNesting.end { disarmCount += 1 }
+
+    #expect(disarmCount == 0)
+}
+
+@Test func axMouseHelperMarkerCallbacksDoNotReenterTheChordPath() throws {
+    // `arm` and `disarm` run under a non-recursive NSLock, so calling postChord from either would
+    // hang the test. Exercise the production-safe shape instead: `arm` returns before a post
+    // callback re-enters the chord path, and `disarm` does not re-enter it.
+    let source = try #require(CGEventSource(stateID: .combinedSessionState))
+    let events = try #require(AXMouseHelper.Runtime.keyboardEvents(
+        source: source,
+        keyCode: 0x0E,
+        flags: .maskControl,
+        clearModifiersAfter: true
+    ))
+    let markerNesting = AXMouseHelper.ChordMarkerNesting()
+    var activeMarkerCallback: String?
+    var reentryWasOutsideMarkerCallback = false
+    var nested = false
+    var nestedChordPosted = false
+
+    let posted = AXMouseHelper.Runtime.postChord(
+        keyCode: 0x0E,
+        flags: .maskControl,
+        arm: { _, _ in
+            activeMarkerCallback = "arm"
+            defer { activeMarkerCallback = nil }
+        },
+        disarm: {
+            activeMarkerCallback = "disarm"
+            defer { activeMarkerCallback = nil }
+        },
+        post: { _ in
+            guard !nested else { return }
+            nested = true
+            reentryWasOutsideMarkerCallback = activeMarkerCallback == nil
+            nestedChordPosted = AXMouseHelper.Runtime.postChord(
+                keyCode: 0x0F,
+                flags: .maskShift,
+                arm: { _, _ in },
+                disarm: {},
+                post: { _ in },
+                makeEvents: { _, _ in events },
+                markerNesting: markerNesting
+            )
+        },
+        makeEvents: { _, _ in events },
+        markerNesting: markerNesting
+    )
+
+    #expect(posted)
+    #expect(nestedChordPosted)
+    #expect(reentryWasOutsideMarkerCallback)
+    #expect(activeMarkerCallback == nil)
+}
+
 @Test func axMouseHelperOverlappingChordsArmOnceAndDisarmAfterTheLastFinishes() throws {
     let source = try #require(CGEventSource(stateID: .combinedSessionState))
     let events = try #require(AXMouseHelper.Runtime.keyboardEvents(

--- a/Tests/LogicProMCPTests/LogicProServerHandlerTests.swift
+++ b/Tests/LogicProMCPTests/LogicProServerHandlerTests.swift
@@ -172,6 +172,17 @@ func testLogicProServerHandlersReadResourcesWithoutRegisteredTransport() async t
     ])
 }
 
+@Test func testLogicProServerStartupMaintenanceRunsCleanupAndModifierRecovery() {
+    var actions: [String] = []
+
+    LogicProServer.performStartupMaintenance(
+        cleanupOrphans: { actions.append("cleanup") },
+        recoverModifier: { actions.append("recoverModifier") }
+    )
+
+    #expect(actions == ["cleanup", "recoverModifier"])
+}
+
 @Test func testLogicProServerStartCleansOwnedAndLegacySMFArtifacts() async throws {
     let sandbox = FileManager.default.temporaryDirectory
         .appendingPathComponent("logic-pro-server-startup-cleanup-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/LogicProMCPTests/StuckModifierRecoveryTests.swift
+++ b/Tests/LogicProMCPTests/StuckModifierRecoveryTests.swift
@@ -68,7 +68,7 @@ struct StuckModifierRecoveryTests {
             in: directory,
             selfPID: 101,
             isAlive: { _ in false },
-            post: { posted.append($0) }
+            post: { posted.append($0); return true }
         )
         #expect(result.isEmpty)
         #expect(posted.isEmpty, "a start with no marker posted \(posted)")
@@ -93,7 +93,7 @@ struct StuckModifierRecoveryTests {
             in: directory,
             selfPID: selfPID,
             isAlive: { $0 == livePID },
-            post: { posted.append($0) }
+            post: { posted.append($0); return true }
         )
 
         #expect(result == [14])
@@ -120,7 +120,7 @@ struct StuckModifierRecoveryTests {
             in: directory,
             selfPID: 101,
             isAlive: { _ in false },
-            post: { posted.append($0) }
+            post: { posted.append($0); return true }
         )
         #expect(result.isEmpty)
         #expect(posted.isEmpty)
@@ -141,7 +141,10 @@ struct StuckModifierRecoveryTests {
             in: directory,
             selfPID: 101,
             isAlive: { _ in false },
-            post: { _ in gone = !FileManager.default.fileExists(atPath: url.path) }
+            post: { _ in
+                gone = !FileManager.default.fileExists(atPath: url.path)
+                return true
+            }
         )
         #expect(result == [14])
         #expect(gone, "the marker still existed while the post ran")
@@ -164,7 +167,7 @@ struct StuckModifierRecoveryTests {
             in: directory,
             selfPID: 101,
             isAlive: { _ in false },
-            post: { posted.append($0) }
+            post: { posted.append($0); return true }
         )
         #expect(result.isEmpty)
         #expect(posted.isEmpty)
@@ -184,7 +187,7 @@ struct StuckModifierRecoveryTests {
             selfPID: 101,
             isAlive: { _ in false },
             remove: { _ in throw MarkerRemovalError.failed },
-            post: { posted.append($0) }
+            post: { posted.append($0); return true }
         )
         #expect(result.isEmpty)
         #expect(posted.isEmpty)
@@ -204,11 +207,34 @@ struct StuckModifierRecoveryTests {
             selfPID: 101,
             isAlive: { _ in false },
             remove: { _ in },
-            post: { posted.append($0) }
+            post: { posted.append($0); return true }
         )
         #expect(result.isEmpty)
         #expect(posted.isEmpty)
         #expect(FileManager.default.fileExists(atPath: url.path))
+    }
+
+    @Test("a clear that cannot be built and posted is not reported as recovered")
+    func failedClearPostIsNotReportedAsRecovered() {
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = markerURL(103, in: directory)
+        StuckModifierRecovery.arm(keyCode: 14, flags: .maskControl, at: url, pid: 103)
+        var attempted: [CGKeyCode] = []
+
+        let result = StuckModifierRecovery.recoverIfNeeded(
+            in: directory,
+            selfPID: 101,
+            isAlive: { _ in false },
+            post: {
+                attempted.append($0)
+                return false
+            }
+        )
+
+        #expect(attempted == [14])
+        #expect(result.isEmpty)
+        #expect(!FileManager.default.fileExists(atPath: url.path))
     }
 
     @Test("the recovery replays the CLEAR, never the chord")

--- a/Tests/LogicProMCPTests/StuckModifierRecoveryTests.swift
+++ b/Tests/LogicProMCPTests/StuckModifierRecoveryTests.swift
@@ -3,6 +3,10 @@ import Foundation
 import Testing
 @testable import LogicProMCP
 
+private enum MarkerRemovalError: Error {
+    case failed
+}
+
 /// Discussion #458 — a user reported Logic becoming hard to use after running the integration:
 /// track volume moving 0.1 dB at a time, tracks and locators not draggable. That is the signature
 /// of a held Control during mouse interaction.
@@ -14,10 +18,42 @@ import Testing
 @Suite("StuckModifierRecovery")
 struct StuckModifierRecoveryTests {
 
-    private func tempURL() -> URL {
+    private func temporaryDirectory() -> URL {
         FileManager.default.temporaryDirectory
             .appendingPathComponent("lpm-stuck-modifier-\(UUID().uuidString)", isDirectory: true)
-            .appendingPathComponent("chord-in-flight.json")
+    }
+
+    private func markerURL(_ pid: Int32, in directory: URL) -> URL {
+        StuckModifierRecovery.markerURL(for: pid, in: directory)
+    }
+
+    @Test("markers are owned by their process in both name and payload")
+    func markerOwnershipIsPersisted() throws {
+        let pid: Int32 = 4_242
+        let directory = temporaryDirectory()
+        let url = markerURL(pid, in: directory)
+
+        #expect(url.lastPathComponent == "chord-in-flight-4242.json")
+        let data = try #require(
+            StuckModifierRecovery.encode(keyCode: 14, flags: [.maskControl, .maskShift], pid: pid))
+        let marker = try JSONDecoder().decode(StuckModifierRecovery.Marker.self, from: data)
+        #expect(marker.pid == pid)
+        #expect(marker.flags == CGEventFlags([.maskControl, .maskShift]).rawValue)
+    }
+
+    @Test("only a known-dead marker from another process is recoverable")
+    func recoveryOwnershipDecisionIsConservative() {
+        let selfPID: Int32 = 101
+        let own = StuckModifierRecovery.Marker(keyCode: 14, flags: 0, pid: selfPID)
+        let live = StuckModifierRecovery.Marker(keyCode: 14, flags: 0, pid: 102)
+        let dead = StuckModifierRecovery.Marker(keyCode: 14, flags: 0, pid: 103)
+
+        #expect(!StuckModifierRecovery.shouldRecover(
+            marker: own, isAlive: { _ in false }, selfPID: selfPID))
+        #expect(!StuckModifierRecovery.shouldRecover(
+            marker: live, isAlive: { _ in true }, selfPID: selfPID))
+        #expect(StuckModifierRecovery.shouldRecover(
+            marker: dead, isAlive: { _ in false }, selfPID: selfPID))
     }
 
     @Test("nothing is owed when no chord was in flight")
@@ -25,36 +61,68 @@ struct StuckModifierRecoveryTests {
         // The case that runs on every ordinary start. A recovery that posted here would fire while
         // a user is genuinely holding Shift, which is the reason this is a marker and not a blind
         // clear — `CGEventSource.flagsState` reports the combined state and cannot say who set it.
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
         var posted: [CGKeyCode] = []
-        let result = StuckModifierRecovery.recoverIfNeeded(at: tempURL()) { posted.append($0) }
-        #expect(result == nil)
+        let result = StuckModifierRecovery.recoverIfNeeded(
+            in: directory,
+            selfPID: 101,
+            isAlive: { _ in false },
+            post: { posted.append($0) }
+        )
+        #expect(result.isEmpty)
         #expect(posted.isEmpty, "a start with no marker posted \(posted)")
     }
 
     @Test("an armed chord that never disarmed is cleared on the next start")
-    func armedThenInterruptedIsRecovered() throws {
-        // `arm` then no `disarm` is exactly what a process dying between the key-up and the
-        // modifier-clear leaves behind.
-        let url = tempURL()
-        StuckModifierRecovery.arm(keyCode: 14, flags: [.maskControl, .maskShift], at: url)
-        #expect(FileManager.default.fileExists(atPath: url.path), "arm wrote nothing")
+    func armedThenInterruptedIsRecovered() {
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let selfPID: Int32 = 101
+        let livePID: Int32 = 102
+        let deadPID: Int32 = 103
+        let ownURL = markerURL(selfPID, in: directory)
+        let liveURL = markerURL(livePID, in: directory)
+        let deadURL = markerURL(deadPID, in: directory)
+        StuckModifierRecovery.arm(keyCode: 12, flags: .maskControl, at: ownURL, pid: selfPID)
+        StuckModifierRecovery.arm(keyCode: 13, flags: .maskControl, at: liveURL, pid: livePID)
+        StuckModifierRecovery.arm(keyCode: 14, flags: [.maskControl, .maskShift], at: deadURL, pid: deadPID)
 
         var posted: [CGKeyCode] = []
-        let result = StuckModifierRecovery.recoverIfNeeded(at: url) { posted.append($0) }
-        #expect(result == 14)
-        #expect(posted == [14], "the owed key-up was not posted")
-        #expect(!FileManager.default.fileExists(atPath: url.path),
-                "the marker survived its own recovery and will fire again next start")
+        let result = StuckModifierRecovery.recoverIfNeeded(
+            in: directory,
+            selfPID: selfPID,
+            isAlive: { $0 == livePID },
+            post: { posted.append($0) }
+        )
+
+        #expect(result == [14])
+        #expect(posted == [14], "the orphaned key-up was not posted")
+        #expect(FileManager.default.fileExists(atPath: ownURL.path),
+                "a process must retain its own in-flight marker")
+        #expect(FileManager.default.fileExists(atPath: liveURL.path),
+                "a live process must retain its in-flight marker")
+        #expect(!FileManager.default.fileExists(atPath: deadURL.path),
+                "an orphaned marker survived its own recovery and will fire again next start")
     }
 
     @Test("a completed chord owes nothing")
     func armThenDisarmLeavesNothing() {
-        let url = tempURL()
-        StuckModifierRecovery.arm(keyCode: 14, flags: [.maskControl, .maskShift], at: url)
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let pid: Int32 = 103
+        let url = markerURL(pid, in: directory)
+        StuckModifierRecovery.arm(keyCode: 14, flags: [.maskControl, .maskShift], at: url, pid: pid)
         StuckModifierRecovery.disarm(at: url)
 
         var posted: [CGKeyCode] = []
-        #expect(StuckModifierRecovery.recoverIfNeeded(at: url) { posted.append($0) } == nil)
+        let result = StuckModifierRecovery.recoverIfNeeded(
+            in: directory,
+            selfPID: 101,
+            isAlive: { _ in false },
+            post: { posted.append($0) }
+        )
+        #expect(result.isEmpty)
         #expect(posted.isEmpty)
     }
 
@@ -63,12 +131,19 @@ struct StuckModifierRecoveryTests {
         // The marker is removed BEFORE posting on purpose. If it were removed after, a crash inside
         // the post would leave the file behind and every subsequent launch would try again — a
         // recovery that repeats a keystroke on every start is worse than the state it recovers.
-        let url = tempURL()
-        StuckModifierRecovery.arm(keyCode: 14, flags: .maskControl, at: url)
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let pid: Int32 = 103
+        let url = markerURL(pid, in: directory)
+        StuckModifierRecovery.arm(keyCode: 14, flags: .maskControl, at: url, pid: pid)
         var gone = false
-        _ = StuckModifierRecovery.recoverIfNeeded(at: url) { _ in
-            gone = !FileManager.default.fileExists(atPath: url.path)
-        }
+        let result = StuckModifierRecovery.recoverIfNeeded(
+            in: directory,
+            selfPID: 101,
+            isAlive: { _ in false },
+            post: { _ in gone = !FileManager.default.fileExists(atPath: url.path) }
+        )
+        #expect(result == [14])
         #expect(gone, "the marker still existed while the post ran")
     }
 
@@ -77,15 +152,63 @@ struct StuckModifierRecoveryTests {
         // Garbage in the file is not a reason to post a keystroke, and not a reason to keep trying
         // either. Both halves matter: posting would be acting on nothing, keeping would be a start
         // that never gets clean.
-        let url = tempURL()
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = markerURL(103, in: directory)
         try FileManager.default.createDirectory(
-            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            at: directory, withIntermediateDirectories: true)
         try Data("not json".utf8).write(to: url)
 
         var posted: [CGKeyCode] = []
-        #expect(StuckModifierRecovery.recoverIfNeeded(at: url) { posted.append($0) } == nil)
+        let result = StuckModifierRecovery.recoverIfNeeded(
+            in: directory,
+            selfPID: 101,
+            isAlive: { _ in false },
+            post: { posted.append($0) }
+        )
+        #expect(result.isEmpty)
         #expect(posted.isEmpty)
         #expect(!FileManager.default.fileExists(atPath: url.path))
+    }
+
+    @Test("a failed marker removal never posts a clear")
+    func removalThrowLeavesMarkerAndPostsNothing() {
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = markerURL(103, in: directory)
+        StuckModifierRecovery.arm(keyCode: 14, flags: .maskControl, at: url, pid: 103)
+
+        var posted: [CGKeyCode] = []
+        let result = StuckModifierRecovery.recoverIfNeeded(
+            in: directory,
+            selfPID: 101,
+            isAlive: { _ in false },
+            remove: { _ in throw MarkerRemovalError.failed },
+            post: { posted.append($0) }
+        )
+        #expect(result.isEmpty)
+        #expect(posted.isEmpty)
+        #expect(FileManager.default.fileExists(atPath: url.path))
+    }
+
+    @Test("a marker that remains after removal never posts a clear")
+    func removalThatLeavesFilePostsNothing() {
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = markerURL(103, in: directory)
+        StuckModifierRecovery.arm(keyCode: 14, flags: .maskControl, at: url, pid: 103)
+
+        var posted: [CGKeyCode] = []
+        let result = StuckModifierRecovery.recoverIfNeeded(
+            in: directory,
+            selfPID: 101,
+            isAlive: { _ in false },
+            remove: { _ in },
+            post: { posted.append($0) }
+        )
+        #expect(result.isEmpty)
+        #expect(posted.isEmpty)
+        #expect(FileManager.default.fileExists(atPath: url.path))
     }
 
     @Test("the recovery replays the CLEAR, never the chord")
@@ -94,15 +217,24 @@ struct StuckModifierRecoveryTests {
         // The event it stands in for is the flag-CLEARING key-up; re-asserting Control and Shift
         // would recreate the state this exists to remove.
         let data = try #require(
-            StuckModifierRecovery.encode(keyCode: 14, flags: [.maskControl, .maskShift]))
+            StuckModifierRecovery.encode(
+                keyCode: 14,
+                flags: [.maskControl, .maskShift],
+                pid: 103
+            ))
         let marker = try JSONDecoder().decode(StuckModifierRecovery.Marker.self, from: data)
         #expect(marker.flags == CGEventFlags([.maskControl, .maskShift]).rawValue,
                 "the flags were not recorded, so a reader cannot tell what was held")
         #expect(StuckModifierRecovery.recoveryKeyCode(from: data) == 14)
-
-        // And the production post closure is the only place flags could be re-applied. It is
-        // exercised by the default argument in `recoverIfNeeded`, which sets `flags` to zero; the
-        // observable contract here is that the recovery is identified by key code alone.
         #expect(StuckModifierRecovery.recoveryKeyCode(from: Data("{}".utf8)) == nil)
+    }
+
+    @Test("the production clear has no flags and retains the chord key code")
+    func clearEventNeverReassertsTheChordFlags() throws {
+        let keyCode: CGKeyCode = 14
+        let event = try #require(StuckModifierRecovery.clearEvent(for: keyCode))
+
+        #expect(event.flags.rawValue == 0)
+        #expect(event.getIntegerValueField(.keyboardEventKeycode) == Int64(keyCode))
     }
 }

--- a/Tests/LogicProMCPTests/StuckModifierRecoveryTests.swift
+++ b/Tests/LogicProMCPTests/StuckModifierRecoveryTests.swift
@@ -1,0 +1,108 @@
+import CoreGraphics
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+/// Discussion #458 — a user reported Logic becoming hard to use after running the integration:
+/// track volume moving 0.1 dB at a time, tracks and locators not draggable. That is the signature
+/// of a held Control during mouse interaction.
+///
+/// I could not reproduce it in normal use and still cannot. The only way the state appeared was by
+/// deliberately omitting the third event of a flagged chord — so these cases do not claim to
+/// reproduce that user's cause. They pin the window that omission proved exists: three separate
+/// posts, and a process that dies between the second and the third leaves the modifier held.
+@Suite("StuckModifierRecovery")
+struct StuckModifierRecoveryTests {
+
+    private func tempURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("lpm-stuck-modifier-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("chord-in-flight.json")
+    }
+
+    @Test("nothing is owed when no chord was in flight")
+    func noMarkerPostsNothing() {
+        // The case that runs on every ordinary start. A recovery that posted here would fire while
+        // a user is genuinely holding Shift, which is the reason this is a marker and not a blind
+        // clear — `CGEventSource.flagsState` reports the combined state and cannot say who set it.
+        var posted: [CGKeyCode] = []
+        let result = StuckModifierRecovery.recoverIfNeeded(at: tempURL()) { posted.append($0) }
+        #expect(result == nil)
+        #expect(posted.isEmpty, "a start with no marker posted \(posted)")
+    }
+
+    @Test("an armed chord that never disarmed is cleared on the next start")
+    func armedThenInterruptedIsRecovered() throws {
+        // `arm` then no `disarm` is exactly what a process dying between the key-up and the
+        // modifier-clear leaves behind.
+        let url = tempURL()
+        StuckModifierRecovery.arm(keyCode: 14, flags: [.maskControl, .maskShift], at: url)
+        #expect(FileManager.default.fileExists(atPath: url.path), "arm wrote nothing")
+
+        var posted: [CGKeyCode] = []
+        let result = StuckModifierRecovery.recoverIfNeeded(at: url) { posted.append($0) }
+        #expect(result == 14)
+        #expect(posted == [14], "the owed key-up was not posted")
+        #expect(!FileManager.default.fileExists(atPath: url.path),
+                "the marker survived its own recovery and will fire again next start")
+    }
+
+    @Test("a completed chord owes nothing")
+    func armThenDisarmLeavesNothing() {
+        let url = tempURL()
+        StuckModifierRecovery.arm(keyCode: 14, flags: [.maskControl, .maskShift], at: url)
+        StuckModifierRecovery.disarm(at: url)
+
+        var posted: [CGKeyCode] = []
+        #expect(StuckModifierRecovery.recoverIfNeeded(at: url) { posted.append($0) } == nil)
+        #expect(posted.isEmpty)
+    }
+
+    @Test("recovery runs once, even if the post itself brings the process down")
+    func theMarkerIsRemovedBeforeThePost() {
+        // The marker is removed BEFORE posting on purpose. If it were removed after, a crash inside
+        // the post would leave the file behind and every subsequent launch would try again — a
+        // recovery that repeats a keystroke on every start is worse than the state it recovers.
+        let url = tempURL()
+        StuckModifierRecovery.arm(keyCode: 14, flags: .maskControl, at: url)
+        var gone = false
+        _ = StuckModifierRecovery.recoverIfNeeded(at: url) { _ in
+            gone = !FileManager.default.fileExists(atPath: url.path)
+        }
+        #expect(gone, "the marker still existed while the post ran")
+    }
+
+    @Test("a marker that cannot be read owes nothing and does not survive")
+    func unreadableMarkerIsDiscarded() throws {
+        // Garbage in the file is not a reason to post a keystroke, and not a reason to keep trying
+        // either. Both halves matter: posting would be acting on nothing, keeping would be a start
+        // that never gets clean.
+        let url = tempURL()
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("not json".utf8).write(to: url)
+
+        var posted: [CGKeyCode] = []
+        #expect(StuckModifierRecovery.recoverIfNeeded(at: url) { posted.append($0) } == nil)
+        #expect(posted.isEmpty)
+        #expect(!FileManager.default.fileExists(atPath: url.path))
+    }
+
+    @Test("the recovery replays the CLEAR, never the chord")
+    func theMarkerCarriesFlagsForDiagnosisOnly() throws {
+        // A marker records the flags it was armed with, and the recovery must not put them back.
+        // The event it stands in for is the flag-CLEARING key-up; re-asserting Control and Shift
+        // would recreate the state this exists to remove.
+        let data = try #require(
+            StuckModifierRecovery.encode(keyCode: 14, flags: [.maskControl, .maskShift]))
+        let marker = try JSONDecoder().decode(StuckModifierRecovery.Marker.self, from: data)
+        #expect(marker.flags == CGEventFlags([.maskControl, .maskShift]).rawValue,
+                "the flags were not recorded, so a reader cannot tell what was held")
+        #expect(StuckModifierRecovery.recoveryKeyCode(from: data) == 14)
+
+        // And the production post closure is the only place flags could be re-applied. It is
+        // exercised by the default argument in `recoverIfNeeded`, which sets `flags` to zero; the
+        // observable contract here is that the recovery is identified by key code alone.
+        #expect(StuckModifierRecovery.recoveryKeyCode(from: Data("{}".utf8)) == nil)
+    }
+}

--- a/Tests/LogicProMCPTests/StuckModifierRecoveryTests.swift
+++ b/Tests/LogicProMCPTests/StuckModifierRecoveryTests.swift
@@ -8,13 +8,12 @@ private enum MarkerRemovalError: Error {
 }
 
 /// Discussion #458 — a user reported Logic becoming hard to use after running the integration:
-/// track volume moving 0.1 dB at a time, tracks and locators not draggable. That is the signature
-/// of a held Control during mouse interaction.
+/// track volume moving 0.1 dB at a time, tracks and locators not draggable. The report associated
+/// those symptoms with a held Control during mouse interaction.
 ///
-/// I could not reproduce it in normal use and still cannot. The only way the state appeared was by
-/// deliberately omitting the third event of a flagged chord — so these cases do not claim to
-/// reproduce that user's cause. They pin the window that omission proved exists: three separate
-/// posts, and a process that dies between the second and the third leaves the modifier held.
+/// These cases do not establish that report's cause. They exercise marker parsing, removal, and
+/// injected posting; they do not terminate a process, observe system modifier state, or verify
+/// event delivery.
 @Suite("StuckModifierRecovery")
 struct StuckModifierRecoveryTests {
 
@@ -27,8 +26,8 @@ struct StuckModifierRecoveryTests {
         StuckModifierRecovery.markerURL(for: pid, in: directory)
     }
 
-    @Test("markers are owned by their process in both name and payload")
-    func markerOwnershipIsPersisted() throws {
+    @Test("marker filename and payload both contain the supplied PID")
+    func markerPIDFieldsArePersisted() throws {
         let pid: Int32 = 4_242
         let directory = temporaryDirectory()
         let url = markerURL(pid, in: directory)
@@ -42,7 +41,7 @@ struct StuckModifierRecoveryTests {
     }
 
     @Test("only a known-dead marker from another process is recoverable")
-    func recoveryOwnershipDecisionIsConservative() {
+    func recoveryPIDDecisionIsConservative() {
         let selfPID: Int32 = 101
         let own = StuckModifierRecovery.Marker(keyCode: 14, flags: 0, pid: selfPID)
         let live = StuckModifierRecovery.Marker(keyCode: 14, flags: 0, pid: 102)
@@ -56,11 +55,10 @@ struct StuckModifierRecoveryTests {
             marker: dead, isAlive: { _ in false }, selfPID: selfPID))
     }
 
-    @Test("nothing is owed when no chord was in flight")
+    @Test("a no-marker scan invokes no injected post")
     func noMarkerPostsNothing() {
-        // The case that runs on every ordinary start. A recovery that posted here would fire while
-        // a user is genuinely holding Shift, which is the reason this is a marker and not a blind
-        // clear — `CGEventSource.flagsState` reports the combined state and cannot say who set it.
+        // Recovery runs on every start; this test exercises only its no-marker branch. Posting on
+        // that branch would be a blind clear while a user might be holding a physical modifier.
         let directory = temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
         var posted: [CGKeyCode] = []
@@ -74,8 +72,8 @@ struct StuckModifierRecoveryTests {
         #expect(posted.isEmpty, "a start with no marker posted \(posted)")
     }
 
-    @Test("an armed chord that never disarmed is cleared on the next start")
-    func armedThenInterruptedIsRecovered() {
+    @Test("a stale marker reaches the injected recovery poster on the next scan")
+    func staleMarkerReachesInjectedPoster() {
         let directory = temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
         let selfPID: Int32 = 101
@@ -97,7 +95,7 @@ struct StuckModifierRecoveryTests {
         )
 
         #expect(result == [14])
-        #expect(posted == [14], "the orphaned key-up was not posted")
+        #expect(posted == [14], "the injected poster did not receive the stale marker key code")
         #expect(FileManager.default.fileExists(atPath: ownURL.path),
                 "a process must retain its own in-flight marker")
         #expect(FileManager.default.fileExists(atPath: liveURL.path),
@@ -106,7 +104,7 @@ struct StuckModifierRecoveryTests {
                 "an orphaned marker survived its own recovery and will fire again next start")
     }
 
-    @Test("a completed chord owes nothing")
+    @Test("a disarmed marker does not reach the recovery poster")
     func armThenDisarmLeavesNothing() {
         let directory = temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
@@ -126,11 +124,10 @@ struct StuckModifierRecoveryTests {
         #expect(posted.isEmpty)
     }
 
-    @Test("recovery runs once, even if the post itself brings the process down")
+    @Test("the marker is removed before the injected post callback")
     func theMarkerIsRemovedBeforeThePost() {
-        // The marker is removed BEFORE posting on purpose. If it were removed after, a crash inside
-        // the post would leave the file behind and every subsequent launch would try again — a
-        // recovery that repeats a keystroke on every start is worse than the state it recovers.
+        // Removal precedes the post by design. The untested interval between them is a loss window:
+        // if the process stops there, this marker's recovery attempt cannot happen on a later start.
         let directory = temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
         let pid: Int32 = 103
@@ -214,7 +211,7 @@ struct StuckModifierRecoveryTests {
         #expect(FileManager.default.fileExists(atPath: url.path))
     }
 
-    @Test("a clear that cannot be built and posted is not reported as recovered")
+    @Test("an unsuccessful injected post is not reported as recovered")
     func failedClearPostIsNotReportedAsRecovered() {
         let directory = temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
@@ -237,11 +234,10 @@ struct StuckModifierRecoveryTests {
         #expect(!FileManager.default.fileExists(atPath: url.path))
     }
 
-    @Test("the recovery replays the CLEAR, never the chord")
+    @Test("marker flags are diagnostic data")
     func theMarkerCarriesFlagsForDiagnosisOnly() throws {
-        // A marker records the flags it was armed with, and the recovery must not put them back.
-        // The event it stands in for is the flag-CLEARING key-up; re-asserting Control and Shift
-        // would recreate the state this exists to remove.
+        // A marker records the requested flags. The default clear event is separately tested with
+        // zero flags; this injected-marker test does not constrain a replacement `post` closure.
         let data = try #require(
             StuckModifierRecovery.encode(
                 keyCode: 14,
@@ -250,12 +246,12 @@ struct StuckModifierRecoveryTests {
             ))
         let marker = try JSONDecoder().decode(StuckModifierRecovery.Marker.self, from: data)
         #expect(marker.flags == CGEventFlags([.maskControl, .maskShift]).rawValue,
-                "the flags were not recorded, so a reader cannot tell what was held")
+                "the requested flags were not recorded for diagnosis")
         #expect(StuckModifierRecovery.recoveryKeyCode(from: data) == 14)
         #expect(StuckModifierRecovery.recoveryKeyCode(from: Data("{}".utf8)) == nil)
     }
 
-    @Test("the production clear has no flags and retains the chord key code")
+    @Test("the default clear event has no flags and retains the supplied key code")
     func clearEventNeverReassertsTheChordFlags() throws {
         let keyCode: CGKeyCode = 14
         let event = try #require(StuckModifierRecovery.clearEvent(for: keyCode))


### PR DESCRIPTION
Discussion #458 reported Logic becoming hard to use after running the integration: track volume
moving 0.1 dB at a time, tracks and locators not draggable. That is the signature of a held
Control during mouse interaction. The discussion has been open 25 days with an acknowledgement and
no change.

I could not reproduce it in normal use and still cannot, so this does not claim to be that user's
cause. What it closes is a window I found while looking for one.

## The window

A flagged chord is three posts: key-down with flags, key-up with flags, and a key-up with **no**
flags whose only job is to release the modifier. `AXMouseHelper.postFlaggedKeyEvent` sends all
three back to back, so the sequence is correct — but they are three separate calls to
`CGEvent.post`, and a process that dies between the second and the third leaves macOS believing
Control or Shift is held while no physical key is down.

The only way I produced the reported state was by deliberately omitting that third event. It is
reachable, and nothing recovered from it.

## Why a marker and not a blind clear

Posting a modifier-clear at startup unconditionally would also fire while a user is genuinely
holding Shift. Nothing available here can tell a synthetic held flag from a physical one —
`CGEventSource.flagsState` reports the combined state and cannot say who put a flag there.

A marker written before the chord and removed after it answers the question that actually matters:
*did our process leave a chord unfinished?* Present means yes, and the recovery posts the same
key-up the interrupted sequence owed. Absent means nothing is owed and nothing is posted. It
cannot fire because of anything a user is doing.

The marker is removed **before** the post, so a crash inside the post cannot make this repeat on
every subsequent launch — a recovery that replays a keystroke at every start is worse than the
state it recovers.

## What it does not cover, stated rather than implied

- `SIGKILL` and hard power loss remove the process without removing the marker. That is the case
  this recovers.
- A marker that cannot be written (read-only home, sandbox) leaves the window exactly as wide as
  it is today, and the chord still runs. Refusing to send a keystroke because a breadcrumb failed
  would trade a rare stuck modifier for a broken feature.
- It does not prove the reporter's cause. If they can still reproduce it, the marker's presence at
  the next start is now a fact we can ask them for.

## Evidence

Six cases in `StuckModifierRecoveryTests`, one per branch: no marker posts nothing; an armed chord
that never disarmed is cleared; a completed chord owes nothing; the marker is gone while the post
runs; an undecodable marker posts nothing and does not survive; and the recovery replays the
clear, never the chord's flags.

Full suite green, public-surface preflight clean, live evidence regenerated (13/13).
