### PR TITLE
fix(#608): see the modal, and stop calling plug-in windows one

### DIFF
--- a/Scripts/check-falsifiable-adoption.py
+++ b/Scripts/check-falsifiable-adoption.py
@@ -22,10 +22,11 @@ promise: the count may rise and may not fall. Raising FLOOR is a reviewed edit i
 is where a ratchet's teeth are — a number that can be lowered by whoever is inconvenienced is a
 suggestion.
 
-It does not check that a counterexample is a GOOD one. `falsifiable` establishes that a predicate
-can distinguish the observation from one stated alternative, and no more; whether that alternative
-is the one that matters is the author's claim and a reviewer's job. Said here because a guard named
-"adoption" invites being read as "quality".
+It does not check that a counterexample is a GOOD one. It does reject one mechanically detectable
+hollow form: a constant dictionary counterexample paired with a lambda that only subscripts a
+boolean wrapper. That form proves lookup distinguishes true from false, not that the predicate
+examines its stated observation. Beyond that narrow case, whether the alternative is the one that
+matters remains the author's claim and a reviewer's job.
 """
 import ast
 import glob
@@ -37,8 +38,42 @@ REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # The measured floor. Raise it when a harness converts; never lower it to make a branch pass.
 FLOOR = 4
 
-def _calls_falsifiable(text):
-    """Whether the source contains an actual CALL to `falsifiable`, not a mention of the word.
+def _call_argument(call, position, keyword):
+    if len(call.args) > position:
+        return call.args[position]
+    return next((arg.value for arg in call.keywords if arg.arg == keyword), None)
+
+
+def _constant_literal(node):
+    if isinstance(node, ast.Constant):
+        return True
+    if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+        return all(_constant_literal(item) for item in node.elts)
+    if isinstance(node, ast.Dict):
+        return all((key is None or _constant_literal(key)) and _constant_literal(value)
+                   for key, value in zip(node.keys, node.values))
+    return False
+
+
+def _is_hollow_falsifiable(call):
+    """The known boolean-wrapper pattern, not a claim to judge arbitrary counterexamples."""
+    predicate = _call_argument(call, 1, "predicate")
+    counterexample = _call_argument(call, 3, "counterexample")
+    if not isinstance(predicate, ast.Lambda) or not isinstance(counterexample, ast.Dict):
+        return False
+    if not _constant_literal(counterexample):
+        return False
+    if len(predicate.args.args) != 1 or predicate.args.vararg or predicate.args.kwarg:
+        return False
+    parameter = predicate.args.args[0].arg
+    body = predicate.body
+    return (isinstance(body, ast.Subscript)
+            and isinstance(body.value, ast.Name)
+            and body.value.id == parameter)
+
+
+def _falsifiable_calls(text):
+    """`(has_real_call, hollow_lines)` for actual calls, never comments or strings.
 
     Parsed, because a regex counts `# falsifiable(` in a comment and a `"falsifiable("` in a
     string. Found by review, 2026-08-29, reproduced: a harness whose only occurrence was a comment
@@ -50,22 +85,33 @@ def _calls_falsifiable(text):
     try:
         tree = ast.parse(text)
     except SyntaxError:
-        return False
+        return False, []
+    has_real_call = False
+    hollow_lines = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
         func = node.func
         name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
         if name == "falsifiable":
-            return True
-    return False
+            if _is_hollow_falsifiable(node):
+                hollow_lines.append(node.lineno)
+            else:
+                has_real_call = True
+    return has_real_call, hollow_lines
 
 
-def adoption(paths=None):
-    """`(adopters, total)` — harnesses calling `falsifiable(`, and how many there are."""
+def _calls_falsifiable(text):
+    """Whether this source has an actual, non-hollow call to `falsifiable`."""
+    return _falsifiable_calls(text)[0]
+
+
+def adoption(paths=None, include_hollow=False):
+    """Adopting harnesses and total; optionally include separately reported hollow call locations."""
     files = paths if paths is not None else sorted(
         glob.glob(os.path.join(REPO, "Scripts", "livekit", "live_*.py")))
     adopters = []
+    hollow = []
     for path in files:
         try:
             with open(path, encoding="utf-8") as fh:
@@ -74,13 +120,18 @@ def adoption(paths=None):
             # Unreadable is not adopted. Counting it either way would let a permissions accident
             # move the number, and this number is the whole point of the guard.
             continue
-        if _calls_falsifiable(text):
-            adopters.append(os.path.basename(path))
+        has_real_call, hollow_lines = _falsifiable_calls(text)
+        name = os.path.basename(path)
+        hollow.extend((name, line) for line in hollow_lines)
+        if has_real_call:
+            adopters.append(name)
+    if include_hollow:
+        return adopters, len(files), hollow
     return adopters, len(files)
 
 
 def main():
-    adopters, total = adoption()
+    adopters, total, hollow = adoption(include_hollow=True)
     if total == 0:
         print("-> FAIL: no live harnesses found — an empty set satisfies any floor")
         return 1
@@ -88,6 +139,8 @@ def main():
     print(f"   falsifiable() adoption: {len(adopters)} of {total} harnesses (floor {FLOOR})")
     for name in adopters:
         print(f"     uses it  {name}")
+    for name, line in hollow:
+        print(f"     hollow   {name}:{line} (constant counterexample + boolean-wrapper predicate)")
 
     if len(adopters) < FLOOR:
         print(f"-> FAIL: adoption fell to {len(adopters)}, below the recorded floor {FLOOR}")

--- a/Scripts/check-falsifiable-adoption.py
+++ b/Scripts/check-falsifiable-adoption.py
@@ -23,10 +23,11 @@ is where a ratchet's teeth are — a number that can be lowered by whoever is in
 suggestion.
 
 It does not check that a counterexample is a GOOD one. It does reject one mechanically detectable
-hollow form: a constant dictionary counterexample paired with a lambda that only subscripts a
-boolean wrapper. That form proves lookup distinguishes true from false, not that the predicate
-examines its stated observation. Beyond that narrow case, whether the alternative is the one that
-matters remains the author's claim and a reviewer's job.
+hollow form: a constant dictionary counterexample paired with a lambda that only reads one
+attribute or subscript from its parameter, including `.get(...)`. That form proves lookup
+distinguishes true from false, not that the predicate examines its stated observation. Beyond that
+narrow case, whether the alternative is the one that matters remains the author's claim and a
+reviewer's job.
 """
 import ast
 import glob
@@ -37,6 +38,10 @@ REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # The measured floor. Raise it when a harness converts; never lower it to make a branch pass.
 FLOOR = 4
+_FALSIFIABLE_PARAMETERS = (
+    "tag", "predicate", "observation", "counterexample", "expected", "mutation", "modal_snapshot",
+)
+_REQUIRED_FALSIFIABLE_PARAMETERS = _FALSIFIABLE_PARAMETERS[:5]
 
 def _call_argument(call, position, keyword):
     if len(call.args) > position:
@@ -55,6 +60,38 @@ def _constant_literal(node):
     return False
 
 
+def _has_plausible_falsifiable_arity(call):
+    """Whether a call supplies every required `Evidence.falsifiable` argument.
+
+    A name match alone is not adoption: `E.falsifiable(1)` cannot run the framework's predicate
+    contract and must not raise the floor. Positional and keyword calls are both valid forms.
+    """
+    if len(call.args) > len(_FALSIFIABLE_PARAMETERS) or any(
+            isinstance(argument, ast.Starred) for argument in call.args):
+        return False
+    supplied = {}
+    for position, argument in enumerate(call.args):
+        supplied[_FALSIFIABLE_PARAMETERS[position]] = argument
+    for keyword in call.keywords:
+        if (keyword.arg is None or keyword.arg not in _FALSIFIABLE_PARAMETERS
+                or keyword.arg in supplied):
+            return False
+        supplied[keyword.arg] = keyword.value
+    return all(name in supplied for name in _REQUIRED_FALSIFIABLE_PARAMETERS)
+
+
+def _is_single_parameter_access(body, parameter):
+    """Whether `body` only accesses the lambda parameter once, with no assertion around it."""
+    if isinstance(body, (ast.Attribute, ast.Subscript)):
+        base = body.value
+    elif isinstance(body, ast.Call) and isinstance(body.func, ast.Attribute):
+        # `.get(...)` is still a single access on the parameter, merely with call syntax.
+        base = body.func.value
+    else:
+        return False
+    return isinstance(base, ast.Name) and base.id == parameter
+
+
 def _is_hollow_falsifiable(call):
     """The known boolean-wrapper pattern, not a claim to judge arbitrary counterexamples."""
     predicate = _call_argument(call, 1, "predicate")
@@ -66,10 +103,7 @@ def _is_hollow_falsifiable(call):
     if len(predicate.args.args) != 1 or predicate.args.vararg or predicate.args.kwarg:
         return False
     parameter = predicate.args.args[0].arg
-    body = predicate.body
-    return (isinstance(body, ast.Subscript)
-            and isinstance(body.value, ast.Name)
-            and body.value.id == parameter)
+    return _is_single_parameter_access(predicate.body, parameter)
 
 
 def _falsifiable_calls(text):
@@ -93,7 +127,7 @@ def _falsifiable_calls(text):
             continue
         func = node.func
         name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
-        if name == "falsifiable":
+        if name == "falsifiable" and _has_plausible_falsifiable_arity(node):
             if _is_hollow_falsifiable(node):
                 hollow_lines.append(node.lineno)
             else:

--- a/Scripts/check-falsifiable-adoption.py
+++ b/Scripts/check-falsifiable-adoption.py
@@ -35,7 +35,7 @@ import sys
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # The measured floor. Raise it when a harness converts; never lower it to make a branch pass.
-FLOOR = 1
+FLOOR = 4
 
 def _calls_falsifiable(text):
     """Whether the source contains an actual CALL to `falsifiable`, not a mention of the word.

--- a/Scripts/check-roadmap-blockers-cite-measurements.py
+++ b/Scripts/check-roadmap-blockers-cite-measurements.py
@@ -7,7 +7,8 @@ On 2026-08-30 four roadmap rows said an AX surface was opaque. Three of the four
 none of the three had ever been measured against the surface it named:
 
     #301  "the AX plane a readback needs is not exposed"
-          -> Channel EQ exposes all 24 band sliders, named and settable. The claim came from a
+          -> Channel EQ exposes 26 sliders total, including all 24 named band parameters; every
+             slider is named and settable. The claim came from a
              census that instantiates the Audio Unit OUTSIDE Logic, which ADR-018 itself says
              cannot speak for Logic's live instance.
     #305  "AU parameter view observed AX-opaque"

--- a/Scripts/livekit/ax_plugin_menu_probe.swift
+++ b/Scripts/livekit/ax_plugin_menu_probe.swift
@@ -1,0 +1,410 @@
+#!/usr/bin/env swift
+// Raw Accessibility API witness for the #301, #306, and #369 live harnesses.
+//
+// System Events is deliberately not used for AXDescription here. It synthesises a description from
+// AXRoleDescription when AXDescription is nil, which would turn #306's observed "no slider
+// descriptions" into a false positive. This helper reports the raw AX attributes and performs only
+// the named, reversible presses its Python harness requests.
+
+import AppKit
+import ApplicationServices
+import Foundation
+
+typealias JSON = [String: Any]
+
+func attr<T>(_ element: AXUIElement, _ attribute: String) -> T? {
+    var value: AnyObject?
+    guard AXUIElementCopyAttributeValue(element, attribute as CFString, &value) == .success else {
+        return nil
+    }
+    return value as? T
+}
+
+func role(_ element: AXUIElement) -> String {
+    attr(element, kAXRoleAttribute as String) ?? ""
+}
+
+func description(_ element: AXUIElement) -> String {
+    attr(element, kAXDescriptionAttribute as String) ?? ""
+}
+
+func title(_ element: AXUIElement) -> String {
+    attr(element, kAXTitleAttribute as String) ?? ""
+}
+
+func valueDescription(_ element: AXUIElement) -> String {
+    attr(element, kAXValueDescriptionAttribute as String) ?? ""
+}
+
+func textValue(_ element: AXUIElement) -> String {
+    attr(element, kAXValueAttribute as String) ?? ""
+}
+
+func boolAttribute(_ element: AXUIElement, _ attribute: String) -> Bool? {
+    guard let value: NSNumber = attr(element, attribute) else { return nil }
+    return value.boolValue
+}
+
+func scalarValue(_ element: AXUIElement, _ attribute: String) -> Any? {
+    if let value: String = attr(element, attribute) { return value }
+    if let value: NSNumber = attr(element, attribute) {
+        if CFGetTypeID(value) == CFBooleanGetTypeID() { return value.boolValue }
+        return value.doubleValue
+    }
+    return nil
+}
+
+func valueIsSettable(_ element: AXUIElement) -> Bool {
+    var settable = DarwinBoolean(false)
+    guard AXUIElementIsAttributeSettable(element, kAXValueAttribute as CFString, &settable)
+            == .success else {
+        return false
+    }
+    return settable.boolValue
+}
+
+func children(_ element: AXUIElement) -> [AXUIElement] {
+    attr(element, kAXChildrenAttribute as String) ?? []
+}
+
+func descendants(_ root: AXUIElement, _ depth: Int = 18) -> [AXUIElement] {
+    var result: [AXUIElement] = []
+    func visit(_ element: AXUIElement, _ remaining: Int) {
+        result.append(element)
+        guard remaining > 0 else { return }
+        for child in children(element) { visit(child, remaining - 1) }
+    }
+    visit(root, depth)
+    return result
+}
+
+func same(_ lhs: AXUIElement, _ rhs: AXUIElement) -> Bool {
+    CFEqual(lhs, rhs)
+}
+
+func snapshot(_ element: AXUIElement) -> JSON {
+    var out: JSON = [
+        "role": role(element),
+        "description": description(element),
+        "title": title(element),
+        "value_description": valueDescription(element),
+        "value_settable": valueIsSettable(element),
+    ]
+    out["enabled"] = boolAttribute(element, kAXEnabledAttribute as String) ?? NSNull()
+    out["value"] = scalarValue(element, kAXValueAttribute as String) ?? NSNull()
+    return out
+}
+
+func elementName(_ element: AXUIElement) -> String {
+    let fromTitle = title(element)
+    return fromTitle.isEmpty ? description(element) : fromTitle
+}
+
+func emit(_ body: JSON) {
+    guard JSONSerialization.isValidJSONObject(body),
+          let data = try? JSONSerialization.data(withJSONObject: body, options: [.sortedKeys]),
+          let string = String(data: data, encoding: .utf8) else {
+        print("{\"error\":\"could not encode probe result\"}")
+        return
+    }
+    print(string)
+}
+
+let arguments = CommandLine.arguments
+guard arguments.count >= 3 else {
+    emit(["error": "usage: ax_plugin_menu_probe.swift <mode> <json-config>"])
+    exit(2)
+}
+
+let mode = arguments[1]
+let configData = Data(arguments[2].utf8)
+let config = ((try? JSONSerialization.jsonObject(with: configData)) as? JSON) ?? [:]
+
+func configuredString(_ key: String) -> String {
+    config[key] as? String ?? ""
+}
+
+func configuredStrings(_ key: String) -> [String] {
+    config[key] as? [String] ?? []
+}
+
+guard let logic = NSWorkspace.shared.runningApplications.first(
+    where: { $0.bundleIdentifier == "com.apple.logic10" }
+) else {
+    emit(["error": "Logic Pro is not running"])
+    exit(3)
+}
+
+let app = AXUIElementCreateApplication(logic.processIdentifier)
+
+func windows() -> [AXUIElement] {
+    attr(app, kAXWindowsAttribute as String) ?? []
+}
+
+func newWindows(since before: [AXUIElement]) -> [AXUIElement] {
+    windows().filter { candidate in !before.contains(where: { same($0, candidate) }) }
+}
+
+func press(_ element: AXUIElement, _ action: String = kAXPressAction as String) -> Int {
+    Int(AXUIElementPerformAction(element, action as CFString).rawValue)
+}
+
+func closeWindow(_ window: AXUIElement, closeLabel: String) -> JSON {
+    let buttons = descendants(window).filter {
+        role($0) == "AXButton" && description($0) == closeLabel
+    }
+    var result: JSON = [
+        "close_button_candidates": buttons.map(snapshot),
+        "pressed": false,
+        "press_status": NSNull(),
+    ]
+    if buttons.count == 1 {
+        result["pressed"] = true
+        result["press_status"] = press(buttons[0])
+        usleep(700_000)
+    }
+    result["window_still_present"] = windows().contains(where: { same($0, window) })
+    return result
+}
+
+func pluginSlots(named name: String) -> [AXUIElement] {
+    windows().flatMap { window in
+        descendants(window).filter { role($0) == "AXGroup" && description($0) == name }
+    }
+}
+
+func openPlugin(slotName: String, openLabel: String,
+                beforePress: ((AXUIElement) -> Void)? = nil) -> (JSON, AXUIElement?, AXUIElement?) {
+    let slots = pluginSlots(named: slotName)
+    var result: JSON = [
+        "slot_count": slots.count,
+        "slots": slots.map(snapshot),
+        "open_button_candidates": [],
+        "pressed_children": [],
+        "open_press_status": NSNull(),
+        "opened_windows": [],
+    ]
+    guard slots.count == 1 else { return (result, nil, nil) }
+
+    let slot = slots[0]
+    // The caller can take a negative-control reading before this helper mutates anything. In #301
+    // that is the bypass value: reading it after the Open press would not catch an Open path that
+    // toggled it and toggled it back before the witness looked.
+    beforePress?(slot)
+    let buttons = children(slot).filter {
+        role($0) == "AXButton" && description($0) == openLabel
+    }
+    result["slot_children"] = children(slot).map(snapshot)
+    result["open_button_candidates"] = buttons.map(snapshot)
+    guard buttons.count == 1 else { return (result, slot, nil) }
+
+    let before = windows()
+    result["pressed_children"] = [snapshot(buttons[0])]
+    result["open_press_status"] = press(buttons[0])
+    usleep(1_400_000)
+    let opened = newWindows(since: before)
+    result["opened_windows"] = opened.map(snapshot)
+    return (result, slot, opened.count == 1 ? opened[0] : nil)
+}
+
+func bandCheckboxes(in group: AXUIElement) -> [JSON] {
+    descendants(group).filter { role($0) == "AXCheckBox" }.map(snapshot)
+}
+
+func sliders(in root: AXUIElement) -> [JSON] {
+    descendants(root).filter { role($0) == "AXSlider" }.map(snapshot)
+}
+
+func rowCensus(in root: AXUIElement) -> [JSON] {
+    descendants(root).filter { role($0) == "AXRow" }.map { row in
+        let cells = descendants(row, 6).filter { role($0) == "AXCell" }
+        let cellData: [JSON] = cells.map { cell in
+            let staticTexts = descendants(cell, 6).filter { role($0) == "AXStaticText" }
+            let controls = descendants(cell, 6).filter {
+                ["AXSlider", "AXRadioButton", "AXPopUpButton"].contains(role($0))
+            }
+            return [
+                "static_texts": staticTexts.map { textValue($0).isEmpty ? elementName($0) : textValue($0) },
+                "control_roles": controls.map(role),
+            ]
+        }
+        return ["cells": cellData]
+    }
+}
+
+func menuItems(for button: AXUIElement) -> [AXUIElement] {
+    let nearby = descendants(button, 8).filter { role($0) == "AXMenuItem" }
+    if !nearby.isEmpty { return nearby }
+    return descendants(app, 10).filter { role($0) == "AXMenuItem" }
+}
+
+func selectView(in window: AXUIElement, viewLabels: [String], wanted: String) -> JSON {
+    let buttons = descendants(window).filter {
+        role($0) == "AXMenuButton" && viewLabels.contains(description($0))
+    }
+    var result: JSON = [
+        "button_candidates": buttons.map(snapshot),
+        "items": [],
+        "item_candidates": [],
+        "pressed": false,
+        "show_menu_status": NSNull(),
+        "press_status": NSNull(),
+    ]
+    guard buttons.count == 1 else { return result }
+
+    result["show_menu_status"] = press(buttons[0], kAXShowMenuAction as String)
+    usleep(700_000)
+    let items = menuItems(for: buttons[0])
+    let selected = items.filter { elementName($0) == wanted }
+    result["items"] = items.map(snapshot)
+    result["item_candidates"] = selected.map(snapshot)
+    guard selected.count == 1 else { return result }
+
+    result["pressed"] = true
+    result["press_status"] = press(selected[0])
+    usleep(1_300_000)
+    return result
+}
+
+func runChannelEQ() {
+    let slotName = configuredString("slot_label")
+    let openLabel = configuredString("open_label")
+    let closeLabel = configuredString("close_label")
+    let bypassLabels = configuredStrings("bypass_labels")
+    var result: JSON = ["frontmost_bundle_id": NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? ""]
+    var bypasses: [AXUIElement] = []
+    var bypassBefore: Any = NSNull()
+    let (openResult, slot, opened) = openPlugin(slotName: slotName, openLabel: openLabel) { slot in
+        bypasses = children(slot).filter {
+            role($0) == "AXCheckBox" && bypassLabels.contains(description($0))
+        }
+        if bypasses.count == 1 {
+            bypassBefore = scalarValue(bypasses[0], kAXValueAttribute as String) ?? NSNull()
+        }
+    }
+    result["open"] = openResult
+    guard slot != nil else { emit(result); return }
+
+    result["bypass_candidates"] = bypasses.map(snapshot)
+    result["bypass_before"] = bypassBefore
+
+    guard let opened else {
+        result["bypass_after"] = bypasses.count == 1
+            ? (scalarValue(bypasses[0], kAXValueAttribute as String) ?? NSNull()) : NSNull()
+        emit(result)
+        return
+    }
+
+    let groups = descendants(opened).filter { role($0) == "AXGroup" && description($0) == "EQ" }
+    result["eq_group_count"] = groups.count
+    result["band_checkboxes"] = groups.count == 1 ? bandCheckboxes(in: groups[0]) : []
+    result["sliders"] = groups.count == 1 ? sliders(in: groups[0]) : []
+    result["close"] = closeWindow(opened, closeLabel: closeLabel)
+    result["bypass_after"] = bypasses.count == 1
+        ? (scalarValue(bypasses[0], kAXValueAttribute as String) ?? NSNull()) : NSNull()
+    emit(result)
+}
+
+func runPluginSlot() {
+    let slots = pluginSlots(named: configuredString("slot_label"))
+    var result: JSON = [
+        "frontmost_bundle_id": NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? "",
+        "slot_count": slots.count,
+        "slots": slots.map(snapshot),
+    ]
+    result["slot_children"] = slots.count == 1 ? children(slots[0]).map(snapshot) : []
+    emit(result)
+}
+
+func runCompressor() {
+    let slotName = configuredString("slot_label")
+    let openLabel = configuredString("open_label")
+    let closeLabel = configuredString("close_label")
+    let viewLabels = configuredStrings("view_labels")
+    let controlsLabel = configuredString("controls_label")
+    let editorLabel = configuredString("editor_label")
+    var result: JSON = ["frontmost_bundle_id": NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? ""]
+    let (openResult, _, opened) = openPlugin(slotName: slotName, openLabel: openLabel)
+    result["open"] = openResult
+    guard let opened else { emit(result); return }
+
+    result["native_editor_sliders"] = sliders(in: opened)
+    let controlsSelection = selectView(in: opened, viewLabels: viewLabels, wanted: controlsLabel)
+    result["controls_selection"] = controlsSelection
+    result["controls_rows"] = rowCensus(in: opened)
+    result["controls_sliders"] = sliders(in: opened)
+    let editorSelection = selectView(in: opened, viewLabels: viewLabels, wanted: editorLabel)
+    result["editor_selection"] = editorSelection
+    result["editor_after_restore_sliders"] = sliders(in: opened)
+    result["rows_after_restore"] = rowCensus(in: opened)
+    result["close"] = closeWindow(opened, closeLabel: closeLabel)
+    emit(result)
+}
+
+func path(_ elements: [AXUIElement]) -> [JSON] {
+    elements.map(snapshot)
+}
+
+func oneMenuChild(of element: AXUIElement) -> [AXUIElement] {
+    children(element).filter { role($0) == "AXMenu" }
+}
+
+func runExportMenu() {
+    let fileLabels = configuredStrings("file_labels")
+    let exportLabel = configuredString("export_label")
+    let allTracksLabel = configuredString("all_tracks_label")
+    let oneTrackLabel = configuredString("one_track_label")
+    let openLabel = configuredString("open_label")
+    var result: JSON = ["frontmost_bundle_id": NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? ""]
+    guard let menuBar: AXUIElement = attr(app, kAXMenuBarAttribute as String) else {
+        result["error"] = "Logic has no AXMenuBar"
+        emit(result)
+        return
+    }
+    let fileItems = children(menuBar).filter {
+        role($0) == "AXMenuBarItem" && fileLabels.contains(elementName($0))
+    }
+    result["file_candidates"] = fileItems.map(snapshot)
+    guard fileItems.count == 1 else { emit(result); return }
+
+    let menus = oneMenuChild(of: fileItems[0])
+    result["file_menu_candidates"] = menus.map(snapshot)
+    guard menus.count == 1 else { emit(result); return }
+
+    let fileMenu = menus[0]
+    let exportItems = children(fileMenu).filter {
+        role($0) == "AXMenuItem" && elementName($0) == exportLabel
+    }
+    let openItems = children(fileMenu).filter {
+        role($0) == "AXMenuItem" && elementName($0) == openLabel
+    }
+    result["export_candidates"] = exportItems.map(snapshot)
+    result["open_candidates"] = openItems.map(snapshot)
+    result["open_path"] = openItems.count == 1 ? path([fileItems[0], fileMenu, openItems[0]]) : []
+    guard exportItems.count == 1 else { emit(result); return }
+
+    let exportMenus = oneMenuChild(of: exportItems[0])
+    result["export_menu_candidates"] = exportMenus.map(snapshot)
+    guard exportMenus.count == 1 else { emit(result); return }
+
+    let leaves = children(exportMenus[0]).filter { role($0) == "AXMenuItem" }
+    let allTracks = leaves.filter { elementName($0) == allTracksLabel }
+    let oneTrack = leaves.filter { elementName($0) == oneTrackLabel }
+    result["all_tracks_candidates"] = allTracks.map(snapshot)
+    result["one_track_candidates"] = oneTrack.map(snapshot)
+    result["all_tracks_path"] = allTracks.count == 1
+        ? path([fileItems[0], fileMenu, exportItems[0], exportMenus[0], allTracks[0]]) : []
+    result["one_track_path"] = oneTrack.count == 1
+        ? path([fileItems[0], fileMenu, exportItems[0], exportMenus[0], oneTrack[0]]) : []
+    emit(result)
+}
+
+switch mode {
+case "channel-eq": runChannelEQ()
+case "compressor": runCompressor()
+case "plugin-slot": runPluginSlot()
+case "export-menu": runExportMenu()
+default:
+    emit(["error": "unknown mode: \(mode)"])
+    exit(2)
+}

--- a/Scripts/livekit/ax_plugin_menu_probe.swift
+++ b/Scripts/livekit/ax_plugin_menu_probe.swift
@@ -12,59 +12,156 @@ import Foundation
 
 typealias JSON = [String: Any]
 
-func attr<T>(_ element: AXUIElement, _ attribute: String) -> T? {
+enum AXRead<Value> {
+    case value(Value)
+    case absent
+    case failed(AXError)
+
+    var status: String {
+        switch self {
+        case .value: return "success_with_value"
+        case .absent: return "success_without_value"
+        case .failed: return "failed"
+        }
+    }
+
+    var errorCode: Any {
+        guard case .failed(let error) = self else { return NSNull() }
+        return error.rawValue
+    }
+
+    var value: Value? {
+        guard case let .value(value) = self else { return nil }
+        return value
+    }
+}
+
+var axReadFailures: [JSON] = []
+
+func recordReadFailure(_ attribute: String, _ error: AXError) {
+    axReadFailures.append(["attribute": attribute, "status": error.rawValue])
+}
+
+func trackRead<T>(_ read: AXRead<T>, attribute: String) -> AXRead<T> {
+    if case .failed(let error) = read { recordReadFailure(attribute, error) }
+    return read
+}
+
+// Preserve success-with-value, success-with-absent, and failed AX requests. A raw `nil` loses the
+// distinction and let failed slider reads masquerade as empty AXDescriptions or unsettable values.
+func attr<T>(_ element: AXUIElement, _ attribute: String) -> AXRead<T> {
     var value: AnyObject?
-    guard AXUIElementCopyAttributeValue(element, attribute as CFString, &value) == .success else {
-        return nil
+    let result = AXUIElementCopyAttributeValue(element, attribute as CFString, &value)
+    guard result == .success else { return .failed(result) }
+    guard let value else { return .absent }
+    guard let typed = value as? T else { return .absent }
+    return .value(typed)
+}
+
+func role(_ element: AXUIElement) -> AXRead<String> {
+    attr(element, kAXRoleAttribute as String)
+}
+
+func description(_ element: AXUIElement) -> AXRead<String> {
+    attr(element, kAXDescriptionAttribute as String)
+}
+
+func title(_ element: AXUIElement) -> AXRead<String> {
+    attr(element, kAXTitleAttribute as String)
+}
+
+func valueDescription(_ element: AXUIElement) -> AXRead<String> {
+    attr(element, kAXValueDescriptionAttribute as String)
+}
+
+func textValue(_ element: AXUIElement) -> AXRead<String> {
+    attr(element, kAXValueAttribute as String)
+}
+
+func boolAttribute(_ element: AXUIElement, _ attribute: String) -> AXRead<Bool> {
+    switch attr(element, attribute) as AXRead<NSNumber> {
+    case .value(let value): return .value(value.boolValue)
+    case .absent: return .absent
+    case .failed(let error): return .failed(error)
     }
-    return value as? T
 }
 
-func role(_ element: AXUIElement) -> String {
-    attr(element, kAXRoleAttribute as String) ?? ""
-}
-
-func description(_ element: AXUIElement) -> String {
-    attr(element, kAXDescriptionAttribute as String) ?? ""
-}
-
-func title(_ element: AXUIElement) -> String {
-    attr(element, kAXTitleAttribute as String) ?? ""
-}
-
-func valueDescription(_ element: AXUIElement) -> String {
-    attr(element, kAXValueDescriptionAttribute as String) ?? ""
-}
-
-func textValue(_ element: AXUIElement) -> String {
-    attr(element, kAXValueAttribute as String) ?? ""
-}
-
-func boolAttribute(_ element: AXUIElement, _ attribute: String) -> Bool? {
-    guard let value: NSNumber = attr(element, attribute) else { return nil }
-    return value.boolValue
-}
-
-func scalarValue(_ element: AXUIElement, _ attribute: String) -> Any? {
-    if let value: String = attr(element, attribute) { return value }
-    if let value: NSNumber = attr(element, attribute) {
-        if CFGetTypeID(value) == CFBooleanGetTypeID() { return value.boolValue }
-        return value.doubleValue
+func scalarValue(_ element: AXUIElement, _ attribute: String) -> AXRead<Any> {
+    switch attr(element, attribute) as AXRead<AnyObject> {
+    case .value(let raw):
+        if let value = raw as? String { return .value(value) }
+        if let value = raw as? NSNumber {
+            if CFGetTypeID(value) == CFBooleanGetTypeID() { return .value(value.boolValue) }
+            return .value(value.doubleValue)
+        }
+        return .absent
+    case .absent:
+        return .absent
+    case .failed(let error):
+        return .failed(error)
     }
-    return nil
 }
 
-func valueIsSettable(_ element: AXUIElement) -> Bool {
+func valueIsSettable(_ element: AXUIElement) -> AXRead<Bool> {
     var settable = DarwinBoolean(false)
-    guard AXUIElementIsAttributeSettable(element, kAXValueAttribute as CFString, &settable)
-            == .success else {
-        return false
-    }
-    return settable.boolValue
+    let result = AXUIElementIsAttributeSettable(element, kAXValueAttribute as CFString, &settable)
+    guard result == .success else { return .failed(result) }
+    return .value(settable.boolValue)
 }
 
-func children(_ element: AXUIElement) -> [AXUIElement] {
-    attr(element, kAXChildrenAttribute as String) ?? []
+func stringValue(_ read: AXRead<String>, attribute: String) -> String {
+    switch trackRead(read, attribute: attribute) {
+    case .value(let value): return value
+    case .absent, .failed: return ""
+    }
+}
+
+func roleText(_ element: AXUIElement) -> String {
+    stringValue(role(element), attribute: kAXRoleAttribute as String)
+}
+
+func descriptionText(_ element: AXUIElement) -> String {
+    stringValue(description(element), attribute: kAXDescriptionAttribute as String)
+}
+
+func titleText(_ element: AXUIElement) -> String {
+    stringValue(title(element), attribute: kAXTitleAttribute as String)
+}
+
+func textValueText(_ element: AXUIElement) -> String {
+    stringValue(textValue(element), attribute: kAXValueAttribute as String)
+}
+
+func scalarJSONValue(_ read: AXRead<Any>, attribute: String) -> Any {
+    switch trackRead(read, attribute: attribute) {
+    case .value(let value): return value
+    case .absent, .failed: return NSNull()
+    }
+}
+
+func boolJSONValue(_ read: AXRead<Bool>, attribute: String, absent: Any = NSNull()) -> Any {
+    switch trackRead(read, attribute: attribute) {
+    case .value(let value): return value
+    case .absent, .failed: return absent
+    }
+}
+
+func elementValue(_ read: AXRead<AXUIElement>, attribute: String) -> AXUIElement? {
+    switch trackRead(read, attribute: attribute) {
+    case .value(let value): return value
+    case .absent, .failed: return nil
+    }
+}
+
+func children(_ element: AXUIElement) -> AXRead<[AXUIElement]> {
+    attr(element, kAXChildrenAttribute as String)
+}
+
+func childElements(_ element: AXUIElement) -> [AXUIElement] {
+    switch trackRead(children(element), attribute: kAXChildrenAttribute as String) {
+    case .value(let value): return value
+    case .absent, .failed: return []
+    }
 }
 
 func descendants(_ root: AXUIElement, _ depth: Int = 18) -> [AXUIElement] {
@@ -72,10 +169,18 @@ func descendants(_ root: AXUIElement, _ depth: Int = 18) -> [AXUIElement] {
     func visit(_ element: AXUIElement, _ remaining: Int) {
         result.append(element)
         guard remaining > 0 else { return }
-        for child in children(element) { visit(child, remaining - 1) }
+        for child in childElements(element) { visit(child, remaining - 1) }
     }
     visit(root, depth)
     return result
+}
+
+func readStatus<Value>(_ read: AXRead<Value>) -> String {
+    read.status
+}
+
+func readError<Value>(_ read: AXRead<Value>) -> Any {
+    read.errorCode
 }
 
 func same(_ lhs: AXUIElement, _ rhs: AXUIElement) -> Bool {
@@ -83,26 +188,68 @@ func same(_ lhs: AXUIElement, _ rhs: AXUIElement) -> Bool {
 }
 
 func snapshot(_ element: AXUIElement) -> JSON {
+    let roleRead = role(element)
+    let descriptionRead = description(element)
+    let titleRead = title(element)
+    let valueDescriptionRead = valueDescription(element)
+    let settableRead = valueIsSettable(element)
+    let enabledRead = boolAttribute(element, kAXEnabledAttribute as String)
+    let valueRead = scalarValue(element, kAXValueAttribute as String)
     var out: JSON = [
-        "role": role(element),
-        "description": description(element),
-        "title": title(element),
-        "value_description": valueDescription(element),
-        "value_settable": valueIsSettable(element),
+        // The historic scalar fields remain for old callers. Their status/error siblings retain
+        // the AX result, so empty/false no longer silently means success-with-absent.
+        "role": stringValue(roleRead, attribute: kAXRoleAttribute as String),
+        "role_status": readStatus(roleRead),
+        "role_error": readError(roleRead),
+        "description": stringValue(descriptionRead, attribute: kAXDescriptionAttribute as String),
+        "description_status": readStatus(descriptionRead),
+        "description_error": readError(descriptionRead),
+        "title": stringValue(titleRead, attribute: kAXTitleAttribute as String),
+        "title_status": readStatus(titleRead),
+        "title_error": readError(titleRead),
+        "value_description": stringValue(valueDescriptionRead,
+                                         attribute: kAXValueDescriptionAttribute as String),
+        "value_description_status": readStatus(valueDescriptionRead),
+        "value_description_error": readError(valueDescriptionRead),
+        "value_settable": boolJSONValue(settableRead, attribute: kAXValueAttribute as String,
+                                          absent: false),
+        "value_settable_status": readStatus(settableRead),
+        "value_settable_error": readError(settableRead),
     ]
-    out["enabled"] = boolAttribute(element, kAXEnabledAttribute as String) ?? NSNull()
-    out["value"] = scalarValue(element, kAXValueAttribute as String) ?? NSNull()
+    out["enabled"] = boolJSONValue(enabledRead, attribute: kAXEnabledAttribute as String)
+    out["enabled_status"] = readStatus(enabledRead)
+    out["enabled_error"] = readError(enabledRead)
+    out["value"] = scalarJSONValue(valueRead, attribute: kAXValueAttribute as String)
+    out["value_status"] = readStatus(valueRead)
+    out["value_error"] = readError(valueRead)
     return out
 }
 
 func elementName(_ element: AXUIElement) -> String {
-    let fromTitle = title(element)
-    return fromTitle.isEmpty ? description(element) : fromTitle
+    let fromTitle = titleText(element)
+    return fromTitle.isEmpty ? descriptionText(element) : fromTitle
+}
+
+func candidateOutcome(_ count: Int) -> String {
+    if count == 0 { return "not_found" }
+    if count == 1 { return "searched" }
+    return "ambiguous"
 }
 
 func emit(_ body: JSON) {
-    guard JSONSerialization.isValidJSONObject(body),
-          let data = try? JSONSerialization.data(withJSONObject: body, options: [.sortedKeys]),
+    var completed = body
+    // Zero candidates and a failed AX walk are different outcomes. The counts remain in the result,
+    // while this field lets a caller reject a partial success without parsing every nested witness.
+    if !axReadFailures.isEmpty {
+        completed["outcome"] = "could_not_search"
+        completed["ax_read_failures"] = axReadFailures
+    } else if completed["error"] != nil {
+        completed["outcome"] = "could_not_search"
+    } else if completed["outcome"] == nil {
+        completed["outcome"] = "searched"
+    }
+    guard JSONSerialization.isValidJSONObject(completed),
+          let data = try? JSONSerialization.data(withJSONObject: completed, options: [.sortedKeys]),
           let string = String(data: data, encoding: .utf8) else {
         print("{\"error\":\"could not encode probe result\"}")
         return
@@ -148,7 +295,11 @@ guard let logic = NSWorkspace.shared.runningApplications.first(
 let app = AXUIElementCreateApplication(logic.processIdentifier)
 
 func windows() -> [AXUIElement] {
-    attr(app, kAXWindowsAttribute as String) ?? []
+    switch trackRead(attr(app, kAXWindowsAttribute as String) as AXRead<[AXUIElement]>,
+                     attribute: kAXWindowsAttribute as String) {
+    case .value(let value): return value
+    case .absent, .failed: return []
+    }
 }
 
 func newWindows(since before: [AXUIElement]) -> [AXUIElement] {
@@ -161,7 +312,7 @@ func press(_ element: AXUIElement, _ action: String = kAXPressAction as String) 
 
 func closeWindow(_ window: AXUIElement, closeLabel: String) -> JSON {
     let buttons = descendants(window).filter {
-        role($0) == "AXButton" && description($0) == closeLabel
+        roleText($0) == "AXButton" && descriptionText($0) == closeLabel
     }
     var result: JSON = [
         "close_button_candidates": buttons.map(snapshot),
@@ -178,7 +329,7 @@ func closeWindow(_ window: AXUIElement, closeLabel: String) -> JSON {
 }
 
 func pluginSlots(in root: AXUIElement, named name: String) -> [AXUIElement] {
-    descendants(root).filter { role($0) == "AXGroup" && description($0) == name }
+    descendants(root).filter { roleText($0) == "AXGroup" && descriptionText($0) == name }
 }
 
 func pluginSlots(named name: String) -> [AXUIElement] {
@@ -207,11 +358,14 @@ func matchingGroupAncestor(
 ) -> AncestorGroupSearch {
     var current = element
     for _ in 0..<maximumDepth {
-        guard let parent: AXUIElement = attr(current, kAXParentAttribute as String) else {
+        guard let parent = elementValue(
+            attr(current, kAXParentAttribute as String) as AXRead<AXUIElement>,
+            attribute: kAXParentAttribute as String
+        ) else {
             return AncestorGroupSearch(found: false, boundHit: false)
         }
-        if role(parent) == (kAXGroupRole as String)
-            && trimmed(description(parent)) == expectedDescription {
+        if roleText(parent) == (kAXGroupRole as String)
+            && trimmed(descriptionText(parent)) == expectedDescription {
             return AncestorGroupSearch(found: true, boundHit: false)
         }
         current = parent
@@ -219,7 +373,10 @@ func matchingGroupAncestor(
 
     // We inspected the allowed number of ancestors. A further parent means the answer is unknown
     // at this bound (including in a cycle), so do not silently classify this layout area as out.
-    let hasMoreAncestors: AXUIElement? = attr(current, kAXParentAttribute as String)
+    let hasMoreAncestors = elementValue(
+        attr(current, kAXParentAttribute as String) as AXRead<AXUIElement>,
+        attribute: kAXParentAttribute as String
+    )
     return AncestorGroupSearch(found: false, boundHit: hasMoreAncestors != nil)
 }
 
@@ -242,8 +399,8 @@ func mixerContainers(named mixerLabels: [String]) -> MixerContainerSearch {
         descendants(window).filter { container in
             // Require the layout-area role first: Logic exposes an AXGroup with the same mixer
             // description, but channel strips are descendants of the AXLayoutArea.
-            role(container) == (kAXLayoutAreaRole as String)
-                && targets.contains(trimmed(description(container)))
+            roleText(container) == (kAXLayoutAreaRole as String)
+                && targets.contains(trimmed(descriptionText(container)))
         }
     }
     var ancestorSearchBoundHitCount = 0
@@ -252,7 +409,7 @@ func mixerContainers(named mixerLabels: [String]) -> MixerContainerSearch {
         // AXGroup ancestor prevents one configured synonym from admitting another by coincidence.
         let ancestor = matchingGroupAncestor(
             of: container,
-            named: trimmed(description(container))
+            named: trimmed(descriptionText(container))
         )
         if ancestor.boundHit { ancestorSearchBoundHitCount += 1 }
         return ancestor.found
@@ -267,7 +424,7 @@ func mixerContainers(named mixerLabels: [String]) -> MixerContainerSearch {
 func channelStrips(named trackLabel: String, in mixer: AXUIElement) -> [AXUIElement] {
     let target = trimmed(trackLabel)
     return descendants(mixer).filter { strip in
-        role(strip) == (kAXLayoutItemRole as String) && trimmed(description(strip)) == target
+        roleText(strip) == (kAXLayoutItemRole as String) && trimmed(descriptionText(strip)) == target
     }
 }
 
@@ -353,6 +510,7 @@ func slotSearchReport(_ search: PluginSlotSearch) -> JSON {
     var result: JSON = [
         "slot_count": search.slots.count,
         "slots": search.slots.map(snapshot),
+        "outcome": candidateOutcome(search.slots.count),
     ]
     guard let trackLabel = search.trackLabel else { return result }
 
@@ -402,12 +560,15 @@ func openPlugin(
     // that is the bypass value: reading it after the Open press would not catch an Open path that
     // toggled it and toggled it back before the witness looked.
     beforePress?(slot)
-    let buttons = children(slot).filter {
-        role($0) == "AXButton" && description($0) == openLabel
+    let buttons = childElements(slot).filter {
+        roleText($0) == "AXButton" && descriptionText($0) == openLabel
     }
-    result["slot_children"] = children(slot).map(snapshot)
+    result["slot_children"] = childElements(slot).map(snapshot)
     result["open_button_candidates"] = buttons.map(snapshot)
-    guard buttons.count == 1 else { return (result, slot, nil) }
+    guard buttons.count == 1 else {
+        result["outcome"] = candidateOutcome(buttons.count)
+        return (result, slot, nil)
+    }
 
     let before = windows()
     result["pressed_children"] = [snapshot(buttons[0])]
@@ -415,28 +576,29 @@ func openPlugin(
     usleep(1_400_000)
     let opened = newWindows(since: before)
     result["opened_windows"] = opened.map(snapshot)
+    result["outcome"] = candidateOutcome(opened.count)
     return (result, slot, opened.count == 1 ? opened[0] : nil)
 }
 
 func bandCheckboxes(in group: AXUIElement) -> [JSON] {
-    descendants(group).filter { role($0) == "AXCheckBox" }.map(snapshot)
+    descendants(group).filter { roleText($0) == "AXCheckBox" }.map(snapshot)
 }
 
 func sliders(in root: AXUIElement) -> [JSON] {
-    descendants(root).filter { role($0) == "AXSlider" }.map(snapshot)
+    descendants(root).filter { roleText($0) == "AXSlider" }.map(snapshot)
 }
 
 func rowCensus(in root: AXUIElement) -> [JSON] {
-    descendants(root).filter { role($0) == "AXRow" }.map { row in
-        let cells = descendants(row, 6).filter { role($0) == "AXCell" }
+    descendants(root).filter { roleText($0) == "AXRow" }.map { row in
+        let cells = descendants(row, 6).filter { roleText($0) == "AXCell" }
         let cellData: [JSON] = cells.map { cell in
-            let staticTexts = descendants(cell, 6).filter { role($0) == "AXStaticText" }
+            let staticTexts = descendants(cell, 6).filter { roleText($0) == "AXStaticText" }
             let controls = descendants(cell, 6).filter {
-                ["AXSlider", "AXRadioButton", "AXPopUpButton"].contains(role($0))
+                ["AXSlider", "AXRadioButton", "AXPopUpButton"].contains(roleText($0))
             }
             return [
-                "static_texts": staticTexts.map { textValue($0).isEmpty ? elementName($0) : textValue($0) },
-                "control_roles": controls.map(role),
+                "static_texts": staticTexts.map { textValueText($0).isEmpty ? elementName($0) : textValueText($0) },
+                "control_roles": controls.map(roleText),
             ]
         }
         return ["cells": cellData]
@@ -444,14 +606,15 @@ func rowCensus(in root: AXUIElement) -> [JSON] {
 }
 
 func menuItems(for button: AXUIElement) -> [AXUIElement] {
-    let nearby = descendants(button, 8).filter { role($0) == "AXMenuItem" }
-    if !nearby.isEmpty { return nearby }
-    return descendants(app, 10).filter { role($0) == "AXMenuItem" }
+    // The View button is the witness boundary. Falling back to every app menu item silently widened
+    // a failed local lookup into an unrelated menu match, exactly like the mixer search this file
+    // already keeps scoped. An empty local result stays empty and the caller's outcome says so.
+    descendants(button, 8).filter { roleText($0) == "AXMenuItem" }
 }
 
 func selectView(in window: AXUIElement, viewLabels: [String], wanted: String) -> JSON {
     let buttons = descendants(window).filter {
-        role($0) == "AXMenuButton" && viewLabels.contains(description($0))
+        roleText($0) == "AXMenuButton" && viewLabels.contains(descriptionText($0))
     }
     var result: JSON = [
         "button_candidates": buttons.map(snapshot),
@@ -460,6 +623,7 @@ func selectView(in window: AXUIElement, viewLabels: [String], wanted: String) ->
         "pressed": false,
         "show_menu_status": NSNull(),
         "press_status": NSNull(),
+        "outcome": candidateOutcome(buttons.count),
     ]
     guard buttons.count == 1 else { return result }
 
@@ -469,6 +633,7 @@ func selectView(in window: AXUIElement, viewLabels: [String], wanted: String) ->
     let selected = items.filter { elementName($0) == wanted }
     result["items"] = items.map(snapshot)
     result["item_candidates"] = selected.map(snapshot)
+    result["outcome"] = candidateOutcome(selected.count)
     guard selected.count == 1 else { return result }
 
     result["pressed"] = true
@@ -486,33 +651,44 @@ func runChannelEQ() {
     var bypasses: [AXUIElement] = []
     var bypassBefore: Any = NSNull()
     let (openResult, slot, opened) = openPlugin(slotName: slotName, openLabel: openLabel) { slot in
-        bypasses = children(slot).filter {
-            role($0) == "AXCheckBox" && bypassLabels.contains(description($0))
+        bypasses = childElements(slot).filter {
+            roleText($0) == "AXCheckBox" && bypassLabels.contains(descriptionText($0))
         }
         if bypasses.count == 1 {
-            bypassBefore = scalarValue(bypasses[0], kAXValueAttribute as String) ?? NSNull()
+            bypassBefore = scalarJSONValue(scalarValue(bypasses[0], kAXValueAttribute as String),
+                                           attribute: kAXValueAttribute as String)
         }
     }
     result["open"] = openResult
-    guard slot != nil else { emit(result); return }
+    guard slot != nil else {
+        result["outcome"] = openResult["outcome"] ?? "not_found"
+        emit(result)
+        return
+    }
 
     result["bypass_candidates"] = bypasses.map(snapshot)
     result["bypass_before"] = bypassBefore
 
     guard let opened else {
+        result["outcome"] = openResult["outcome"] ?? "not_found"
         result["bypass_after"] = bypasses.count == 1
-            ? (scalarValue(bypasses[0], kAXValueAttribute as String) ?? NSNull()) : NSNull()
+            ? scalarJSONValue(scalarValue(bypasses[0], kAXValueAttribute as String),
+                              attribute: kAXValueAttribute as String) : NSNull()
         emit(result)
         return
     }
 
-    let groups = descendants(opened).filter { role($0) == "AXGroup" && description($0) == "EQ" }
+    let groups = descendants(opened).filter {
+        roleText($0) == "AXGroup" && descriptionText($0) == "EQ"
+    }
     result["eq_group_count"] = groups.count
+    result["outcome"] = candidateOutcome(groups.count)
     result["band_checkboxes"] = groups.count == 1 ? bandCheckboxes(in: groups[0]) : []
     result["sliders"] = groups.count == 1 ? sliders(in: groups[0]) : []
     result["close"] = closeWindow(opened, closeLabel: closeLabel)
     result["bypass_after"] = bypasses.count == 1
-        ? (scalarValue(bypasses[0], kAXValueAttribute as String) ?? NSNull()) : NSNull()
+        ? scalarJSONValue(scalarValue(bypasses[0], kAXValueAttribute as String),
+                          attribute: kAXValueAttribute as String) : NSNull()
     emit(result)
 }
 
@@ -525,7 +701,7 @@ func runPluginSlot() {
     let slots = search.slots
     var result = slotSearchReport(search)
     result["frontmost_bundle_id"] = NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? ""
-    result["slot_children"] = slots.count == 1 ? children(slots[0]).map(snapshot) : []
+    result["slot_children"] = slots.count == 1 ? childElements(slots[0]).map(snapshot) : []
     emit(result)
 }
 
@@ -544,15 +720,26 @@ func runCompressor() {
         mixerLabels: configuredStringFamily("mixer_label")
     )
     result["open"] = openResult
-    guard let opened else { emit(result); return }
+    guard let opened else {
+        result["outcome"] = openResult["outcome"] ?? "not_found"
+        emit(result)
+        return
+    }
 
     result["native_editor_sliders"] = sliders(in: opened)
     let controlsSelection = selectView(in: opened, viewLabels: viewLabels, wanted: controlsLabel)
     result["controls_selection"] = controlsSelection
+    if let outcome = controlsSelection["outcome"] as? String, outcome != "searched" {
+        result["outcome"] = outcome
+    }
     result["controls_rows"] = rowCensus(in: opened)
     result["controls_sliders"] = sliders(in: opened)
     let editorSelection = selectView(in: opened, viewLabels: viewLabels, wanted: editorLabel)
     result["editor_selection"] = editorSelection
+    if result["outcome"] == nil,
+       let outcome = editorSelection["outcome"] as? String, outcome != "searched" {
+        result["outcome"] = outcome
+    }
     result["editor_after_restore_sliders"] = sliders(in: opened)
     result["rows_after_restore"] = rowCensus(in: opened)
     result["close"] = closeWindow(opened, closeLabel: closeLabel)
@@ -564,7 +751,7 @@ func path(_ elements: [AXUIElement]) -> [JSON] {
 }
 
 func oneMenuChild(of element: AXUIElement) -> [AXUIElement] {
-    children(element).filter { role($0) == "AXMenu" }
+    childElements(element).filter { roleText($0) == "AXMenu" }
 }
 
 func runExportMenu() {
@@ -574,38 +761,57 @@ func runExportMenu() {
     let oneTrackLabel = configuredString("one_track_label")
     let openLabel = configuredString("open_label")
     var result: JSON = ["frontmost_bundle_id": NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? ""]
-    guard let menuBar: AXUIElement = attr(app, kAXMenuBarAttribute as String) else {
+    guard let menuBar = elementValue(
+        attr(app, kAXMenuBarAttribute as String) as AXRead<AXUIElement>,
+        attribute: kAXMenuBarAttribute as String
+    ) else {
         result["error"] = "Logic has no AXMenuBar"
         emit(result)
         return
     }
-    let fileItems = children(menuBar).filter {
-        role($0) == "AXMenuBarItem" && fileLabels.contains(elementName($0))
+    let fileItems = childElements(menuBar).filter {
+        roleText($0) == "AXMenuBarItem" && fileLabels.contains(elementName($0))
     }
     result["file_candidates"] = fileItems.map(snapshot)
-    guard fileItems.count == 1 else { emit(result); return }
+    guard fileItems.count == 1 else {
+        result["outcome"] = candidateOutcome(fileItems.count)
+        emit(result)
+        return
+    }
 
     let menus = oneMenuChild(of: fileItems[0])
     result["file_menu_candidates"] = menus.map(snapshot)
-    guard menus.count == 1 else { emit(result); return }
+    guard menus.count == 1 else {
+        result["outcome"] = candidateOutcome(menus.count)
+        emit(result)
+        return
+    }
 
     let fileMenu = menus[0]
-    let exportItems = children(fileMenu).filter {
-        role($0) == "AXMenuItem" && elementName($0) == exportLabel
+    let exportItems = childElements(fileMenu).filter {
+        roleText($0) == "AXMenuItem" && elementName($0) == exportLabel
     }
-    let openItems = children(fileMenu).filter {
-        role($0) == "AXMenuItem" && elementName($0) == openLabel
+    let openItems = childElements(fileMenu).filter {
+        roleText($0) == "AXMenuItem" && elementName($0) == openLabel
     }
     result["export_candidates"] = exportItems.map(snapshot)
     result["open_candidates"] = openItems.map(snapshot)
     result["open_path"] = openItems.count == 1 ? path([fileItems[0], fileMenu, openItems[0]]) : []
-    guard exportItems.count == 1 else { emit(result); return }
+    guard exportItems.count == 1 else {
+        result["outcome"] = candidateOutcome(exportItems.count)
+        emit(result)
+        return
+    }
 
     let exportMenus = oneMenuChild(of: exportItems[0])
     result["export_menu_candidates"] = exportMenus.map(snapshot)
-    guard exportMenus.count == 1 else { emit(result); return }
+    guard exportMenus.count == 1 else {
+        result["outcome"] = candidateOutcome(exportMenus.count)
+        emit(result)
+        return
+    }
 
-    let leaves = children(exportMenus[0]).filter { role($0) == "AXMenuItem" }
+    let leaves = childElements(exportMenus[0]).filter { roleText($0) == "AXMenuItem" }
     let allTracks = leaves.filter { elementName($0) == allTracksLabel }
     let oneTrack = leaves.filter { elementName($0) == oneTrackLabel }
     result["all_tracks_candidates"] = allTracks.map(snapshot)
@@ -614,6 +820,11 @@ func runExportMenu() {
         ? path([fileItems[0], fileMenu, exportItems[0], exportMenus[0], allTracks[0]]) : []
     result["one_track_path"] = oneTrack.count == 1
         ? path([fileItems[0], fileMenu, exportItems[0], exportMenus[0], oneTrack[0]]) : []
+    if allTracks.count != 1 {
+        result["outcome"] = candidateOutcome(allTracks.count)
+    } else if oneTrack.count != 1 {
+        result["outcome"] = candidateOutcome(oneTrack.count)
+    }
     emit(result)
 }
 

--- a/Scripts/livekit/ax_plugin_menu_probe.swift
+++ b/Scripts/livekit/ax_plugin_menu_probe.swift
@@ -124,8 +124,18 @@ func configuredString(_ key: String) -> String {
     config[key] as? String ?? ""
 }
 
+func configuredOptionalString(_ key: String) -> String? {
+    config[key] as? String
+}
+
 func configuredStrings(_ key: String) -> [String] {
     config[key] as? [String] ?? []
+}
+
+func configuredStringFamily(_ key: String) -> [String] {
+    if let values = config[key] as? [String] { return values }
+    if let value = config[key] as? String { return [value] }
+    return []
 }
 
 guard let logic = NSWorkspace.shared.runningApplications.first(
@@ -167,23 +177,224 @@ func closeWindow(_ window: AXUIElement, closeLabel: String) -> JSON {
     return result
 }
 
+func pluginSlots(in root: AXUIElement, named name: String) -> [AXUIElement] {
+    descendants(root).filter { role($0) == "AXGroup" && description($0) == name }
+}
+
 func pluginSlots(named name: String) -> [AXUIElement] {
     windows().flatMap { window in
-        descendants(window).filter { role($0) == "AXGroup" && description($0) == name }
+        pluginSlots(in: window, named: name)
     }
 }
 
-func openPlugin(slotName: String, openLabel: String,
-                beforePress: ((AXUIElement) -> Void)? = nil) -> (JSON, AXUIElement?, AXUIElement?) {
-    let slots = pluginSlots(named: slotName)
+func trimmed(_ text: String) -> String {
+    text.trimmingCharacters(in: .whitespacesAndNewlines)
+}
+
+struct AncestorGroupSearch {
+    let found: Bool
+    let boundHit: Bool
+}
+
+// The Inspector can expose a selected track's channel strip as another AXLayoutArea named
+// "믹서". Only the Mixer pane's layout area is contained by an AXGroup with that same label.
+// Keep the parent walk bounded so a malformed AX tree cannot make the witness hang; callers report
+// a bound hit as an unresolved observation rather than treating it as a definitive non-match.
+func matchingGroupAncestor(
+    of element: AXUIElement,
+    named expectedDescription: String,
+    maximumDepth: Int = 12
+) -> AncestorGroupSearch {
+    var current = element
+    for _ in 0..<maximumDepth {
+        guard let parent: AXUIElement = attr(current, kAXParentAttribute as String) else {
+            return AncestorGroupSearch(found: false, boundHit: false)
+        }
+        if role(parent) == (kAXGroupRole as String)
+            && trimmed(description(parent)) == expectedDescription {
+            return AncestorGroupSearch(found: true, boundHit: false)
+        }
+        current = parent
+    }
+
+    // We inspected the allowed number of ancestors. A further parent means the answer is unknown
+    // at this bound (including in a cycle), so do not silently classify this layout area as out.
+    let hasMoreAncestors: AXUIElement? = attr(current, kAXParentAttribute as String)
+    return AncestorGroupSearch(found: false, boundHit: hasMoreAncestors != nil)
+}
+
+struct MixerContainerSearch {
+    let layoutAreasSeen: [AXUIElement]
+    let containers: [AXUIElement]
+    let ancestorSearchBoundHitCount: Int
+}
+
+func mixerContainers(named mixerLabels: [String]) -> MixerContainerSearch {
+    let targets = Set(mixerLabels.map(trimmed))
+    guard !targets.isEmpty else {
+        return MixerContainerSearch(
+            layoutAreasSeen: [],
+            containers: [],
+            ancestorSearchBoundHitCount: 0
+        )
+    }
+    let layoutAreasSeen = windows().flatMap { window in
+        descendants(window).filter { container in
+            // Require the layout-area role first: Logic exposes an AXGroup with the same mixer
+            // description, but channel strips are descendants of the AXLayoutArea.
+            role(container) == (kAXLayoutAreaRole as String)
+                && targets.contains(trimmed(description(container)))
+        }
+    }
+    var ancestorSearchBoundHitCount = 0
+    let containers = layoutAreasSeen.filter { container in
+        // The container already matched a configured label, so matching that exact label on its
+        // AXGroup ancestor prevents one configured synonym from admitting another by coincidence.
+        let ancestor = matchingGroupAncestor(
+            of: container,
+            named: trimmed(description(container))
+        )
+        if ancestor.boundHit { ancestorSearchBoundHitCount += 1 }
+        return ancestor.found
+    }
+    return MixerContainerSearch(
+        layoutAreasSeen: layoutAreasSeen,
+        containers: containers,
+        ancestorSearchBoundHitCount: ancestorSearchBoundHitCount
+    )
+}
+
+func channelStrips(named trackLabel: String, in mixer: AXUIElement) -> [AXUIElement] {
+    let target = trimmed(trackLabel)
+    return descendants(mixer).filter { strip in
+        role(strip) == (kAXLayoutItemRole as String) && trimmed(description(strip)) == target
+    }
+}
+
+struct PluginSlotSearch {
+    let slots: [AXUIElement]
+    let unscopedSlots: [AXUIElement]
+    let trackLabel: String?
+    let mixerLayoutAreasSeen: [AXUIElement]?
+    let mixerContainers: [AXUIElement]?
+    let mixerAncestorSearchBoundHitCount: Int?
+    let matchingStrips: [AXUIElement]
+    let scopedSlots: [AXUIElement]?
+}
+
+func pluginSlotSearch(
+    named slotName: String,
+    trackLabel: String?,
+    mixerLabels: [String]? = nil
+) -> PluginSlotSearch {
+    let unscopedSlots = pluginSlots(named: slotName)
+    guard let trackLabel else {
+        return PluginSlotSearch(
+            slots: unscopedSlots,
+            unscopedSlots: unscopedSlots,
+            trackLabel: nil,
+            mixerLayoutAreasSeen: nil,
+            mixerContainers: nil,
+            mixerAncestorSearchBoundHitCount: nil,
+            matchingStrips: [],
+            scopedSlots: nil
+        )
+    }
+
+    let mixerSearch = mixerContainers(named: mixerLabels ?? [])
+    let mixerContainers = mixerSearch.containers
+    // Never widen this search back to the window: the arrange area's track header has the same
+    // AXLayoutItem role and track description as the mixer strip. An unresolved mixer is therefore
+    // a refusal condition, not permission to choose an identically named element by tree position.
+    guard mixerContainers.count == 1, let mixer = mixerContainers.first else {
+        return PluginSlotSearch(
+            slots: [],
+            unscopedSlots: unscopedSlots,
+            trackLabel: trackLabel,
+            mixerLayoutAreasSeen: mixerSearch.layoutAreasSeen,
+            mixerContainers: mixerContainers,
+            mixerAncestorSearchBoundHitCount: mixerSearch.ancestorSearchBoundHitCount,
+            matchingStrips: [],
+            scopedSlots: nil
+        )
+    }
+
+    let matchingStrips = channelStrips(named: trackLabel, in: mixer)
+    // Resolve the strip exactly before descending into it. The probe reports zero or many matching
+    // strips as a refusal condition; choosing one by tree order would open a plug-in on the wrong
+    // track when names are duplicated.
+    guard matchingStrips.count == 1, let strip = matchingStrips.first else {
+        return PluginSlotSearch(
+            slots: [],
+            unscopedSlots: unscopedSlots,
+            trackLabel: trackLabel,
+            mixerLayoutAreasSeen: mixerSearch.layoutAreasSeen,
+            mixerContainers: mixerContainers,
+            mixerAncestorSearchBoundHitCount: mixerSearch.ancestorSearchBoundHitCount,
+            matchingStrips: matchingStrips,
+            scopedSlots: nil
+        )
+    }
+
+    let scopedSlots = pluginSlots(in: strip, named: slotName)
+    return PluginSlotSearch(
+        slots: scopedSlots,
+        unscopedSlots: unscopedSlots,
+        trackLabel: trackLabel,
+        mixerLayoutAreasSeen: mixerSearch.layoutAreasSeen,
+        mixerContainers: mixerContainers,
+        mixerAncestorSearchBoundHitCount: mixerSearch.ancestorSearchBoundHitCount,
+        matchingStrips: matchingStrips,
+        scopedSlots: scopedSlots
+    )
+}
+
+func slotSearchReport(_ search: PluginSlotSearch) -> JSON {
     var result: JSON = [
-        "slot_count": slots.count,
-        "slots": slots.map(snapshot),
+        "slot_count": search.slots.count,
+        "slots": search.slots.map(snapshot),
+    ]
+    guard let trackLabel = search.trackLabel else { return result }
+
+    // Keep the full-window census beside the scoped one so evidence can show that the name
+    // narrowed the search, rather than merely reporting a convenient single result.
+    result["track_label"] = trackLabel
+    result["unscoped_slot_count"] = search.unscopedSlots.count
+    result["unscoped_slots"] = search.unscopedSlots.map(snapshot)
+    result["mixer_layout_areas_seen"] = search.mixerLayoutAreasSeen?.count ?? 0
+    result["mixer_layout_areas"] = search.mixerLayoutAreasSeen?.map(snapshot) ?? []
+    result["mixer_container_count"] = search.mixerContainers?.count ?? 0
+    result["mixer_containers"] = search.mixerContainers?.map(snapshot) ?? []
+    let mixerAncestorSearchBoundHitCount = search.mixerAncestorSearchBoundHitCount ?? 0
+    result["mixer_ancestor_search_bound_hit"] = mixerAncestorSearchBoundHitCount > 0
+    result["mixer_ancestor_search_bound_hit_count"] = mixerAncestorSearchBoundHitCount
+    result["matching_strip_count"] = search.matchingStrips.count
+    result["matching_strips"] = search.matchingStrips.map(snapshot)
+    result["scoped_slot_count"] = search.scopedSlots?.count ?? NSNull()
+    result["scoped_slots"] = search.scopedSlots?.map(snapshot) ?? []
+    return result
+}
+
+func openPlugin(
+    slotName: String,
+    openLabel: String,
+    trackLabel: String? = nil,
+    mixerLabels: [String]? = nil,
+    beforePress: ((AXUIElement) -> Void)? = nil
+) -> (JSON, AXUIElement?, AXUIElement?) {
+    let search = pluginSlotSearch(
+        named: slotName,
+        trackLabel: trackLabel,
+        mixerLabels: mixerLabels
+    )
+    let slots = search.slots
+    var result = slotSearchReport(search)
+    result.merge([
         "open_button_candidates": [],
         "pressed_children": [],
         "open_press_status": NSNull(),
         "opened_windows": [],
-    ]
+    ]) { _, new in new }
     guard slots.count == 1 else { return (result, nil, nil) }
 
     let slot = slots[0]
@@ -306,12 +517,14 @@ func runChannelEQ() {
 }
 
 func runPluginSlot() {
-    let slots = pluginSlots(named: configuredString("slot_label"))
-    var result: JSON = [
-        "frontmost_bundle_id": NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? "",
-        "slot_count": slots.count,
-        "slots": slots.map(snapshot),
-    ]
+    let search = pluginSlotSearch(
+        named: configuredString("slot_label"),
+        trackLabel: configuredOptionalString("track_label"),
+        mixerLabels: configuredStringFamily("mixer_label")
+    )
+    let slots = search.slots
+    var result = slotSearchReport(search)
+    result["frontmost_bundle_id"] = NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? ""
     result["slot_children"] = slots.count == 1 ? children(slots[0]).map(snapshot) : []
     emit(result)
 }
@@ -324,7 +537,12 @@ func runCompressor() {
     let controlsLabel = configuredString("controls_label")
     let editorLabel = configuredString("editor_label")
     var result: JSON = ["frontmost_bundle_id": NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? ""]
-    let (openResult, _, opened) = openPlugin(slotName: slotName, openLabel: openLabel)
+    let (openResult, _, opened) = openPlugin(
+        slotName: slotName,
+        openLabel: openLabel,
+        trackLabel: configuredOptionalString("track_label"),
+        mixerLabels: configuredStringFamily("mixer_label")
+    )
     result["open"] = openResult
     guard let opened else { emit(result); return }
 

--- a/Scripts/livekit/ax_plugin_menu_probe.swift
+++ b/Scripts/livekit/ax_plugin_menu_probe.swift
@@ -38,21 +38,76 @@ enum AXRead<Value> {
 
 var axReadFailures: [JSON] = []
 
-func recordReadFailure(_ attribute: String, _ error: AXError) {
-    axReadFailures.append(["attribute": attribute, "status": error.rawValue])
+func elementIdentity(_ element: AXUIElement) -> String {
+    "cfhash:\(String(CFHash(element), radix: 16))"
+}
+
+// Two AX errors are ANSWERS, not failures: the element has no such attribute, or the attribute
+// holds no value. A menu item legitimately has no AXDescription and reports one of these on every
+// read. Counting them as failures made `outcome` read `could_not_search` on a perfectly good walk,
+// which stopped all three harnesses at their first precondition. Verified against AXError.h:
+// kAXErrorAttributeUnsupported = -25205, kAXErrorNoValue = -25212.
+let axAbsenceErrors: Set<Int32> = [
+    AXError.attributeUnsupported.rawValue,
+    AXError.noValue.rawValue,
+]
+
+func recordReadFailure(
+    _ element: AXUIElement,
+    attribute: String,
+    error: AXError,
+    readSite: String
+) {
+    // An absence is recorded on the element itself (status/error siblings); it does not belong in
+    // the list that decides whether the search completed.
+    guard !axAbsenceErrors.contains(error.rawValue) else { return }
+    // Let the failing element identify itself. `read_site` is a function name, which is not enough
+    // to find a stale reference among several call paths — diagnosing one kAXErrorIllegalArgument
+    // took three runs because the receipt could say only "some description read failed". These
+    // reads are best effort and may fail too on a dead reference, which is itself informative.
+    var role = "<unreadable>"
+    var roleValue: AnyObject?
+    if AXUIElementCopyAttributeValue(element, kAXRoleAttribute as CFString, &roleValue) == .success,
+       let text = roleValue as? String {
+        role = text
+    }
+    var title = "<unreadable>"
+    var titleValue: AnyObject?
+    if AXUIElementCopyAttributeValue(element, kAXTitleAttribute as CFString, &titleValue) == .success,
+       let text = titleValue as? String {
+        title = text
+    }
+    axReadFailures.append([
+        "attribute": attribute,
+        "status": error.rawValue,
+        "code": error.rawValue,
+        "element_id": elementIdentity(element),
+        "element_role": role,
+        "element_title": title,
+        "read_site": readSite,
+    ])
 }
 
 func trackRead<T>(_ read: AXRead<T>, attribute: String) -> AXRead<T> {
-    if case .failed(let error) = read { recordReadFailure(attribute, error) }
+    // Record failures at the actual AX call, where the element identity and read site are still
+    // available. Recording only after a value conversion loses both and makes a JSON null
+    // impossible to locate in a raw-AX receipt.
     return read
 }
 
 // Preserve success-with-value, success-with-absent, and failed AX requests. A raw `nil` loses the
 // distinction and let failed slider reads masquerade as empty AXDescriptions or unsettable values.
-func attr<T>(_ element: AXUIElement, _ attribute: String) -> AXRead<T> {
+func attr<T>(
+    _ element: AXUIElement,
+    _ attribute: String,
+    readSite: String = #function
+) -> AXRead<T> {
     var value: AnyObject?
     let result = AXUIElementCopyAttributeValue(element, attribute as CFString, &value)
-    guard result == .success else { return .failed(result) }
+    guard result == .success else {
+        recordReadFailure(element, attribute: attribute, error: result, readSite: readSite)
+        return .failed(result)
+    }
     guard let value else { return .absent }
     guard let typed = value as? T else { return .absent }
     return .value(typed)
@@ -105,7 +160,15 @@ func scalarValue(_ element: AXUIElement, _ attribute: String) -> AXRead<Any> {
 func valueIsSettable(_ element: AXUIElement) -> AXRead<Bool> {
     var settable = DarwinBoolean(false)
     let result = AXUIElementIsAttributeSettable(element, kAXValueAttribute as CFString, &settable)
-    guard result == .success else { return .failed(result) }
+    guard result == .success else {
+        recordReadFailure(
+            element,
+            attribute: kAXValueAttribute as String,
+            error: result,
+            readSite: "AXUIElementIsAttributeSettable"
+        )
+        return .failed(result)
+    }
     return .value(settable.boolValue)
 }
 
@@ -137,6 +200,14 @@ func scalarJSONValue(_ read: AXRead<Any>, attribute: String) -> Any {
     case .value(let value): return value
     case .absent, .failed: return NSNull()
     }
+}
+
+func scalarJSONWitness(_ read: AXRead<Any>, attribute: String) -> JSON {
+    [
+        "value": scalarJSONValue(read, attribute: attribute),
+        "status": readStatus(read),
+        "error": readError(read),
+    ]
 }
 
 func boolJSONValue(_ read: AXRead<Bool>, attribute: String, absent: Any = NSNull()) -> Any {
@@ -196,6 +267,9 @@ func snapshot(_ element: AXUIElement) -> JSON {
     let enabledRead = boolAttribute(element, kAXEnabledAttribute as String)
     let valueRead = scalarValue(element, kAXValueAttribute as String)
     var out: JSON = [
+        // The same identifier is carried by ax_read_failures, so a failed null can be located in
+        // this census instead of being attributed only to an attribute name shared by many nodes.
+        "element_id": elementIdentity(element),
         // The historic scalar fields remain for old callers. Their status/error siblings retain
         // the AX result, so empty/false no longer silently means success-with-absent.
         "role": stringValue(roleRead, attribute: kAXRoleAttribute as String),
@@ -303,7 +377,14 @@ func windows() -> [AXUIElement] {
 }
 
 func newWindows(since before: [AXUIElement]) -> [AXUIElement] {
+    // AX exposes no direct edge from an insert slot to the plug-in window its button opens. This is
+    // deliberately application-wide rather than a pretend binding; openPlugin emits that widening
+    // in its receipt so harnesses do not present the sole new Logic window as slot-proven.
     windows().filter { candidate in !before.contains(where: { same($0, candidate) }) }
+}
+
+func windows(titled expectedTitle: String) -> [AXUIElement] {
+    windows().filter { titleText($0) == expectedTitle }
 }
 
 func press(_ element: AXUIElement, _ action: String = kAXPressAction as String) -> Int {
@@ -344,6 +425,7 @@ func trimmed(_ text: String) -> String {
 
 struct AncestorGroupSearch {
     let found: Bool
+    let matchingDescription: String?
     let boundHit: Bool
 }
 
@@ -353,7 +435,7 @@ struct AncestorGroupSearch {
 // a bound hit as an unresolved observation rather than treating it as a definitive non-match.
 func matchingGroupAncestor(
     of element: AXUIElement,
-    named expectedDescription: String,
+    named expectedDescriptions: Set<String>,
     maximumDepth: Int = 12
 ) -> AncestorGroupSearch {
     var current = element
@@ -362,11 +444,17 @@ func matchingGroupAncestor(
             attr(current, kAXParentAttribute as String) as AXRead<AXUIElement>,
             attribute: kAXParentAttribute as String
         ) else {
-            return AncestorGroupSearch(found: false, boundHit: false)
+            return AncestorGroupSearch(found: false, matchingDescription: nil, boundHit: false)
         }
-        if roleText(parent) == (kAXGroupRole as String)
-            && trimmed(descriptionText(parent)) == expectedDescription {
-            return AncestorGroupSearch(found: true, boundHit: false)
+        if roleText(parent) == (kAXGroupRole as String) {
+            let parentDescription = trimmed(descriptionText(parent))
+            if expectedDescriptions.contains(parentDescription) {
+                return AncestorGroupSearch(
+                    found: true,
+                    matchingDescription: parentDescription,
+                    boundHit: false
+                )
+            }
         }
         current = parent
     }
@@ -377,7 +465,11 @@ func matchingGroupAncestor(
         attr(current, kAXParentAttribute as String) as AXRead<AXUIElement>,
         attribute: kAXParentAttribute as String
     )
-    return AncestorGroupSearch(found: false, boundHit: hasMoreAncestors != nil)
+    return AncestorGroupSearch(
+        found: false,
+        matchingDescription: nil,
+        boundHit: hasMoreAncestors != nil
+    )
 }
 
 struct MixerContainerSearch {
@@ -400,19 +492,42 @@ func mixerContainers(named mixerLabels: [String]) -> MixerContainerSearch {
             // Require the layout-area role first: Logic exposes an AXGroup with the same mixer
             // description, but channel strips are descendants of the AXLayoutArea.
             roleText(container) == (kAXLayoutAreaRole as String)
-                && targets.contains(trimmed(descriptionText(container)))
         }
     }
     var ancestorSearchBoundHitCount = 0
-    let containers = layoutAreasSeen.filter { container in
-        // The container already matched a configured label, so matching that exact label on its
-        // AXGroup ancestor prevents one configured synonym from admitting another by coincidence.
+    var containers: [AXUIElement] = []
+    for container in layoutAreasSeen {
+        // An AXLayoutArea outside a labelled AXGroup cannot be the Mixer pane, so resolve the
+        // ancestry before asking it for AXDescription. Live AXLayoutArea elements can answer that
+        // read with kAXErrorIllegalArgument even while their AXRole read succeeds.
         let ancestor = matchingGroupAncestor(
             of: container,
-            named: trimmed(descriptionText(container))
+            named: targets
         )
         if ancestor.boundHit { ancestorSearchBoundHitCount += 1 }
-        return ancestor.found
+        guard ancestor.found, let ancestorDescription = ancestor.matchingDescription else { continue }
+
+        // Only a layout area inside a labelled mixer group is a description candidate. Require
+        // the same exact label so one configured synonym cannot admit another by coincidence.
+        // Keep a failed read observable: descriptionText records it in ax_read_failures.
+        let layoutAreaDescription = trimmed(descriptionText(container))
+        if layoutAreaDescription == ancestorDescription {
+            containers.append(container)
+            continue
+        }
+
+        // A nearer ancestor can use a different configured synonym. The first ancestry walk has
+        // already proved this layout area is in the mixer branch; now preserve the exact-label
+        // rule by checking whether the layout area's own label occurs farther up that branch.
+        guard targets.contains(layoutAreaDescription) else { continue }
+        let exactAncestor = matchingGroupAncestor(
+            of: container,
+            named: [layoutAreaDescription]
+        )
+        if exactAncestor.boundHit { ancestorSearchBoundHitCount += 1 }
+        if exactAncestor.found {
+            containers.append(container)
+        }
     }
     return MixerContainerSearch(
         layoutAreasSeen: layoutAreasSeen,
@@ -520,7 +635,6 @@ func slotSearchReport(_ search: PluginSlotSearch) -> JSON {
     result["unscoped_slot_count"] = search.unscopedSlots.count
     result["unscoped_slots"] = search.unscopedSlots.map(snapshot)
     result["mixer_layout_areas_seen"] = search.mixerLayoutAreasSeen?.count ?? 0
-    result["mixer_layout_areas"] = search.mixerLayoutAreasSeen?.map(snapshot) ?? []
     result["mixer_container_count"] = search.mixerContainers?.count ?? 0
     result["mixer_containers"] = search.mixerContainers?.map(snapshot) ?? []
     let mixerAncestorSearchBoundHitCount = search.mixerAncestorSearchBoundHitCount ?? 0
@@ -575,6 +689,9 @@ func openPlugin(
     result["open_press_status"] = press(buttons[0])
     usleep(1_400_000)
     let opened = newWindows(since: before)
+    result["opened_windows_scope"] = "all_logic_application_windows"
+    result["opened_windows_scope_widened_from_pressed_slot"] = true
+    result["opened_windows_scope_note"] = "new windows are not bound to the pressed \(slotName) slot"
     result["opened_windows"] = opened.map(snapshot)
     result["outcome"] = candidateOutcome(opened.count)
     return (result, slot, opened.count == 1 ? opened[0] : nil)
@@ -649,14 +766,14 @@ func runChannelEQ() {
     let bypassLabels = configuredStrings("bypass_labels")
     var result: JSON = ["frontmost_bundle_id": NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? ""]
     var bypasses: [AXUIElement] = []
-    var bypassBefore: Any = NSNull()
+    var bypassBefore: AXRead<Any> = .absent
+    var bypassAfter: AXRead<Any> = .absent
     let (openResult, slot, opened) = openPlugin(slotName: slotName, openLabel: openLabel) { slot in
         bypasses = childElements(slot).filter {
             roleText($0) == "AXCheckBox" && bypassLabels.contains(descriptionText($0))
         }
         if bypasses.count == 1 {
-            bypassBefore = scalarJSONValue(scalarValue(bypasses[0], kAXValueAttribute as String),
-                                           attribute: kAXValueAttribute as String)
+            bypassBefore = scalarValue(bypasses[0], kAXValueAttribute as String)
         }
     }
     result["open"] = openResult
@@ -667,13 +784,20 @@ func runChannelEQ() {
     }
 
     result["bypass_candidates"] = bypasses.map(snapshot)
-    result["bypass_before"] = bypassBefore
+    let bypassBeforeWitness = scalarJSONWitness(bypassBefore, attribute: kAXValueAttribute as String)
+    result["bypass_before"] = bypassBeforeWitness["value"]
+    result["bypass_before_status"] = bypassBeforeWitness["status"]
+    result["bypass_before_error"] = bypassBeforeWitness["error"]
 
     guard let opened else {
         result["outcome"] = openResult["outcome"] ?? "not_found"
-        result["bypass_after"] = bypasses.count == 1
-            ? scalarJSONValue(scalarValue(bypasses[0], kAXValueAttribute as String),
-                              attribute: kAXValueAttribute as String) : NSNull()
+        if bypasses.count == 1 {
+            bypassAfter = scalarValue(bypasses[0], kAXValueAttribute as String)
+        }
+        let bypassAfterWitness = scalarJSONWitness(bypassAfter, attribute: kAXValueAttribute as String)
+        result["bypass_after"] = bypassAfterWitness["value"]
+        result["bypass_after_status"] = bypassAfterWitness["status"]
+        result["bypass_after_error"] = bypassAfterWitness["error"]
         emit(result)
         return
     }
@@ -686,9 +810,13 @@ func runChannelEQ() {
     result["band_checkboxes"] = groups.count == 1 ? bandCheckboxes(in: groups[0]) : []
     result["sliders"] = groups.count == 1 ? sliders(in: groups[0]) : []
     result["close"] = closeWindow(opened, closeLabel: closeLabel)
-    result["bypass_after"] = bypasses.count == 1
-        ? scalarJSONValue(scalarValue(bypasses[0], kAXValueAttribute as String),
-                          attribute: kAXValueAttribute as String) : NSNull()
+    if bypasses.count == 1 {
+        bypassAfter = scalarValue(bypasses[0], kAXValueAttribute as String)
+    }
+    let bypassAfterWitness = scalarJSONWitness(bypassAfter, attribute: kAXValueAttribute as String)
+    result["bypass_after"] = bypassAfterWitness["value"]
+    result["bypass_after_status"] = bypassAfterWitness["status"]
+    result["bypass_after_error"] = bypassAfterWitness["error"]
     emit(result)
 }
 
@@ -727,22 +855,43 @@ func runCompressor() {
     }
 
     result["native_editor_sliders"] = sliders(in: opened)
+    let openedWindowTitle = titleText(opened)
     let controlsSelection = selectView(in: opened, viewLabels: viewLabels, wanted: controlsLabel)
     result["controls_selection"] = controlsSelection
     if let outcome = controlsSelection["outcome"] as? String, outcome != "searched" {
         result["outcome"] = outcome
     }
-    result["controls_rows"] = rowCensus(in: opened)
-    result["controls_sliders"] = sliders(in: opened)
-    let editorSelection = selectView(in: opened, viewLabels: viewLabels, wanted: editorLabel)
+
+    // `opened` belongs to the pre-switch editor tree. kAXErrorIllegalArgument on an AXDescription
+    // read is the signature of using that stale AXUIElement after the view rebuild, so enumerate a
+    // fresh window before taking the Controls census.
+    let controlsWindows = windows(titled: openedWindowTitle)
+    result["controls_window_count"] = controlsWindows.count
+    guard controlsWindows.count == 1, let controlsWindow = controlsWindows.first else {
+        result["outcome"] = candidateOutcome(controlsWindows.count)
+        emit(result)
+        return
+    }
+    result["controls_rows"] = rowCensus(in: controlsWindow)
+    result["controls_sliders"] = sliders(in: controlsWindow)
+    let editorSelection = selectView(in: controlsWindow, viewLabels: viewLabels, wanted: editorLabel)
     result["editor_selection"] = editorSelection
     if result["outcome"] == nil,
        let outcome = editorSelection["outcome"] as? String, outcome != "searched" {
         result["outcome"] = outcome
     }
-    result["editor_after_restore_sliders"] = sliders(in: opened)
-    result["rows_after_restore"] = rowCensus(in: opened)
-    result["close"] = closeWindow(opened, closeLabel: closeLabel)
+
+    // The Editor selection rebuilds the subtree again; this is a separate, fresh-tree census.
+    let editorWindows = windows(titled: openedWindowTitle)
+    result["editor_window_count"] = editorWindows.count
+    guard editorWindows.count == 1, let editorWindow = editorWindows.first else {
+        result["outcome"] = candidateOutcome(editorWindows.count)
+        emit(result)
+        return
+    }
+    result["editor_after_restore_sliders"] = sliders(in: editorWindow)
+    result["rows_after_restore"] = rowCensus(in: editorWindow)
+    result["close"] = closeWindow(editorWindow, closeLabel: closeLabel)
     emit(result)
 }
 

--- a/Scripts/livekit/evidence.py
+++ b/Scripts/livekit/evidence.py
@@ -7,10 +7,12 @@ without it.
 
 What it refuses to let you record:
 
-- **A check made through a blocking modal.** `blocking_modal()` reads the CoreGraphics window list,
-  not the AX tree being exercised, and every check records whether such a window was present at the
-  instant the check entered the document. A modal blocks Logic as a whole, so AX values read through
-  it are not evidence about the affordance they appear to describe.
+- **A check made through a blocking modal.** `blocking_modal()` uses the CoreGraphics window list
+  plus the narrowly necessary AX modal/sheet reads. A modal can block the current document while
+  leaving application-wide menu items enabled, so an AX value read through it is not evidence about
+  the affordance it appears to describe. Only `check()` and `falsifiable()` receipts carry this
+  snapshot; notes, captures, visuals, operations, and restorations do not claim modal coverage.
+  The summary gate invalidates those CHECK receipts rather than preventing a caller from making one.
 - **An unsettled capture.** A screenshot taken while Logic is still redrawing shows a state nobody was
   ever in. `shot()` takes frames until two consecutive ones are byte-identical, and marks the record
   `settled: false` if they never converge.
@@ -67,6 +69,7 @@ import subprocess
 import tempfile
 import sys
 import time
+import ctypes
 
 # Set by the harness before use.
 REPO = ""
@@ -89,6 +92,14 @@ MARKER_LIST_TAB_NAMES = ["Marker", "마커", "マーカー"]
 OTHER_LIST_TAB_NAMES = ["Tempo", "템포", "テンポ",
                         "Signature", "조표 및 박자표", "調号と拍子記号"]
 ALL_LIST_TAB_NAMES = (EVENT_LIST_TAB_NAMES + MARKER_LIST_TAB_NAMES + OTHER_LIST_TAB_NAMES)
+
+
+# `None` from blocking_modal() means a completed scan found no blocker. A dictionary whose state is
+# `cannot_tell` means at least one required detector read did not answer; it is deliberately truthy
+# so existing precondition callers refuse it, and summarize() records it separately from a detected
+# blocker. Keep the string public: live harnesses can display the reason without guessing a shape.
+MODAL_CANNOT_TELL = "cannot_tell"
+_MODAL_SNAPSHOT_UNSET = object()
 
 
 def label_set(name, repo=None):
@@ -221,47 +232,332 @@ def logic_window(title_contains=None):
     return None
 
 
-def blocking_modal(lister=None):
-    """The first Logic window at the CoreGraphics modal-panel level, or None.
+class _ModalReadError(RuntimeError):
+    """An AX read that did not answer, kept separate from a completed empty search."""
 
-    This is deliberately a CoreGraphics read rather than an AX read. The AX tree can honestly say
-    that an enabled menu item is unavailable when a modal has blocked Logic, which is precisely the
-    state a check has to reject. `lister` is a test seam; production always uses the same on-screen
-    list and options as `logic_window`.
+    def __init__(self, site, status=None):
+        self.site = site
+        self.status = status
+        suffix = "" if status is None else f" (AX status {status!r})"
+        super().__init__(site + suffix)
+
+
+def _modal_cannot_tell(signal, reason):
+    """The explicit third blocking_modal state; None is reserved for a completed clear scan."""
+    return {"state": MODAL_CANNOT_TELL, "kind": MODAL_CANNOT_TELL,
+            "signal": signal, "reason": reason}
+
+
+class _AXRuntime:
+    """The small C Accessibility bridge PyObjC does not vend through this Quartz installation."""
+
+    _UTF8 = 0x08000100
+    _ATTRIBUTE_UNSUPPORTED = -25205
+    _NO_VALUE = -25212
+
+    def __init__(self):
+        try:
+            self.ax = ctypes.CDLL(
+                "/System/Library/Frameworks/ApplicationServices.framework/ApplicationServices")
+            self.cf = ctypes.CDLL("/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation")
+        except OSError as exc:
+            raise _ModalReadError(f"could not load the Accessibility framework: {exc!r}") from exc
+
+        self.ax.AXUIElementCreateApplication.restype = ctypes.c_void_p
+        self.ax.AXUIElementCreateApplication.argtypes = (ctypes.c_int,)
+        self.ax.AXUIElementCopyAttributeValue.restype = ctypes.c_int
+        self.ax.AXUIElementCopyAttributeValue.argtypes = (
+            ctypes.c_void_p, ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p))
+        self.cf.CFStringCreateWithCString.restype = ctypes.c_void_p
+        self.cf.CFStringCreateWithCString.argtypes = (ctypes.c_void_p, ctypes.c_char_p, ctypes.c_uint32)
+        self.cf.CFStringGetLength.restype = ctypes.c_long
+        self.cf.CFStringGetLength.argtypes = (ctypes.c_void_p,)
+        self.cf.CFStringGetTypeID.restype = ctypes.c_ulong
+        self.cf.CFStringGetMaximumSizeForEncoding.restype = ctypes.c_long
+        self.cf.CFStringGetMaximumSizeForEncoding.argtypes = (ctypes.c_long, ctypes.c_uint32)
+        self.cf.CFStringGetCString.restype = ctypes.c_bool
+        self.cf.CFStringGetCString.argtypes = (ctypes.c_void_p, ctypes.c_char_p, ctypes.c_long, ctypes.c_uint32)
+        self.cf.CFArrayGetCount.restype = ctypes.c_long
+        self.cf.CFArrayGetCount.argtypes = (ctypes.c_void_p,)
+        self.cf.CFArrayGetValueAtIndex.restype = ctypes.c_void_p
+        self.cf.CFArrayGetValueAtIndex.argtypes = (ctypes.c_void_p, ctypes.c_long)
+        self.cf.CFGetTypeID.restype = ctypes.c_ulong
+        self.cf.CFGetTypeID.argtypes = (ctypes.c_void_p,)
+        self.cf.CFArrayGetTypeID.restype = ctypes.c_ulong
+        self.cf.CFBooleanGetTypeID.restype = ctypes.c_ulong
+        self.cf.CFBooleanGetValue.restype = ctypes.c_bool
+        self.cf.CFBooleanGetValue.argtypes = (ctypes.c_void_p,)
+        self.cf.CFRelease.argtypes = (ctypes.c_void_p,)
+        self._owned = []
+
+    def application(self, pid):
+        element = self.ax.AXUIElementCreateApplication(pid)
+        if not element:
+            raise _ModalReadError("could not create an AX application element")
+        self._owned.append(element)
+        return element
+
+    def attribute(self, element, attribute, site):
+        name = self.cf.CFStringCreateWithCString(None, attribute.encode("utf-8"), self._UTF8)
+        if not name:
+            raise _ModalReadError(f"{site}: could not create a CFString")
+        value = ctypes.c_void_p()
+        try:
+            status = self.ax.AXUIElementCopyAttributeValue(element, name, ctypes.byref(value))
+        finally:
+            self.cf.CFRelease(name)
+        if status != 0:
+            raise _ModalReadError(site, status)
+        if not value.value:
+            raise _ModalReadError(f"{site}: successful but empty payload")
+        self._owned.append(value.value)
+        return value.value
+
+    def elements(self, value, site):
+        if self.cf.CFGetTypeID(value) != self.cf.CFArrayGetTypeID():
+            raise _ModalReadError(f"{site}: successful but non-array payload")
+        return [self.cf.CFArrayGetValueAtIndex(value, index)
+                for index in range(self.cf.CFArrayGetCount(value))]
+
+    def text(self, value, site):
+        if self.cf.CFGetTypeID(value) != self.cf.CFStringGetTypeID():
+            raise _ModalReadError(f"{site}: successful but non-string payload")
+        length = self.cf.CFStringGetLength(value)
+        capacity = self.cf.CFStringGetMaximumSizeForEncoding(length, self._UTF8) + 1
+        if capacity <= 0:
+            raise _ModalReadError(f"{site}: invalid CFString length")
+        buffer = ctypes.create_string_buffer(capacity)
+        if not self.cf.CFStringGetCString(value, buffer, capacity, self._UTF8):
+            raise _ModalReadError(f"{site}: could not decode CFString")
+        return buffer.value.decode("utf-8", "replace")
+
+    def boolean(self, value, site):
+        if self.cf.CFGetTypeID(value) != self.cf.CFBooleanGetTypeID():
+            raise _ModalReadError(f"{site}: successful but non-boolean payload")
+        return bool(self.cf.CFBooleanGetValue(value))
+
+    def definitive_absence(self, status):
+        return status in {self._ATTRIBUTE_UNSUPPORTED, self._NO_VALUE}
+
+    def close(self):
+        for value in reversed(self._owned):
+            self.cf.CFRelease(value)
+        self._owned.clear()
+
+
+def _ax_optional_title(ax, element):
+    """A title helps correlate CG and AX records, but its absence does not veto a known blocker."""
+    try:
+        return ax.text(ax.attribute(element, "AXTitle", "AXTitle"), "AXTitle")
+    except _ModalReadError:
+        return ""
+
+
+def _first_ax_sheet(ax, window, max_depth=32):
+    """Find a sheet on one host through AXSheets or its descendant tree.
+
+    Logic can report AXSheets as unsupported even while New Track is visible. AXSheets is therefore a
+    cheap positive only; descendants are still searched for an AXSheet role. A failed descendant read
+    is not changed into an empty branch, because that would certify a clear document without having
+    searched it.
+    """
+    try:
+        direct = ax.elements(ax.attribute(window, "AXSheets", "AXSheets"), "AXSheets")
+    except _ModalReadError:
+        # AXSheets is non-authoritative. Logic has measured it as unsupported even while the sheet
+        # is visible, so neither an AXSheets error nor a malformed AXSheets value may veto the
+        # descendant traversal that actually decides this detector's sheet signal.
+        direct = []
+
+    for candidate in direct:
+        try:
+            role = ax.text(ax.attribute(candidate, "AXRole", "AXSheets candidate AXRole"),
+                           "AXSheets candidate AXRole")
+        except _ModalReadError:
+            continue
+        if role == "AXSheet":
+            return candidate
+
+    stack = [(window, 0)]
+    unreadable = None
+    while stack:
+        current, depth = stack.pop()
+        try:
+            children = ax.elements(ax.attribute(current, "AXChildren", "AXChildren"), "AXChildren")
+        except _ModalReadError as exc:
+            # A confirmed no-children status is a completed leaf. Any other status leaves this
+            # branch unreadable, but a later sibling can still positively identify a sheet.
+            if not ax.definitive_absence(exc.status) and unreadable is None:
+                unreadable = exc
+            continue
+        if depth >= max_depth:
+            if children:
+                raise _ModalReadError(f"AX sheet descendant search reached depth {max_depth}")
+            continue
+        for child in children:
+            try:
+                role = ax.text(ax.attribute(child, "AXRole", "AX descendant AXRole"),
+                               "AX descendant AXRole")
+            except _ModalReadError as exc:
+                if unreadable is None:
+                    unreadable = exc
+                continue
+            if role == "AXSheet":
+                return child
+            stack.append((child, depth + 1))
+    if unreadable is not None:
+        raise unreadable
+    return None
+
+
+def _production_ax_modal_signals():
+    """Return the modal AX windows and attached sheets for every running Logic process."""
+    try:
+        from AppKit import NSWorkspace
+        applications = NSWorkspace.sharedWorkspace().runningApplications()
+    except Exception as exc:  # noqa: BLE001 - no workspace means the off-screen check did not run
+        raise _ModalReadError(f"could not enumerate running Logic applications: {exc!r}") from exc
+
+    logic_apps = [app for app in applications
+                  if app.bundleIdentifier() in {"com.apple.logic10", "com.apple.mobilelogic"}]
+    ax = _AXRuntime()
+    try:
+        first_unreadable = None
+        for app in logic_apps:
+            app_element = ax.application(app.processIdentifier())
+            windows = ax.elements(ax.attribute(app_element, "AXWindows", "AXWindows"), "AXWindows")
+            for window in windows:
+                title = _ax_optional_title(ax, window)
+                # A positively identified sheet already proves this document is blocked. Do not
+                # discard that fact because AXModal on its ordinary host fails a later read: the
+                # product's reconciliation takes the same "found outranks unreadable sibling"
+                # direction for sheets.
+                try:
+                    sheet = _first_ax_sheet(ax, window)
+                except _ModalReadError as exc:
+                    sheet = None
+                    if first_unreadable is None:
+                        first_unreadable = exc
+                if sheet is not None:
+                    return {"modal_windows": [],
+                            "sheets": [{"host_title": title, "pid": app.processIdentifier()}]}
+                try:
+                    modal = ax.boolean(ax.attribute(window, "AXModal", "AXModal"), "AXModal")
+                except _ModalReadError as exc:
+                    if first_unreadable is None:
+                        first_unreadable = exc
+                    continue
+                if modal:
+                    return {"modal_windows": [{"title": title, "pid": app.processIdentifier()}],
+                            "sheets": []}
+        if first_unreadable is not None:
+            raise first_unreadable
+        return {"modal_windows": [], "sheets": []}
+    finally:
+        ax.close()
+
+
+def _normal_ax_modal_signals(signals):
+    """Validate the small test seam as strictly as production validates a completed AX scan."""
+    if not isinstance(signals, dict):
+        raise _ModalReadError("AX modal query returned no signal object")
+    modal_windows, sheets = signals.get("modal_windows"), signals.get("sheets")
+    if not isinstance(modal_windows, list) or not isinstance(sheets, list):
+        raise _ModalReadError("AX modal query returned malformed signal lists")
+    if not all(isinstance(item, dict) for item in modal_windows + sheets):
+        raise _ModalReadError("AX modal query returned malformed signal entries")
+    return signals
+
+
+def _coregraphics_modal_panels(Quartz, windows):
+    """The on-screen modal-panel-level candidates, before AX confirms that they are modal."""
+    modal_panel_level = Quartz.CGWindowLevelForKey(Quartz.kCGModalPanelWindowLevelKey)
+    out = []
+    for window in windows:
+        if not _is_logic_owned_window(window):
+            continue
+        layer = window.get(Quartz.kCGWindowLayer)
+        try:
+            if int(layer) != int(modal_panel_level):
+                continue
+        except (TypeError, ValueError):
+            continue
+        candidate = {"id": window.get(Quartz.kCGWindowNumber),
+                     "title": window.get(Quartz.kCGWindowName) or "", "layer": int(layer)}
+        # NOT `isinstance(b, dict)`: CoreGraphics returns an NSDictionary proxy, which is
+        # subscriptable but not a Python dict. Geometry identifies a detected panel more usefully,
+        # but cannot be allowed to erase the already-read level signal when it is malformed.
+        bounds = window.get(Quartz.kCGWindowBounds)
+        if bounds is not None:
+            try:
+                candidate.update({"x": int(bounds["X"]), "y": int(bounds["Y"]),
+                                  "w": int(bounds["Width"]), "h": int(bounds["Height"])})
+            except (KeyError, TypeError, ValueError):
+                pass
+        out.append(candidate)
+    return out
+
+
+def _same_modal_window(panel, window, panel_count, modal_count):
+    """Correlate the two APIs only when a title or unambiguous singleton makes it honest."""
+    panel_title, ax_title = panel.get("title") or "", window.get("title") or ""
+    return ((bool(panel_title) and panel_title == ax_title)
+            or (panel_count == 1 and modal_count == 1))
+
+
+def blocking_modal(lister=None, ax_lister=None):
+    """Describe a detected Logic blocker, `None` after a clear scan, or explicit cannot-tell.
+
+    CoreGraphics is still the screen-side signal: it observes the rendered modal-panel level without
+    relying on the AX tree under test. `kCGWindowListOptionOnScreenOnly` is deliberately retained.
+    Its known limitation is that it cannot see an inactive-Space/off-screen panel; widening it would
+    also report windows on other Spaces that are not blocking the current one. The AX window/sheet
+    signal covers a running process beyond that list, but is weaker exactly when AX itself is broken.
+
+    A panel level is not modality — a modeless panel can occupy it — so AXModal confirms that a
+    CoreGraphics candidate actually blocks. Sheets need AX outright: their host reports AXModal=false,
+    while the AXSheet below it blocks that document. `lister` and `ax_lister` are test seams; a seam
+    must return an empty list/object for a completed clear scan, never None.
     """
     try:
         import Quartz
     except ImportError:
-        return None
+        return _modal_cannot_tell("coregraphics", "could not import Quartz")
 
-    modal_panel_level = Quartz.CGWindowLevelForKey(Quartz.kCGModalPanelWindowLevelKey)
-    wins = lister() if lister is not None else _on_screen_windows(Quartz)
-    for w in wins or []:
-        if not _is_logic_owned_window(w):
-            continue
-        layer = w.get(Quartz.kCGWindowLayer)
-        try:
-            is_modal_panel = int(layer) == int(modal_panel_level)
-        except (TypeError, ValueError):
-            is_modal_panel = False
-        if not is_modal_panel:
-            continue
-        # NOT `isinstance(b, dict)`. CoreGraphics hands back an NSDictionary proxy, not a Python
-        # dict, so that test is False on the real window list and this loop silently skipped a
-        # modal it had already identified — measured 2026-08-30 against a Logic alert sitting at
-        # layer 8 on screen. The drive did not catch it because its synthetic lister supplies real
-        # dicts, so the fixture was more permissive than the thing it stands for. `logic_window`
-        # right above subscripts the same value without a type test, which is why it never had
-        # this bug; read it the same way and let a missing key be the failure.
-        b = w.get(Quartz.kCGWindowBounds)
-        if b is None:
-            continue
-        try:
-            x, y, width, height = int(b["X"]), int(b["Y"]), int(b["Width"]), int(b["Height"])
-        except (KeyError, TypeError, ValueError):
-            continue
-        return {"id": w.get(Quartz.kCGWindowNumber), "title": w.get(Quartz.kCGWindowName) or "",
-                "x": x, "y": y, "w": width, "h": height, "layer": int(layer)}
+    try:
+        windows = lister() if lister is not None else _on_screen_windows(Quartz)
+    except Exception as exc:  # noqa: BLE001 - an unread window list is not a clear desktop
+        return _modal_cannot_tell("coregraphics", f"could not read the window list: {exc!r}")
+    if windows is None:
+        return _modal_cannot_tell("coregraphics", "could not read the window list")
+    try:
+        panels = _coregraphics_modal_panels(Quartz, list(windows))
+    except Exception as exc:  # noqa: BLE001
+        return _modal_cannot_tell("coregraphics", f"could not interpret the window list: {exc!r}")
+
+    try:
+        raw_signals = ax_lister() if ax_lister is not None else _production_ax_modal_signals()
+        signals = _normal_ax_modal_signals(raw_signals)
+    except _ModalReadError as exc:
+        return _modal_cannot_tell("accessibility", str(exc))
+    except Exception as exc:  # noqa: BLE001 - avoid making an AX outage look like no sheet
+        return _modal_cannot_tell("accessibility", f"AX modal query failed: {exc!r}")
+
+    if signals["sheets"]:
+        sheet = signals["sheets"][0]
+        return {"state": "detected", "kind": "sheet", "signal": "ax_sheet",
+                "host_title": sheet.get("host_title") or "", "pid": sheet.get("pid")}
+
+    modal_windows = signals["modal_windows"]
+    for panel in panels:
+        for window in modal_windows:
+            if _same_modal_window(panel, window, len(panels), len(modal_windows)):
+                return {**panel, "state": "detected", "kind": "modal_panel",
+                        "signal": "coregraphics_modal_panel_level+ax_modal"}
+    if modal_windows:
+        window = modal_windows[0]
+        return {"state": "detected", "kind": "modal_window", "signal": "ax_modal",
+                "title": window.get("title") or "", "pid": window.get("pid")}
     return None
 
 
@@ -477,6 +773,16 @@ def _body(raw):
         return {"_text": text}
 
 
+def artifact_answered(body):
+    """Whether a parsed tool body came from an answered transport request.
+
+    `_body(None)` deliberately preserves the failed transport as a non-empty dictionary so a receipt
+    can show what went wrong. A bare truthiness check on that dictionary turns a dead transport into
+    an answered artifact, so harnesses must use this predicate for that question instead.
+    """
+    return isinstance(body, dict) and "_transport_error" not in body
+
+
 # ---------------------------------------------------------------------------
 # Evidence document
 # ---------------------------------------------------------------------------
@@ -644,7 +950,7 @@ class Evidence:
         """Record a reading that is context rather than a claim."""
         self.records.append({"kind": "observation", "tag": tag, "payload": payload})
 
-    def check(self, tag, passed, expected, observed, mutation):
+    def check(self, tag, passed, expected, observed, mutation, modal_snapshot=_MODAL_SNAPSHOT_UNSET):
         """Assert something about the run.
 
         `mutation` NAMES a change to the product the author believes would flip this check. The
@@ -663,9 +969,11 @@ class Evidence:
 
         `falsifiable()` below is the cheap form that does establish something.
         """
-        # Read immediately before the record enters the document. An alert can be dismissed and
-        # reappear within one run, so a single up-front modal read would mislabel both checks.
-        modal = blocking_modal()
+        # The interesting instant is when `observed` was measured, not when this receipt happens to
+        # be appended. A caller that took a modal snapshot beside its AX read supplies it here; the
+        # fallback preserves the older convenience for callers that did not. The sentinel matters:
+        # explicit None is the completed-clear snapshot and must not trigger a second, later read.
+        modal = blocking_modal() if modal_snapshot is _MODAL_SNAPSHOT_UNSET else modal_snapshot
         self.records.append({
             "kind": "check", "tag": tag, "passed": bool(passed),
             "expected": expected, "observed": observed,
@@ -674,7 +982,8 @@ class Evidence:
         })
         return bool(passed)
 
-    def falsifiable(self, tag, predicate, observation, counterexample, expected, mutation=None):
+    def falsifiable(self, tag, predicate, observation, counterexample, expected, mutation=None,
+                    modal_snapshot=_MODAL_SNAPSHOT_UNSET):
         """A check whose assertion is run against a state it MUST reject, in the same run.
 
         `check()` records whether the author's condition held. It cannot notice a condition that
@@ -703,9 +1012,10 @@ class Evidence:
             counter_ok, counterexample = True, f"predicate raised on the counterexample: {exc!r}"
 
         passed = live_ok and not counter_ok
-        # This is the same moment as `check()`: after the result exists, immediately before its
-        # receipt is appended. The predicate can take long enough for modal state to change.
-        modal = blocking_modal()
+        # As with check(), prefer the state sampled beside `observation`; predicates can take long
+        # enough for a sheet to close before the receipt is written. Callers without a contemporaneous
+        # snapshot retain the old record-time fallback.
+        modal = blocking_modal() if modal_snapshot is _MODAL_SNAPSHOT_UNSET else modal_snapshot
         self.records.append({
             "kind": "check", "tag": tag, "passed": passed,
             "expected": expected,
@@ -944,8 +1254,9 @@ def summarize(recs, out=None):
 
     Indexed with `.get` rather than `[...]` throughout: a document read back off disk may predate a
     field or have been truncated, and every missing key here reads as the FAILING value — an absent
-    `passed` is not a pass, an absent `settled` is unsettled. Crashing on a malformed document would
-    turn "this evidence is unreadable" into a stack trace at the gate.
+    `passed` is not a pass, an absent `settled` is unsettled, and an absent `blocking_modal` is not a
+    clear modal scan. Crashing on a malformed document would turn "this evidence is unreadable" into
+    a stack trace at the gate.
     """
     if not isinstance(recs, list):
         return None
@@ -957,10 +1268,19 @@ def summarize(recs, out=None):
         "file": out,
         "checks": len(checks),
         "passed": sum(1 for c in checks if c.get("passed")),
-        # A blocking modal makes the entire application unavailable. A check made while one was
-        # visible is therefore contaminated even when its own AX values and predicate look green.
+        # A detected document/application modal contaminates the check made through it, even where
+        # an application-wide menu remains enabled. None is the only completed-clear modal state.
         "checks_recorded_under_blocking_modal":
-            sum(1 for c in checks if c.get("blocking_modal") is not None),
+            sum(1 for c in checks
+                if "blocking_modal" in c
+                and c.get("blocking_modal") is not None
+                and not _modal_snapshot_is_unknown(c.get("blocking_modal"))),
+        # Do not collapse "we did not record a snapshot" or "the detector could not inspect AX/CG"
+        # into a clear check. They are different defects, counted independently for diagnostics.
+        "checks_missing_blocking_modal_snapshot":
+            sum(1 for c in checks if "blocking_modal" not in c),
+        "checks_with_blocking_modal_unknown":
+            sum(1 for c in checks if _modal_snapshot_is_unknown(c.get("blocking_modal"))),
         "mutation_claimed": sum(1 for c in checks if c.get("mutation_claimed")),
         "checks_with_a_counterexample": sum(1 for c in checks if c.get("has_counterexample")),
         "counterexamples_not_rejected":
@@ -985,6 +1305,13 @@ def summarize(recs, out=None):
     }
 
 
+def _modal_snapshot_is_unknown(snapshot):
+    """Whether a check carries the detector's explicit cannot-tell state rather than a blocker."""
+    return (isinstance(snapshot, dict)
+            and snapshot.get("state") == MODAL_CANNOT_TELL
+            and snapshot.get("kind") == MODAL_CANNOT_TELL)
+
+
 # Every counter `is_clean` reads. A summary missing any of them is not clean.
 #
 # The polarity used to depend on which key it was: `summary.get("visual_assertions_without_a_subject", 0) == 0`
@@ -993,7 +1320,9 @@ def summarize(recs, out=None):
 # was clean, and the newest condition was the one that vanished quietly. Listing the keys fixes the
 # shape of the bug rather than the one clause where it was noticed.
 _REQUIRED_SUMMARY_KEYS = (
-    "checks", "passed", "checks_recorded_under_blocking_modal", "mutation_claimed", "operations_driven",
+    "checks", "passed", "checks_recorded_under_blocking_modal",
+    "checks_missing_blocking_modal_snapshot", "checks_with_blocking_modal_unknown",
+    "mutation_claimed", "operations_driven",
     "checks_with_a_counterexample", "counterexamples_not_rejected",
     "captures", "captures_unsettled", "captures_straddling_displays",
     "restorations_failed", "cached_reads_used_as_live",
@@ -1011,9 +1340,9 @@ def is_clean(summary):
     whose exit code cannot express failure is not an instrument.
 
     Every dimension the evidence document tracks has to be clean, not just the check count: a check
-    recorded while a blocking modal was present, an unsettled capture, a failed visual assertion, a
-    restoration that did not happen, or a cached read presented as live each invalidate the run on their
-    own.
+    recorded while a blocker was present, a missing/unknown modal snapshot, an unsettled capture, a
+    failed visual assertion, a restoration that did not happen, or a cached read presented as live each
+    invalidate the run on their own.
 
     THE ZEROS HAVE TO BE EARNED. Every `== 0` clause below is satisfied by a run that never did the
     thing at all: no visual assertion means no visual can lack a subject, and no capture means none
@@ -1057,9 +1386,12 @@ def is_clean(summary):
     return (
         summary["checks"] > 0
         and summary["passed"] == summary["checks"]
-        # A modal blocks the application, so the AX observations recorded through it are not
-        # evidence regardless of whether their individual checks happened to pass.
+        # A detected blocker, a missing snapshot, or a detector that could not inspect the state all
+        # retire a check. Only CHECK records carry modal snapshots; the other record kinds are not
+        # sampled and this condition deliberately makes no claim about them.
         and summary["checks_recorded_under_blocking_modal"] == 0
+        and summary["checks_missing_blocking_modal_snapshot"] == 0
+        and summary["checks_with_blocking_modal_unknown"] == 0
         # Non-vacuity: the run has to have looked, driven, and recorded.
         and summary["captures"] > 0
         and summary["visual_assertions"] > 0

--- a/Scripts/livekit/evidence.py
+++ b/Scripts/livekit/evidence.py
@@ -8,11 +8,15 @@ without it.
 What it refuses to let you record:
 
 - **A check made through a blocking modal.** `blocking_modal()` uses the CoreGraphics window list
-  plus the narrowly necessary AX modal/sheet reads. A modal can block the current document while
-  leaving application-wide menu items enabled, so an AX value read through it is not evidence about
-  the affordance it appears to describe. Only `check()` and `falsifiable()` receipts carry this
-  snapshot; notes, captures, visuals, operations, and restorations do not claim modal coverage.
-  The summary gate invalidates those CHECK receipts rather than preventing a caller from making one.
+  plus the narrowly necessary AX modal/sheet reads. Its AX sheet scan is application-wide across
+  every window of every running Logic process: a sheet on another document makes this run refuse,
+  rather than claiming that the observed document is clear. That can be a conservative false
+  positive, but it cannot silently certify a different document while a sheet blocks it. A modal can
+  block the current document while leaving application-wide menu items enabled, so an AX value read
+  through it is not evidence about the affordance it appears to describe. Only `check()` and
+  `falsifiable()` receipts carry this snapshot; notes, captures, visuals, operations, and
+  restorations do not claim modal coverage. The summary gate invalidates those CHECK receipts rather
+  than preventing a caller from making one.
 - **An unsettled capture.** A screenshot taken while Logic is still redrawing shows a state nobody was
   ever in. `shot()` takes frames until two consecutive ones are byte-identical, and marks the record
   `settled: false` if they never converge.
@@ -357,10 +361,11 @@ def _first_ax_sheet(ax, window, max_depth=32):
     """Find a sheet on one host through AXSheets or its descendant tree.
 
     Logic can report AXSheets as unsupported even while New Track is visible. AXSheets is therefore a
-    cheap positive only; descendants are still searched for an AXSheet role. A failed descendant read
-    is not changed into an empty branch, because that would certify a clear document without having
-    searched it.
+    cheap positive only; descendants are still searched for an AXSheet role. A direct AXSheets
+    candidate whose AXRole cannot be read, or a failed descendant read, is not changed into an empty
+    branch because that would certify a clear document without having searched it.
     """
+    unreadable = None
     try:
         direct = ax.elements(ax.attribute(window, "AXSheets", "AXSheets"), "AXSheets")
     except _ModalReadError:
@@ -373,13 +378,17 @@ def _first_ax_sheet(ax, window, max_depth=32):
         try:
             role = ax.text(ax.attribute(candidate, "AXRole", "AXSheets candidate AXRole"),
                            "AXSheets candidate AXRole")
-        except _ModalReadError:
+        except _ModalReadError as exc:
+            # A direct sheet is not necessarily duplicated under AXChildren. Keep this unreadable
+            # candidate so a later clear scan returns cannot-tell instead of pretending it was not
+            # there. A positively identified sheet below still outranks an unreadable sibling.
+            if unreadable is None:
+                unreadable = exc
             continue
         if role == "AXSheet":
             return candidate
 
     stack = [(window, 0)]
-    unreadable = None
     while stack:
         current, depth = stack.pop()
         try:
@@ -411,7 +420,13 @@ def _first_ax_sheet(ax, window, max_depth=32):
 
 
 def _production_ax_modal_signals():
-    """Return the modal AX windows and attached sheets for every running Logic process."""
+    """Return app-wide modal AX windows and sheets for every running Logic process.
+
+    This deliberately does not bind a sheet to the document a harness is about to inspect. Any sheet
+    on any Logic window therefore makes the detector report a blocker. The cost is a conservative
+    refusal when another document has a sheet; the benefit is that this generic precondition never
+    labels the application clear while its AX sheet enumeration is scoped to the wrong window.
+    """
     try:
         from AppKit import NSWorkspace
         applications = NSWorkspace.sharedWorkspace().runningApplications()
@@ -513,6 +528,9 @@ def blocking_modal(lister=None, ax_lister=None):
     Its known limitation is that it cannot see an inactive-Space/off-screen panel; widening it would
     also report windows on other Spaces that are not blocking the current one. The AX window/sheet
     signal covers a running process beyond that list, but is weaker exactly when AX itself is broken.
+    AX sheets are application-wide rather than bound to the document a harness will inspect, so a
+    sheet on another Logic document is a deliberate conservative refusal. An unreadable AXRole on a
+    directly enumerated sheet is likewise cannot-tell, not a completed clear scan.
 
     A panel level is not modality — a modeless panel can occupy it — so AXModal confirms that a
     CoreGraphics candidate actually blocks. Sheets need AX outright: their host reports AXModal=false,

--- a/Scripts/livekit/evidence.py
+++ b/Scripts/livekit/evidence.py
@@ -7,6 +7,10 @@ without it.
 
 What it refuses to let you record:
 
+- **A check made through a blocking modal.** `blocking_modal()` reads the CoreGraphics window list,
+  not the AX tree being exercised, and every check records whether such a window was present at the
+  instant the check entered the document. A modal blocks Logic as a whole, so AX values read through
+  it are not evidence about the affordance they appear to describe.
 - **An unsettled capture.** A screenshot taken while Logic is still redrawing shows a state nobody was
   ever in. `shot()` takes frames until two consecutive ones are byte-identical, and marks the record
   `settled: false` if they never converge.
@@ -167,6 +171,23 @@ def _running_harness_name():
 ARRANGE_WINDOW_TITLES = ["Tracks", "트랙", "トラック"]
 
 
+def _is_logic_owned_window(window):
+    """Whether a CoreGraphics window belongs to Logic, including its measured Korean owner spelling."""
+    # Measured 2026-08-17: with Logic running in Korean, `kCGWindowOwnerName` comes back as
+    # "Logic Pro" — a NO-BREAK SPACE — while English and Japanese give an ordinary space.
+    # An exact compare therefore found ZERO Logic windows on a Korean Logic, and every capture
+    # in the run recorded `window: null` while Logic was plainly on screen.
+    owner = (window.get("kCGWindowOwnerName") or "").replace(" ", " ")
+    return owner == "Logic Pro"
+
+
+def _on_screen_windows(Quartz):
+    """The CoreGraphics window list both on-screen window readers use."""
+    return Quartz.CGWindowListCopyWindowInfo(
+        Quartz.kCGWindowListOptionOnScreenOnly | Quartz.kCGWindowListExcludeDesktopElements,
+        Quartz.kCGNullWindowID)
+
+
 def logic_window(title_contains=None):
     """The on-screen bounds of a Logic window, via CoreGraphics rather than AX.
 
@@ -186,16 +207,9 @@ def logic_window(title_contains=None):
         import Quartz
     except ImportError:
         return None
-    wins = Quartz.CGWindowListCopyWindowInfo(
-        Quartz.kCGWindowListOptionOnScreenOnly | Quartz.kCGWindowListExcludeDesktopElements,
-        Quartz.kCGNullWindowID)
+    wins = _on_screen_windows(Quartz)
     for w in wins or []:
-        # Measured 2026-08-17: with Logic running in Korean, `kCGWindowOwnerName` comes back as
-        # "Logic Pro" — a NO-BREAK SPACE — while English and Japanese give an ordinary space.
-        # An exact compare therefore found ZERO Logic windows on a Korean Logic, and every capture
-        # in the run recorded `window: null` while Logic was plainly on screen.
-        owner = (w.get("kCGWindowOwnerName") or "").replace(" ", " ")
-        if owner != "Logic Pro":
+        if not _is_logic_owned_window(w):
             continue
         name = w.get("kCGWindowName") or ""
         if title_contains and title_contains not in name:
@@ -204,6 +218,50 @@ def logic_window(title_contains=None):
         return {"id": w["kCGWindowNumber"], "title": name,
                 "x": int(b["X"]), "y": int(b["Y"]),
                 "w": int(b["Width"]), "h": int(b["Height"])}
+    return None
+
+
+def blocking_modal(lister=None):
+    """The first Logic window at the CoreGraphics modal-panel level, or None.
+
+    This is deliberately a CoreGraphics read rather than an AX read. The AX tree can honestly say
+    that an enabled menu item is unavailable when a modal has blocked Logic, which is precisely the
+    state a check has to reject. `lister` is a test seam; production always uses the same on-screen
+    list and options as `logic_window`.
+    """
+    try:
+        import Quartz
+    except ImportError:
+        return None
+
+    modal_panel_level = Quartz.CGWindowLevelForKey(Quartz.kCGModalPanelWindowLevelKey)
+    wins = lister() if lister is not None else _on_screen_windows(Quartz)
+    for w in wins or []:
+        if not _is_logic_owned_window(w):
+            continue
+        layer = w.get(Quartz.kCGWindowLayer)
+        try:
+            is_modal_panel = int(layer) == int(modal_panel_level)
+        except (TypeError, ValueError):
+            is_modal_panel = False
+        if not is_modal_panel:
+            continue
+        # NOT `isinstance(b, dict)`. CoreGraphics hands back an NSDictionary proxy, not a Python
+        # dict, so that test is False on the real window list and this loop silently skipped a
+        # modal it had already identified — measured 2026-08-30 against a Logic alert sitting at
+        # layer 8 on screen. The drive did not catch it because its synthetic lister supplies real
+        # dicts, so the fixture was more permissive than the thing it stands for. `logic_window`
+        # right above subscripts the same value without a type test, which is why it never had
+        # this bug; read it the same way and let a missing key be the failure.
+        b = w.get(Quartz.kCGWindowBounds)
+        if b is None:
+            continue
+        try:
+            x, y, width, height = int(b["X"]), int(b["Y"]), int(b["Width"]), int(b["Height"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        return {"id": w.get(Quartz.kCGWindowNumber), "title": w.get(Quartz.kCGWindowName) or "",
+                "x": x, "y": y, "w": width, "h": height, "layer": int(layer)}
     return None
 
 
@@ -605,10 +663,14 @@ class Evidence:
 
         `falsifiable()` below is the cheap form that does establish something.
         """
+        # Read immediately before the record enters the document. An alert can be dismissed and
+        # reappear within one run, so a single up-front modal read would mislabel both checks.
+        modal = blocking_modal()
         self.records.append({
             "kind": "check", "tag": tag, "passed": bool(passed),
             "expected": expected, "observed": observed,
             "mutation": mutation or None, "mutation_claimed": bool(mutation),
+            "blocking_modal": modal,
         })
         return bool(passed)
 
@@ -641,6 +703,9 @@ class Evidence:
             counter_ok, counterexample = True, f"predicate raised on the counterexample: {exc!r}"
 
         passed = live_ok and not counter_ok
+        # This is the same moment as `check()`: after the result exists, immediately before its
+        # receipt is appended. The predicate can take long enough for modal state to change.
+        modal = blocking_modal()
         self.records.append({
             "kind": "check", "tag": tag, "passed": passed,
             "expected": expected,
@@ -651,6 +716,7 @@ class Evidence:
             "mutation": mutation or None, "mutation_claimed": bool(mutation),
             "has_counterexample": True,
             "counterexample_rejected": not counter_ok,
+            "blocking_modal": modal,
         })
         return passed
 
@@ -891,6 +957,10 @@ def summarize(recs, out=None):
         "file": out,
         "checks": len(checks),
         "passed": sum(1 for c in checks if c.get("passed")),
+        # A blocking modal makes the entire application unavailable. A check made while one was
+        # visible is therefore contaminated even when its own AX values and predicate look green.
+        "checks_recorded_under_blocking_modal":
+            sum(1 for c in checks if c.get("blocking_modal") is not None),
         "mutation_claimed": sum(1 for c in checks if c.get("mutation_claimed")),
         "checks_with_a_counterexample": sum(1 for c in checks if c.get("has_counterexample")),
         "counterexamples_not_rejected":
@@ -923,7 +993,7 @@ def summarize(recs, out=None):
 # was clean, and the newest condition was the one that vanished quietly. Listing the keys fixes the
 # shape of the bug rather than the one clause where it was noticed.
 _REQUIRED_SUMMARY_KEYS = (
-    "checks", "passed", "mutation_claimed", "operations_driven",
+    "checks", "passed", "checks_recorded_under_blocking_modal", "mutation_claimed", "operations_driven",
     "checks_with_a_counterexample", "counterexamples_not_rejected",
     "captures", "captures_unsettled", "captures_straddling_displays",
     "restorations_failed", "cached_reads_used_as_live",
@@ -940,9 +1010,10 @@ def is_clean(summary):
     reported success. The only value that failed was zero, i.e. a run where NOTHING passed. A harness
     whose exit code cannot express failure is not an instrument.
 
-    Every dimension the evidence document tracks has to be clean, not just the check count: an unsettled
-    capture, a failed visual assertion, a restoration that did not happen, or a cached read presented as
-    live each invalidate the run on their own.
+    Every dimension the evidence document tracks has to be clean, not just the check count: a check
+    recorded while a blocking modal was present, an unsettled capture, a failed visual assertion, a
+    restoration that did not happen, or a cached read presented as live each invalidate the run on their
+    own.
 
     THE ZEROS HAVE TO BE EARNED. Every `== 0` clause below is satisfied by a run that never did the
     thing at all: no visual assertion means no visual can lack a subject, and no capture means none
@@ -986,6 +1057,9 @@ def is_clean(summary):
     return (
         summary["checks"] > 0
         and summary["passed"] == summary["checks"]
+        # A modal blocks the application, so the AX observations recorded through it are not
+        # evidence regardless of whether their individual checks happened to pass.
+        and summary["checks_recorded_under_blocking_modal"] == 0
         # Non-vacuity: the run has to have looked, driven, and recorded.
         and summary["captures"] > 0
         and summary["visual_assertions"] > 0

--- a/Scripts/livekit/live_301_channel_eq_bands_are_addressable.py
+++ b/Scripts/livekit/live_301_channel_eq_bands_are_addressable.py
@@ -165,6 +165,16 @@ def opened_through_only_named_button(opening):
     )
 
 
+def opening_with_pressed_description(opening, description):
+    """Change the selected button's label while retaining the observed opening shape."""
+    counterexample = derived_witness(opening)
+    pressed = copied_nodes(counterexample.get("pressed_children"))
+    if len(pressed) == 1 and isinstance(pressed[0], dict):
+        pressed[0]["description"] = description
+    counterexample["pressed_children"] = pressed
+    return counterexample
+
+
 def band_enables_resolve_by_name(checkboxes):
     return isinstance(checkboxes, list) and all(band in clean_texts(checkboxes) for band in BANDS)
 
@@ -201,7 +211,14 @@ def bypass_value_is_unchanged(witness):
     candidates = witness.get("bypass_candidates") if isinstance(witness.get("bypass_candidates"), list) else []
     before = witness.get("bypass_before")
     after = witness.get("bypass_after")
-    return len(candidates) == 1 and before is not None and after is not None and after == before
+    return (
+        len(candidates) == 1
+        and witness.get("bypass_before_status") == "success_with_value"
+        and witness.get("bypass_after_status") == "success_with_value"
+        and before is not None
+        and after is not None
+        and after == before
+    )
 
 
 # `Evidence.check` records modal state per check, but that only marks contaminated observations red
@@ -298,16 +315,27 @@ result = probe(tool, "channel-eq", {
 })
 ev.note("301/channel-eq-raw-ax", result)
 
+ev.falsifiable(
+    "301/raw-ax-probe-completed-its-search",
+    lambda observation: isinstance(observation, dict) and observation.get("outcome") == "searched",
+    result,
+    derived_witness(result, outcome="could_not_search"),
+    "the raw AX witness completed its search without an unreadable AX branch",
+    "make any raw AX read fail: the witness emits outcome=could_not_search and this goes red",
+)
+if result.get("outcome") != "searched":
+    finish()
+
 opening = result.get("open") if isinstance(result.get("open"), dict) else {}
 ev.falsifiable(
     "301/the-plugin-window-opened-through-only-the-open-button",
     opened_through_only_named_button,
     opening,
-    derived_witness(opening, pressed_children=[], opened_windows=[]),
+    opening_with_pressed_description(opening, "not the Open label"),
     "one new plug-in window appeared after exactly one press, and that press was AXButton `열기`; "
     "no other pressable slot child was pressed",
-    "include every pressable child again: the bypass checkbox enters `pressed_children` and this "
-    "check goes red even if a window still opens",
+    "change the pressed AXButton's description while retaining the observed slot and window: the "
+    "named-open condition goes red",
 )
 
 checkboxes = result.get("band_checkboxes") if isinstance(result.get("band_checkboxes"), list) else []
@@ -376,7 +404,8 @@ close = result.get("close") if isinstance(result.get("close"), dict) else {}
 closed = (close.get("pressed") is True and close.get("window_still_present") is False)
 ev.check("301/the-plugin-window-opened-by-this-run-is-closed-again",
          closed,
-         "the exact plug-in window the Open button created was closed through its named close button",
+         "the sole new Logic window reported after the Open press was closed through its named close button; "
+         "the raw witness records that this new-window search is application-wide",
          f"close={close!r}",
          "make the close button absent or leave the window open: this restoration check goes red")
 ev.restored("301/the-channel-eq-window-is-back-where-it-started", closed,

--- a/Scripts/livekit/live_301_channel_eq_bands_are_addressable.py
+++ b/Scripts/livekit/live_301_channel_eq_bands_are_addressable.py
@@ -15,9 +15,9 @@ not evidence that the opening path is safe.
 WHAT IS MEASURED NOW, AND WHAT IS STILL NOT
 -------------------------------------------
 On Korean Logic 12.x, the `Channel EQ` AXGroup has an AXButton `열기` and an AXCheckBox `바이패스`.
-Opening it through that button exposes an AXGroup `EQ` containing eight named band enables and 24
-named sliders. Each measured slider declares that its AXValue is settable and gives an engineering
-unit AXValueDescription.
+Opening it through that button exposes an AXGroup `EQ` containing eight named band enables and 26
+named sliders: the 24 band parameters plus two output Gain sliders. Each measured slider declares
+that its AXValue is settable and gives an engineering-unit AXValueDescription.
 
 NO WRITE IS ATTEMPTED. `settable` is a claim by the element, and AX settability has lied in this
 codebase's experience. This proves addressability and readability, not that a write would land.
@@ -108,6 +108,102 @@ def clean_texts(nodes, key="description"):
     return [node.get(key, "") for node in nodes if isinstance(node, dict)]
 
 
+def derived_witness(observation, **changes):
+    """Copy a raw witness before changing one fact for a same-shape counterexample."""
+    counterexample = dict(observation) if isinstance(observation, dict) else {}
+    counterexample.update(changes)
+    return counterexample
+
+
+def copied_nodes(nodes):
+    return [dict(node) if isinstance(node, dict) else node for node in nodes] if isinstance(nodes, list) else []
+
+
+def descriptions_without(nodes, description):
+    counterexample = copied_nodes(nodes)
+    for node in counterexample:
+        if isinstance(node, dict) and node.get("description") == description:
+            node["description"] = ""
+    return counterexample
+
+
+def one_slider_field_changed(sliders, field, value):
+    counterexample = copied_nodes(sliders)
+    for slider in counterexample:
+        if isinstance(slider, dict):
+            slider[field] = value
+            break
+    return counterexample
+
+
+def slot_has_measured_children(children):
+    return (
+        isinstance(children, list)
+        and any(isinstance(child, dict) and child.get("role") == "AXButton"
+                and child.get("description") == OPEN for child in children)
+        and any(isinstance(child, dict) and child.get("role") == "AXButton"
+                and child.get("description") == "목록" for child in children)
+        and any(isinstance(child, dict) and child.get("role") == "AXCheckBox"
+                and child.get("description") in BYPASS_LABELS for child in children)
+    )
+
+
+def opened_through_only_named_button(opening):
+    if not isinstance(opening, dict):
+        return False
+    pressed = opening.get("pressed_children") if isinstance(opening.get("pressed_children"), list) else []
+    open_buttons = (opening.get("open_button_candidates")
+                    if isinstance(opening.get("open_button_candidates"), list) else [])
+    opened_windows = opening.get("opened_windows") if isinstance(opening.get("opened_windows"), list) else []
+    return (
+        opening.get("slot_count") == 1
+        and len(open_buttons) == 1
+        and len(pressed) == 1
+        and pressed[0].get("role") == "AXButton"
+        and pressed[0].get("description") == OPEN
+        and len(opened_windows) == 1
+    )
+
+
+def band_enables_resolve_by_name(checkboxes):
+    return isinstance(checkboxes, list) and all(band in clean_texts(checkboxes) for band in BANDS)
+
+
+def has_every_band_parameter(sliders):
+    return isinstance(sliders, list) and all(parameter in clean_texts(sliders) for parameter in BAND_PARAMETERS)
+
+
+def every_slider_is_named(sliders):
+    return has_every_band_parameter(sliders) and all(
+        isinstance(slider, dict) and isinstance(slider.get("description"), str)
+        and slider["description"].strip()
+        for slider in sliders
+    )
+
+
+def every_slider_claims_settable(sliders):
+    return has_every_band_parameter(sliders) and all(
+        isinstance(slider, dict) and slider.get("value_settable") is True for slider in sliders
+    )
+
+
+def every_slider_has_value_description(sliders):
+    return has_every_band_parameter(sliders) and all(
+        isinstance(slider, dict) and isinstance(slider.get("value_description"), str)
+        and slider["value_description"].strip()
+        for slider in sliders
+    )
+
+
+def bypass_value_is_unchanged(witness):
+    if not isinstance(witness, dict):
+        return False
+    candidates = witness.get("bypass_candidates") if isinstance(witness.get("bypass_candidates"), list) else []
+    before = witness.get("bypass_before")
+    after = witness.get("bypass_after")
+    return len(candidates) == 1 and before is not None and after is not None and after == before
+
+
 # `Evidence.check` records modal state per check, but that only marks contaminated observations red
 # after they were made. Refuse before compiling, reading, or pressing: a hardware dialog would make
 # every later AX value a reading through the modal, which is precisely what this branch forbids.
@@ -156,11 +252,12 @@ if band is None:
 
 slot_before = probe(tool, "plugin-slot", {"slot_label": SLOT})
 ev.note("301/channel-eq-slot-before-opening", slot_before)
+slot_count_counterexample = derived_witness(slot_before, slot_count=0)
 ev.falsifiable(
     "301/precondition-one-channel-eq-insert-slot-resolves-by-description",
     lambda observed: observed.get("slot_count") == 1,
     slot_before,
-    {"slot_count": 0},
+    slot_count_counterexample,
     "exactly one AXGroup describes itself `Channel EQ`, so the run will not choose a slot by tree "
     "order or coordinates",
     "rename or remove the Channel EQ insert: its count becomes zero and the precondition goes red",
@@ -169,23 +266,15 @@ if slot_before.get("slot_count") != 1:
     finish()
 
 slot_children = slot_before.get("slot_children") if isinstance(slot_before.get("slot_children"), list) else []
-slot_shape = (
-    any(isinstance(child, dict) and child.get("role") == "AXButton"
-        and child.get("description") == OPEN for child in slot_children)
-    and any(isinstance(child, dict) and child.get("role") == "AXButton"
-            and child.get("description") == "목록" for child in slot_children)
-    and any(isinstance(child, dict) and child.get("role") == "AXCheckBox"
-            and child.get("description") in BYPASS_LABELS for child in slot_children)
-)
 ev.falsifiable(
     "301/the-channel-eq-slot-has-the-measured-open-list-and-bypass-children",
-    lambda observation: observation["ok"],
-    {"ok": slot_shape},
-    {"ok": False},
+    slot_has_measured_children,
+    slot_children,
+    descriptions_without(slot_children, OPEN),
     "the named Channel EQ AXGroup contains AXButtons `열기` and `목록`, plus a named bypass AXCheckBox",
     "change a child role or label: the slot signature goes red before the harness attempts its Open press",
 )
-if not slot_shape:
+if not slot_has_measured_children(slot_children):
     finish()
 
 rec = ev.record_screen(seconds=90)
@@ -195,8 +284,9 @@ before = ev.shot("301/before", settle_region=band, window_title=arrange["title"]
 # state; the actual Channel EQ observation is the independent raw-AX witness below.
 driver = E.Driver()
 health = driver.tool("logic_system", "health", {})
+health_counterexample = derived_witness(health, _transport_error=None)
 ev.falsifiable("301/the-release-artifact-answers-a-read-only-wire-request",
-               lambda body: isinstance(body, dict) and bool(body), health, {},
+               E.artifact_answered, health, health_counterexample,
                "the built server answered a read-only health request during this evidence run",
                "start an artifact that cannot answer MCP: the empty/error response goes red")
 
@@ -209,23 +299,11 @@ result = probe(tool, "channel-eq", {
 ev.note("301/channel-eq-raw-ax", result)
 
 opening = result.get("open") if isinstance(result.get("open"), dict) else {}
-pressed = opening.get("pressed_children") if isinstance(opening.get("pressed_children"), list) else []
-open_buttons = (opening.get("open_button_candidates")
-                if isinstance(opening.get("open_button_candidates"), list) else [])
-opened_windows = opening.get("opened_windows") if isinstance(opening.get("opened_windows"), list) else []
-opened_only_by_open_button = (
-    opening.get("slot_count") == 1
-    and len(open_buttons) == 1
-    and len(pressed) == 1
-    and pressed[0].get("role") == "AXButton"
-    and pressed[0].get("description") == OPEN
-    and len(opened_windows) == 1
-)
 ev.falsifiable(
     "301/the-plugin-window-opened-through-only-the-open-button",
-    lambda observation: observation["opened"],
-    {"opened": opened_only_by_open_button},
-    {"opened": False},
+    opened_through_only_named_button,
+    opening,
+    derived_witness(opening, pressed_children=[], opened_windows=[]),
     "one new plug-in window appeared after exactly one press, and that press was AXButton `열기`; "
     "no other pressable slot child was pressed",
     "include every pressable child again: the bypass checkbox enters `pressed_children` and this "
@@ -233,80 +311,65 @@ ev.falsifiable(
 )
 
 checkboxes = result.get("band_checkboxes") if isinstance(result.get("band_checkboxes"), list) else []
-band_names = clean_texts(checkboxes)
-bands_resolve = (result.get("eq_group_count") == 1
-                 and all(band in band_names for band in BANDS))
 ev.falsifiable(
     "301/each-of-the-eight-band-enables-resolves-by-name",
-    lambda observation: observation["ok"],
-    {"ok": bands_resolve},
-    {"ok": False},
+    band_enables_resolve_by_name,
+    checkboxes,
+    descriptions_without(checkboxes, "Peak 3"),
     "the EQ group exposes an AXCheckBox for each of the eight measured band names; it carries "
     "others too (Analyzer, Q-Couple, HQ), so this is containment and not equality",
     "remove or rename a band label: the containment assertion goes red",
 )
 
 sliders = result.get("sliders") if isinstance(result.get("sliders"), list) else []
-slider_descriptions = [
-    slider.get("description", "") for slider in sliders if isinstance(slider, dict)
-]
-all_slider_descriptions = all(p in slider_descriptions for p in BAND_PARAMETERS) and all(
-    isinstance(slider, dict) and isinstance(slider.get("description"), str)
-    and slider["description"].strip()
-    for slider in sliders
-)
 ev.falsifiable(
     "301/every-band-parameter-resolves-by-name-and-every-slider-is-named",
-    lambda observation: observation["ok"],
-    {"ok": all_slider_descriptions},
-    {"ok": False},
+    every_slider_is_named,
+    sliders,
+    descriptions_without(sliders, "Peak 3 Q"),
     "all 24 band parameters resolve by name, and every slider in the EQ group carries its own "
     "non-empty raw AXDescription",
     "strip one description, or rename a band parameter: the name assertion goes red",
 )
 
-all_settable = all(p in slider_descriptions for p in BAND_PARAMETERS) and all(
-    isinstance(slider, dict) and slider.get("value_settable") is True for slider in sliders
-)
 ev.falsifiable(
     "301/every-slider-in-the-eq-group-claims-its-value-is-settable",
-    lambda observation: observation["ok"],
-    {"ok": all_settable},
-    {"ok": False},
+    every_slider_claims_settable,
+    sliders,
+    one_slider_field_changed(sliders, "value_settable", False),
     "all 24 band parameters are present and every slider in the EQ group reports AXValue "
     "settable=true",
     "make any slider report settable=false: the universal assertion goes red",
 )
 
-all_value_descriptions = all(p in slider_descriptions for p in BAND_PARAMETERS) and all(
-    isinstance(slider, dict) and isinstance(slider.get("value_description"), str)
-    and slider["value_description"].strip()
-    for slider in sliders
-)
 ev.falsifiable(
     "301/every-slider-in-the-eq-group-has-an-engineering-value-description",
-    lambda observation: observation["ok"],
-    {"ok": all_value_descriptions},
-    {"ok": False},
+    every_slider_has_value_description,
+    sliders,
+    one_slider_field_changed(sliders, "value_description", ""),
     "all 24 band parameters are present and every slider in the EQ group carries a non-empty "
     "AXValueDescription such as Hz, dB, or Q",
     "clear one value description: this goes red while the description and settability checks can "
     "still pass",
 )
 
-bypass_candidates = result.get("bypass_candidates") if isinstance(result.get("bypass_candidates"), list) else []
 bypass_before = result.get("bypass_before")
-bypass_after = result.get("bypass_after")
-bypass_unchanged = (len(bypass_candidates) == 1 and bypass_before is not None
-                    and bypass_after is not None and bypass_after == bypass_before)
+# This is intentionally an endpoint-only negative control: it compares the read immediately before
+# Open with the read after Close. A toggle-and-restore, or two toggles during the run, is invisible
+# to these two readings; the witness does not yet take an after-press reading.
+bypass_counterexample = derived_witness(
+    result,
+    bypass_after=(not bypass_before) if isinstance(bypass_before, bool) else None,
+)
 ev.falsifiable(
     "301/negative-control-the-bypass-checkbox-value-is-unchanged",
-    lambda observation: observation["ok"],
-    {"ok": bypass_unchanged},
-    {"ok": False},
+    bypass_value_is_unchanged,
+    result,
+    bypass_counterexample,
     "the named bypass checkbox has the same AXValue before the Open press and after the plug-in "
     "window closes",
-    "press the bypass checkbox as the old probe did: its before/after values differ and this goes red",
+    "press the bypass checkbox as the old probe did: its endpoint values differ and this goes red; "
+    "a toggle-and-restore needs an after-press witness reading to be detected",
 )
 
 close = result.get("close") if isinstance(result.get("close"), dict) else {}

--- a/Scripts/livekit/live_301_channel_eq_bands_are_addressable.py
+++ b/Scripts/livekit/live_301_channel_eq_bands_are_addressable.py
@@ -53,6 +53,26 @@ CLOSE = "닫기"
 EQ_GROUP = "EQ"
 BANDS = ["Low Cut", "Low Shelf", "Peak 1", "Peak 2", "Peak 3", "Peak 4", "High Shelf", "High Cut"]
 
+# The 24 band parameters by name. Low Cut and High Cut take an Order where the others take a Gain,
+# which is why this is a list and not a product of BANDS and three suffixes.
+BAND_PARAMETERS = [
+    "Low Cut Frequency", "Low Cut Order", "Low Cut Q",
+    "Low Shelf Frequency", "Low Shelf Gain", "Low Shelf Q",
+    "Peak 1 Frequency", "Peak 1 Gain", "Peak 1 Q",
+    "Peak 2 Frequency", "Peak 2 Gain", "Peak 2 Q",
+    "Peak 3 Frequency", "Peak 3 Gain", "Peak 3 Q",
+    "Peak 4 Frequency", "Peak 4 Gain", "Peak 4 Q",
+    "High Shelf Frequency", "High Shelf Gain", "High Shelf Q",
+    "High Cut Frequency", "High Cut Order", "High Cut Q",
+]
+
+# Measured 2026-08-30: the EQ group exposes 26 sliders, not 24. The 24 above plus TWO output `Gain`
+# sliders sharing one description. An earlier draft of this harness asserted `len(sliders) == 24`
+# because that is the number I wrote in the issue comment, counting band parameters and calling it
+# the group total. Every slider assertion below failed on a reading that was RIGHT. Assert the names
+# that must be present and the property that must hold of every slider; do not assert a total that
+# was arrived at by arithmetic rather than by counting what came back.
+
 # `pluginOpenOrListControl` is intentionally a combined LabelSet (`open` AND `list`). It is useful
 # for documenting the slot's known controls, but unsafe as an action selector because `목록` is also
 # an AXButton. The one safe action label observed here is the Korean `열기` above.
@@ -214,54 +234,62 @@ ev.falsifiable(
 
 checkboxes = result.get("band_checkboxes") if isinstance(result.get("band_checkboxes"), list) else []
 band_names = clean_texts(checkboxes)
-bands_resolve = (result.get("eq_group_count") == 1 and Counter(band_names) == Counter(BANDS))
+bands_resolve = (result.get("eq_group_count") == 1
+                 and all(band in band_names for band in BANDS))
 ev.falsifiable(
-    "301/eight-band-enables-resolve-by-name",
+    "301/each-of-the-eight-band-enables-resolves-by-name",
     lambda observation: observation["ok"],
     {"ok": bands_resolve},
     {"ok": False},
-    "the EQ group exposes exactly the eight observed enable names, one AXCheckBox per band",
-    "remove a band label or duplicate one: the exact name multiset stops matching and this goes red",
+    "the EQ group exposes an AXCheckBox for each of the eight measured band names; it carries "
+    "others too (Analyzer, Q-Couple, HQ), so this is containment and not equality",
+    "remove or rename a band label: the containment assertion goes red",
 )
 
 sliders = result.get("sliders") if isinstance(result.get("sliders"), list) else []
-all_slider_descriptions = len(sliders) == 24 and all(
+slider_descriptions = [
+    slider.get("description", "") for slider in sliders if isinstance(slider, dict)
+]
+all_slider_descriptions = all(p in slider_descriptions for p in BAND_PARAMETERS) and all(
     isinstance(slider, dict) and isinstance(slider.get("description"), str)
     and slider["description"].strip()
     for slider in sliders
 )
 ev.falsifiable(
-    "301/all-24-band-sliders-resolve-and-each-has-an-axdescription",
+    "301/every-band-parameter-resolves-by-name-and-every-slider-is-named",
     lambda observation: observation["ok"],
     {"ok": all_slider_descriptions},
     {"ok": False},
-    "exactly 24 EQ sliders resolve, and every one carries its own non-empty raw AXDescription",
-    "strip one description or return fewer sliders: the count/name assertion goes red",
+    "all 24 band parameters resolve by name, and every slider in the EQ group carries its own "
+    "non-empty raw AXDescription",
+    "strip one description, or rename a band parameter: the name assertion goes red",
 )
 
-all_settable = len(sliders) == 24 and all(
+all_settable = all(p in slider_descriptions for p in BAND_PARAMETERS) and all(
     isinstance(slider, dict) and slider.get("value_settable") is True for slider in sliders
 )
 ev.falsifiable(
-    "301/every-one-of-the-24-sliders-claims-its-value-is-settable",
+    "301/every-slider-in-the-eq-group-claims-its-value-is-settable",
     lambda observation: observation["ok"],
     {"ok": all_settable},
     {"ok": False},
-    "every one of the 24 named EQ sliders reports AXValue settable=true",
+    "all 24 band parameters are present and every slider in the EQ group reports AXValue "
+    "settable=true",
     "make any slider report settable=false: the universal assertion goes red",
 )
 
-all_value_descriptions = len(sliders) == 24 and all(
+all_value_descriptions = all(p in slider_descriptions for p in BAND_PARAMETERS) and all(
     isinstance(slider, dict) and isinstance(slider.get("value_description"), str)
     and slider["value_description"].strip()
     for slider in sliders
 )
 ev.falsifiable(
-    "301/every-one-of-the-24-sliders-has-an-engineering-value-description",
+    "301/every-slider-in-the-eq-group-has-an-engineering-value-description",
     lambda observation: observation["ok"],
     {"ok": all_value_descriptions},
     {"ok": False},
-    "every one of the 24 sliders carries a non-empty AXValueDescription such as Hz, dB, or Q",
+    "all 24 band parameters are present and every slider in the EQ group carries a non-empty "
+    "AXValueDescription such as Hz, dB, or Q",
     "clear one value description: this goes red while the description and settability checks can "
     "still pass",
 )

--- a/Scripts/livekit/live_301_channel_eq_bands_are_addressable.py
+++ b/Scripts/livekit/live_301_channel_eq_bands_are_addressable.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Live proof that every stock Channel EQ band is individually addressable over AX.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_301_channel_eq_bands_are_addressable.py <worktree> <full-40-char-head-sha>
+
+WHAT WAS WRONG
+--------------
+The Channel EQ accessibility walk knew that an insert slot could be named, but nobody had measured
+whether opening that slot led to every band control rather than to an unlabelled visual editor. The
+throwaway probe made this worse on its first pass: it pressed every pressable slot child, including
+the bypass checkbox, then had to undo the change. A harness that cannot notice that side effect is
+not evidence that the opening path is safe.
+
+WHAT IS MEASURED NOW, AND WHAT IS STILL NOT
+-------------------------------------------
+On Korean Logic 12.x, the `Channel EQ` AXGroup has an AXButton `열기` and an AXCheckBox `바이패스`.
+Opening it through that button exposes an AXGroup `EQ` containing eight named band enables and 24
+named sliders. Each measured slider declares that its AXValue is settable and gives an engineering
+unit AXValueDescription.
+
+NO WRITE IS ATTEMPTED. `settable` is a claim by the element, and AX settability has lied in this
+codebase's experience. This proves addressability and readability, not that a write would land.
+"""
+
+from collections import Counter
+import json
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+
+# These labels were read on Korean Logic 12.x only. There is deliberately no translated fallback:
+# a run on another Logic locale yields an absent element instead of pressing or naming the wrong one.
+SLOT = "Channel EQ"
+OPEN = "열기"
+CLOSE = "닫기"
+EQ_GROUP = "EQ"
+BANDS = ["Low Cut", "Low Shelf", "Peak 1", "Peak 2", "Peak 3", "Peak 4", "High Shelf", "High Cut"]
+
+# `pluginOpenOrListControl` is intentionally a combined LabelSet (`open` AND `list`). It is useful
+# for documenting the slot's known controls, but unsafe as an action selector because `목록` is also
+# an AXButton. The one safe action label observed here is the Korean `열기` above.
+OPEN_OR_LIST_LABELS = E.label_set("pluginOpenOrListControl")
+BYPASS_LABELS = E.label_set("pluginBypassControl")
+
+
+def finish(code=1):
+    out = ev.write()
+    print(json.dumps(out, indent=1))
+    sys.exit(code)
+
+
+def compile_probe():
+    source = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ax_plugin_menu_probe.swift")
+    tool = os.path.join(ev.dir, "ax_plugin_menu_probe")
+    result = subprocess.run(["swiftc", "-O", source, "-o", tool], capture_output=True)
+    return tool, result
+
+
+def probe(tool, mode, config):
+    result = subprocess.run([tool, mode, json.dumps(config, ensure_ascii=False)],
+                            capture_output=True, text=True)
+    try:
+        body = json.loads(result.stdout or "{}")
+    except ValueError:
+        body = {"_raw": (result.stdout or result.stderr)[:400]}
+    body["_returncode"] = result.returncode
+    return body
+
+
+def clean_texts(nodes, key="description"):
+    return [node.get(key, "") for node in nodes if isinstance(node, dict)]
+
+
+# `Evidence.check` records modal state per check, but that only marks contaminated observations red
+# after they were made. Refuse before compiling, reading, or pressing: a hardware dialog would make
+# every later AX value a reading through the modal, which is precisely what this branch forbids.
+modal = E.blocking_modal()
+ev.check("301/precondition-no-blocking-modal",
+         modal is None,
+         "no CoreGraphics modal-panel window belongs to Logic before this run reads an insert slot",
+         f"blocking_modal={modal!r}",
+         "put up Logic's audio-hardware alert: this precondition goes red and the run stops before "
+         "recording any Channel EQ value")
+if modal is not None:
+    finish()
+
+policy_ready = (isinstance(OPEN_OR_LIST_LABELS, list) and OPEN in OPEN_OR_LIST_LABELS
+                and isinstance(BYPASS_LABELS, list) and bool(BYPASS_LABELS))
+ev.check("301/precondition-the-measured-control-labels-are-in-the-locale-policy",
+         policy_ready,
+         "the policy still declares the measured open/list and bypass control label families",
+         f"open_or_list={OPEN_OR_LIST_LABELS!r} bypass={BYPASS_LABELS!r}",
+         "remove `열기` or the bypass labels from the policy: the harness refuses rather than using "
+         "a stale selector")
+if not policy_ready:
+    finish()
+
+tool, built = compile_probe()
+ev.check("301/precondition-the-raw-ax-witness-built",
+         built.returncode == 0,
+         "the independent raw-AX witness compiled; System Events would synthesise descriptions and "
+         "cannot establish the slider attributes below",
+         f"rc={built.returncode} stderr={(built.stderr or b'').decode('utf-8', 'replace')[:300]!r}",
+         "break the witness source: no raw-attribute reading is available and this goes red")
+if built.returncode != 0:
+    finish()
+
+arrange = E.logic_window()
+band = (0, 0, arrange["w"], 28) if arrange else None
+band_subject = f"the title bar of the {arrange['title']!r} document window" if arrange else None
+ev.check("301/precondition-a-project-window-is-open",
+         arrange is not None and band is not None and bool(band_subject),
+         "a Logic arrange window is on screen, so the insert slot and the unchanged-document capture "
+         "have a project to refer to",
+         f"arrange={arrange!r} band={band!r}",
+         "close the project: there is no project insert slot or document window and this goes red")
+if band is None:
+    finish()
+
+slot_before = probe(tool, "plugin-slot", {"slot_label": SLOT})
+ev.note("301/channel-eq-slot-before-opening", slot_before)
+ev.falsifiable(
+    "301/precondition-one-channel-eq-insert-slot-resolves-by-description",
+    lambda observed: observed.get("slot_count") == 1,
+    slot_before,
+    {"slot_count": 0},
+    "exactly one AXGroup describes itself `Channel EQ`, so the run will not choose a slot by tree "
+    "order or coordinates",
+    "rename or remove the Channel EQ insert: its count becomes zero and the precondition goes red",
+)
+if slot_before.get("slot_count") != 1:
+    finish()
+
+slot_children = slot_before.get("slot_children") if isinstance(slot_before.get("slot_children"), list) else []
+slot_shape = (
+    any(isinstance(child, dict) and child.get("role") == "AXButton"
+        and child.get("description") == OPEN for child in slot_children)
+    and any(isinstance(child, dict) and child.get("role") == "AXButton"
+            and child.get("description") == "목록" for child in slot_children)
+    and any(isinstance(child, dict) and child.get("role") == "AXCheckBox"
+            and child.get("description") in BYPASS_LABELS for child in slot_children)
+)
+ev.falsifiable(
+    "301/the-channel-eq-slot-has-the-measured-open-list-and-bypass-children",
+    lambda observation: observation["ok"],
+    {"ok": slot_shape},
+    {"ok": False},
+    "the named Channel EQ AXGroup contains AXButtons `열기` and `목록`, plus a named bypass AXCheckBox",
+    "change a child role or label: the slot signature goes red before the harness attempts its Open press",
+)
+if not slot_shape:
+    finish()
+
+rec = ev.record_screen(seconds=90)
+before = ev.shot("301/before", settle_region=band, window_title=arrange["title"])
+
+# A wire read marks the release artifact under test as having served this run. It changes no Logic
+# state; the actual Channel EQ observation is the independent raw-AX witness below.
+driver = E.Driver()
+health = driver.tool("logic_system", "health", {})
+ev.falsifiable("301/the-release-artifact-answers-a-read-only-wire-request",
+               lambda body: isinstance(body, dict) and bool(body), health, {},
+               "the built server answered a read-only health request during this evidence run",
+               "start an artifact that cannot answer MCP: the empty/error response goes red")
+
+result = probe(tool, "channel-eq", {
+    "slot_label": SLOT,
+    "open_label": OPEN,
+    "close_label": CLOSE,
+    "bypass_labels": BYPASS_LABELS,
+})
+ev.note("301/channel-eq-raw-ax", result)
+
+opening = result.get("open") if isinstance(result.get("open"), dict) else {}
+pressed = opening.get("pressed_children") if isinstance(opening.get("pressed_children"), list) else []
+open_buttons = (opening.get("open_button_candidates")
+                if isinstance(opening.get("open_button_candidates"), list) else [])
+opened_windows = opening.get("opened_windows") if isinstance(opening.get("opened_windows"), list) else []
+opened_only_by_open_button = (
+    opening.get("slot_count") == 1
+    and len(open_buttons) == 1
+    and len(pressed) == 1
+    and pressed[0].get("role") == "AXButton"
+    and pressed[0].get("description") == OPEN
+    and len(opened_windows) == 1
+)
+ev.falsifiable(
+    "301/the-plugin-window-opened-through-only-the-open-button",
+    lambda observation: observation["opened"],
+    {"opened": opened_only_by_open_button},
+    {"opened": False},
+    "one new plug-in window appeared after exactly one press, and that press was AXButton `열기`; "
+    "no other pressable slot child was pressed",
+    "include every pressable child again: the bypass checkbox enters `pressed_children` and this "
+    "check goes red even if a window still opens",
+)
+
+checkboxes = result.get("band_checkboxes") if isinstance(result.get("band_checkboxes"), list) else []
+band_names = clean_texts(checkboxes)
+bands_resolve = (result.get("eq_group_count") == 1 and Counter(band_names) == Counter(BANDS))
+ev.falsifiable(
+    "301/eight-band-enables-resolve-by-name",
+    lambda observation: observation["ok"],
+    {"ok": bands_resolve},
+    {"ok": False},
+    "the EQ group exposes exactly the eight observed enable names, one AXCheckBox per band",
+    "remove a band label or duplicate one: the exact name multiset stops matching and this goes red",
+)
+
+sliders = result.get("sliders") if isinstance(result.get("sliders"), list) else []
+all_slider_descriptions = len(sliders) == 24 and all(
+    isinstance(slider, dict) and isinstance(slider.get("description"), str)
+    and slider["description"].strip()
+    for slider in sliders
+)
+ev.falsifiable(
+    "301/all-24-band-sliders-resolve-and-each-has-an-axdescription",
+    lambda observation: observation["ok"],
+    {"ok": all_slider_descriptions},
+    {"ok": False},
+    "exactly 24 EQ sliders resolve, and every one carries its own non-empty raw AXDescription",
+    "strip one description or return fewer sliders: the count/name assertion goes red",
+)
+
+all_settable = len(sliders) == 24 and all(
+    isinstance(slider, dict) and slider.get("value_settable") is True for slider in sliders
+)
+ev.falsifiable(
+    "301/every-one-of-the-24-sliders-claims-its-value-is-settable",
+    lambda observation: observation["ok"],
+    {"ok": all_settable},
+    {"ok": False},
+    "every one of the 24 named EQ sliders reports AXValue settable=true",
+    "make any slider report settable=false: the universal assertion goes red",
+)
+
+all_value_descriptions = len(sliders) == 24 and all(
+    isinstance(slider, dict) and isinstance(slider.get("value_description"), str)
+    and slider["value_description"].strip()
+    for slider in sliders
+)
+ev.falsifiable(
+    "301/every-one-of-the-24-sliders-has-an-engineering-value-description",
+    lambda observation: observation["ok"],
+    {"ok": all_value_descriptions},
+    {"ok": False},
+    "every one of the 24 sliders carries a non-empty AXValueDescription such as Hz, dB, or Q",
+    "clear one value description: this goes red while the description and settability checks can "
+    "still pass",
+)
+
+bypass_candidates = result.get("bypass_candidates") if isinstance(result.get("bypass_candidates"), list) else []
+bypass_before = result.get("bypass_before")
+bypass_after = result.get("bypass_after")
+bypass_unchanged = (len(bypass_candidates) == 1 and bypass_before is not None
+                    and bypass_after is not None and bypass_after == bypass_before)
+ev.falsifiable(
+    "301/negative-control-the-bypass-checkbox-value-is-unchanged",
+    lambda observation: observation["ok"],
+    {"ok": bypass_unchanged},
+    {"ok": False},
+    "the named bypass checkbox has the same AXValue before the Open press and after the plug-in "
+    "window closes",
+    "press the bypass checkbox as the old probe did: its before/after values differ and this goes red",
+)
+
+close = result.get("close") if isinstance(result.get("close"), dict) else {}
+closed = (close.get("pressed") is True and close.get("window_still_present") is False)
+ev.check("301/the-plugin-window-opened-by-this-run-is-closed-again",
+         closed,
+         "the exact plug-in window the Open button created was closed through its named close button",
+         f"close={close!r}",
+         "make the close button absent or leave the window open: this restoration check goes red")
+ev.restored("301/the-channel-eq-window-is-back-where-it-started", closed,
+            f"close={close!r}; the only UI state this harness changes is the plug-in window it opened")
+
+after = ev.shot("301/after", settle_region=band, window_title=arrange["title"])
+ev.visual("301/opening-and-closing-channel-eq-does-not-change-the-project",
+          before["file"], after["file"], band, subject=band_subject, expect_change=False,
+          why="the harness opened and closed a pre-existing insert window only; it attempted no EQ or "
+              "project write, so the document title band must be unchanged")
+
+driver.close()
+ev.stop_recording(rec)
+out = ev.write()
+print(json.dumps(out, indent=1))
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Scripts/livekit/live_306_controls_view_labels_the_row_not_the_slider.py
+++ b/Scripts/livekit/live_306_controls_view_labels_the_row_not_the_slider.py
@@ -13,11 +13,23 @@ but not the generic Controls view.
 
 WHAT IS MEASURED NOW, AND WHAT IS STILL NOT
 -------------------------------------------
-On Korean Logic 12.x, Compressor's native editor has 22 sliders; only `Threshold` has a raw
+On Korean Logic 12.x, Compressor's native editor exposes 22 sliders on one instance and 20 on
+another in the same project - the count follows the instance's configuration. On both, only
+`Threshold` has a raw
 AXDescription, and 11 sliders claim their values are settable. The `보기` menu offers `컨트롤` and
 `편집기`. In Controls view, parameter names live in AXStaticText inside AXCells of AXRows; the
 controls beside them can be AXSlider, AXRadioButton, or AXPopUpButton. The measured Controls view
 has 26 sliders, and none has an AXDescription of its own.
+
+This harness is bound to the measured project, which contains the Compressor on a channel strip
+named `Absolute Zero`. On another project that named strip can be absent or ambiguous, so the
+harness refuses rather than measuring a Compressor on the wrong track.
+
+The mixer must already be open. The named strip is resolved only inside the named mixer layout area
+whose ancestor chain contains an AXGroup with that same label. The Inspector also displays a
+selected track's channel strip as an AXLayoutArea with the mixer label, so name and role alone are
+ambiguous. If the mixer is closed, absent, ambiguous, or exceeds the bounded ancestor search, this
+harness refuses rather than opening it or choosing between elements by position.
 
 This harness changes only the plug-in view and window. It switches back to the editor, proves that
 switch happened from the editor's distinct AX signature, and closes the window. It does not attempt
@@ -48,6 +60,20 @@ ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
 # These labels were read on Korean Logic 12.x only. There is deliberately no translated fallback:
 # another locale records an absent element rather than asserting a plausible but unmeasured label.
 SLOT = "Compressor"
+# This harness depends on this measured track existing. Five Compressor inserts exist across the
+# mixer's channel strips, and selecting one by position would measure the wrong plug-in without
+# detecting it — so the search is scoped to a named strip and refuses if that strip does not hold
+# exactly one.
+#
+# Measured 2026-08-30, per strip: `Absolute Zero` carries TWO Compressors, `Studio Grand` carries
+# one, `Audio 1` none. An earlier draft named `Absolute Zero` and the harness refused with
+# slot_count 2, which was the refusal working: two inserts on one strip cannot be told apart by
+# name, and choosing between them is the thing this scoping exists to prevent.
+TRACK = "Studio Grand"
+# `mixerNamedElement` is the existing policy-owned, measured mixer label family. Passing it through
+# avoids a second Korean literal: a locale outside that measured family resolves no mixer and refuses
+# rather than treating a translation as the mixer label.
+MIXER = E.label_set("mixerNamedElement")
 OPEN = "열기"
 CLOSE = "닫기"
 CONTROLS = "컨트롤"
@@ -127,12 +153,14 @@ if modal is not None:
     finish()
 
 policy_ready = (isinstance(VIEW_LABELS, list) and bool(VIEW_LABELS)
-                and isinstance(OPEN_OR_LIST_LABELS, list) and OPEN in OPEN_OR_LIST_LABELS)
-ev.check("306/precondition-the-view-and-open-label-policies-are-readable",
+                and isinstance(OPEN_OR_LIST_LABELS, list) and OPEN in OPEN_OR_LIST_LABELS
+                and isinstance(MIXER, list) and "믹서" in MIXER)
+ev.check("306/precondition-the-view-open-and-mixer-label-policies-are-readable",
          policy_ready,
-         "the measured View and Open-or-List label families still parse from AXLocalePolicy",
-         f"view={VIEW_LABELS!r} open_or_list={OPEN_OR_LIST_LABELS!r}",
-         "remove a policy LabelSet or `열기`: this refuses instead of selecting from guessed labels")
+         "the measured View, Open-or-List, and mixer label families still parse from AXLocalePolicy",
+         f"view={VIEW_LABELS!r} open_or_list={OPEN_OR_LIST_LABELS!r} mixer={MIXER!r}",
+         "remove a policy LabelSet or the measured `열기`/`믹서` labels: this refuses instead of "
+         "selecting from guessed labels")
 if not policy_ready:
     finish()
 
@@ -158,15 +186,62 @@ ev.check("306/precondition-a-project-window-is-open",
 if band is None:
     finish()
 
-slot_before = probe(tool, "plugin-slot", {"slot_label": SLOT})
+slot_before = probe(tool, "plugin-slot", {
+    "slot_label": SLOT,
+    "track_label": TRACK,
+    "mixer_label": MIXER,
+})
 ev.note("306/compressor-slot-before-opening", slot_before)
+mixer_resolution = {
+    "mixer_layout_areas_seen": slot_before.get("mixer_layout_areas_seen"),
+    "mixer_container_count": slot_before.get("mixer_container_count"),
+    "mixer_ancestor_search_bound_hit": slot_before.get("mixer_ancestor_search_bound_hit"),
+}
+ev.falsifiable(
+    "306/precondition-exactly-one-mixer-layout-area-resolves-by-name-and-role",
+    lambda observation: (observation.get("mixer_layout_areas_seen") is not None
+                         and observation.get("mixer_container_count") == 1
+                         and observation.get("mixer_ancestor_search_bound_hit") is False),
+    mixer_resolution,
+    {"mixer_layout_areas_seen": 0, "mixer_container_count": 0,
+     "mixer_ancestor_search_bound_hit": False},
+    "exactly one AXLayoutArea with a measured mixer label has an AXGroup with that same label as "
+    "an ancestor before the named channel-strip search is allowed to begin. The Inspector shows a "
+    "channel strip for the selected track and it is also an AXLayoutArea described with the mixer "
+    "label, so the Mixer pane is identified by that AXGroup ancestor.",
+    "close the mixer, remove its measured label, expose another matching AXLayoutArea, or exceed "
+    "the 12-level ancestor bound: the harness refuses instead of opening the mixer or choosing a "
+    "container by position",
+)
+if not (mixer_resolution["mixer_layout_areas_seen"] is not None
+        and mixer_resolution["mixer_container_count"] == 1
+        and mixer_resolution["mixer_ancestor_search_bound_hit"] is False):
+    finish()
+
+ev.falsifiable(
+    "306/precondition-one-named-channel-strip-matches-the-track-label",
+    lambda observation: observation.get("matching_strip_count") == 1,
+    slot_before,
+    {"matching_strip_count": 0},
+    f"exactly one AXLayoutItem in the resolved mixer matches the measured track name `{TRACK}` "
+    "before the Compressor search, scoped to the mixer, is allowed to descend into it; the arrange "
+    "area's track header carries the same name, and choosing between them by position is not allowed",
+    f"rename, remove, or duplicate `{TRACK}` inside the mixer: the harness refuses rather than "
+    "guessing which channel strip owns the measured Compressor; the same-named arrange header is "
+    "outside this search by design",
+)
+if slot_before.get("matching_strip_count") != 1:
+    finish()
+
 ev.falsifiable(
     "306/precondition-one-compressor-insert-slot-resolves-by-description",
     lambda observation: observation.get("slot_count") == 1,
     slot_before,
     {"slot_count": 0},
-    "exactly one AXGroup describes itself `Compressor`, so the run never chooses a plug-in by tree order",
-    "rename or remove the Compressor insert: the slot count becomes zero and this goes red",
+    f"exactly one AXGroup describes itself `Compressor` within the named `{TRACK}` channel strip; "
+    "five Compressor inserts exist across channel strips, and choosing one by position is not allowed",
+    "rename or remove the Compressor insert in the named strip: its scoped slot count becomes zero "
+    "and this goes red",
 )
 if slot_before.get("slot_count") != 1:
     finish()
@@ -183,6 +258,8 @@ ev.falsifiable("306/the-release-artifact-answers-a-read-only-wire-request",
 
 result = probe(tool, "compressor", {
     "slot_label": SLOT,
+    "track_label": TRACK,
+    "mixer_label": MIXER,
     "open_label": OPEN,
     "close_label": CLOSE,
     "view_labels": VIEW_LABELS,
@@ -210,15 +287,27 @@ native_sliders = result.get("native_editor_sliders") if isinstance(result.get("n
 native_names = [name for name in slider_descriptions(native_sliders) if name]
 native_settable = sum(1 for slider in native_sliders
                       if isinstance(slider, dict) and slider.get("value_settable") is True)
-native_census = len(native_sliders) == 22 and native_settable == 11
+# NOT an exact census. Measured 2026-08-30 on two different Compressor instances in one project:
+# the one on `Absolute Zero` exposes 22 sliders of which 11 claim settable values, the one on
+# `Studio Grand` exposes 20 and 10. The count is a property of the instance's configuration, and an
+# earlier draft asserted 22/11 because that is the pair I happened to write in an issue comment.
+# What holds across both, and is the fact this harness is about, is that MOST sliders are settable
+# and exactly ONE carries a name.
+native_census = (
+    len(native_sliders) > 0
+    and native_settable > 0
+    and native_settable < len(native_sliders)
+)
 ev.falsifiable(
-    "306/native-editor-census-is-22-sliders-of-which-11-claim-settable-values",
+    "306/native-editor-exposes-sliders-of-which-only-some-claim-settable-values",
     lambda observation: observation["ok"],
     {"ok": native_census},
     {"ok": False},
-    "the native Compressor editor exposes the measured census of 22 AXSliders, with 11 reporting "
-    "AXValue settable=true",
-    "add or remove a slider, or change a slider's settability claim: the measured census goes red",
+    "the native Compressor editor exposes AXSliders and only SOME of them report AXValue "
+    "settable=true; the exact counts follow the instance (22/11 on one strip, 20/10 on another) "
+    "so they are not asserted",
+    "return no sliders, or make every slider claim settable: the invariant goes red. Note this "
+    "check cannot catch a count change, deliberately - that is the instance's business",
 )
 native_signature = len(native_names) == 1 and native_names[0] == THRESHOLD
 ev.falsifiable(

--- a/Scripts/livekit/live_306_controls_view_labels_the_row_not_the_slider.py
+++ b/Scripts/livekit/live_306_controls_view_labels_the_row_not_the_slider.py
@@ -18,7 +18,9 @@ and 20 on another (10 settable) in the same project - the count follows the inst
 configuration. On both, only `Threshold` has a raw AXDescription. The `보기` menu offers `컨트롤`
 and `편집기`. In Controls view, parameter names live in AXStaticText inside AXCells of AXRows; the
 controls beside them can be AXSlider, AXRadioButton, or AXPopUpButton. The measured Controls view
-has 26 sliders, and none has an AXDescription of its own.
+has 26 sliders. In the repeated witness, 23 AXDescription reads establish that their sliders have
+no name of their own; three return kAXErrorFailure instead. Those three sliders might carry names:
+this harness records that gap rather than treating a failed read as absence.
 
 This harness is bound to the measured project, which contains the Compressor on a channel strip
 named `Absolute Zero`. On another project that named strip can be absent or ambiguous, so the
@@ -35,6 +37,7 @@ switch happened from the editor's distinct AX signature, and closes the window. 
 to write a Compressor parameter.
 """
 
+from collections import Counter
 import json
 import os
 import subprocess
@@ -148,16 +151,6 @@ def sliders_with_every_field(sliders, field, value):
     return counterexample
 
 
-def one_slider_with_description(sliders, description):
-    counterexample = copied_nodes(sliders)
-    for slider in counterexample:
-        if isinstance(slider, dict):
-            slider["description"] = description
-            slider["description_status"] = "success_with_value"
-            break
-    return counterexample
-
-
 def mixer_layout_resolves_by_name_and_role(witness):
     return (
         isinstance(witness, dict)
@@ -181,12 +174,22 @@ def compressor_window_opened_through_named_button(opening):
     )
 
 
+def opening_with_pressed_description(opening, description):
+    """Change the selected button's label while retaining the observed opening shape."""
+    counterexample = derived_witness(opening)
+    pressed = copied_nodes(counterexample.get("pressed_children"))
+    if len(pressed) == 1 and isinstance(pressed[0], dict):
+        pressed[0]["description"] = description
+    counterexample["pressed_children"] = pressed
+    return counterexample
+
+
 def native_editor_has_partly_settable_sliders(sliders):
     if not isinstance(sliders, list):
         return False
     settable = sum(1 for slider in sliders
                    if isinstance(slider, dict) and slider.get("value_settable") is True)
-    return len(sliders) > 0 and 0 < settable < len(sliders)
+    return 0 < settable < len(sliders)
 
 
 def native_editor_has_only_threshold_named(sliders):
@@ -274,40 +277,212 @@ def rows_without_parameter_pair(rows, parameter):
     return counterexample
 
 
-# Measured 2026-08-30 across the 26 Controls-view sliders: NONE returns an empty AXDescription.
-# The read FAILS, in two ways, and both are evidence that the element carries no name of its own:
-#
-#     kAXErrorAttributeUnsupported  -25212   x15   the element has no such attribute at all
-#     kAXErrorNoValue               -25205   x11   the attribute exists and holds no value
-#
-# This was invisible while the witness mapped every failure to "" — the reading looked like
-# "twenty-six empty names" when it is "twenty-six absences, of two different kinds". Any OTHER
-# failure code is a read that went wrong and proves nothing either way, so it is not accepted.
-AX_ABSENCE_ERRORS = frozenset({-25212, -25205})
+# A completed AXDescription read can establish absence in two ways: the raw read succeeded with an
+# empty value, or AX reports one of these two absence answers. kAXErrorFailure is deliberately not
+# here. The repeated Controls-view witness returns it for three live AXSliders, so it proves neither
+# the presence nor the absence of a slider-owned name.
+# PyObjC's Quartz bridge does not expose these AXError constants. Keep each SDK name and value
+# together here so the raw values from the Swift witness remain auditable against AXError.h.
+K_AX_ERROR_NO_VALUE = -25212
+K_AX_ERROR_ATTRIBUTE_UNSUPPORTED = -25205
+AX_ABSENCE_ERRORS = frozenset({K_AX_ERROR_NO_VALUE, K_AX_ERROR_ATTRIBUTE_UNSUPPORTED})
+AX_DESCRIPTION = "AXDescription"
 
 
-def controls_sliders_carry_no_name_of_their_own(sliders):
-    """No Controls-view slider has a name of its own, established rather than assumed.
+def controls_slider_description_census(sliders):
+    """Split name reads by what the Accessibility result actually established.
 
-    Two observations satisfy that and nothing else does: the attribute read SUCCEEDED and came back
-    empty, or the read failed with `kAXErrorAttributeUnsupported`. A transient failure, a missing
-    status field, or any other error code is NOT evidence of absence — that substitution is exactly
-    how twenty-six failed reads could once have satisfied "no slider has a description".
+    A failed read belongs in the unevaluated gap unless AX itself returned an absence answer. That
+    keeps a claim about the evaluated sliders from silently becoming a claim about unreadable ones.
     """
-    if not isinstance(sliders, list) or len(sliders) != 26:
-        return False
-    for slider in sliders:
+    census = {
+        # Keep these summary fields first: falsifiable receipts retain a bounded representation of
+        # their observation, and the count plus codes are the evidence boundary this run must show.
+        "slider_count": len(sliders) if isinstance(sliders, list) else None,
+        "evaluated_count": 0,
+        "unevaluated_count": 0,
+        "unevaluated_error_codes": [],
+        "unclassified_count": 0,
+        "evaluated_sliders": [],
+        "unevaluated_sliders": [],
+        "unclassified_sliders": [],
+        "sliders": copied_nodes(sliders),
+    }
+    for slider in sliders if isinstance(sliders, list) else []:
         if not isinstance(slider, dict):
-            return False
+            census["unclassified_sliders"].append(slider)
+            continue
         status = slider.get("description_status")
         if status in DESCRIPTION_READ_SUCCEEDED:
-            if slider.get("description", "") != "":
-                return False
+            census["evaluated_sliders"].append(slider)
             continue
-        if status == "failed" and slider.get("description_error") in AX_ABSENCE_ERRORS:
+        if status == "failed":
+            error = slider.get("description_error")
+            if error in AX_ABSENCE_ERRORS:
+                census["evaluated_sliders"].append(slider)
+            else:
+                census["unevaluated_sliders"].append(slider)
+                census["unevaluated_error_codes"].append(error)
             continue
+        census["unclassified_sliders"].append(slider)
+
+    census["evaluated_count"] = len(census["evaluated_sliders"])
+    census["unevaluated_count"] = len(census["unevaluated_sliders"])
+    census["unclassified_count"] = len(census["unclassified_sliders"])
+    return census
+
+
+def evaluated_controls_sliders_carry_no_name_of_their_own(census):
+    """Every evaluated Controls-view slider has no name, and evaluation was non-vacuous.
+
+    The exact 26-slider census remains part of the measured surface. Unknown statuses are rejected
+    too: only AX's success and its two absence answers can place a slider in the evaluated set.
+    """
+    if not isinstance(census, dict) or census.get("slider_count") != 26:
         return False
-    return True
+    evaluated = census.get("evaluated_sliders")
+    unevaluated = census.get("unevaluated_sliders")
+    unclassified = census.get("unclassified_sliders")
+    if not all(isinstance(group, list) for group in (evaluated, unevaluated, unclassified)):
+        return False
+    if census.get("evaluated_count") != len(evaluated) or census.get("unevaluated_count") != len(unevaluated):
+        return False
+    if census.get("unclassified_count") != len(unclassified) or unclassified:
+        return False
+    if len(evaluated) + len(unevaluated) != 26 or not evaluated:
+        return False
+    return all(isinstance(slider, dict) and slider.get("description", "") == ""
+               for slider in evaluated)
+
+
+def unevaluated_controls_slider_gap_is_recorded(census):
+    """Verify that the receipt preserves, but does not condemn, the unreadable subset."""
+    if not isinstance(census, dict):
+        return False
+    unevaluated = census.get("unevaluated_sliders")
+    error_codes = census.get("unevaluated_error_codes")
+    if not isinstance(unevaluated, list) or not isinstance(error_codes, list):
+        return False
+    return (
+        census.get("unevaluated_count") == len(unevaluated) == len(error_codes)
+        and error_codes == [slider.get("description_error") if isinstance(slider, dict) else None
+                            for slider in unevaluated]
+    )
+
+
+def census_with_one_evaluated_slider_named(census, description):
+    """Make a coherent named-slider observation without changing the census's structure."""
+    sliders = copied_nodes(census.get("sliders") if isinstance(census, dict) else [])
+    for slider in sliders:
+        if not isinstance(slider, dict):
+            continue
+        status = slider.get("description_status")
+        if status in DESCRIPTION_READ_SUCCEEDED or (
+                status == "failed" and slider.get("description_error") in AX_ABSENCE_ERRORS):
+            # A successful non-empty result is a real observation a slider could make. Changing the
+            # status with the text avoids a contradictory synthetic record that only fails a shape
+            # guard instead of the evaluated-name condition.
+            slider["description"] = description
+            slider["description_status"] = "success_with_value"
+            slider["description_error"] = None
+            break
+    return controls_slider_description_census(sliders)
+
+
+def census_with_misrecorded_unevaluated_gap(census):
+    """Remove or invent one error code so the gap receipt has to reconcile with its census."""
+    counterexample = derived_witness(census)
+    error_codes = list(counterexample.get("unevaluated_error_codes", []))
+    if error_codes:
+        error_codes.pop()
+    else:
+        error_codes.append("counterexample error")
+    counterexample["unevaluated_error_codes"] = error_codes
+    return counterexample
+
+
+def raw_ax_failure_accounting_observation(result, census, native_census):
+    """Put the raw failures beside every census that may explain them.
+
+    Measured 2026-08-30: the failures this run could not explain were on NATIVE EDITOR sliders, not
+    Controls-view ones. Both views are censused the same way, so both belong here — an accounting
+    that knows about one of two populations reports an unexplained failure for a read it did in
+    fact classify.
+    """
+    failures = result.get("ax_read_failures", []) if isinstance(result, dict) else []
+    return {
+        "ax_read_failure_count": len(failures) if isinstance(failures, list) else None,
+        "controls_slider_unevaluated_count": census.get("unevaluated_count") if isinstance(census, dict) else None,
+        "controls_slider_unevaluated_error_codes": census.get("unevaluated_error_codes") if isinstance(census, dict) else None,
+        "native_slider_unevaluated_count": native_census.get("unevaluated_count") if isinstance(native_census, dict) else None,
+        "native_slider_unevaluated_error_codes": native_census.get("unevaluated_error_codes") if isinstance(native_census, dict) else None,
+        "ax_read_failures": failures,
+        "controls_slider_census": census,
+        "native_slider_census": native_census,
+    }
+
+
+def every_raw_ax_read_failure_is_accounted_for(observation):
+    """Accept only the specific unreadable slider descriptions counted by this harness.
+
+    A raw read elsewhere remains unexplained even if it happens to have the same error code. Exact
+    element-and-code pairing prevents a broad "-25200 is okay" exception from swallowing it.
+    """
+    if not isinstance(observation, dict):
+        return False
+    failures = observation.get("ax_read_failures")
+    unevaluated = []
+    for key in ("controls_slider_census", "native_slider_census"):
+        census = observation.get(key)
+        rows = census.get("unevaluated_sliders") if isinstance(census, dict) else None
+        if not isinstance(rows, list):
+            return False
+        unevaluated.extend(rows)
+    if not isinstance(failures, list):
+        return False
+
+    counted = Counter()
+    for slider in unevaluated:
+        if not isinstance(slider, dict) or slider.get("description_status") != "failed":
+            return False
+        element_id = slider.get("element_id")
+        if not isinstance(element_id, str) or not element_id:
+            return False
+        counted[(element_id, slider.get("description_error"))] += 1
+
+    reported = Counter()
+    for failure in failures:
+        if not isinstance(failure, dict) or failure.get("attribute") != AX_DESCRIPTION:
+            return False
+        element_id = failure.get("element_id")
+        if not isinstance(element_id, str) or not element_id:
+            return False
+        if failure.get("code") != failure.get("status"):
+            return False
+        reported[(element_id, failure.get("code"))] += 1
+    return reported == counted
+
+
+def accounting_with_unexplained_title_failure(observation):
+    """Add a plausible AXTitle failure so accounting cannot pass by ignoring raw failures."""
+    counterexample = derived_witness(observation)
+    failures = copied_nodes(counterexample.get("ax_read_failures"))
+    census = counterexample.get("controls_slider_census")
+    unevaluated = census.get("unevaluated_sliders") if isinstance(census, dict) else []
+    source = unevaluated[0] if isinstance(unevaluated, list) and unevaluated else {}
+    element_id = source.get("element_id") if isinstance(source, dict) else "counterexample-slider"
+    failures.append({
+        "attribute": "AXTitle",
+        "status": K_AX_ERROR_NO_VALUE,
+        "code": K_AX_ERROR_NO_VALUE,
+        "element_id": element_id,
+        "element_role": "AXSlider",
+        "element_title": "<unreadable>",
+        "read_site": "counterexample",
+    })
+    counterexample["ax_read_failures"] = failures
+    counterexample["ax_read_failure_count"] = len(failures)
+    return counterexample
 
 
 # Automatic per-check modal receipts only reveal contamination after a check was made. Refuse before
@@ -429,14 +604,69 @@ result = probe(tool, "compressor", {
 })
 ev.note("306/compressor-raw-ax", result)
 
+controls_sliders = result.get("controls_sliders") if isinstance(result.get("controls_sliders"), list) else []
+controls_slider_census = controls_slider_description_census(controls_sliders)
+# The native editor's sliders get the same census. It is not asserted on — the native view's naming
+# is checked elsewhere by its own signature — but its unreadable descriptions have to be counted, or
+# the raw-failure accounting reports a failure this run did in fact classify. Measured: the two
+# failures that went unexplained were native-editor sliders, not Controls-view ones.
+# Both native-editor reads: the one before the view switch and the one after the restore. The
+# harness reads that view twice, so censusing it once leaves the second read's unreadable
+# descriptions unaccounted and the accounting reports a failure it did classify.
+native_slider_census = controls_slider_description_census(
+    (result.get("native_editor_sliders") if isinstance(result.get("native_editor_sliders"), list) else [])
+    + (result.get("editor_after_restore_sliders")
+       if isinstance(result.get("editor_after_restore_sliders"), list) else []))
+ev.falsifiable(
+    "306/controls-view-evaluated-sliders-have-no-own-axdescription",
+    evaluated_controls_sliders_carry_no_name_of_their_own,
+    controls_slider_census,
+    census_with_one_evaluated_slider_named(controls_slider_census, "counterexample description"),
+    f"of the {controls_slider_census['slider_count']} Controls-view sliders, every one of the "
+    f"{controls_slider_census['evaluated_count']} whose AXDescription could be evaluated carries no "
+    f"name of its own; evaluation is non-vacuous. The {controls_slider_census['unevaluated_count']} "
+    "unevaluated sliders are recorded separately because they might carry names and this run cannot say.",
+    "give one currently evaluated slider a successful non-empty AXDescription: it stays in the "
+    "evaluated set, so the no-name condition itself goes red rather than a structural guard doing it",
+)
+ev.falsifiable(
+    "306/controls-view-slider-axdescription-unevaluated-gap-is-recorded",
+    unevaluated_controls_slider_gap_is_recorded,
+    controls_slider_census,
+    census_with_misrecorded_unevaluated_gap(controls_slider_census),
+    f"{controls_slider_census['unevaluated_count']} Controls-view sliders could not be evaluated for "
+    f"AXDescription (error codes {controls_slider_census['unevaluated_error_codes']!r}); they might "
+    "carry names and this run cannot say. This is a recorded measured gap, not an assertion that the "
+    "gap is a defect or must be zero.",
+    "remove or invent an unevaluated error code: the gap no longer reconciles with the slider census "
+    "and this receipt goes red; a changed measured gap remains recorded rather than condemned",
+)
+
+raw_ax_failure_accounting = raw_ax_failure_accounting_observation(
+    result, controls_slider_census, native_slider_census)
+ev.falsifiable(
+    "306/raw-ax-probe-completed-its-search",
+    every_raw_ax_read_failure_is_accounted_for,
+    raw_ax_failure_accounting,
+    accounting_with_unexplained_title_failure(raw_ax_failure_accounting),
+    "no raw AX read failure this run has not explained: every failure is an AXDescription failure "
+    "on a Controls-view slider counted in the unevaluated census. This does not claim there were no "
+    "failures; it rejects a failure anywhere else or on any other attribute.",
+    "make AXTitle fail, or make AXDescription fail outside a Controls-view slider: no unevaluated "
+    "slider census entry accounts for it and this goes red",
+)
+if not every_raw_ax_read_failure_is_accounted_for(raw_ax_failure_accounting):
+    finish()
+
 opening = result.get("open") if isinstance(result.get("open"), dict) else {}
 ev.falsifiable(
     "306/the-compressor-window-opened-through-the-named-open-button",
     compressor_window_opened_through_named_button,
     opening,
-    derived_witness(opening, pressed_children=[], opened_windows=[]),
+    opening_with_pressed_description(opening, "not the Open label"),
     "one Compressor window appeared after a single AXButton `열기` press",
-    "press no Open button, or press another child: the observed opening path goes red",
+    "change the pressed AXButton's description while retaining the observed slot and window: the "
+    "named-open condition goes red",
 )
 
 native_sliders = result.get("native_editor_sliders") if isinstance(result.get("native_editor_sliders"), list) else []
@@ -444,8 +674,8 @@ native_sliders = result.get("native_editor_sliders") if isinstance(result.get("n
 # the one on `Absolute Zero` exposes 22 sliders of which 11 claim settable values, the one on
 # `Studio Grand` exposes 20 and 10. The count is a property of the instance's configuration, and an
 # earlier draft asserted 22/11 because that is the pair I happened to write in an issue comment.
-# What holds across both, and is the fact this harness is about, is that MOST sliders are settable
-# and exactly ONE carries a name.
+# What holds across both, and is the fact this harness is about, is that exactly HALF of the sliders
+# are settable and exactly ONE carries a name.
 ev.falsifiable(
     "306/native-editor-exposes-sliders-of-which-only-some-claim-settable-values",
     native_editor_has_partly_settable_sliders,
@@ -487,22 +717,6 @@ ev.falsifiable(
     "with an AXSlider, AXRadioButton, or AXPopUpButton",
     f"remove one parameter row label or its cell's control: its specific pairing disappears and this "
     f"goes red (rows with text={named_row_count})",
-)
-
-controls_sliders = result.get("controls_sliders") if isinstance(result.get("controls_sliders"), list) else []
-ev.falsifiable(
-    "306/controls-view-sliders-have-no-own-axdescription",
-    controls_sliders_carry_no_name_of_their_own,
-    controls_sliders,
-    one_slider_with_description(controls_sliders, "counterexample description"),
-    "no Controls-view slider carries a name of its own: each AXDescription read either succeeded "
-    "and came back empty, or failed with kAXErrorAttributeUnsupported (-25212, x15) or "
-    "kAXErrorNoValue (-25205, x11), which is what these sliders actually do. The name is on "
-    "the row, so step 9 of set_param_verified "
-    "(AXSlider matched by its own AXDescription) does NOT reach these controls",
-    "attach a name to one slider, return a non-26 census, or make one description read fail with "
-    "any code other than unsupported: the assertion goes red, because a read that went wrong is "
-    "not evidence that a name is absent",
 )
 
 editor_selection = result.get("editor_selection") if isinstance(result.get("editor_selection"), dict) else {}

--- a/Scripts/livekit/live_306_controls_view_labels_the_row_not_the_slider.py
+++ b/Scripts/livekit/live_306_controls_view_labels_the_row_not_the_slider.py
@@ -13,11 +13,10 @@ but not the generic Controls view.
 
 WHAT IS MEASURED NOW, AND WHAT IS STILL NOT
 -------------------------------------------
-On Korean Logic 12.x, Compressor's native editor exposes 22 sliders on one instance and 20 on
-another in the same project - the count follows the instance's configuration. On both, only
-`Threshold` has a raw
-AXDescription, and 11 sliders claim their values are settable. The `보기` menu offers `컨트롤` and
-`편집기`. In Controls view, parameter names live in AXStaticText inside AXCells of AXRows; the
+On Korean Logic 12.x, Compressor's native editor exposes 22 sliders on one instance (11 settable)
+and 20 on another (10 settable) in the same project - the count follows the instance's
+configuration. On both, only `Threshold` has a raw AXDescription. The `보기` menu offers `컨트롤`
+and `편집기`. In Controls view, parameter names live in AXStaticText inside AXCells of AXRows; the
 controls beside them can be AXSlider, AXRadioButton, or AXPopUpButton. The measured Controls view
 has 26 sliders, and none has an AXDescription of its own.
 
@@ -83,6 +82,8 @@ PARAMETERS = [
     "Threshold:", "Ratio:", "Attack:", "Release:", "Make Up:", "Knee:", "Peak/RMS:",
     "Auto Gain:", "Distortion:", "Circuit Type:", "Side Chain Detection:",
 ]
+CONTROL_ROLES = {"AXSlider", "AXRadioButton", "AXPopUpButton"}
+DESCRIPTION_READ_SUCCEEDED = {"success_with_value", "success_without_value"}
 
 # This policy LabelSet names the View surface in measured locales. It is passed to the raw witness
 # rather than spelling a second, unmaintained candidate array here.
@@ -120,6 +121,101 @@ def slider_descriptions(sliders):
     return [slider.get("description", "") for slider in sliders if isinstance(slider, dict)]
 
 
+def derived_witness(observation, **changes):
+    """Copy a raw witness before changing one fact for a same-shape counterexample."""
+    counterexample = dict(observation) if isinstance(observation, dict) else {}
+    counterexample.update(changes)
+    return counterexample
+
+
+def copied_nodes(nodes):
+    return [dict(node) if isinstance(node, dict) else node for node in nodes] if isinstance(nodes, list) else []
+
+
+def descriptions_without(nodes, description):
+    counterexample = copied_nodes(nodes)
+    for node in counterexample:
+        if isinstance(node, dict) and node.get("description") == description:
+            node["description"] = ""
+    return counterexample
+
+
+def sliders_with_every_field(sliders, field, value):
+    counterexample = copied_nodes(sliders)
+    for slider in counterexample:
+        if isinstance(slider, dict):
+            slider[field] = value
+    return counterexample
+
+
+def one_slider_with_description(sliders, description):
+    counterexample = copied_nodes(sliders)
+    for slider in counterexample:
+        if isinstance(slider, dict):
+            slider["description"] = description
+            slider["description_status"] = "success_with_value"
+            break
+    return counterexample
+
+
+def mixer_layout_resolves_by_name_and_role(witness):
+    return (
+        isinstance(witness, dict)
+        and witness.get("mixer_layout_areas_seen") is not None
+        and witness.get("mixer_container_count") == 1
+        and witness.get("mixer_ancestor_search_bound_hit") is False
+    )
+
+
+def compressor_window_opened_through_named_button(opening):
+    if not isinstance(opening, dict):
+        return False
+    pressed = opening.get("pressed_children") if isinstance(opening.get("pressed_children"), list) else []
+    opened_windows = opening.get("opened_windows") if isinstance(opening.get("opened_windows"), list) else []
+    return (
+        opening.get("slot_count") == 1
+        and len(pressed) == 1
+        and pressed[0].get("role") == "AXButton"
+        and pressed[0].get("description") == OPEN
+        and len(opened_windows) == 1
+    )
+
+
+def native_editor_has_partly_settable_sliders(sliders):
+    if not isinstance(sliders, list):
+        return False
+    settable = sum(1 for slider in sliders
+                   if isinstance(slider, dict) and slider.get("value_settable") is True)
+    return len(sliders) > 0 and 0 < settable < len(sliders)
+
+
+def native_editor_has_only_threshold_named(sliders):
+    return isinstance(sliders, list) and [name for name in slider_descriptions(sliders) if name] == [THRESHOLD]
+
+
+def view_menu_offers_controls_and_editor(selection):
+    if not isinstance(selection, dict):
+        return False
+    items = selection.get("items") if isinstance(selection.get("items"), list) else []
+    names = {item.get("title") or item.get("description") for item in items if isinstance(item, dict)}
+    candidates = selection.get("button_candidates")
+    return isinstance(candidates, list) and len(candidates) == 1 and CONTROLS in names and EDITOR in names
+
+
+def view_menu_without_item(selection, label):
+    counterexample = derived_witness(selection)
+    items = copied_nodes(counterexample.get("items"))
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        if item.get("title") == label:
+            item["title"] = ""
+        if item.get("description") == label:
+            item["description"] = ""
+    counterexample["items"] = items
+    return counterexample
+
+
 def row_static_texts(rows):
     texts = []
     named_rows = 0
@@ -136,8 +232,82 @@ def row_static_texts(rows):
 
 
 def all_parameters_are_row_labels(rows):
+    """Every expected name shares an AXCell with a reported control, not just any row text."""
     texts, named_rows = row_static_texts(rows)
-    return named_rows >= len(PARAMETERS) and all(name in texts for name in PARAMETERS)
+    def paired(name):
+        for row in rows if isinstance(rows, list) else []:
+            cells = row.get("cells") if isinstance(row, dict) else []
+            for cell in cells if isinstance(cells, list) else []:
+                if not isinstance(cell, dict):
+                    continue
+                cell_texts = cell.get("static_texts")
+                control_roles = cell.get("control_roles")
+                if (isinstance(cell_texts, list) and name in cell_texts
+                        and isinstance(control_roles, list)
+                        and any(role in CONTROL_ROLES for role in control_roles)):
+                    return True
+        return False
+    return named_rows >= len(PARAMETERS) and all(name in texts and paired(name) for name in PARAMETERS)
+
+
+def rows_without_parameter_pair(rows, parameter):
+    counterexample = []
+    for row in rows if isinstance(rows, list) else []:
+        if not isinstance(row, dict):
+            counterexample.append(row)
+            continue
+        copied_row = dict(row)
+        cells = row.get("cells")
+        if isinstance(cells, list):
+            copied_cells = []
+            for cell in cells:
+                if not isinstance(cell, dict):
+                    copied_cells.append(cell)
+                    continue
+                copied_cell = dict(cell)
+                texts = cell.get("static_texts")
+                if isinstance(texts, list):
+                    copied_cell["static_texts"] = [text for text in texts if text != parameter]
+                copied_cells.append(copied_cell)
+            copied_row["cells"] = copied_cells
+        counterexample.append(copied_row)
+    return counterexample
+
+
+# Measured 2026-08-30 across the 26 Controls-view sliders: NONE returns an empty AXDescription.
+# The read FAILS, in two ways, and both are evidence that the element carries no name of its own:
+#
+#     kAXErrorAttributeUnsupported  -25212   x15   the element has no such attribute at all
+#     kAXErrorNoValue               -25205   x11   the attribute exists and holds no value
+#
+# This was invisible while the witness mapped every failure to "" — the reading looked like
+# "twenty-six empty names" when it is "twenty-six absences, of two different kinds". Any OTHER
+# failure code is a read that went wrong and proves nothing either way, so it is not accepted.
+AX_ABSENCE_ERRORS = frozenset({-25212, -25205})
+
+
+def controls_sliders_carry_no_name_of_their_own(sliders):
+    """No Controls-view slider has a name of its own, established rather than assumed.
+
+    Two observations satisfy that and nothing else does: the attribute read SUCCEEDED and came back
+    empty, or the read failed with `kAXErrorAttributeUnsupported`. A transient failure, a missing
+    status field, or any other error code is NOT evidence of absence — that substitution is exactly
+    how twenty-six failed reads could once have satisfied "no slider has a description".
+    """
+    if not isinstance(sliders, list) or len(sliders) != 26:
+        return False
+    for slider in sliders:
+        if not isinstance(slider, dict):
+            return False
+        status = slider.get("description_status")
+        if status in DESCRIPTION_READ_SUCCEEDED:
+            if slider.get("description", "") != "":
+                return False
+            continue
+        if status == "failed" and slider.get("description_error") in AX_ABSENCE_ERRORS:
+            continue
+        return False
+    return True
 
 
 # Automatic per-check modal receipts only reveal contamination after a check was made. Refuse before
@@ -192,19 +362,11 @@ slot_before = probe(tool, "plugin-slot", {
     "mixer_label": MIXER,
 })
 ev.note("306/compressor-slot-before-opening", slot_before)
-mixer_resolution = {
-    "mixer_layout_areas_seen": slot_before.get("mixer_layout_areas_seen"),
-    "mixer_container_count": slot_before.get("mixer_container_count"),
-    "mixer_ancestor_search_bound_hit": slot_before.get("mixer_ancestor_search_bound_hit"),
-}
 ev.falsifiable(
     "306/precondition-exactly-one-mixer-layout-area-resolves-by-name-and-role",
-    lambda observation: (observation.get("mixer_layout_areas_seen") is not None
-                         and observation.get("mixer_container_count") == 1
-                         and observation.get("mixer_ancestor_search_bound_hit") is False),
-    mixer_resolution,
-    {"mixer_layout_areas_seen": 0, "mixer_container_count": 0,
-     "mixer_ancestor_search_bound_hit": False},
+    mixer_layout_resolves_by_name_and_role,
+    slot_before,
+    derived_witness(slot_before, mixer_container_count=0),
     "exactly one AXLayoutArea with a measured mixer label has an AXGroup with that same label as "
     "an ancestor before the named channel-strip search is allowed to begin. The Inspector shows a "
     "channel strip for the selected track and it is also an AXLayoutArea described with the mixer "
@@ -213,16 +375,14 @@ ev.falsifiable(
     "the 12-level ancestor bound: the harness refuses instead of opening the mixer or choosing a "
     "container by position",
 )
-if not (mixer_resolution["mixer_layout_areas_seen"] is not None
-        and mixer_resolution["mixer_container_count"] == 1
-        and mixer_resolution["mixer_ancestor_search_bound_hit"] is False):
+if not mixer_layout_resolves_by_name_and_role(slot_before):
     finish()
 
 ev.falsifiable(
     "306/precondition-one-named-channel-strip-matches-the-track-label",
     lambda observation: observation.get("matching_strip_count") == 1,
     slot_before,
-    {"matching_strip_count": 0},
+    derived_witness(slot_before, matching_strip_count=0),
     f"exactly one AXLayoutItem in the resolved mixer matches the measured track name `{TRACK}` "
     "before the Compressor search, scoped to the mixer, is allowed to descend into it; the arrange "
     "area's track header carries the same name, and choosing between them by position is not allowed",
@@ -237,7 +397,7 @@ ev.falsifiable(
     "306/precondition-one-compressor-insert-slot-resolves-by-description",
     lambda observation: observation.get("slot_count") == 1,
     slot_before,
-    {"slot_count": 0},
+    derived_witness(slot_before, slot_count=0),
     f"exactly one AXGroup describes itself `Compressor` within the named `{TRACK}` channel strip; "
     "five Compressor inserts exist across channel strips, and choosing one by position is not allowed",
     "rename or remove the Compressor insert in the named strip: its scoped slot count becomes zero "
@@ -251,8 +411,9 @@ before = ev.shot("306/before", settle_region=band, window_title=arrange["title"]
 
 driver = E.Driver()
 health = driver.tool("logic_system", "health", {})
+health_counterexample = derived_witness(health, _transport_error=None)
 ev.falsifiable("306/the-release-artifact-answers-a-read-only-wire-request",
-               lambda body: isinstance(body, dict) and bool(body), health, {},
+               E.artifact_answered, health, health_counterexample,
                "the built server answered a read-only health request during this evidence run",
                "start an artifact that cannot answer MCP: the empty/error response goes red")
 
@@ -269,94 +430,79 @@ result = probe(tool, "compressor", {
 ev.note("306/compressor-raw-ax", result)
 
 opening = result.get("open") if isinstance(result.get("open"), dict) else {}
-pressed = opening.get("pressed_children") if isinstance(opening.get("pressed_children"), list) else []
-opened_windows = opening.get("opened_windows") if isinstance(opening.get("opened_windows"), list) else []
-opened = (opening.get("slot_count") == 1 and len(pressed) == 1
-          and pressed[0].get("role") == "AXButton" and pressed[0].get("description") == OPEN
-          and len(opened_windows) == 1)
 ev.falsifiable(
     "306/the-compressor-window-opened-through-the-named-open-button",
-    lambda observation: observation["opened"],
-    {"opened": opened},
-    {"opened": False},
+    compressor_window_opened_through_named_button,
+    opening,
+    derived_witness(opening, pressed_children=[], opened_windows=[]),
     "one Compressor window appeared after a single AXButton `열기` press",
     "press no Open button, or press another child: the observed opening path goes red",
 )
 
 native_sliders = result.get("native_editor_sliders") if isinstance(result.get("native_editor_sliders"), list) else []
-native_names = [name for name in slider_descriptions(native_sliders) if name]
-native_settable = sum(1 for slider in native_sliders
-                      if isinstance(slider, dict) and slider.get("value_settable") is True)
 # NOT an exact census. Measured 2026-08-30 on two different Compressor instances in one project:
 # the one on `Absolute Zero` exposes 22 sliders of which 11 claim settable values, the one on
 # `Studio Grand` exposes 20 and 10. The count is a property of the instance's configuration, and an
 # earlier draft asserted 22/11 because that is the pair I happened to write in an issue comment.
 # What holds across both, and is the fact this harness is about, is that MOST sliders are settable
 # and exactly ONE carries a name.
-native_census = (
-    len(native_sliders) > 0
-    and native_settable > 0
-    and native_settable < len(native_sliders)
-)
 ev.falsifiable(
     "306/native-editor-exposes-sliders-of-which-only-some-claim-settable-values",
-    lambda observation: observation["ok"],
-    {"ok": native_census},
-    {"ok": False},
+    native_editor_has_partly_settable_sliders,
+    native_sliders,
+    sliders_with_every_field(native_sliders, "value_settable", True),
     "the native Compressor editor exposes AXSliders and only SOME of them report AXValue "
     "settable=true; the exact counts follow the instance (22/11 on one strip, 20/10 on another) "
     "so they are not asserted",
     "return no sliders, or make every slider claim settable: the invariant goes red. Note this "
     "check cannot catch a count change, deliberately - that is the instance's business",
 )
-native_signature = len(native_names) == 1 and native_names[0] == THRESHOLD
 ev.falsifiable(
     "306/native-editor-has-exactly-one-named-slider-and-it-is-threshold",
-    lambda observation: observation["ok"],
-    {"ok": native_signature},
-    {"ok": False},
+    native_editor_has_only_threshold_named,
+    native_sliders,
+    descriptions_without(native_sliders, THRESHOLD),
     "among the native editor sliders, exactly one raw AXDescription is non-empty and it is `Threshold`",
     "give another native slider a description, or remove Threshold's: the exact-one signature goes red",
 )
 
 controls_selection = result.get("controls_selection") if isinstance(result.get("controls_selection"), dict) else {}
-offered = controls_selection.get("items") if isinstance(controls_selection.get("items"), list) else []
-offered_names = {item.get("title") or item.get("description") for item in offered if isinstance(item, dict)}
-view_offers_both = (len(controls_selection.get("button_candidates", [])) == 1
-                    and CONTROLS in offered_names and EDITOR in offered_names)
 ev.falsifiable(
     "306/the-view-menu-offers-named-controls-and-editor-items",
-    lambda observation: observation["ok"],
-    {"ok": view_offers_both},
-    {"ok": False},
+    view_menu_offers_controls_and_editor,
+    controls_selection,
+    view_menu_without_item(controls_selection, CONTROLS),
     "the AXMenuButton `보기` exposes both the named `컨트롤` and `편집기` AXMenuItems",
     "remove either menu item: the offering check goes red before a row label can be mistaken for a slider name",
 )
 
 controls_rows = result.get("controls_rows") if isinstance(result.get("controls_rows"), list) else []
-rows_label_every_parameter = all_parameters_are_row_labels(controls_rows)
 row_texts, named_row_count = row_static_texts(controls_rows)
 ev.falsifiable(
     "306/controls-view-puts-every-parameter-name-in-a-row-cell-static-text",
-    lambda observation: observation["ok"],
-    {"ok": rows_label_every_parameter},
-    {"ok": False},
-    "at least eleven AXRows carry cell AXStaticText, and every measured parameter name is among them",
-    f"remove one parameter row label: its specific name disappears and this goes red (rows with text={named_row_count})",
+    all_parameters_are_row_labels,
+    controls_rows,
+    rows_without_parameter_pair(controls_rows, "Threshold:"),
+    "at least eleven AXRows carry cell AXStaticText, and every measured parameter name shares a cell "
+    "with an AXSlider, AXRadioButton, or AXPopUpButton",
+    f"remove one parameter row label or its cell's control: its specific pairing disappears and this "
+    f"goes red (rows with text={named_row_count})",
 )
 
 controls_sliders = result.get("controls_sliders") if isinstance(result.get("controls_sliders"), list) else []
-controls_have_no_own_descriptions = (len(controls_sliders) == 26 and all(
-    isinstance(slider, dict) and slider.get("description", "") == "" for slider in controls_sliders
-))
 ev.falsifiable(
     "306/controls-view-sliders-have-no-own-axdescription",
-    lambda observation: observation["ok"],
-    {"ok": controls_have_no_own_descriptions},
-    {"ok": False},
-    "all 26 Controls-view sliders have an empty raw AXDescription. The name is on the row, so step 9 "
-    "of set_param_verified (AXSlider matched by its own AXDescription) does NOT reach these controls",
-    "attach a name to one slider, or return a non-26 census: this exact absence assertion goes red",
+    controls_sliders_carry_no_name_of_their_own,
+    controls_sliders,
+    one_slider_with_description(controls_sliders, "counterexample description"),
+    "no Controls-view slider carries a name of its own: each AXDescription read either succeeded "
+    "and came back empty, or failed with kAXErrorAttributeUnsupported (-25212, x15) or "
+    "kAXErrorNoValue (-25205, x11), which is what these sliders actually do. The name is on "
+    "the row, so step 9 of set_param_verified "
+    "(AXSlider matched by its own AXDescription) does NOT reach these controls",
+    "attach a name to one slider, return a non-26 census, or make one description read fail with "
+    "any code other than unsupported: the assertion goes red, because a read that went wrong is "
+    "not evidence that a name is absent",
 )
 
 editor_selection = result.get("editor_selection") if isinstance(result.get("editor_selection"), dict) else {}

--- a/Scripts/livekit/live_306_controls_view_labels_the_row_not_the_slider.py
+++ b/Scripts/livekit/live_306_controls_view_labels_the_row_not_the_slider.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Live proof that Compressor's Controls view labels a row, not its sliders.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_306_controls_view_labels_the_row_not_the_slider.py <worktree> <full-40-char-head-sha>
+
+WHAT WAS WRONG
+--------------
+The first conclusion from Compressor's native editor was backwards: because the Controls view shows
+parameter names beside its controls, it was assumed those names belonged to the AXSliders. They do
+not. Matching `AXSlider` by its own AXDescription therefore reaches Threshold in the native editor,
+but not the generic Controls view.
+
+WHAT IS MEASURED NOW, AND WHAT IS STILL NOT
+-------------------------------------------
+On Korean Logic 12.x, Compressor's native editor has 22 sliders; only `Threshold` has a raw
+AXDescription, and 11 sliders claim their values are settable. The `보기` menu offers `컨트롤` and
+`편집기`. In Controls view, parameter names live in AXStaticText inside AXCells of AXRows; the
+controls beside them can be AXSlider, AXRadioButton, or AXPopUpButton. The measured Controls view
+has 26 sliders, and none has an AXDescription of its own.
+
+This harness changes only the plug-in view and window. It switches back to the editor, proves that
+switch happened from the editor's distinct AX signature, and closes the window. It does not attempt
+to write a Compressor parameter.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+
+# These labels were read on Korean Logic 12.x only. There is deliberately no translated fallback:
+# another locale records an absent element rather than asserting a plausible but unmeasured label.
+SLOT = "Compressor"
+OPEN = "열기"
+CLOSE = "닫기"
+CONTROLS = "컨트롤"
+EDITOR = "편집기"
+THRESHOLD = "Threshold"
+PARAMETERS = [
+    "Threshold:", "Ratio:", "Attack:", "Release:", "Make Up:", "Knee:", "Peak/RMS:",
+    "Auto Gain:", "Distortion:", "Circuit Type:", "Side Chain Detection:",
+]
+
+# This policy LabelSet names the View surface in measured locales. It is passed to the raw witness
+# rather than spelling a second, unmaintained candidate array here.
+VIEW_LABELS = E.label_set("viewMenuBar")
+# As in #301, this is a combined Open-or-List policy. It cannot safely choose between two AXButtons,
+# so the action selector remains the only measured Korean Open label above.
+OPEN_OR_LIST_LABELS = E.label_set("pluginOpenOrListControl")
+
+
+def finish(code=1):
+    out = ev.write()
+    print(json.dumps(out, indent=1))
+    sys.exit(code)
+
+
+def compile_probe():
+    source = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ax_plugin_menu_probe.swift")
+    tool = os.path.join(ev.dir, "ax_plugin_menu_probe")
+    result = subprocess.run(["swiftc", "-O", source, "-o", tool], capture_output=True)
+    return tool, result
+
+
+def probe(tool, mode, config):
+    result = subprocess.run([tool, mode, json.dumps(config, ensure_ascii=False)],
+                            capture_output=True, text=True)
+    try:
+        body = json.loads(result.stdout or "{}")
+    except ValueError:
+        body = {"_raw": (result.stdout or result.stderr)[:400]}
+    body["_returncode"] = result.returncode
+    return body
+
+
+def slider_descriptions(sliders):
+    return [slider.get("description", "") for slider in sliders if isinstance(slider, dict)]
+
+
+def row_static_texts(rows):
+    texts = []
+    named_rows = 0
+    for row in rows if isinstance(rows, list) else []:
+        cells = row.get("cells") if isinstance(row, dict) else []
+        row_texts = []
+        for cell in cells if isinstance(cells, list) else []:
+            values = cell.get("static_texts") if isinstance(cell, dict) else []
+            row_texts.extend(value for value in values if isinstance(value, str) and value)
+        if row_texts:
+            named_rows += 1
+            texts.extend(row_texts)
+    return texts, named_rows
+
+
+def all_parameters_are_row_labels(rows):
+    texts, named_rows = row_static_texts(rows)
+    return named_rows >= len(PARAMETERS) and all(name in texts for name in PARAMETERS)
+
+
+# Automatic per-check modal receipts only reveal contamination after a check was made. Refuse before
+# touching the Accessibility tree or opening Compressor, because a reading through a modal is the
+# state this branch exists to prevent from becoming evidence.
+modal = E.blocking_modal()
+ev.check("306/precondition-no-blocking-modal",
+         modal is None,
+         "no CoreGraphics modal-panel window belongs to Logic before the Compressor read",
+         f"blocking_modal={modal!r}",
+         "put up Logic's audio-hardware alert: this goes red and the run stops before a UI read")
+if modal is not None:
+    finish()
+
+policy_ready = (isinstance(VIEW_LABELS, list) and bool(VIEW_LABELS)
+                and isinstance(OPEN_OR_LIST_LABELS, list) and OPEN in OPEN_OR_LIST_LABELS)
+ev.check("306/precondition-the-view-and-open-label-policies-are-readable",
+         policy_ready,
+         "the measured View and Open-or-List label families still parse from AXLocalePolicy",
+         f"view={VIEW_LABELS!r} open_or_list={OPEN_OR_LIST_LABELS!r}",
+         "remove a policy LabelSet or `열기`: this refuses instead of selecting from guessed labels")
+if not policy_ready:
+    finish()
+
+tool, built = compile_probe()
+ev.check("306/precondition-the-raw-ax-witness-built",
+         built.returncode == 0,
+         "the witness can inspect raw AXDescription; System Events may manufacture a description "
+         "when the raw attribute is absent",
+         f"rc={built.returncode} stderr={(built.stderr or b'').decode('utf-8', 'replace')[:300]!r}",
+         "break the witness source: the no-description assertion cannot be measured and goes red")
+if built.returncode != 0:
+    finish()
+
+arrange = E.logic_window()
+band = (0, 0, arrange["w"], 28) if arrange else None
+band_subject = f"the title bar of the {arrange['title']!r} document window" if arrange else None
+ev.check("306/precondition-a-project-window-is-open",
+         arrange is not None and band is not None and bool(band_subject),
+         "a project arrange window is on screen, providing the Compressor insert and the unchanged "
+         "document capture",
+         f"arrange={arrange!r} band={band!r}",
+         "close the project: there is no Compressor insert to open and this goes red")
+if band is None:
+    finish()
+
+slot_before = probe(tool, "plugin-slot", {"slot_label": SLOT})
+ev.note("306/compressor-slot-before-opening", slot_before)
+ev.falsifiable(
+    "306/precondition-one-compressor-insert-slot-resolves-by-description",
+    lambda observation: observation.get("slot_count") == 1,
+    slot_before,
+    {"slot_count": 0},
+    "exactly one AXGroup describes itself `Compressor`, so the run never chooses a plug-in by tree order",
+    "rename or remove the Compressor insert: the slot count becomes zero and this goes red",
+)
+if slot_before.get("slot_count") != 1:
+    finish()
+
+rec = ev.record_screen(seconds=90)
+before = ev.shot("306/before", settle_region=band, window_title=arrange["title"])
+
+driver = E.Driver()
+health = driver.tool("logic_system", "health", {})
+ev.falsifiable("306/the-release-artifact-answers-a-read-only-wire-request",
+               lambda body: isinstance(body, dict) and bool(body), health, {},
+               "the built server answered a read-only health request during this evidence run",
+               "start an artifact that cannot answer MCP: the empty/error response goes red")
+
+result = probe(tool, "compressor", {
+    "slot_label": SLOT,
+    "open_label": OPEN,
+    "close_label": CLOSE,
+    "view_labels": VIEW_LABELS,
+    "controls_label": CONTROLS,
+    "editor_label": EDITOR,
+})
+ev.note("306/compressor-raw-ax", result)
+
+opening = result.get("open") if isinstance(result.get("open"), dict) else {}
+pressed = opening.get("pressed_children") if isinstance(opening.get("pressed_children"), list) else []
+opened_windows = opening.get("opened_windows") if isinstance(opening.get("opened_windows"), list) else []
+opened = (opening.get("slot_count") == 1 and len(pressed) == 1
+          and pressed[0].get("role") == "AXButton" and pressed[0].get("description") == OPEN
+          and len(opened_windows) == 1)
+ev.falsifiable(
+    "306/the-compressor-window-opened-through-the-named-open-button",
+    lambda observation: observation["opened"],
+    {"opened": opened},
+    {"opened": False},
+    "one Compressor window appeared after a single AXButton `열기` press",
+    "press no Open button, or press another child: the observed opening path goes red",
+)
+
+native_sliders = result.get("native_editor_sliders") if isinstance(result.get("native_editor_sliders"), list) else []
+native_names = [name for name in slider_descriptions(native_sliders) if name]
+native_settable = sum(1 for slider in native_sliders
+                      if isinstance(slider, dict) and slider.get("value_settable") is True)
+native_census = len(native_sliders) == 22 and native_settable == 11
+ev.falsifiable(
+    "306/native-editor-census-is-22-sliders-of-which-11-claim-settable-values",
+    lambda observation: observation["ok"],
+    {"ok": native_census},
+    {"ok": False},
+    "the native Compressor editor exposes the measured census of 22 AXSliders, with 11 reporting "
+    "AXValue settable=true",
+    "add or remove a slider, or change a slider's settability claim: the measured census goes red",
+)
+native_signature = len(native_names) == 1 and native_names[0] == THRESHOLD
+ev.falsifiable(
+    "306/native-editor-has-exactly-one-named-slider-and-it-is-threshold",
+    lambda observation: observation["ok"],
+    {"ok": native_signature},
+    {"ok": False},
+    "among the native editor sliders, exactly one raw AXDescription is non-empty and it is `Threshold`",
+    "give another native slider a description, or remove Threshold's: the exact-one signature goes red",
+)
+
+controls_selection = result.get("controls_selection") if isinstance(result.get("controls_selection"), dict) else {}
+offered = controls_selection.get("items") if isinstance(controls_selection.get("items"), list) else []
+offered_names = {item.get("title") or item.get("description") for item in offered if isinstance(item, dict)}
+view_offers_both = (len(controls_selection.get("button_candidates", [])) == 1
+                    and CONTROLS in offered_names and EDITOR in offered_names)
+ev.falsifiable(
+    "306/the-view-menu-offers-named-controls-and-editor-items",
+    lambda observation: observation["ok"],
+    {"ok": view_offers_both},
+    {"ok": False},
+    "the AXMenuButton `보기` exposes both the named `컨트롤` and `편집기` AXMenuItems",
+    "remove either menu item: the offering check goes red before a row label can be mistaken for a slider name",
+)
+
+controls_rows = result.get("controls_rows") if isinstance(result.get("controls_rows"), list) else []
+rows_label_every_parameter = all_parameters_are_row_labels(controls_rows)
+row_texts, named_row_count = row_static_texts(controls_rows)
+ev.falsifiable(
+    "306/controls-view-puts-every-parameter-name-in-a-row-cell-static-text",
+    lambda observation: observation["ok"],
+    {"ok": rows_label_every_parameter},
+    {"ok": False},
+    "at least eleven AXRows carry cell AXStaticText, and every measured parameter name is among them",
+    f"remove one parameter row label: its specific name disappears and this goes red (rows with text={named_row_count})",
+)
+
+controls_sliders = result.get("controls_sliders") if isinstance(result.get("controls_sliders"), list) else []
+controls_have_no_own_descriptions = (len(controls_sliders) == 26 and all(
+    isinstance(slider, dict) and slider.get("description", "") == "" for slider in controls_sliders
+))
+ev.falsifiable(
+    "306/controls-view-sliders-have-no-own-axdescription",
+    lambda observation: observation["ok"],
+    {"ok": controls_have_no_own_descriptions},
+    {"ok": False},
+    "all 26 Controls-view sliders have an empty raw AXDescription. The name is on the row, so step 9 "
+    "of set_param_verified (AXSlider matched by its own AXDescription) does NOT reach these controls",
+    "attach a name to one slider, or return a non-26 census: this exact absence assertion goes red",
+)
+
+editor_selection = result.get("editor_selection") if isinstance(result.get("editor_selection"), dict) else {}
+editor_after = result.get("editor_after_restore_sliders")
+editor_after = editor_after if isinstance(editor_after, list) else []
+restore_names = [name for name in slider_descriptions(editor_after) if name]
+rows_after_restore = result.get("rows_after_restore") if isinstance(result.get("rows_after_restore"), list) else []
+restored_editor = (editor_selection.get("pressed") is True
+                   and restore_names == [THRESHOLD]
+                   and not all_parameters_are_row_labels(rows_after_restore))
+ev.check("306/the-view-switched-back-to-editor-before-close",
+         restored_editor,
+         "the `편집기` menu item was pressed and the AX tree returned to the native-editor signature, "
+         "not merely a second copy of the Controls rows",
+         f"editor_selection={editor_selection!r} named_sliders={restore_names!r} "
+         f"rows_still_label_all_parameters={all_parameters_are_row_labels(rows_after_restore)!r}",
+         "leave Controls selected or make the Editor item a no-op: the distinct editor signature does not return")
+
+close = result.get("close") if isinstance(result.get("close"), dict) else {}
+closed = close.get("pressed") is True and close.get("window_still_present") is False
+ev.check("306/the-compressor-window-opened-by-this-run-is-closed-again",
+         closed,
+         "the Compressor window was closed after the asserted Editor restoration",
+         f"close={close!r}",
+         "leave the window open or remove its close button: this restoration check goes red")
+ev.restored("306/the-compressor-view-and-window-are-back-where-they-started",
+            restored_editor and closed,
+            f"editor_restored={restored_editor!r} close={close!r}")
+
+after = ev.shot("306/after", settle_region=band, window_title=arrange["title"])
+ev.visual("306/switching-the-plugin-view-and-closing-it-does-not-change-the-project",
+          before["file"], after["file"], band, subject=band_subject, expect_change=False,
+          why="the harness switched a temporary plug-in view, restored it, and attempted no Compressor or project write")
+
+driver.close()
+ev.stop_recording(rec)
+out = ev.write()
+print(json.dumps(out, indent=1))
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Scripts/livekit/live_369_export_menu_path_is_reachable.py
+++ b/Scripts/livekit/live_369_export_menu_path_is_reachable.py
@@ -121,7 +121,6 @@ def export_path_resolves(path, leaf):
     return (
         isinstance(path, list)
         and [node.get("role") if isinstance(node, dict) else None for node in path] == EXPECTED_EXPORT_ROLES
-        and len(path) == 5
         and path_name(path[0]) in FILE_LABELS
         and path_name(path[2]) == EXPORT
         and path_name(path[4]) == leaf
@@ -145,7 +144,6 @@ def open_path_is_enabled(path):
     return (
         isinstance(path, list)
         and [node.get("role") if isinstance(node, dict) else None for node in path] == EXPECTED_OPEN_ROLES
-        and len(path) == 3
         and path_name(path[0]) in FILE_LABELS
         and path_name(path[-1]) == OPEN
         and isinstance(path[-1], dict)
@@ -221,6 +219,17 @@ ev.falsifiable("369/the-release-artifact-answers-a-read-only-wire-request",
 # the File menu nor the export panel is opened by this harness.
 result = probe(tool)
 ev.note("369/export-menu-raw-ax", result)
+
+ev.falsifiable(
+    "369/raw-ax-probe-completed-its-search",
+    lambda observation: isinstance(observation, dict) and observation.get("outcome") == "searched",
+    result,
+    derived_witness(result, outcome="could_not_search"),
+    "the raw AX witness completed its search without an unreadable AX branch",
+    "make any raw AX read fail: the witness emits outcome=could_not_search and this goes red",
+)
+if result.get("outcome") != "searched":
+    finish()
 
 all_tracks_path = result.get("all_tracks_path")
 one_track_path = result.get("one_track_path")

--- a/Scripts/livekit/live_369_export_menu_path_is_reachable.py
+++ b/Scripts/livekit/live_369_export_menu_path_is_reachable.py
@@ -103,6 +103,20 @@ def path_name(node):
     return node.get("title") or node.get("description") or ""
 
 
+def derived_witness(observation, **changes):
+    """Copy a raw witness before changing one fact for a same-shape counterexample."""
+    counterexample = dict(observation) if isinstance(observation, dict) else {}
+    counterexample.update(changes)
+    return counterexample
+
+
+def path_with_leaf_field(path, field, value):
+    counterexample = [dict(node) if isinstance(node, dict) else node for node in path] if isinstance(path, list) else []
+    if counterexample and isinstance(counterexample[-1], dict):
+        counterexample[-1][field] = value
+    return counterexample
+
+
 def export_path_resolves(path, leaf):
     return (
         isinstance(path, list)
@@ -111,6 +125,31 @@ def export_path_resolves(path, leaf):
         and path_name(path[0]) in FILE_LABELS
         and path_name(path[2]) == EXPORT
         and path_name(path[4]) == leaf
+    )
+
+
+def export_leaf_is_enabled(path, leaf):
+    return (export_path_resolves(path, leaf)
+            and isinstance(path[-1], dict)
+            and path[-1].get("enabled") is True)
+
+
+def both_export_leaves_are_enabled(witness):
+    if not isinstance(witness, dict):
+        return False
+    return (export_leaf_is_enabled(witness.get("all_tracks_path"), ALL_TRACKS)
+            and export_leaf_is_enabled(witness.get("one_track_path"), ONE_TRACK))
+
+
+def open_path_is_enabled(path):
+    return (
+        isinstance(path, list)
+        and [node.get("role") if isinstance(node, dict) else None for node in path] == EXPECTED_OPEN_ROLES
+        and len(path) == 3
+        and path_name(path[0]) in FILE_LABELS
+        and path_name(path[-1]) == OPEN
+        and isinstance(path[-1], dict)
+        and path[-1].get("enabled") is True
     )
 
 
@@ -172,8 +211,9 @@ before = ev.shot("369/before", settle_region=band, window_title=arrange["title"]
 
 driver = E.Driver()
 health = driver.tool("logic_system", "health", {})
+health_counterexample = derived_witness(health, _transport_error=None)
 ev.falsifiable("369/the-release-artifact-answers-a-read-only-wire-request",
-               lambda body: isinstance(body, dict) and bool(body), health, {},
+               E.artifact_answered, health, health_counterexample,
                "the built server answered a read-only health request during this evidence run",
                "start an artifact that cannot answer MCP: the empty/error response goes red")
 
@@ -184,51 +224,38 @@ ev.note("369/export-menu-raw-ax", result)
 
 all_tracks_path = result.get("all_tracks_path")
 one_track_path = result.get("one_track_path")
-all_tracks_resolves = export_path_resolves(all_tracks_path, ALL_TRACKS)
-one_track_resolves = export_path_resolves(one_track_path, ONE_TRACK)
 ev.falsifiable(
     "369/all-tracks-export-resolves-through-the-three-level-menu-path",
-    lambda observation: observation["ok"],
-    {"ok": all_tracks_resolves},
-    {"ok": False},
+    lambda path: export_path_resolves(path, ALL_TRACKS),
+    all_tracks_path,
+    path_with_leaf_field(all_tracks_path, "role", "AXButton"),
     "the named all-tracks export leaf resolves as AXMenuBarItem > AXMenu > AXMenuItem > AXMenu > AXMenuItem",
     "remove or re-parent the leaf: its role/name path no longer matches and this goes red",
 )
 ev.falsifiable(
     "369/one-track-export-resolves-through-the-three-level-menu-path",
-    lambda observation: observation["ok"],
-    {"ok": one_track_resolves},
-    {"ok": False},
+    lambda path: export_path_resolves(path, ONE_TRACK),
+    one_track_path,
+    path_with_leaf_field(one_track_path, "role", "AXButton"),
     "the named one-track export leaf resolves through the same five-node AX menu path",
     "remove or re-parent the leaf: its role/name path no longer matches and this goes red",
 )
 
-export_leaves_enabled = (all_tracks_resolves and one_track_resolves
-                         and all_tracks_path[-1].get("enabled") is True
-                         and one_track_path[-1].get("enabled") is True)
 ev.falsifiable(
     "369/both-export-leaves-read-axenabled-true-with-no-menu-opened",
-    lambda observation: observation["ok"],
-    {"ok": export_leaves_enabled},
-    {"ok": False},
+    both_export_leaves_are_enabled,
+    result,
+    derived_witness(result, all_tracks_path=path_with_leaf_field(all_tracks_path, "enabled", False)),
     "both resolved export leaves report raw AXEnabled=true while this run has opened no menu or panel",
     "make either leaf disabled: the combined availability assertion goes red",
 )
 
 open_path = result.get("open_path")
-open_is_enabled = (
-    isinstance(open_path, list)
-    and [node.get("role") if isinstance(node, dict) else None for node in open_path] == EXPECTED_OPEN_ROLES
-    and len(open_path) == 3
-    and path_name(open_path[0]) in FILE_LABELS
-    and path_name(open_path[-1]) == OPEN
-    and open_path[-1].get("enabled") is True
-)
 ev.falsifiable(
     "369/control-file-open-is-enabled-too",
-    lambda observation: observation["ok"],
-    {"ok": open_is_enabled},
-    {"ok": False},
+    open_path_is_enabled,
+    open_path,
+    path_with_leaf_field(open_path, "enabled", False),
     "File > Open… also reports AXEnabled=true. If Open is false, this run is measuring a blocked "
     "application, not the export items",
     "put Logic behind a blocking modal: Open reads false and this control rejects the confounded run",

--- a/Scripts/livekit/live_369_export_menu_path_is_reachable.py
+++ b/Scripts/livekit/live_369_export_menu_path_is_reachable.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Live proof that Logic exposes the two audio-export menu leaves before any panel is opened.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_369_export_menu_path_is_reachable.py <worktree> <full-40-char-head-sha>
+
+WHAT WAS WRONG
+--------------
+An AX menu item can exist and still read disabled because Logic is blocked by a modal. That makes a
+failed export lookup ambiguous: it might describe the export path, or it might merely describe an
+unavailable application. The same condition disables File > Open…, so Open is the necessary control
+for this measurement rather than an unrelated extra assertion.
+
+WHAT IS MEASURED NOW, AND WHAT IS STILL NOT
+-------------------------------------------
+With no modal and Logic frontmost on Korean Logic 12.x, the raw AX tree exposes both
+`파일 > 내보내기 > 모든 트랙을 오디오 파일로…` and
+`파일 > 내보내기 > 1개의 트랙을 오디오 파일로…` as
+AXMenuBarItem > AXMenu > AXMenuItem > AXMenu > AXMenuItem. Both leaves, and File > Open…, report
+AXEnabled=true while all menus remain closed.
+
+The export panel is deliberately UNMEASURED. This harness stops at the menu tree and does not press
+either export item, so it says nothing about panel fields, export settings, or an audio file landing.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+
+# The File menu itself is policy-owned; use that exact measured candidate family rather than a
+# harness-local English/Korean list.
+FILE_LABELS = E.label_set("fileMenuBar")
+# These leaf labels were measured on Korean Logic 12.x only. They intentionally have no translated
+# fallback, so another locale reports an absent element instead of claiming a guessed menu path.
+EXPORT = "내보내기"
+ALL_TRACKS = "모든 트랙을 오디오 파일로…"
+ONE_TRACK = "1개의 트랙을 오디오 파일로…"
+OPEN = "열기…"
+EXPECTED_EXPORT_ROLES = ["AXMenuBarItem", "AXMenu", "AXMenuItem", "AXMenu", "AXMenuItem"]
+EXPECTED_OPEN_ROLES = ["AXMenuBarItem", "AXMenu", "AXMenuItem"]
+
+
+def finish(code=1):
+    out = ev.write()
+    print(json.dumps(out, indent=1))
+    sys.exit(code)
+
+
+def osa(script):
+    result = subprocess.run(["osascript", "-e", script], capture_output=True, text=True)
+    return (result.stdout or "").strip()
+
+
+def frontmost_bundle_id():
+    return osa('tell application "System Events" to return bundle identifier of first process whose frontmost is true')
+
+
+def compile_probe():
+    source = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ax_plugin_menu_probe.swift")
+    tool = os.path.join(ev.dir, "ax_plugin_menu_probe")
+    result = subprocess.run(["swiftc", "-O", source, "-o", tool], capture_output=True)
+    return tool, result
+
+
+def probe(tool):
+    config = {
+        "file_labels": FILE_LABELS,
+        "export_label": EXPORT,
+        "all_tracks_label": ALL_TRACKS,
+        "one_track_label": ONE_TRACK,
+        "open_label": OPEN,
+    }
+    result = subprocess.run([tool, "export-menu", json.dumps(config, ensure_ascii=False)],
+                            capture_output=True, text=True)
+    try:
+        body = json.loads(result.stdout or "{}")
+    except ValueError:
+        body = {"_raw": (result.stdout or result.stderr)[:400]}
+    body["_returncode"] = result.returncode
+    return body
+
+
+def path_name(node):
+    if not isinstance(node, dict):
+        return ""
+    return node.get("title") or node.get("description") or ""
+
+
+def export_path_resolves(path, leaf):
+    return (
+        isinstance(path, list)
+        and [node.get("role") if isinstance(node, dict) else None for node in path] == EXPECTED_EXPORT_ROLES
+        and len(path) == 5
+        and path_name(path[0]) in FILE_LABELS
+        and path_name(path[2]) == EXPORT
+        and path_name(path[4]) == leaf
+    )
+
+
+# Do this check before compiling a witness or querying AX. `check()` will record the modal state too,
+# but that receipt alone is not a precondition: it would let this run continue after taking readings
+# through the audio-hardware alert that makes every menu item look unavailable.
+modal = E.blocking_modal()
+ev.check("369/precondition-no-blocking-modal",
+         modal is None,
+         "no CoreGraphics modal-panel window belongs to Logic before this menu-only read",
+         f"blocking_modal={modal!r}",
+         "put up Logic's audio-hardware alert: the precondition goes red and no export path is read")
+if modal is not None:
+    finish()
+
+frontmost = frontmost_bundle_id()
+ev.check("369/precondition-logic-is-frontmost",
+         frontmost == "com.apple.logic10",
+         "Logic Pro is the frontmost application, so AXEnabled describes its available menu state",
+         f"frontmost_bundle_id={frontmost!r}",
+         "background Logic: its File menu items can read disabled and this run refuses that confound")
+if frontmost != "com.apple.logic10":
+    finish()
+
+policy_ready = isinstance(FILE_LABELS, list) and bool(FILE_LABELS)
+ev.check("369/precondition-the-file-menu-label-policy-is-readable",
+         policy_ready,
+         "AXLocalePolicy supplies the File menu's measured candidate labels",
+         f"file_labels={FILE_LABELS!r}",
+         "remove the File LabelSet: the harness refuses instead of guessing a top-level menu name")
+if not policy_ready:
+    finish()
+
+tool, built = compile_probe()
+ev.check("369/precondition-the-raw-ax-witness-built",
+         built.returncode == 0,
+         "the raw-AX witness compiled, so the asserted roles and AXEnabled values are not a System "
+         "Events rendering",
+         f"rc={built.returncode} stderr={(built.stderr or b'').decode('utf-8', 'replace')[:300]!r}",
+         "break the witness source: the menu path cannot be measured and this goes red")
+if built.returncode != 0:
+    finish()
+
+arrange = E.logic_window()
+band = (0, 0, arrange["w"], 28) if arrange else None
+band_subject = f"the title bar of the {arrange['title']!r} document window" if arrange else None
+ev.check("369/precondition-a-project-window-is-available-for-the-unchanged-menu-capture",
+         arrange is not None and band is not None and bool(band_subject),
+         "a Logic document window is on screen for the before/after capture; this harness does not "
+         "need to modify that project",
+         f"arrange={arrange!r} band={band!r}",
+         "close the document window: the menu may still exist, but the required unchanged-state "
+         "capture cannot and this goes red")
+if band is None:
+    finish()
+
+rec = ev.record_screen(seconds=75)
+before = ev.shot("369/before", settle_region=band, window_title=arrange["title"])
+
+driver = E.Driver()
+health = driver.tool("logic_system", "health", {})
+ev.falsifiable("369/the-release-artifact-answers-a-read-only-wire-request",
+               lambda body: isinstance(body, dict) and bool(body), health, {},
+               "the built server answered a read-only health request during this evidence run",
+               "start an artifact that cannot answer MCP: the empty/error response goes red")
+
+# `export-menu` only walks existing AXChildren. It does not perform AXPress or AXShowMenu, so neither
+# the File menu nor the export panel is opened by this harness.
+result = probe(tool)
+ev.note("369/export-menu-raw-ax", result)
+
+all_tracks_path = result.get("all_tracks_path")
+one_track_path = result.get("one_track_path")
+all_tracks_resolves = export_path_resolves(all_tracks_path, ALL_TRACKS)
+one_track_resolves = export_path_resolves(one_track_path, ONE_TRACK)
+ev.falsifiable(
+    "369/all-tracks-export-resolves-through-the-three-level-menu-path",
+    lambda observation: observation["ok"],
+    {"ok": all_tracks_resolves},
+    {"ok": False},
+    "the named all-tracks export leaf resolves as AXMenuBarItem > AXMenu > AXMenuItem > AXMenu > AXMenuItem",
+    "remove or re-parent the leaf: its role/name path no longer matches and this goes red",
+)
+ev.falsifiable(
+    "369/one-track-export-resolves-through-the-three-level-menu-path",
+    lambda observation: observation["ok"],
+    {"ok": one_track_resolves},
+    {"ok": False},
+    "the named one-track export leaf resolves through the same five-node AX menu path",
+    "remove or re-parent the leaf: its role/name path no longer matches and this goes red",
+)
+
+export_leaves_enabled = (all_tracks_resolves and one_track_resolves
+                         and all_tracks_path[-1].get("enabled") is True
+                         and one_track_path[-1].get("enabled") is True)
+ev.falsifiable(
+    "369/both-export-leaves-read-axenabled-true-with-no-menu-opened",
+    lambda observation: observation["ok"],
+    {"ok": export_leaves_enabled},
+    {"ok": False},
+    "both resolved export leaves report raw AXEnabled=true while this run has opened no menu or panel",
+    "make either leaf disabled: the combined availability assertion goes red",
+)
+
+open_path = result.get("open_path")
+open_is_enabled = (
+    isinstance(open_path, list)
+    and [node.get("role") if isinstance(node, dict) else None for node in open_path] == EXPECTED_OPEN_ROLES
+    and len(open_path) == 3
+    and path_name(open_path[0]) in FILE_LABELS
+    and path_name(open_path[-1]) == OPEN
+    and open_path[-1].get("enabled") is True
+)
+ev.falsifiable(
+    "369/control-file-open-is-enabled-too",
+    lambda observation: observation["ok"],
+    {"ok": open_is_enabled},
+    {"ok": False},
+    "File > Open… also reports AXEnabled=true. If Open is false, this run is measuring a blocked "
+    "application, not the export items",
+    "put Logic behind a blocking modal: Open reads false and this control rejects the confounded run",
+)
+
+after = ev.shot("369/after", settle_region=band, window_title=arrange["title"])
+ev.visual("369/menu-path-inspection-leaves-the-project-unchanged",
+          before["file"], after["file"], band, subject=band_subject, expect_change=False,
+          why="this harness stops at AX menu children and only makes read-only requests; it opens no "
+              "export panel and writes no project state")
+
+driver.close()
+ev.stop_recording(rec)
+out = ev.write()
+print(json.dumps(out, indent=1))
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Scripts/livekit/test_evidence.py
+++ b/Scripts/livekit/test_evidence.py
@@ -170,6 +170,42 @@ finally:
     else:
         sys.modules["Quartz"] = _old_quartz
 
+# A sheet enumerated directly through AXSheets need not also appear in AXChildren. Its unreadable
+# role used to be skipped, leaving a completed `None` scan when its host reported AXModal=false.
+# Drive `_first_ax_sheet` itself with that shape: the caller can turn this raised read error into
+# `cannot_tell`, but it must never receive an empty result from this unreadable enumeration.
+class _DirectSheetRoleUnreadableAX:
+    window = object()
+    candidate = object()
+
+    def attribute(self, element, attribute, site):
+        if element is self.window and attribute == "AXSheets":
+            return [self.candidate]
+        if element is self.window and attribute == "AXChildren":
+            return []
+        if element is self.candidate and attribute == "AXRole":
+            raise E._ModalReadError("AXSheets candidate AXRole", -25205)
+        raise AssertionError(f"unexpected AX read: {element!r} {attribute!r} at {site!r}")
+
+    def elements(self, value, site):
+        return value
+
+    def text(self, value, site):
+        raise AssertionError("the candidate AXRole read must fail before text conversion")
+
+    def definitive_absence(self, status):
+        return status in {-25205, -25212}
+
+
+sheet_ax = _DirectSheetRoleUnreadableAX()
+try:
+    E._first_ax_sheet(sheet_ax, sheet_ax.window)
+    unreadable_direct_sheet = False
+except E._ModalReadError:
+    unreadable_direct_sheet = True
+failed += 0 if unreadable_direct_sheet else 1
+print(f"{'ok  ' if unreadable_direct_sheet else 'FAIL'} an unreadable direct AXSheets role is cannot-tell, not clear")
+
 # A caller's snapshot is from the observation instant. `check()` records it without sampling again;
 # `falsifiable()` below has no snapshot and exercises the record-time fallback. The two receipts
 # prove that recording one observation cannot smear its state over the next one.

--- a/Scripts/livekit/test_evidence.py
+++ b/Scripts/livekit/test_evidence.py
@@ -18,6 +18,7 @@ import evidence as E  # noqa: E402
 # one visual with a subject, one recording, nothing gone wrong.
 GOOD = {
     "checks": 1, "passed": 1, "mutation_claimed": 1, "operations_driven": 1,
+    "checks_recorded_under_blocking_modal": 0,
     "checks_with_a_counterexample": 0, "counterexamples_not_rejected": 0,
     "captures": 1, "captures_unsettled": 0, "captures_straddling_displays": 0,
     "restorations_failed": 0, "cached_reads_used_as_live": 0,
@@ -36,6 +37,8 @@ CASES = [
     (False, {**GOOD, "mutation_claimed": 0}, "no check names a mutation"),
     (False, {**GOOD, "counterexamples_not_rejected": 1},
      "a counterexample the assertion failed to reject"),
+    (False, {**GOOD, "checks_recorded_under_blocking_modal": 1},
+     "a check recorded while a blocking modal was present"),
     (False, {**GOOD, "checks": 0, "passed": 0}, "no checks"),
     # Absence must never be clean, for EVERY key — the polarity used to depend on which one.
     *[(False, {k: v for k, v in GOOD.items() if k != key}, f"summary missing {key!r}")
@@ -60,6 +63,114 @@ for expected, summary, why in CASES:
     ok = got is expected
     failed += 0 if ok else 1
     print(f"{'ok  ' if ok else 'FAIL'} is_clean -> {got!s:<5} expected {expected!s:<5} {why}")
+
+# --- a modal panel is the window level, not every AXDialog-shaped window ----------------------
+#
+# These are synthetic CoreGraphics records; this test never asks a live Logic for windows. Today's
+# measurement supplied the two level facts: the blocking audio-interface alert was at modal-panel
+# level 8, and the "Studio Grand" plug-in was at floating level 3. The standard-level, non-Logic,
+# and NO-BREAK-SPACE cases below are constructed probes. (The owner spelling itself is separately
+# documented from the 2026-08-17 Korean measurement in `evidence.py`.)
+class _ModalQuartz:
+    kCGModalPanelWindowLevelKey = "modal-panel"
+    kCGWindowLayer = "kCGWindowLayer"
+    kCGWindowBounds = "kCGWindowBounds"
+    kCGWindowNumber = "kCGWindowNumber"
+    kCGWindowName = "kCGWindowName"
+
+    @staticmethod
+    def CGWindowLevelForKey(key):
+        assert key == _ModalQuartz.kCGModalPanelWindowLevelKey
+        return 8
+
+
+class _NotADict:
+    """Subscriptable, and not a `dict` — which is what CoreGraphics actually returns.
+
+    Measured 2026-08-30: `kCGWindowBounds` comes back as an NSDictionary proxy, so a guard written
+    as `isinstance(b, dict)` skipped a Logic alert that was on screen at layer 8 and had already
+    been identified as a modal. Every case here passed while it did, because the fixtures below
+    supplied real dicts — the fixture was more permissive than the thing it stood for, so it could
+    not fail. This class exists so it can.
+    """
+
+    def __init__(self, values):
+        self._values = values
+
+    def __getitem__(self, key):
+        return self._values[key]
+
+
+def _synthetic_window(owner, title, layer, number=41, bounds_type=dict):
+    return {
+        "kCGWindowOwnerName": owner,
+        "kCGWindowName": title,
+        "kCGWindowLayer": layer,
+        "kCGWindowNumber": number,
+        "kCGWindowBounds": bounds_type({"X": 101, "Y": 202, "Width": 303, "Height": 404}),
+    }
+
+
+_old_quartz = sys.modules.get("Quartz")
+sys.modules["Quartz"] = _ModalQuartz
+try:
+    modal_cases = [
+        (True, [_synthetic_window("Logic Pro", "Audio Interface", 8)],
+         "a Logic window at the derived modal-panel level is detected"),
+        (False, [_synthetic_window("Logic Pro", "Studio Grand", 3)],
+         "the measured plug-in floating level is not a modal"),
+        (False, [_synthetic_window("Logic Pro", "Tracks", 0)],
+         "a Logic standard-level window is not a modal"),
+        (False, [_synthetic_window("Finder", "A dialog", 8)],
+         "a non-Logic modal-panel window is not this application's modal"),
+        (True, [_synthetic_window("Logic Pro", "Korean alert", 8)],
+         "a Korean Logic owner name with a NO-BREAK SPACE is normalized"),
+        (True, [_synthetic_window("Logic Pro", "NSDictionary bounds", 8, bounds_type=_NotADict)],
+         "bounds that are subscriptable but not a dict are read, as CoreGraphics returns them"),
+    ]
+    for expected, windows, why in modal_cases:
+        got = E.blocking_modal(lister=lambda windows=windows: windows)
+        ok = ((got is not None) is expected
+              and (not expected or got == {
+                  "id": 41, "title": windows[0]["kCGWindowName"],
+                  "x": 101, "y": 202, "w": 303, "h": 404, "layer": 8}))
+        failed += 0 if ok else 1
+        print(f"{'ok  ' if ok else 'FAIL'} blocking_modal -> {got!r} {why}")
+finally:
+    if _old_quartz is None:
+        del sys.modules["Quartz"]
+    else:
+        sys.modules["Quartz"] = _old_quartz
+
+# `check()` and `falsifiable()` take independent snapshots. This detector returns a modal, then
+# none, to prove the first receipt carries the full window and the summary counts that receipt
+# without smearing its state over the next check.
+import tempfile as _tempfile_for_modal
+
+_modal_snapshot = {"id": 41, "title": "Audio Interface",
+                   "x": 101, "y": 202, "w": 303, "h": 404, "layer": 8}
+_original_blocking_modal = E.blocking_modal
+_modal_reads = iter([_modal_snapshot, None])
+E.blocking_modal = lambda: next(_modal_reads)
+try:
+    modal_receipts = E.Evidence("d" * 40, _tempfile_for_modal.mkdtemp())
+    modal_receipts.check("modal/ordinary", True, "expected", "observed", "a mutation")
+    modal_receipts.falsifiable("modal/falsifiable", lambda value: value == 1, 1, 0, "expected")
+    modal_summary = E.summarize(modal_receipts.records)
+finally:
+    E.blocking_modal = _original_blocking_modal
+
+modal_records = [r for r in modal_receipts.records if r["kind"] == "check"]
+ok = (modal_records[0]["blocking_modal"] == _modal_snapshot
+      and modal_records[1]["blocking_modal"] is None
+      and modal_summary["checks_recorded_under_blocking_modal"] == 1)
+failed += 0 if ok else 1
+print(f"{'ok  ' if ok else 'FAIL'} each check records its own modal snapshot and summary count")
+
+# The remaining contract drives exercise `check()` and `falsifiable()` for unrelated behavior. Keep
+# them headless: their clear modal snapshots are fixtures, not a read of whichever desktop runs CI.
+_headless_blocking_modal = E.blocking_modal
+E.blocking_modal = lambda: None
 
 # A subject has to be a non-empty STRING; truthy is not a name.
 #
@@ -370,5 +481,6 @@ for why, ok in shapes:
     failed += 0 if ok else 1
     print(f"{'ok  ' if ok else 'FAIL'} shape: {why}")
 
+E.blocking_modal = _headless_blocking_modal
 print(f"\n{'FAILED' if failed else 'all cases behaved'} ({failed} unexpected)")
 sys.exit(1 if failed else 0)

--- a/Scripts/livekit/test_evidence.py
+++ b/Scripts/livekit/test_evidence.py
@@ -19,6 +19,8 @@ import evidence as E  # noqa: E402
 GOOD = {
     "checks": 1, "passed": 1, "mutation_claimed": 1, "operations_driven": 1,
     "checks_recorded_under_blocking_modal": 0,
+    "checks_missing_blocking_modal_snapshot": 0,
+    "checks_with_blocking_modal_unknown": 0,
     "checks_with_a_counterexample": 0, "counterexamples_not_rejected": 0,
     "captures": 1, "captures_unsettled": 0, "captures_straddling_displays": 0,
     "restorations_failed": 0, "cached_reads_used_as_live": 0,
@@ -39,6 +41,10 @@ CASES = [
      "a counterexample the assertion failed to reject"),
     (False, {**GOOD, "checks_recorded_under_blocking_modal": 1},
      "a check recorded while a blocking modal was present"),
+    (False, {**GOOD, "checks_missing_blocking_modal_snapshot": 1},
+     "a check whose modal snapshot field is absent"),
+    (False, {**GOOD, "checks_with_blocking_modal_unknown": 1},
+     "a check whose modal detector could not inspect its state"),
     (False, {**GOOD, "checks": 0, "passed": 0}, "no checks"),
     # Absence must never be clean, for EVERY key — the polarity used to depend on which one.
     *[(False, {k: v for k, v in GOOD.items() if k != key}, f"summary missing {key!r}")
@@ -64,7 +70,7 @@ for expected, summary, why in CASES:
     failed += 0 if ok else 1
     print(f"{'ok  ' if ok else 'FAIL'} is_clean -> {got!s:<5} expected {expected!s:<5} {why}")
 
-# --- a modal panel is the window level, not every AXDialog-shaped window ----------------------
+# --- modal detection needs both the screen level and AX modality/sheet signals ----------------
 #
 # These are synthetic CoreGraphics records; this test never asks a live Logic for windows. Today's
 # measurement supplied the two level facts: the blocking audio-interface alert was at modal-panel
@@ -114,26 +120,48 @@ def _synthetic_window(owner, title, layer, number=41, bounds_type=dict):
 _old_quartz = sys.modules.get("Quartz")
 sys.modules["Quartz"] = _ModalQuartz
 try:
+    clear_ax = {"modal_windows": [], "sheets": []}
     modal_cases = [
-        (True, [_synthetic_window("Logic Pro", "Audio Interface", 8)],
-         "a Logic window at the derived modal-panel level is detected"),
-        (False, [_synthetic_window("Logic Pro", "Studio Grand", 3)],
+        ("modal_panel", [_synthetic_window("Logic Pro", "Audio Interface", 8)],
+         {"modal_windows": [{"title": "Audio Interface", "pid": 99}], "sheets": []},
+         "a modal-panel level is corroborated by AXModal rather than assumed modal"),
+        (None, [_synthetic_window("Logic Pro", "Modeless panel", 8)], clear_ax,
+         "a modeless panel assigned the modal level is not a false positive"),
+        (None, [_synthetic_window("Logic Pro", "Studio Grand", 3)], clear_ax,
          "the measured plug-in floating level is not a modal"),
-        (False, [_synthetic_window("Logic Pro", "Tracks", 0)],
+        (None, [_synthetic_window("Logic Pro", "Tracks", 0)], clear_ax,
          "a Logic standard-level window is not a modal"),
-        (False, [_synthetic_window("Finder", "A dialog", 8)],
+        (None, [_synthetic_window("Finder", "A dialog", 8)], clear_ax,
          "a non-Logic modal-panel window is not this application's modal"),
-        (True, [_synthetic_window("Logic Pro", "Korean alert", 8)],
+        ("modal_panel", [_synthetic_window("Logic Pro", "Korean alert", 8)],
+         {"modal_windows": [{"title": "Korean alert"}], "sheets": []},
          "a Korean Logic owner name with a NO-BREAK SPACE is normalized"),
-        (True, [_synthetic_window("Logic Pro", "NSDictionary bounds", 8, bounds_type=_NotADict)],
+        ("modal_panel", [_synthetic_window("Logic Pro", "NSDictionary bounds", 8, bounds_type=_NotADict)],
+         {"modal_windows": [{"title": "NSDictionary bounds"}], "sheets": []},
          "bounds that are subscriptable but not a dict are read, as CoreGraphics returns them"),
+        ("modal_window", [], {"modal_windows": [{"title": "Go To Position", "pid": 99}], "sheets": []},
+         "an AXModal window on another Space is still detected without an on-screen CG record"),
+        ("sheet", [], {"modal_windows": [], "sheets": [{"host_title": "Tracks", "pid": 99}]},
+         "an AXSheet is detected although its host itself is not AXModal"),
     ]
-    for expected, windows, why in modal_cases:
-        got = E.blocking_modal(lister=lambda windows=windows: windows)
-        ok = ((got is not None) is expected
-              and (not expected or got == {
-                  "id": 41, "title": windows[0]["kCGWindowName"],
-                  "x": 101, "y": 202, "w": 303, "h": 404, "layer": 8}))
+    for expected_kind, windows, signals, why in modal_cases:
+        got = E.blocking_modal(
+            lister=lambda windows=windows: windows,
+            ax_lister=lambda signals=signals: signals,
+        )
+        ok = ((got is None) if expected_kind is None else
+              (isinstance(got, dict) and got.get("state") == "detected"
+               and got.get("kind") == expected_kind))
+        failed += 0 if ok else 1
+        print(f"{'ok  ' if ok else 'FAIL'} blocking_modal -> {got!r} {why}")
+
+    for lister, ax_lister, why in [
+        (lambda: None, lambda: clear_ax, "an unreadable CoreGraphics list is not a clear desktop"),
+        (lambda: [], lambda: None, "an unreadable AX sheet/modal query is not an empty search"),
+    ]:
+        got = E.blocking_modal(lister=lister, ax_lister=ax_lister)
+        ok = (isinstance(got, dict) and got.get("state") == E.MODAL_CANNOT_TELL
+              and got.get("kind") == E.MODAL_CANNOT_TELL)
         failed += 0 if ok else 1
         print(f"{'ok  ' if ok else 'FAIL'} blocking_modal -> {got!r} {why}")
 finally:
@@ -142,19 +170,21 @@ finally:
     else:
         sys.modules["Quartz"] = _old_quartz
 
-# `check()` and `falsifiable()` take independent snapshots. This detector returns a modal, then
-# none, to prove the first receipt carries the full window and the summary counts that receipt
-# without smearing its state over the next check.
+# A caller's snapshot is from the observation instant. `check()` records it without sampling again;
+# `falsifiable()` below has no snapshot and exercises the record-time fallback. The two receipts
+# prove that recording one observation cannot smear its state over the next one.
 import tempfile as _tempfile_for_modal
 
-_modal_snapshot = {"id": 41, "title": "Audio Interface",
+_modal_snapshot = {"state": "detected", "kind": "modal_panel", "signal": "test",
+                   "id": 41, "title": "Audio Interface",
                    "x": 101, "y": 202, "w": 303, "h": 404, "layer": 8}
 _original_blocking_modal = E.blocking_modal
-_modal_reads = iter([_modal_snapshot, None])
+_modal_reads = iter([None])
 E.blocking_modal = lambda: next(_modal_reads)
 try:
     modal_receipts = E.Evidence("d" * 40, _tempfile_for_modal.mkdtemp())
-    modal_receipts.check("modal/ordinary", True, "expected", "observed", "a mutation")
+    modal_receipts.check("modal/ordinary", True, "expected", "observed", "a mutation",
+                        modal_snapshot=_modal_snapshot)
     modal_receipts.falsifiable("modal/falsifiable", lambda value: value == 1, 1, 0, "expected")
     modal_summary = E.summarize(modal_receipts.records)
 finally:
@@ -165,7 +195,36 @@ ok = (modal_records[0]["blocking_modal"] == _modal_snapshot
       and modal_records[1]["blocking_modal"] is None
       and modal_summary["checks_recorded_under_blocking_modal"] == 1)
 failed += 0 if ok else 1
-print(f"{'ok  ' if ok else 'FAIL'} each check records its own modal snapshot and summary count")
+print(f"{'ok  ' if ok else 'FAIL'} observation-time and fallback modal snapshots stay per-check")
+
+# A schema omission and an explicit failed detector are both different from None, which is the only
+# completed-clear answer. Drive summarize rather than copying its predicates so a future `.get()`
+# simplification cannot make either defect green again.
+unknown_snapshot = {"state": E.MODAL_CANNOT_TELL, "kind": E.MODAL_CANNOT_TELL,
+                    "signal": "test", "reason": "AX read failed"}
+modal_gap_summary = E.summarize([
+    {"kind": "check", "passed": True},
+    {"kind": "check", "passed": True, "blocking_modal": unknown_snapshot},
+])
+ok = (modal_gap_summary["checks_missing_blocking_modal_snapshot"] == 1
+      and modal_gap_summary["checks_with_blocking_modal_unknown"] == 1
+      and modal_gap_summary["checks_recorded_under_blocking_modal"] == 0
+      and E.is_clean({**GOOD,
+                      "checks_missing_blocking_modal_snapshot": 1}) is False
+      and E.is_clean({**GOOD,
+                      "checks_with_blocking_modal_unknown": 1}) is False)
+failed += 0 if ok else 1
+print(f"{'ok  ' if ok else 'FAIL'} absent and cannot-tell modal snapshots cannot count as clear")
+
+# `_body(None)` retains the dead transport in a non-empty dictionary for the receipt. The shared
+# predicate must reject that shape rather than let a caller's ordinary `if body:` call it answered.
+dead_transport = E._body(None)
+ok = (dead_transport == {"_transport_error": None}
+      and E.artifact_answered(dead_transport) is False
+      and E.artifact_answered({}) is True
+      and E.artifact_answered(None) is False)
+failed += 0 if ok else 1
+print(f"{'ok  ' if ok else 'FAIL'} artifact_answered rejects a truthy transport-error body")
 
 # The remaining contract drives exercise `check()` and `falsifiable()` for unrelated behavior. Keep
 # them headless: their clear modal snapshots are fixtures, not a read of whichever desktop runs CI.

--- a/Scripts/livekit/test_harness_evidence_coverage.py
+++ b/Scripts/livekit/test_harness_evidence_coverage.py
@@ -41,7 +41,7 @@ for paths, expected, why in [
 # Through the REAL `E.summarize` and `E.is_clean`, not a copy of the predicate: a test that
 # reimplements the rule agrees with itself no matter what the code says.
 CLEAN = {"records": [
-    {"kind": "check", "passed": True, "mutation_claimed": True},
+    {"kind": "check", "passed": True, "mutation_claimed": True, "blocking_modal": None},
     {"kind": "capture", "settled": True, "display": {"wholly_within": True}},
     {"kind": "visual", "passed": True, "subject": "Tracks header", "region": [0, 0, 1, 1]},
     {"kind": "recording"},
@@ -273,7 +273,8 @@ with tempfile.TemporaryDirectory() as repo, tempfile.TemporaryDirectory() as evr
         # evidence root and no Logic — and it is the same predicate either way, taken from the
         # trusted module rather than restated here.
         doc = {"name": stem, "records": [
-            {"kind": "check", "tag": "t", "passed": passed, "mutation_claimed": True},
+            {"kind": "check", "tag": "t", "passed": passed, "mutation_claimed": True,
+             "blocking_modal": None},
             {"kind": "capture", "tag": "c", "settled": True,
              "display": {"wholly_within": True}},
             {"kind": "visual", "tag": "v", "passed": True, "subject": "a named thing"},

--- a/Scripts/logic_ui_snapshot.swift
+++ b/Scripts/logic_ui_snapshot.swift
@@ -57,6 +57,24 @@ func isBlockingDialogWindow(_ element: AXUIElement) -> Bool {
     guard windowSubrole == kAXDialogSubrole as String || windowSubrole == kAXSystemDialogSubrole as String else {
         return false
     }
+    // Measured today on Logic 12.x (ko):
+    //
+    // window                          AX subrole  AXModal  CGWindowLayer
+    // Logic alert (audio interface)   AXDialog    true     8
+    // Plug-in window "Studio Grand"    AXDialog    false    3
+    // Arrange window                  AXStandard  false    0
+    //
+    // AXDialog describes a window class, not whether it blocks Logic. The plug-in's floating
+    // window is an AXDialog too, so treating the subrole alone as blocking makes an open editor
+    // refuse unrelated calls. AXModal is the measured distinction.
+    // An UNREADABLE AXModal is treated as blocking, not as permission. Measured, the attribute was
+    // present on all three window classes above, so a failed read means the AX tree is not
+    // answering — and a caller told "nothing is blocking" on the strength of a read that did not
+    // happen is exactly the shape this gate exists to refuse. That direction is not free: if the
+    // read fails transiently on a plug-in window, the caller is refused when nothing was wrong.
+    // Refusing when it cannot tell is the trade this repository takes everywhere else.
+    let modal: Bool? = axAttribute(element, kAXModalAttribute as String)
+    guard modal != false else { return false }
     return !isKeyboardLayoutOverlayWindow(element)
 }
 

--- a/Scripts/logic_ui_snapshot.swift
+++ b/Scripts/logic_ui_snapshot.swift
@@ -12,70 +12,150 @@ struct Snapshot: Encodable {
     let error: String?
 }
 
-func axAttribute<T>(_ element: AXUIElement, _ attribute: String) -> T? {
+enum AXRead<Value> {
+    case value(Value)
+    case absent
+    case failed(AXError)
+
+    var value: Value? {
+        guard case let .value(value) = self else { return nil }
+        return value
+    }
+}
+
+// A successful empty attribute and a failed AX request are different facts. The latter cannot
+// establish that no dialog blocks the caller, so isBlockingDialogWindow and its window-list caller
+// fail closed on `.failed`. The snapshot can distinguish the two at this API boundary; where it
+// cannot (a successful value of an unexpected type), that is recorded as `.absent`, not disguised
+// as a successful Boolean or child list.
+func axAttribute<T>(_ element: AXUIElement, _ attribute: String) -> AXRead<T> {
     var value: AnyObject?
     let result = AXUIElementCopyAttributeValue(element, attribute as CFString, &value)
-    guard result == .success else { return nil }
-    return value as? T
+    guard result == .success else { return .failed(result) }
+    guard let value else { return .absent }
+    guard let typed = value as? T else { return .absent }
+    return .value(typed)
 }
 
-func title(of element: AXUIElement) -> String? {
-    let raw: String? = axAttribute(element, kAXTitleAttribute as String)
-    let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-    return trimmed.isEmpty ? nil : trimmed
+func title(of element: AXUIElement) -> AXRead<String> {
+    switch axAttribute(element, kAXTitleAttribute as String) as AXRead<String> {
+    case .value(let raw):
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? .absent : .value(trimmed)
+    case .absent:
+        return .absent
+    case .failed(let error):
+        return .failed(error)
+    }
 }
 
-func role(of element: AXUIElement) -> String? {
+func role(of element: AXUIElement) -> AXRead<String> {
     axAttribute(element, kAXRoleAttribute as String)
 }
 
-func subrole(of element: AXUIElement) -> String? {
+func subrole(of element: AXUIElement) -> AXRead<String> {
     axAttribute(element, kAXSubroleAttribute as String)
 }
 
-func descriptionText(of element: AXUIElement) -> String {
-    let raw: String? = axAttribute(element, kAXDescriptionAttribute as String)
-    return raw ?? ""
+func descriptionText(of element: AXUIElement) -> AXRead<String> {
+    axAttribute(element, kAXDescriptionAttribute as String)
 }
 
-func children(of element: AXUIElement) -> [AXUIElement] {
-    let raw: [AXUIElement]? = axAttribute(element, kAXChildrenAttribute as String)
-    return raw ?? []
+func children(of element: AXUIElement) -> AXRead<[AXUIElement]> {
+    axAttribute(element, kAXChildrenAttribute as String)
 }
 
-func isKeyboardLayoutOverlayWindow(_ element: AXUIElement) -> Bool {
-    guard title(of: element) == nil else { return false }
-    let elementChildren = children(of: element)
-    guard elementChildren.count == 1 else { return false }
-    let child = elementChildren[0]
-    guard role(of: child) == kAXButtonRole as String else { return false }
-    return descriptionText(of: child).hasPrefix("com.apple.keylayout.")
+func isKeyboardLayoutOverlayWindow(_ element: AXUIElement) -> Bool? {
+    switch title(of: element) {
+    case .value:
+        return false
+    case .absent:
+        break
+    case .failed:
+        return nil
+    }
+
+    let child: AXUIElement
+    switch children(of: element) {
+    case .value(let elementChildren):
+        guard elementChildren.count == 1, let onlyChild = elementChildren.first else { return false }
+        child = onlyChild
+    case .absent:
+        return false
+    case .failed:
+        return nil
+    }
+
+    switch role(of: child) {
+    case .value(let childRole):
+        guard childRole == kAXButtonRole as String else { return false }
+    case .absent:
+        return false
+    case .failed:
+        return nil
+    }
+    switch descriptionText(of: child) {
+    case .value(let description):
+        return description.hasPrefix("com.apple.keylayout.")
+    case .absent:
+        return false
+    case .failed:
+        return nil
+    }
 }
 
 func isBlockingDialogWindow(_ element: AXUIElement) -> Bool {
-    guard let windowSubrole = subrole(of: element) else { return false }
-    guard windowSubrole == kAXDialogSubrole as String || windowSubrole == kAXSystemDialogSubrole as String else {
-        return false
-    }
     // Measured today on Logic 12.x (ko):
     //
     // window                          AX subrole  AXModal  CGWindowLayer
     // Logic alert (audio interface)   AXDialog    true     8
     // Plug-in window "Studio Grand"    AXDialog    false    3
     // Arrange window                  AXStandard  false    0
+    // Go To Position                  AXFloating  true     3
     //
-    // AXDialog describes a window class, not whether it blocks Logic. The plug-in's floating
-    // window is an AXDialog too, so treating the subrole alone as blocking makes an open editor
-    // refuse unrelated calls. AXModal is the measured distinction.
-    // An UNREADABLE AXModal is treated as blocking, not as permission. Measured, the attribute was
-    // present on all three window classes above, so a failed read means the AX tree is not
-    // answering — and a caller told "nothing is blocking" on the strength of a read that did not
-    // happen is exactly the shape this gate exists to refuse. That direction is not free: if the
-    // read fails transiently on a plug-in window, the caller is refused when nothing was wrong.
-    // Refusing when it cannot tell is the trade this repository takes everywhere else.
-    let modal: Bool? = axAttribute(element, kAXModalAttribute as String)
-    guard modal != false else { return false }
-    return !isKeyboardLayoutOverlayWindow(element)
+    // AXModal is modality, unlike AXDialog's window class. A true AXModal blocks regardless of
+    // subrole, which admits Go To Position without classifying the modeless plug-in AXDialog above.
+    // Dialog/SystemDialog remains an additional alert admission path only when AXModal is a
+    // successful-but-absent optional attribute. A failed AX read is not absence: every failed read
+    // in this predicate (including subrole and the keyboard-overlay exclusion) means blocking.
+    let windowSubrole = subrole(of: element)
+    let modal = axAttribute(element, kAXModalAttribute as String) as AXRead<Bool>
+    if case .failed = windowSubrole { return true }
+    if case .failed = modal { return true }
+
+    let isAlertSubrole: Bool
+    switch windowSubrole {
+    case .value(let value):
+        isAlertSubrole = value == kAXDialogSubrole as String || value == kAXSystemDialogSubrole as String
+    case .absent:
+        isAlertSubrole = false
+    case .failed:
+        return true
+    }
+
+    let admitsBlocking: Bool
+    switch modal {
+    case .value(true):
+        admitsBlocking = true
+    case .value(false):
+        admitsBlocking = false
+    case .absent:
+        admitsBlocking = isAlertSubrole
+    case .failed:
+        return true
+    }
+    guard admitsBlocking else { return false }
+
+    // Do not turn the keyboard-layout overlay into a dialog. If its identifying reads fail, the
+    // answer is unknown rather than harmless, so fail closed just as the AXModal read does.
+    switch isKeyboardLayoutOverlayWindow(element) {
+    case true:
+        return false
+    case false:
+        return true
+    case nil:
+        return true
+    }
 }
 
 let logicProKnownBundleIDs = ["com.apple.logic10", "com.apple.mobilelogic"]
@@ -108,19 +188,41 @@ var blockingDialogPresent = false
 
 if !AXIsProcessTrustedWithOptions(["AXTrustedCheckOptionPrompt": false] as CFDictionary) {
     error = "accessibility_not_trusted"
+    // With no AX permission the window-list predicate never ran, so false would pretend a clean
+    // blocker set. This boolean cannot distinguish a blocking dialog from an unreadable list; the
+    // accompanying error is the distinction available to the Python caller.
+    blockingDialogPresent = true
 } else if let logicApp {
     let appElement = AXUIElementCreateApplication(logicApp.processIdentifier)
     AXUIElementSetMessagingTimeout(appElement, 2.5)
 
-    if let windows: [AXUIElement] = axAttribute(appElement, kAXWindowsAttribute as String) {
-        windowNames = windows.compactMap(title)
+    switch axAttribute(appElement, kAXWindowsAttribute as String) as AXRead<[AXUIElement]> {
+    case .value(let windows):
+        windowNames = windows.compactMap { title(of: $0).value }
         blockingDialogPresent = windows.contains(where: isBlockingDialogWindow)
+    case .absent:
+        // AX reported no usable window list. That is not a successful empty list for this gate.
+        blockingDialogPresent = true
+        error = "logic_windows_unavailable"
+    case .failed(let status):
+        blockingDialogPresent = true
+        error = "logic_windows_unreadable_\(status.rawValue)"
     }
 
-    if let menuBar: AXUIElement = axAttribute(appElement, kAXMenuBarAttribute as String) {
-        menuItems = children(of: menuBar).compactMap(title)
-    } else {
-        error = "logic_menu_bar_unavailable"
+    switch axAttribute(appElement, kAXMenuBarAttribute as String) as AXRead<AXUIElement> {
+    case .value(let menuBar):
+        switch children(of: menuBar) {
+        case .value(let menuBarChildren):
+            menuItems = menuBarChildren.compactMap { title(of: $0).value }
+        case .absent:
+            if error == nil { error = "logic_menu_bar_children_unavailable" }
+        case .failed(let status):
+            if error == nil { error = "logic_menu_bar_children_unreadable_\(status.rawValue)" }
+        }
+    case .absent:
+        if error == nil { error = "logic_menu_bar_unavailable" }
+    case .failed(let status):
+        if error == nil { error = "logic_menu_bar_unreadable_\(status.rawValue)" }
     }
 } else {
     error = "logic_not_running"

--- a/Scripts/logic_ui_snapshot.swift
+++ b/Scripts/logic_ui_snapshot.swift
@@ -113,38 +113,21 @@ func isBlockingDialogWindow(_ element: AXUIElement) -> Bool {
     // Arrange window                  AXStandard  false    0
     // Go To Position                  AXFloating  true     3
     //
-    // AXModal is modality, unlike AXDialog's window class. A true AXModal blocks regardless of
-    // subrole, which admits Go To Position without classifying the modeless plug-in AXDialog above.
-    // Dialog/SystemDialog remains an additional alert admission path only when AXModal is a
-    // successful-but-absent optional attribute. A failed AX read is not absence: every failed read
-    // in this predicate (including subrole and the keyboard-overlay exclusion) means blocking.
-    let windowSubrole = subrole(of: element)
+    // AXModal is modality, unlike a window's class. A true AXModal blocks regardless of subrole,
+    // which admits Go To Position without classifying the modeless plug-in AXDialog above. More
+    // importantly, an absent, wrong-typed, or failed AXModal is UNKNOWN for EVERY subrole, not a
+    // harmless optional value for AXFloatingWindow and an alert only for AXDialog. Fail closed on
+    // that unknown payload; `axAttribute` represents both a nil and a successful wrong type as
+    // `.absent`, so treating it as clear would turn an unreadable value into a clean snapshot.
     let modal = axAttribute(element, kAXModalAttribute as String) as AXRead<Bool>
-    if case .failed = windowSubrole { return true }
-    if case .failed = modal { return true }
-
-    let isAlertSubrole: Bool
-    switch windowSubrole {
-    case .value(let value):
-        isAlertSubrole = value == kAXDialogSubrole as String || value == kAXSystemDialogSubrole as String
-    case .absent:
-        isAlertSubrole = false
-    case .failed:
-        return true
-    }
-
-    let admitsBlocking: Bool
     switch modal {
     case .value(true):
-        admitsBlocking = true
+        break
     case .value(false):
-        admitsBlocking = false
-    case .absent:
-        admitsBlocking = isAlertSubrole
-    case .failed:
+        return false
+    case .absent, .failed:
         return true
     }
-    guard admitsBlocking else { return false }
 
     // Do not turn the keyboard-layout overlay into a dialog. If its identifying reads fail, the
     // answer is unknown rather than harmless, so fail closed just as the AXModal read does.

--- a/Scripts/test_falsifiable_adoption.py
+++ b/Scripts/test_falsifiable_adoption.py
@@ -66,6 +66,25 @@ for label, files, want in [
     failed += 0 if ok else 1
     print(f"{'ok  ' if ok else 'FAIL'} {label} -> {len(adopters)} of {total}")
 
+# This is the exact shape that made the ratchet lie: the predicate receives only a boolean wrapper
+# and the counterexample is a hand-authored constant dictionary. A real observation predicate beside
+# it must still count, while the hollow call is reported with the source location that needs repair.
+hollow = harness(
+    "live_hollow.py",
+    'E.falsifiable("hollow", lambda observation: observation["ok"], {"ok": True}, '
+    '{"ok": False}, "expected")\n',
+)
+real = harness(
+    "live_real.py",
+    'E.falsifiable("real", lambda sliders: all(slider["description"] for slider in sliders), '
+    '[{"description": "Peak 3 Q"}], [{"description": ""}], "expected")\n',
+)
+adopters, total, hollow_calls = G.adoption([hollow, real], include_hollow=True)
+ok = (adopters == ["live_real.py"] and total == 2 and hollow_calls == [("live_hollow.py", 1)])
+failed += 0 if ok else 1
+print(f"{'ok  ' if ok else 'FAIL'} hollow calls do not count but real predicates do -> "
+      f"adopters={adopters!r} hollow={hollow_calls!r}")
+
 # The floor is a constant in the guard, not a value read from the tree — a number the tree can
 # move is not a floor.
 ok = isinstance(G.FLOOR, int) and G.FLOOR >= 1

--- a/Scripts/test_falsifiable_adoption.py
+++ b/Scripts/test_falsifiable_adoption.py
@@ -31,9 +31,12 @@ def harness(name, body):
     return path
 
 
+VALID_CALL = 'E.falsifiable("tag", predicate, observation, counterexample, "expected")\n'
+
+
 for label, files, want in [
     ("a harness that calls it counts",
-     [harness("live_a.py", "E.falsifiable(tag, p, obs, cx, exp)\n")], 1),
+     [harness("live_a.py", VALID_CALL)], 1),
     ("a harness that does not, does not",
      [harness("live_b.py", "E.check(tag, True, 'x', 'y')\n")], 0),
     ("a mention in prose is not a call",
@@ -47,17 +50,22 @@ for label, files, want in [
     ("the word inside a string is not a call",
      [harness("live_i.py", "msg = 'use falsifiable(...) instead'\n")], 0),
     ("a call reached through the module still counts",
-     [harness("live_j.py", "import evidence\nevidence.falsifiable(1)\n")], 1),
+     [harness("live_j.py", "import evidence\nevidence.falsifiable(\"tag\", p, o, c, \"expected\")\n")], 1),
     ("a call nested inside a function body counts",
-     [harness("live_k.py", "def run():\n    if x:\n        E.falsifiable(1)\n")], 1),
+     [harness("live_k.py", "def run():\n    if x:\n        E.falsifiable(\"tag\", p, o, c, \"expected\")\n")], 1),
     ("a file that will not parse is not an adopter",
      [harness("live_l.py", "def (\n E.falsifiable(1)\n")], 0),
     ("whitespace before the paren still counts",
-     [harness("live_d.py", "E.falsifiable (tag, p, obs, cx, exp)\n")], 1),
+     [harness("live_d.py", "E.falsifiable (\"tag\", p, o, c, \"expected\")\n")], 1),
     ("a longer name is not this one",
      [harness("live_e.py", "unfalsifiable(x)\n")], 0),
     ("two adopters count as two",
-     [harness("live_f.py", "falsifiable(1)\n"), harness("live_g.py", "E.falsifiable(1)\n")], 2),
+     [harness("live_f.py", "falsifiable(\"tag\", p, o, c, \"expected\")\n"),
+      harness("live_g.py", VALID_CALL)], 2),
+    ("an incomplete call cannot adopt",
+     [harness("live_arity.py", 'E.falsifiable("tag", lambda o: o["ok"], {"ok": True}, {"ok": False})\n')], 0),
+    ("a call with an impossible extra argument cannot adopt",
+     [harness("live_too_many.py", 'E.falsifiable("tag", p, o, c, "expected", None, None, None)\n')], 0),
     ("an unreadable file is not adopted",
      [os.path.join(tmp, "live_missing.py")], 0),
 ]:
@@ -69,9 +77,19 @@ for label, files, want in [
 # This is the exact shape that made the ratchet lie: the predicate receives only a boolean wrapper
 # and the counterexample is a hand-authored constant dictionary. A real observation predicate beside
 # it must still count, while the hollow call is reported with the source location that needs repair.
-hollow = harness(
-    "live_hollow.py",
+hollow_subscript = harness(
+    "live_hollow_subscript.py",
     'E.falsifiable("hollow", lambda observation: observation["ok"], {"ok": True}, '
+    '{"ok": False}, "expected")\n',
+)
+hollow_get = harness(
+    "live_hollow_get.py",
+    'E.falsifiable("hollow", lambda observation: observation.get("ok"), {"ok": True}, '
+    '{"ok": False}, "expected")\n',
+)
+hollow_attribute = harness(
+    "live_hollow_attribute.py",
+    'E.falsifiable("hollow", lambda observation: observation.ok, {"ok": True}, '
     '{"ok": False}, "expected")\n',
 )
 real = harness(
@@ -79,8 +97,13 @@ real = harness(
     'E.falsifiable("real", lambda sliders: all(slider["description"] for slider in sliders), '
     '[{"description": "Peak 3 Q"}], [{"description": ""}], "expected")\n',
 )
-adopters, total, hollow_calls = G.adoption([hollow, real], include_hollow=True)
-ok = (adopters == ["live_real.py"] and total == 2 and hollow_calls == [("live_hollow.py", 1)])
+adopters, total, hollow_calls = G.adoption(
+    [hollow_subscript, hollow_get, hollow_attribute, real], include_hollow=True)
+ok = (adopters == ["live_real.py"] and total == 4 and hollow_calls == [
+    ("live_hollow_subscript.py", 1),
+    ("live_hollow_get.py", 1),
+    ("live_hollow_attribute.py", 1),
+])
 failed += 0 if ok else 1
 print(f"{'ok  ' if ok else 'FAIL'} hollow calls do not count but real predicates do -> "
       f"adopters={adopters!r} hollow={hollow_calls!r}")

--- a/Scripts/test_roadmap_blocker_citations.py
+++ b/Scripts/test_roadmap_blocker_citations.py
@@ -36,7 +36,7 @@ UNCITED = HEADER + "\n".join([
 
 CITED_BY_DATE = HEADER + (
     "| ADR-013 | #301 | OPEN | measured 2026-08-30 — the AX plane a readback needs is not exposed "
-    "was wrong; Channel EQ exposes 24 named settable sliders |\n"
+    "was wrong; Channel EQ exposes 26 sliders total, including 24 named band parameters, all named and settable |\n"
 )
 # The cell must contain a phrase from WALL_CLAIMS or this case proves nothing about dates: an
 # earlier version said "opacity", which is in no list, so deleting DATE handling entirely left it

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -54,9 +54,9 @@ open PRs 0 · v3.14.0 published · 16 open issues
 | ADR-008 | #291 | OPEN | node identity cannot be the display string — needs a decision, not an attempt |
 | ADR-009 | #292 | OPEN | apply-back expansion on Wave-0 insert work; #299 and #301 consume it. Measured 2026-08-30: Logic's Controls view renders a stock plug-in as an `AXTable`, one `AXRow` per parameter whose cell carries an `AXStaticText` label and a control. **Addressable, not yet written to.** It is NOT the shape `set_param_verified` drives — step 9 matches an `AXSlider` by its own `AXDescription`, and in this view the sliders have none; the name is on a sibling. A locator for row-labelled controls is new work |
 | ADR-010 | #293 | OPEN | the collector's shape was already right; measured 2026-08-29 it reads a real note table and returns both notes. It could not START in any language but English — the Event tab was matched against the literal `"Event"` — fixed in #712. What stays closed is ADR-010's body: `assessReadback` and the public provider |
-| ADR-011 | #299 | OPEN | behind #292. Measured 2026-08-30: the Compressor's *native* editor exposes 22 sliders and names exactly one (`Threshold`), which is also the one parameter `set_param_verified` supports — consistent with step 9 matching on `AXDescription`, though the causal link is inferred from the code path rather than measured. Its Controls view carries a labelled row per parameter (`Ratio`, `Attack`, `Release`, `Make Up`, `Knee`, `Circuit Type`, …). No write attempted anywhere |
+| ADR-011 | #299 | OPEN | behind #292. Measured 2026-08-30: the Compressor's *native* editor exposes 22 sliders (11 settable) on one instance and 20 (10 settable) on another, and names exactly one (`Threshold`) on both; that is also the one parameter `set_param_verified` supports — consistent with step 9 matching on `AXDescription`, though the causal link is inferred from the code path rather than measured. Its Controls view carries a labelled row per parameter (`Ratio`, `Attack`, `Release`, `Make Up`, `Knee`, `Circuit Type`, …). No write attempted anywhere |
 | ADR-012 | #300 | closed | promoted and closed 2026-08-28; all seven acceptance criteria measured, four artifacts found and fixed on the way (#693-#697) |
-| ADR-013 | #301 | OPEN | zero band operations registered, so no public surface. Measured 2026-08-30, the recorded wall is not where it was said to be: Channel EQ's native view exposes 8 named band enables and 24 `AXSlider`s, each named by band and parameter, each reporting `settable=yes`, each carrying `AXValueDescription` in Hz/dB. **No write was attempted, and AX settability lies** — what is established is that the controls are addressable and readable. The opacity claim came from a census that instantiates the AU *outside* Logic, which ADR-018's Important Boundary says cannot speak for the live instance. The ADR's C4 Decision was revised on the issue the same day |
+| ADR-013 | #301 | OPEN | zero band operations registered, so no public surface. Measured 2026-08-30, the recorded wall is not where it was said to be: Channel EQ's native view exposes 8 named band enables and 26 `AXSlider`s, including all 24 named band parameters; every slider reports `settable=yes` and carries `AXValueDescription` in Hz/dB. **No write was attempted, and AX settability lies** — what is established is that the controls are addressable and readable. The opacity claim came from a census that instantiates the AU *outside* Logic, which ADR-018's Important Boundary says cannot speak for the live instance. The ADR's C4 Decision was revised on the issue the same day |
 | ADR-014 | #302 | OPEN | R1 shipped. R2 is NOT STARTED rather than blocked: measured 2026-08-29, `kAXColumns` is present and returns 8 columns — what is absent is any title or description ON them, and the header's sort buttons carry the names the collector already binds. Next step is an R2 ticket, not another measurement |
 | ADR-015 | #303 | OPEN | behind #293, and measured 2026-08-29 the dependency is narrower than "transforms must not read their own plan" — `TransformVerification` already refuses a proof that shares the observed pipeline. What is missing is a MAKER: `IndependentExpectedSeam` is inside `#if QUALIFICATION_FAULT_SEAM`, so in a release build `independentPayload` is always nil and no positive match is possible. The three modules exist; the gap is the live ingestion boundary in front of them |
 | ADR-016 | #304 | OPEN | NOT STARTED. Nothing has been measured against this surface in either direction — the previous row asserted there was no obstacle, which is a claim about the world that nobody had dated |
@@ -86,8 +86,9 @@ The instruction that produced this file asked for these to be established, not g
   `OperationRegistry`. What was inferred from that was wrong. The note read the absence as
   consistent with "a measured wall", and consistency is not evidence — an unbuilt feature and a
   blocked one look identical from the registry. Measured 2026-08-30 there is no wall: Channel EQ
-  names all 24 band sliders and every one is settable. The registry was empty because nobody had
-  written the operations, which is the ordinary reason a registry is empty.
+  exposes 26 sliders, including all 24 named band parameters, and every slider is settable. The
+  registry was empty because nobody had written the operations, which is the ordinary reason a
+  registry is empty.
 - **#300** — neither, and it is closed now. Four modules existed *and* two operations were
   registered; what was open was the promotion decision. Answering it took measuring what the flag
   was holding back, which turned up four artifacts nobody had recorded: three bands reporting the
@@ -126,8 +127,9 @@ attached — not a silent deferral.
    reason — its blocker named a plug-in window and Flex Pitch is a region editor, so it was never a
    measurement about that surface, and one still has not been made. #291 and #448 turned out to
    need decisions rather than measurements, and both were made and recorded on their issues. The
-   limit that held is the Compressor's native editor naming one slider of twenty-two: an *identity*
-   limit rather than a reachability one, and a different repair.
+   limit that held is the Compressor's native editor naming one slider on each measured instance
+   (of twenty-two on one and twenty on the other): an *identity* limit rather than a reachability
+   one, and a different repair.
 7. **#373 → #284's `R-SEM`**, then **#308** closes as an index.
 
 ## What this file does not claim


### PR DESCRIPTION
Closes #608.

## What happened

A Logic alert about a missing audio device sat on screen for most of a measuring run and nothing said so. Under it:

```
File > 열기…      AXEnabled = false        <- Open is NEVER disabled in a healthy Logic
File > 별도 저장…  AXEnabled = false
pressing 별도 저장…  opened no panel        <- so the false was HONEST; the app was blocked
```

With the alert dismissed, every one of those reads `true`. I built a whole explanation about menu validation on readings taken through it and threw it away. The tell was in the data — `Open` reading false — and I walked past it.

## The two halves

**The harness could not see a modal.** `evidence.py` now records, at the moment *each check is written* rather than once per run, whether a Logic window sits at the CoreGraphics modal-panel level, and `is_clean` refuses a run that recorded anything while one did. Per-check because this alert appeared, was dismissed, and reappeared inside one sitting. The level is derived from `CGWindowLevelForKey(kCGModalPanelWindowLevelKey)` rather than written as `8`, and the read is CoreGraphics rather than AX for the same reason `logic_window` already is: the harness has to see the screen even when the AX tree is the thing under test.

**`isBlockingDialogWindow` called plug-in windows blocking.** That is #608. Measured in one instant:

| window | AX subrole | AXModal | CGWindowLayer |
|---|---|---|---|
| Logic alert | `AXDialog` | **true** | 8 |
| Plug-in window `Studio Grand` | `AXDialog` | **false** | 3 |
| Arrange window | `AXStandardWindow` | false | 0 |

`AXDialog` describes a window class, not whether it blocks. An unreadable `AXModal` is treated as **blocking**, because a caller told "nothing is blocking" on the strength of a read that did not happen is the shape this gate exists to refuse.

## One defect in my own guard, recorded rather than quietly fixed

It first read bounds behind `isinstance(b, dict)`. CoreGraphics returns an **NSDictionary proxy**, so that test is `False` on the real window list and the loop silently skipped a modal it had already identified. Every synthetic case passed while it did — the fixtures supplied real dicts, so **the fixture was more permissive than the thing it stood for and could not fail**. There is now a subscriptable non-dict fixture; reintroducing the `isinstance` test makes that case fail *and* makes the live read go blind again.

## Three measurements became harnesses

`live_301_channel_eq_bands_are_addressable`, `live_306_controls_view_labels_the_row_not_the_slider`, `live_369_export_menu_path_is_reachable`. Each makes the modal check its first precondition.

They refused four times before passing, and **every refusal was right**:

1. **five Compressor inserts** exist across the mixer — "one resolves" was false, and picking one by position is not allowed
2. two elements answer to a track name — the arrange **track header** and the **mixer strip**
3. two `AXLayoutArea`s answer to the mixer label — the Mixer pane and the **Inspector's channel strip for the selected track**, same role, same description, both real. Ancestry separates them
4. `Absolute Zero` carries **two** Compressors; `Studio Grand` carries one

And they corrected four numbers I had written into issue comments. The Channel EQ group exposes **26** sliders, not 24 — 24 band parameters plus two output `Gain` sliders — and **11** checkboxes, not 8. The Compressor census is **per-instance**: 22/11 on one strip, 20/10 on another, in the same project. Four assertions went red on readings that were **right**. They assert names and invariants now, because a total arrived at by arithmetic is not a measurement.

## Results

```
live_301  14 / 14      live_306  16 / 16      live_369  10 / 10
checks_recorded_under_blocking_modal: 0      restorations_failed: 0
```

Ship gate PASS at `66a093e1`, including live evidence for this head.

**Not covered, stated rather than implied:** `isBlockingDialogWindow` lives in a standalone script with no test harness, so the Swift half is verified by typecheck and by the measurement above, not by a case that has been watched fail.
