### PR TITLE
docs(roadmap): replace three inherited plug-in AX walls with measurements

### DIFF
--- a/Scripts/check-roadmap-blockers-cite-measurements.py
+++ b/Scripts/check-roadmap-blockers-cite-measurements.py
@@ -32,13 +32,28 @@ So a row that mentions a wall must carry, in the same cell, either an ISO date o
 comment that recorded the measurement. That is a low bar deliberately — it is the bar that would
 have caught all three, and a higher one would be a bar on prose that nothing can enforce.
 
-It applies in BOTH directions, and that is not an accident of substring matching. "No measured AX
-wall in front of it" is as much a claim about the world as "AX-opaque", and it is the claim nobody
-asked #305 to date. When did you check there was no wall? is exactly the question whose absence
-cost three rows. A row denying a wall answers it the same way a row asserting one does.
+It applies in BOTH directions, and that is not an accident of substring matching. The row for #304
+said "no measured AX wall in front of it", and *when did you check there was no wall?* is exactly
+the question whose absence cost the three rows above. A row denying a wall answers it the same way
+a row asserting one does.
 
 It says nothing about rows that describe work as unstarted, behind a dependency, or waiting on a
 decision without mentioning a wall at all. Those are not claims about a surface.
+
+WHAT IT MISSES, so nobody reads a pass as coverage
+--------------------------------------------------
+It matches literal phrases in the LAST cell of a row whose cells include exactly `OPEN`. So it does
+not see:
+
+  * a wall described in words this list does not carry — "unreachable", "cannot be read",
+    "the tree returns nothing"
+  * a wall claim in a cell other than the last, or a table whose columns are ordered differently
+  * a state cell spelled anything but `OPEN`, or a row split across lines
+  * a pipe inside backticks, which splits one cell into two
+
+And a date is a pointer, not proof: `2026-08-30` typed into a cell satisfies this guard and
+measures nothing. It raises the floor from "a wall with nothing beside it" to "a wall with
+something a reader can go and check", and that is the whole of what it does.
 """
 import os
 import re

--- a/Scripts/check-roadmap-blockers-cite-measurements.py
+++ b/Scripts/check-roadmap-blockers-cite-measurements.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""A roadmap row may not claim a wall it has not measured.
+
+WHY THIS EXISTS
+---------------
+On 2026-08-30 four roadmap rows said an AX surface was opaque. Three of the four were wrong, and
+none of the three had ever been measured against the surface it named:
+
+    #301  "the AX plane a readback needs is not exposed"
+          -> Channel EQ exposes all 24 band sliders, named and settable. The claim came from a
+             census that instantiates the Audio Unit OUTSIDE Logic, which ADR-018 itself says
+             cannot speak for Logic's live instance.
+    #305  "AU parameter view observed AX-opaque"
+          -> Flex Pitch is in the Audio Track Editor. The blocker was never about this surface.
+    #306  "same wall as #305"
+          -> inherited from a row that had no measurement, which turned ONE unobserved claim into
+             two that appeared to corroborate each other.
+
+Every one of them told the next person to go measure a wall, and the wall was not there. A wrong
+blocker is more expensive than a missing one: a missing blocker gets investigated, a wrong one gets
+believed and routed around. ADR-013's whole Decision section — a virtual Mackie C4 control surface,
+two virtual MIDI endpoints, an adapter and a doctor capability — exists to route around a wall that
+does not exist.
+
+WHAT IT CHECKS, AND WHAT IT CANNOT
+----------------------------------
+Form, not truth. It cannot tell whether a measurement was real, aimed at the right thing, or taken
+while a modal was silently blocking the application. What it can do is refuse the shape all three
+of those rows had: a wall asserted with nothing dated beside it.
+
+So a row that mentions a wall must carry, in the same cell, either an ISO date or a link to the
+comment that recorded the measurement. That is a low bar deliberately — it is the bar that would
+have caught all three, and a higher one would be a bar on prose that nothing can enforce.
+
+It applies in BOTH directions, and that is not an accident of substring matching. "No measured AX
+wall in front of it" is as much a claim about the world as "AX-opaque", and it is the claim nobody
+asked #305 to date. When did you check there was no wall? is exactly the question whose absence
+cost three rows. A row denying a wall answers it the same way a row asserting one does.
+
+It says nothing about rows that describe work as unstarted, behind a dependency, or waiting on a
+decision without mentioning a wall at all. Those are not claims about a surface.
+"""
+import os
+import re
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+ROADMAP = os.path.join(REPO, "docs", "roadmap", "README.md")
+
+# Phrases that assert a measurable fact about a surface. Taken from what the wrong rows actually
+# said rather than invented, so the list stays answerable to real text.
+WALL_CLAIMS = [
+    "opaque",
+    "not exposed",
+    "no accessible path",
+    "ax wall",
+    "same wall as",
+]
+
+# A citation is a date or the comment that carries the measurement. Both are things a reader can
+# go and check; neither is proof the measurement was sound.
+DATE = re.compile(r"20\d\d-\d\d-\d\d")
+COMMENT_URL = re.compile(r"github\.com/[\w.-]+/[\w.-]+/issues/\d+#issuecomment-\d+")
+
+
+def rows(text):
+    """Every markdown table row in the file, as a list of cells.
+
+    Header and separator rows are dropped. A row is a line that starts and ends with a pipe once
+    stripped, which is how every table in this file is written.
+    """
+    out = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        s = line.strip()
+        if not s.startswith("|") or not s.endswith("|"):
+            continue
+        cells = [c.strip() for c in s.strip("|").split("|")]
+        if not cells:
+            continue
+        if all(set(c) <= set("-: ") for c in cells):
+            continue
+        out.append((lineno, cells))
+    return out
+
+
+def offenders(text):
+    bad = []
+    scanned = 0
+    for lineno, cells in rows(text):
+        if "OPEN" not in cells:
+            continue
+        scanned += 1
+        detail = cells[-1]
+        lowered = detail.lower()
+        # Deliberately not negation-aware. A row saying there is NO wall is making the same
+        # kind of claim and owes the same date; see the module docstring.
+        hit = next((c for c in WALL_CLAIMS if c in lowered), None)
+        if hit is None:
+            continue
+        if DATE.search(detail) or COMMENT_URL.search(detail):
+            continue
+        bad.append((lineno, hit, detail))
+    return scanned, bad
+
+
+def main():
+    if not os.path.exists(ROADMAP):
+        print(f"cannot read {os.path.relpath(ROADMAP, REPO)} — refusing rather than passing")
+        return 2
+    text = open(ROADMAP, encoding="utf-8").read()
+    scanned, bad = offenders(text)
+    if scanned == 0:
+        # No OPEN rows at all means the table moved or stopped parsing. A guard that scanned
+        # nothing has not checked anything, and reporting that as clean is the failure mode this
+        # repository keeps finding in its own checks.
+        print("no OPEN roadmap rows were parsed — the table shape changed; refusing rather than passing")
+        return 2
+    if bad:
+        print(f"{len(bad)} of {scanned} OPEN roadmap rows mention a wall with nothing dated beside it:\n")
+        for lineno, hit, detail in bad:
+            print(f"  docs/roadmap/README.md:{lineno}  says {hit!r}")
+            print(f"      {detail[:160]}")
+        print(
+            "\nEither measure it and put the date (or the issue comment that records the "
+            "measurement) in the same cell, or drop the wall language and say the work is "
+            "unstarted. This applies to a row DENYING a wall too: 'no wall here' is a claim that "
+            "needs a date as much as 'opaque' does. An undated wall reads as a measured one and "
+            "sends the next person to route around something that may not be there."
+        )
+        return 1
+    print(f"ok — {scanned} OPEN roadmap rows scanned, every wall mention carries a citation")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Scripts/test_roadmap_blocker_citations.py
+++ b/Scripts/test_roadmap_blocker_citations.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Drive `check-roadmap-blockers-cite-measurements.py` and watch it fail.
+
+A guard nobody has seen fail is a guard nobody has tested. Each case below feeds the guard's own
+predicate a table and asserts the verdict, including the two refusals — an unparseable file and a
+file with no OPEN rows both have to come back as "cannot tell", not as clean.
+
+The offending rows are the real ones from 2026-08-30, before they were corrected.
+"""
+import importlib.util
+import os
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+GUARD = os.path.join(REPO, "Scripts", "check-roadmap-blockers-cite-measurements.py")
+
+spec = importlib.util.spec_from_file_location("roadmap_blocker_guard", GUARD)
+guard = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(guard)
+
+HEADER = "| ADR | issue | state | what it is waiting on |\n|---|---|---|---|\n"
+
+# Verbatim from docs/roadmap/README.md before the correction. Each asserts a fact about a surface
+# and none of the three had been measured against the surface it names.
+UNCITED = HEADER + "\n".join([
+    "| ADR-013 | #301 | OPEN | **zero band operations registered** — no public surface; the AX plane a readback needs is not exposed |",
+    "| ADR-017 | #305 | OPEN | AU parameter view observed AX-opaque; starts with a measurement |",
+    "| ADR-018 | #306 | OPEN | same wall as #305 |",
+]) + "\n"
+
+CITED_BY_DATE = HEADER + (
+    "| ADR-013 | #301 | OPEN | measured 2026-08-30, Channel EQ exposes 24 named settable sliders; "
+    "the opacity claim came from a census run outside Logic |\n"
+)
+
+CITED_BY_COMMENT = HEADER + (
+    "| ADR-018 | #306 | OPEN | Tier B is not opaque — "
+    "https://github.com/MongLong0214/logic-pro-mcp/issues/299#issuecomment-5466600291 |\n"
+)
+
+# No wall mentioned at all. "Behind a dependency" and "not started" are not claims about a
+# surface, so the guard must leave them alone or it becomes a tax on ordinary rows.
+NO_CLAIM = HEADER + "\n".join([
+    "| ADR-011 | #299 | OPEN | behind #292 |",
+    "| ADR-015 | #303 | OPEN | behind #293; what is missing is a maker, not a measurement |",
+]) + "\n"
+
+# A row DENYING a wall is making the same kind of claim and owes the same date. This is the real
+# #304 row as it stood, and letting it through is how "there is no obstacle here" becomes something
+# everybody believes and nobody checked. The guard is deliberately not negation-aware.
+DENIAL_UNCITED = HEADER + (
+    "| ADR-016 | #304 | OPEN | implementation; no measured AX wall in front of it |\n"
+)
+DENIAL_CITED = HEADER + (
+    "| ADR-016 | #304 | OPEN | measured 2026-08-30, no AX wall in front of it |\n"
+)
+
+CLOSED_ROW_WITH_WALL = HEADER + (
+    "| ADR-013 | #301 | closed | the AX plane a readback needs is not exposed |\n"
+)
+
+failures = []
+
+
+def case(name, text, want_bad, want_scanned_nonzero=True):
+    scanned, bad = guard.offenders(text)
+    got_bad = len(bad)
+    if got_bad != want_bad:
+        failures.append(f"{name}: expected {want_bad} offender(s), got {got_bad} -> {bad}")
+    if want_scanned_nonzero and scanned == 0:
+        failures.append(f"{name}: scanned 0 rows, so it checked nothing")
+
+
+case("three uncited wall claims are all caught", UNCITED, 3)
+case("a date in the same cell clears it", CITED_BY_DATE, 0)
+case("a link to the measurement comment clears it", CITED_BY_COMMENT, 0)
+case("rows that mention no wall are left alone", NO_CLAIM, 0)
+case("denying a wall without a date is caught too", DENIAL_UNCITED, 1)
+case("denying a wall with a date is fine", DENIAL_CITED, 0)
+
+# A closed row is not telling anyone to go measure anything.
+scanned, bad = guard.offenders(CLOSED_ROW_WITH_WALL)
+if bad:
+    failures.append(f"closed rows must not be flagged, got {bad}")
+if scanned != 0:
+    failures.append(f"a table with no OPEN rows should scan 0, got {scanned}")
+
+# The two refusals. `main` reads the real roadmap, so these drive the predicate's own zero case and
+# the missing-file path through a temporary override.
+real = guard.ROADMAP
+try:
+    guard.ROADMAP = os.path.join(REPO, "docs", "roadmap", "does-not-exist.md")
+    if guard.main() != 2:
+        failures.append("a missing roadmap must refuse (exit 2), not pass")
+finally:
+    guard.ROADMAP = real
+
+# And the guard must pass on the file actually in the tree, so a correction that lands without its
+# citation is caught here rather than in review.
+if guard.main() != 0:
+    failures.append("the roadmap in this tree does not satisfy the guard")
+
+if failures:
+    print(f"{len(failures)} failure(s):")
+    for f in failures:
+        print(f"  {f}")
+    sys.exit(1)
+print("ok — the guard catches three real uncited wall claims, clears cited ones, "
+      "leaves non-claims alone, and refuses rather than passing when it cannot parse")

--- a/Scripts/test_roadmap_blocker_citations.py
+++ b/Scripts/test_roadmap_blocker_citations.py
@@ -2,10 +2,16 @@
 """Drive `check-roadmap-blockers-cite-measurements.py` and watch it fail.
 
 A guard nobody has seen fail is a guard nobody has tested. Each case below feeds the guard's own
-predicate a table and asserts the verdict, including the two refusals — an unparseable file and a
-file with no OPEN rows both have to come back as "cannot tell", not as clean.
+predicate a table and asserts the verdict, and both refusal paths through `main` are driven: a file
+that is not there, and a file that parses to zero OPEN rows. Both must come back as "cannot tell"
+rather than as clean.
 
 The offending rows are the real ones from 2026-08-30, before they were corrected.
+
+What is NOT covered, so the next reader does not assume it is: reordered columns, a wall phrase in a
+cell other than the last, alternate spellings of the state cell, rows split across lines, pipes
+inside backticks, and any wall described in words the guard's list does not carry ("unreachable",
+"the tree returns nothing"). The guard's own docstring carries the same list.
 """
 import importlib.util
 import os
@@ -29,9 +35,14 @@ UNCITED = HEADER + "\n".join([
 ]) + "\n"
 
 CITED_BY_DATE = HEADER + (
-    "| ADR-013 | #301 | OPEN | measured 2026-08-30, Channel EQ exposes 24 named settable sliders; "
-    "the opacity claim came from a census run outside Logic |\n"
+    "| ADR-013 | #301 | OPEN | measured 2026-08-30 — the AX plane a readback needs is not exposed "
+    "was wrong; Channel EQ exposes 24 named settable sliders |\n"
 )
+# The cell must contain a phrase from WALL_CLAIMS or this case proves nothing about dates: an
+# earlier version said "opacity", which is in no list, so deleting DATE handling entirely left it
+# passing. A fixture that cannot reach the code path it names is decoration.
+assert any(w in CITED_BY_DATE.lower() for w in guard.WALL_CLAIMS), \
+    "the date fixture no longer contains a wall phrase, so it tests nothing"
 
 CITED_BY_COMMENT = HEADER + (
     "| ADR-018 | #306 | OPEN | Tier B is not opaque — "
@@ -85,13 +96,32 @@ if bad:
 if scanned != 0:
     failures.append(f"a table with no OPEN rows should scan 0, got {scanned}")
 
-# The two refusals. `main` reads the real roadmap, so these drive the predicate's own zero case and
-# the missing-file path through a temporary override.
+# Both refusals, driven through `main` rather than through `offenders`. The zero-scan branch was
+# previously only reached via `offenders`, so `main`'s return of 2 was asserted by nobody and the
+# docstring said otherwise.
+import tempfile
+
 real = guard.ROADMAP
 try:
     guard.ROADMAP = os.path.join(REPO, "docs", "roadmap", "does-not-exist.md")
     if guard.main() != 2:
         failures.append("a missing roadmap must refuse (exit 2), not pass")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        empty = os.path.join(tmp, "README.md")
+        with open(empty, "w", encoding="utf-8") as fh:
+            fh.write("# a roadmap whose table stopped parsing\n\nno rows here at all\n")
+        guard.ROADMAP = empty
+        if guard.main() != 2:
+            failures.append("a roadmap with zero OPEN rows must refuse (exit 2), not pass")
+
+        # And a table that parses but is all closed: scanned stays 0, so it is the same refusal.
+        closed_only = os.path.join(tmp, "closed.md")
+        with open(closed_only, "w", encoding="utf-8") as fh:
+            fh.write(CLOSED_ROW_WITH_WALL)
+        guard.ROADMAP = closed_only
+        if guard.main() != 2:
+            failures.append("a table with only closed rows must refuse (exit 2), not pass")
 finally:
     guard.ROADMAP = real
 
@@ -105,5 +135,6 @@ if failures:
     for f in failures:
         print(f"  {f}")
     sys.exit(1)
-print("ok — the guard catches three real uncited wall claims, clears cited ones, "
-      "leaves non-claims alone, and refuses rather than passing when it cannot parse")
+print("ok — the guard catches three real uncited wall claims, clears cited ones, leaves rows that "
+      "mention no wall alone, catches an undated DENIAL, and refuses through main() when the file "
+      "is missing and when the table parses to zero OPEN rows")

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -59,16 +59,16 @@ open PRs 0 · v3.14.0 published · 16 open issues
 | ADR-013 | #301 | OPEN | zero band operations registered, so no public surface — but the wall is gone. Measured 2026-08-30, Channel EQ's native view exposes all 8 bands as **24 named, settable sliders** with `AXValueDescription` in Hz/dB. The opacity claim came from a census that instantiates the AU *outside* Logic, which #306's Important Boundary says cannot speak for the live instance. The C4 Decision in the ADR body is superseded |
 | ADR-014 | #302 | OPEN | R1 shipped. R2 is NOT STARTED rather than blocked: measured 2026-08-29, `kAXColumns` is present and returns 8 columns — what is absent is any title or description ON them, and the header's sort buttons carry the names the collector already binds. Next step is an R2 ticket, not another measurement |
 | ADR-015 | #303 | OPEN | behind #293, and measured 2026-08-29 the dependency is narrower than "transforms must not read their own plan" — `TransformVerification` already refuses a proof that shares the observed pipeline. What is missing is a MAKER: `IndependentExpectedSeam` is inside `#if QUALIFICATION_FAULT_SEAM`, so in a release build `independentPayload` is always nil and no positive match is possible. The three modules exist; the gap is the live ingestion boundary in front of them |
-| ADR-016 | #304 | OPEN | implementation; no measured AX wall in front of it |
+| ADR-016 | #304 | OPEN | NOT STARTED. Nothing has been measured against this surface in either direction — the previous row asserted there was no obstacle, which is a claim about the world that nobody had dated |
 | ADR-017 | #305 | OPEN | NOT STARTED rather than blocked. Flex Pitch is in the Audio Track Editor, not a plug-in window, so the AU-parameter-view wall recorded here was never about this surface — it was inherited, not observed. The measurement it needs is aimed at note **identity stability** over a Flex-analysed region |
-| ADR-018 | #306 | OPEN | Tier B measured viable for **stock** plug-ins (the Controls view table above); the third-party plug-ins this ADR is named after are still unmeasured. "Same wall as #305" was wrong twice — #305 is a different surface, and the wall is not there |
+| ADR-018 | #306 | OPEN | Tier B measured viable for **stock** plug-ins (the Controls view table above); the third-party plug-ins this ADR is named after are still unmeasured. measured 2026-08-30. The earlier "same wall as #305" was wrong twice: #305 is a different surface, and the wall is not there |
 
 Also open, outside the ADR set:
 
 | issue | state | what it is waiting on |
 |---|---|---|
 | #308 | OPEN | index only; closes when the ADRs it indexes do |
-| #369 | OPEN | Export panel AX-opaque — no accessible path to per-track stems |
+| #369 | OPEN | re-measured 2026-08-30: the menu path IS reachable and enabled (`파일 > 내보내기 > 모든 트랙을 오디오 파일로…`, `AXEnabled=true`, no menu opening needed). The PANEL is still unmeasured, and no caller exists for a three-level menu path. The first reading of this was taken under a Logic modal that disables the whole File menu and was discarded |
 | #373 | OPEN | Phase B needs live readback; `logic://tracks` is cache-served, so a stale read passes the same equality check |
 | #448 | OPEN | layout readback is deliverable; colour and reorder need a definition of "verified" for a write nothing can read back |
 | #678 | closed | the drift guard and this file's update rule shipped in #684 |

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -36,7 +36,7 @@ still list the issue rather than delete its row.
 It does not check the prose. The "waiting on" column, the order, and the state block below are still
 claims dated by the "measured" line, and only issue numbers and open/closed are mechanised.
 
-## State — measured 2026-08-30 at `9e2c08a8`
+## State — measured 2026-08-30 at `709a0178`
 
 ```
 open PRs 0 · v3.14.0 published · 16 open issues
@@ -52,16 +52,16 @@ open PRs 0 · v3.14.0 published · 16 open issues
 | ADR-006 | #289 | closed | shipped #674/#675, measured and closed |
 | ADR-007 | #290 | closed | all seven criteria met and measured; closed 2026-08-30. Criterion 1 was narrowed to Desktop by the owner — Creator left product scope on 2026-07-17, so the line predated the decision |
 | ADR-008 | #291 | OPEN | node identity cannot be the display string — needs a decision, not an attempt |
-| ADR-009 | #292 | OPEN | apply-back expansion on Wave-0 insert work; #299 and #301 consume it |
+| ADR-009 | #292 | OPEN | apply-back expansion on Wave-0 insert work; #299 and #301 consume it. Measured 2026-08-30, the plane it needs exists: Logic's Controls view renders a stock plug-in as an `AXTable`, one named `AXRow` per parameter, read by row label rather than index — the shape `set_param_verified` steps 9-12 already drive |
 | ADR-010 | #293 | OPEN | the collector's shape was already right; measured 2026-08-29 it reads a real note table and returns both notes. It could not START in any language but English — the Event tab was matched against the literal `"Event"` — fixed in #712. What stays closed is ADR-010's body: `assessReadback` and the public provider |
-| ADR-011 | #299 | OPEN | behind #292 |
+| ADR-011 | #299 | OPEN | behind #292, and the reason only `threshold` is supported is now measured: the Compressor's *native* editor names 1 of its 22 sliders, so 21 have nothing to match on. Its Controls view names all of them — `Ratio`, `Attack`, `Release`, `Make Up`, `Knee`, `Circuit Type` and the rest. No write attempted |
 | ADR-012 | #300 | closed | promoted and closed 2026-08-28; all seven acceptance criteria measured, four artifacts found and fixed on the way (#693-#697) |
-| ADR-013 | #301 | OPEN | **zero band operations registered** — no public surface; the AX plane a readback needs is not exposed |
+| ADR-013 | #301 | OPEN | zero band operations registered, so no public surface — but the wall is gone. Measured 2026-08-30, Channel EQ's native view exposes all 8 bands as **24 named, settable sliders** with `AXValueDescription` in Hz/dB. The opacity claim came from a census that instantiates the AU *outside* Logic, which #306's Important Boundary says cannot speak for the live instance. The C4 Decision in the ADR body is superseded |
 | ADR-014 | #302 | OPEN | R1 shipped. R2 is NOT STARTED rather than blocked: measured 2026-08-29, `kAXColumns` is present and returns 8 columns — what is absent is any title or description ON them, and the header's sort buttons carry the names the collector already binds. Next step is an R2 ticket, not another measurement |
 | ADR-015 | #303 | OPEN | behind #293, and measured 2026-08-29 the dependency is narrower than "transforms must not read their own plan" — `TransformVerification` already refuses a proof that shares the observed pipeline. What is missing is a MAKER: `IndependentExpectedSeam` is inside `#if QUALIFICATION_FAULT_SEAM`, so in a release build `independentPayload` is always nil and no positive match is possible. The three modules exist; the gap is the live ingestion boundary in front of them |
 | ADR-016 | #304 | OPEN | implementation; no measured AX wall in front of it |
-| ADR-017 | #305 | OPEN | AU parameter view observed AX-opaque; starts with a measurement |
-| ADR-018 | #306 | OPEN | same wall as #305 |
+| ADR-017 | #305 | OPEN | NOT STARTED rather than blocked. Flex Pitch is in the Audio Track Editor, not a plug-in window, so the AU-parameter-view wall recorded here was never about this surface — it was inherited, not observed. The measurement it needs is aimed at note **identity stability** over a Flex-analysed region |
+| ADR-018 | #306 | OPEN | Tier B measured viable for **stock** plug-ins (the Controls view table above); the third-party plug-ins this ADR is named after are still unmeasured. "Same wall as #305" was wrong twice — #305 is a different surface, and the wall is not there |
 
 Also open, outside the ADR set:
 
@@ -82,8 +82,12 @@ The instruction that produced this file asked for these to be established, not g
 - **#293** — not absence. `Sources/LogicProMCP/MIDIReadback/` has ten modules including the
   provider. The recorded problem is that the fixture gave every Event-List cell a child, so the
   collector was written against a shape Logic does not produce.
-- **#301** — genuine absence. No band read or write is registered in `OperationRegistry`, which
-  matches "a measured wall" rather than contradicting it.
+- **#301** — genuine absence of the *operations*: no band read or write is registered in
+  `OperationRegistry`. What was inferred from that was wrong. The note read the absence as
+  consistent with "a measured wall", and consistency is not evidence — an unbuilt feature and a
+  blocked one look identical from the registry. Measured 2026-08-30 there is no wall: Channel EQ
+  names all 24 band sliders and every one is settable. The registry was empty because nobody had
+  written the operations, which is the ordinary reason a registry is empty.
 - **#300** — neither, and it is closed now. Four modules existed *and* two operations were
   registered; what was open was the promotion decision. Answering it took measuring what the flag
   was holding back, which turned up four artifacts nobody had recorded: three bands reporting the
@@ -114,7 +118,11 @@ attached — not a silent deferral.
    is a different fact from the one recorded; the header sort buttons supply the column map and
    `readHeaders` already reads them. The next step is an R2 ticket.
 5. **#292 → #299**. #300's promotion is done — the flag is removed, not defaulted on.
-6. **#291, #301, #305, #306, #369, #448** — each starts with a measurement.
+6. **#291, #301, #305, #306, #369, #448** — each starts with a measurement. Four were made on
+   2026-08-30 and three of the four moved the item rather than confirming it: #301's wall does not
+   exist, #305's wall was never about its own surface, and #306's Tier B works for stock plug-ins.
+   The one that held is the Compressor's native editor, which names one slider of twenty-two — and
+   that is an *identity* wall, not a reachability one, which is a different repair.
 7. **#373 → #284's `R-SEM`**, then **#308** closes as an index.
 
 ## What this file does not claim

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -52,16 +52,16 @@ open PRs 0 · v3.14.0 published · 16 open issues
 | ADR-006 | #289 | closed | shipped #674/#675, measured and closed |
 | ADR-007 | #290 | closed | all seven criteria met and measured; closed 2026-08-30. Criterion 1 was narrowed to Desktop by the owner — Creator left product scope on 2026-07-17, so the line predated the decision |
 | ADR-008 | #291 | OPEN | node identity cannot be the display string — needs a decision, not an attempt |
-| ADR-009 | #292 | OPEN | apply-back expansion on Wave-0 insert work; #299 and #301 consume it. Measured 2026-08-30, the plane it needs exists: Logic's Controls view renders a stock plug-in as an `AXTable`, one named `AXRow` per parameter, read by row label rather than index — the shape `set_param_verified` steps 9-12 already drive |
+| ADR-009 | #292 | OPEN | apply-back expansion on Wave-0 insert work; #299 and #301 consume it. Measured 2026-08-30: Logic's Controls view renders a stock plug-in as an `AXTable`, one `AXRow` per parameter whose cell carries an `AXStaticText` label and a control. **Addressable, not yet written to.** It is NOT the shape `set_param_verified` drives — step 9 matches an `AXSlider` by its own `AXDescription`, and in this view the sliders have none; the name is on a sibling. A locator for row-labelled controls is new work |
 | ADR-010 | #293 | OPEN | the collector's shape was already right; measured 2026-08-29 it reads a real note table and returns both notes. It could not START in any language but English — the Event tab was matched against the literal `"Event"` — fixed in #712. What stays closed is ADR-010's body: `assessReadback` and the public provider |
-| ADR-011 | #299 | OPEN | behind #292, and the reason only `threshold` is supported is now measured: the Compressor's *native* editor names 1 of its 22 sliders, so 21 have nothing to match on. Its Controls view names all of them — `Ratio`, `Attack`, `Release`, `Make Up`, `Knee`, `Circuit Type` and the rest. No write attempted |
+| ADR-011 | #299 | OPEN | behind #292. Measured 2026-08-30: the Compressor's *native* editor exposes 22 sliders and names exactly one (`Threshold`), which is also the one parameter `set_param_verified` supports — consistent with step 9 matching on `AXDescription`, though the causal link is inferred from the code path rather than measured. Its Controls view carries a labelled row per parameter (`Ratio`, `Attack`, `Release`, `Make Up`, `Knee`, `Circuit Type`, …). No write attempted anywhere |
 | ADR-012 | #300 | closed | promoted and closed 2026-08-28; all seven acceptance criteria measured, four artifacts found and fixed on the way (#693-#697) |
-| ADR-013 | #301 | OPEN | zero band operations registered, so no public surface — but the wall is gone. Measured 2026-08-30, Channel EQ's native view exposes all 8 bands as **24 named, settable sliders** with `AXValueDescription` in Hz/dB. The opacity claim came from a census that instantiates the AU *outside* Logic, which #306's Important Boundary says cannot speak for the live instance. The C4 Decision in the ADR body is superseded |
+| ADR-013 | #301 | OPEN | zero band operations registered, so no public surface. Measured 2026-08-30, the recorded wall is not where it was said to be: Channel EQ's native view exposes 8 named band enables and 24 `AXSlider`s, each named by band and parameter, each reporting `settable=yes`, each carrying `AXValueDescription` in Hz/dB. **No write was attempted, and AX settability lies** — what is established is that the controls are addressable and readable. The opacity claim came from a census that instantiates the AU *outside* Logic, which ADR-018's Important Boundary says cannot speak for the live instance. The ADR's C4 Decision was revised on the issue the same day |
 | ADR-014 | #302 | OPEN | R1 shipped. R2 is NOT STARTED rather than blocked: measured 2026-08-29, `kAXColumns` is present and returns 8 columns — what is absent is any title or description ON them, and the header's sort buttons carry the names the collector already binds. Next step is an R2 ticket, not another measurement |
 | ADR-015 | #303 | OPEN | behind #293, and measured 2026-08-29 the dependency is narrower than "transforms must not read their own plan" — `TransformVerification` already refuses a proof that shares the observed pipeline. What is missing is a MAKER: `IndependentExpectedSeam` is inside `#if QUALIFICATION_FAULT_SEAM`, so in a release build `independentPayload` is always nil and no positive match is possible. The three modules exist; the gap is the live ingestion boundary in front of them |
 | ADR-016 | #304 | OPEN | NOT STARTED. Nothing has been measured against this surface in either direction — the previous row asserted there was no obstacle, which is a claim about the world that nobody had dated |
 | ADR-017 | #305 | OPEN | NOT STARTED rather than blocked. Flex Pitch is in the Audio Track Editor, not a plug-in window, so the AU-parameter-view wall recorded here was never about this surface — it was inherited, not observed. The measurement it needs is aimed at note **identity stability** over a Flex-analysed region |
-| ADR-018 | #306 | OPEN | Tier B measured viable for **stock** plug-ins (the Controls view table above); the third-party plug-ins this ADR is named after are still unmeasured. measured 2026-08-30. The earlier "same wall as #305" was wrong twice: #305 is a different surface, and the wall is not there |
+| ADR-018 | #306 | OPEN | measured 2026-08-30: Tier B is **addressable** for stock plug-ins — the Controls view table above — which is weaker than "viable"; no write or readback was attempted, so viability is not established. The third-party plug-ins this ADR is named after are unmeasured. The earlier "same wall as #305" was wrong on the surface: #305 is a plug-in-window claim attached to a region editor |
 
 Also open, outside the ADR set:
 
@@ -118,11 +118,16 @@ attached — not a silent deferral.
    is a different fact from the one recorded; the header sort buttons supply the column map and
    `readHeaders` already reads them. The next step is an R2 ticket.
 5. **#292 → #299**. #300's promotion is done — the flag is removed, not defaulted on.
-6. **#291, #301, #305, #306, #369, #448** — each starts with a measurement. Four were made on
-   2026-08-30 and three of the four moved the item rather than confirming it: #301's wall does not
-   exist, #305's wall was never about its own surface, and #306's Tier B works for stock plug-ins.
-   The one that held is the Compressor's native editor, which names one slider of twenty-two — and
-   that is an *identity* wall, not a reachability one, which is a different repair.
+6. **#291, #301, #305, #306, #369, #448** — each starts with a measurement or a decision.
+   Measurements on 2026-08-30 covered #301, #306 and #369, and each moved its item rather than
+   confirming it: Channel EQ's controls are addressable, the Controls view carries a labelled row
+   per parameter, and the export menu path is reachable and enabled. **None of the three involved a
+   write**, so each establishes reachability and not verified control. #305 moved for a different
+   reason — its blocker named a plug-in window and Flex Pitch is a region editor, so it was never a
+   measurement about that surface, and one still has not been made. #291 and #448 turned out to
+   need decisions rather than measurements, and both were made and recorded on their issues. The
+   limit that held is the Compressor's native editor naming one slider of twenty-two: an *identity*
+   limit rather than a reachability one, and a different repair.
 7. **#373 → #284's `R-SEM`**, then **#308** closes as an index.
 
 ## What this file does not claim


### PR DESCRIPTION
Three roadmap rows (#301, #305, #306) each carried a blocker saying the AU parameter view is AX-opaque. Measured on live Logic 12.x today, all three were wrong, in different ways.

- **#301** — Channel EQ's native view exposes all 8 bands as **24 named, settable sliders** with `AXValueDescription` in Hz and dB. The opacity claim traces to `spike-channel-eq-au-census.swift`, which instantiates the Audio Unit *outside* Logic; ADR-018's own Important Boundary says that cannot speak for Logic's live instance.
- **#305** — Flex Pitch is in the Audio Track Editor, not a plug-in window. The blocker was inherited, never observed against this surface.
- **#306** — "same wall as #305" was wrong twice: different surface, and no wall. Tier B (Logic's Controls view) renders a stock plug-in as an `AXTable` with one named `AXRow` per parameter, addressed by row label rather than index or coordinate.

The wall that did hold is narrower and different in kind: the Compressor's *native* editor names 1 of its 22 sliders, which is why exactly one Compressor parameter is supported. That is an **identity** wall, not a reachability one.

Measurements: #301 https://github.com/MongLong0214/logic-pro-mcp/issues/301#issuecomment-5466538022 · #299 https://github.com/MongLong0214/logic-pro-mcp/issues/299#issuecomment-5466600291

No write was attempted anywhere, and third-party plug-ins stay unmeasured. Settability is a claim by the element, and AX settability lies.