### PR TITLE
feat(#301): verified Channel EQ band control by walking the slider

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "6c926ace4eed5db8b503d612fccba4dff0e0122b4c622d86bdc4e8e972219044",
+  "originHash" : "556ef8452b5e29e7d89a39cb4ccd602017b20d5779c03e16152b41fa1d5339a6",
   "pins" : [
-    {
-      "identity" : "async-http-client",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swift-server/async-http-client.git",
-      "state" : {
-        "revision" : "3a5b74a58782c3b4c1f0bc75e9b67b10c2494e8f",
-        "version" : "1.33.1"
-      }
-    },
     {
       "identity" : "eventsource",
       "kind" : "remoteSourceControl",
@@ -17,33 +8,6 @@
       "state" : {
         "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
         "version" : "1.4.1"
-      }
-    },
-    {
-      "identity" : "swift-algorithms",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-algorithms.git",
-      "state" : {
-        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
-        "version" : "1.2.1"
-      }
-    },
-    {
-      "identity" : "swift-asn1",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-asn1.git",
-      "state" : {
-        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
-        "version" : "1.7.1"
-      }
-    },
-    {
-      "identity" : "swift-async-algorithms",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-async-algorithms.git",
-      "state" : {
-        "revision" : "3da39bbc4e687d4192af7c9cf4eab805745a0b9c",
-        "version" : "1.1.5"
       }
     },
     {
@@ -56,57 +20,12 @@
       }
     },
     {
-      "identity" : "swift-certificates",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-certificates.git",
-      "state" : {
-        "revision" : "89fbc3714264cce8db8e4ec51b64e01c3e28c6c5",
-        "version" : "1.19.3"
-      }
-    },
-    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
         "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
         "version" : "1.4.1"
-      }
-    },
-    {
-      "identity" : "swift-crypto",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-crypto.git",
-      "state" : {
-        "revision" : "47d3869a7291f085c1fb9fb1e6d3b97a793f45c6",
-        "version" : "4.5.1"
-      }
-    },
-    {
-      "identity" : "swift-distributed-tracing",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-distributed-tracing.git",
-      "state" : {
-        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
-        "version" : "1.4.1"
-      }
-    },
-    {
-      "identity" : "swift-http-structured-headers",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-http-structured-headers.git",
-      "state" : {
-        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
-        "version" : "1.7.0"
-      }
-    },
-    {
-      "identity" : "swift-http-types",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-http-types.git",
-      "state" : {
-        "revision" : "db774a277f60063a32d854f2980299caf06da041",
-        "version" : "1.6.0"
       }
     },
     {
@@ -128,75 +47,12 @@
       }
     },
     {
-      "identity" : "swift-nio-extras",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-extras.git",
-      "state" : {
-        "revision" : "88a51340f59cf181ebde888bd1b749296b3ec029",
-        "version" : "1.34.3"
-      }
-    },
-    {
-      "identity" : "swift-nio-http2",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-http2.git",
-      "state" : {
-        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
-        "version" : "1.44.0"
-      }
-    },
-    {
-      "identity" : "swift-nio-ssl",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-ssl.git",
-      "state" : {
-        "revision" : "3f337058ccd7243c4cac7911477d8ad4c598d4da",
-        "version" : "2.37.0"
-      }
-    },
-    {
-      "identity" : "swift-nio-transport-services",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-transport-services.git",
-      "state" : {
-        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
-        "version" : "1.28.0"
-      }
-    },
-    {
-      "identity" : "swift-numerics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-numerics.git",
-      "state" : {
-        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
-        "version" : "1.1.1"
-      }
-    },
-    {
       "identity" : "swift-sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
       "state" : {
         "revision" : "a0ae212ebf6eab5f754c3129608bc5557637e605",
         "version" : "0.12.1"
-      }
-    },
-    {
-      "identity" : "swift-service-context",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-service-context.git",
-      "state" : {
-        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
-        "version" : "1.3.0"
-      }
-    },
-    {
-      "identity" : "swift-service-lifecycle",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
-      "state" : {
-        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
-        "version" : "2.11.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "556ef8452b5e29e7d89a39cb4ccd602017b20d5779c03e16152b41fa1d5339a6",
+  "originHash" : "6c926ace4eed5db8b503d612fccba4dff0e0122b4c622d86bdc4e8e972219044",
   "pins" : [
+    {
+      "identity" : "async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/async-http-client.git",
+      "state" : {
+        "revision" : "3a5b74a58782c3b4c1f0bc75e9b67b10c2494e8f",
+        "version" : "1.33.1"
+      }
+    },
     {
       "identity" : "eventsource",
       "kind" : "remoteSourceControl",
@@ -8,6 +17,33 @@
       "state" : {
         "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
         "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "3da39bbc4e687d4192af7c9cf4eab805745a0b9c",
+        "version" : "1.1.5"
       }
     },
     {
@@ -20,12 +56,57 @@
       }
     },
     {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "89fbc3714264cce8db8e4ec51b64e01c3e28c6c5",
+        "version" : "1.19.3"
+      }
+    },
+    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
         "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
         "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "47d3869a7291f085c1fb9fb1e6d3b97a793f45c6",
+        "version" : "4.5.1"
+      }
+    },
+    {
+      "identity" : "swift-distributed-tracing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
+      "state" : {
+        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "db774a277f60063a32d854f2980299caf06da041",
+        "version" : "1.6.0"
       }
     },
     {
@@ -47,12 +128,75 @@
       }
     },
     {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "88a51340f59cf181ebde888bd1b749296b3ec029",
+        "version" : "1.34.3"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
+        "version" : "1.44.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "3f337058ccd7243c4cac7911477d8ad4c598d4da",
+        "version" : "2.37.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
       "identity" : "swift-sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
       "state" : {
         "revision" : "a0ae212ebf6eab5f754c3129608bc5557637e605",
         "version" : "0.12.1"
+      }
+    },
+    {
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
+      "state" : {
+        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
+        "version" : "2.11.0"
       }
     },
     {

--- a/Scripts/check-falsifiable-adoption.py
+++ b/Scripts/check-falsifiable-adoption.py
@@ -37,7 +37,7 @@ import sys
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # The measured floor. Raise it when a harness converts; never lower it to make a branch pass.
-FLOOR = 4
+FLOOR = 5
 _FALSIFIABLE_PARAMETERS = (
     "tag", "predicate", "observation", "counterexample", "expected", "mutation", "modal_snapshot",
 )

--- a/Scripts/check-falsifiable-adoption.py
+++ b/Scripts/check-falsifiable-adoption.py
@@ -37,7 +37,7 @@ import sys
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # The measured floor. Raise it when a harness converts; never lower it to make a branch pass.
-FLOOR = 5
+FLOOR = 6
 _FALSIFIABLE_PARAMETERS = (
     "tag", "predicate", "observation", "counterexample", "expected", "mutation", "modal_snapshot",
 )

--- a/Scripts/livekit/ax_plugin_menu_probe.swift
+++ b/Scripts/livekit/ax_plugin_menu_probe.swift
@@ -771,7 +771,7 @@ func runChannelEQ() {
     // pass a track.
     let trackLabelRaw = configuredString("track_label")
     let trackLabel: String? = trackLabelRaw.isEmpty ? nil : trackLabelRaw
-    let mixerLabels = configuredStrings("mixer_labels")
+    let mixerLabels = configuredStringFamily("mixer_label")
     var result: JSON = ["frontmost_bundle_id": NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? ""]
     var bypasses: [AXUIElement] = []
     var bypassBefore: AXRead<Any> = .absent

--- a/Scripts/livekit/ax_plugin_menu_probe.swift
+++ b/Scripts/livekit/ax_plugin_menu_probe.swift
@@ -764,11 +764,24 @@ func runChannelEQ() {
     let openLabel = configuredString("open_label")
     let closeLabel = configuredString("close_label")
     let bypassLabels = configuredStrings("bypass_labels")
+    // Scope the slot search the way every other mode here does. Without it a `Channel EQ` search
+    // finds TWO: the mixer strip's insert and the Inspector's copy of the same strip for the
+    // selected track. They are the same plug-in seen twice, and refusing on `slot_count == 2` is
+    // correct but unusable. Optional so the unscoped behaviour is unchanged for callers that do not
+    // pass a track.
+    let trackLabelRaw = configuredString("track_label")
+    let trackLabel: String? = trackLabelRaw.isEmpty ? nil : trackLabelRaw
+    let mixerLabels = configuredStrings("mixer_labels")
     var result: JSON = ["frontmost_bundle_id": NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? ""]
     var bypasses: [AXUIElement] = []
     var bypassBefore: AXRead<Any> = .absent
     var bypassAfter: AXRead<Any> = .absent
-    let (openResult, slot, opened) = openPlugin(slotName: slotName, openLabel: openLabel) { slot in
+    let (openResult, slot, opened) = openPlugin(
+        slotName: slotName,
+        openLabel: openLabel,
+        trackLabel: trackLabel,
+        mixerLabels: mixerLabels.isEmpty ? nil : mixerLabels
+    ) { slot in
         bypasses = childElements(slot).filter {
             roleText($0) == "AXCheckBox" && bypassLabels.contains(descriptionText($0))
         }

--- a/Scripts/livekit/evidence.py
+++ b/Scripts/livekit/evidence.py
@@ -520,7 +520,17 @@ def _same_modal_window(panel, window, panel_count, modal_count):
             or (panel_count == 1 and modal_count == 1))
 
 
-def blocking_modal(lister=None, ax_lister=None):
+# kAXErrorCannotComplete. Measured 2026-08-31: a scan taken while Logic was busy answering
+# `system.refresh_cache` came back cannot-tell with `AX status -25204`, and five scans a moment
+# later were all clean. That code means the request did not finish in time, which is a statement
+# about timing and not about the screen — so it is the ONE error worth asking again about. Every
+# other failure stays cannot-tell on the first answer: a scan that failed for a reason other than
+# a timeout has no reason to succeed on a retry, and retrying it would only blur a real refusal.
+AX_ERROR_CANNOT_COMPLETE = -25204
+_MODAL_RETRY_DELAY_SEC = 0.35
+
+
+def blocking_modal(lister=None, ax_lister=None, _attempt=0):
     """Describe a detected Logic blocker, `None` after a clear scan, or explicit cannot-tell.
 
     CoreGraphics is still the screen-side signal: it observes the rendered modal-panel level without
@@ -557,9 +567,12 @@ def blocking_modal(lister=None, ax_lister=None):
         raw_signals = ax_lister() if ax_lister is not None else _production_ax_modal_signals()
         signals = _normal_ax_modal_signals(raw_signals)
     except _ModalReadError as exc:
-        return _modal_cannot_tell("accessibility", str(exc))
+        return _modal_retry_or_give_up(
+            _modal_cannot_tell("accessibility", str(exc)), lister, ax_lister, _attempt)
     except Exception as exc:  # noqa: BLE001 - avoid making an AX outage look like no sheet
-        return _modal_cannot_tell("accessibility", f"AX modal query failed: {exc!r}")
+        return _modal_retry_or_give_up(
+            _modal_cannot_tell("accessibility", f"AX modal query failed: {exc!r}"),
+            lister, ax_lister, _attempt)
 
     if signals["sheets"]:
         sheet = signals["sheets"][0]
@@ -577,6 +590,26 @@ def blocking_modal(lister=None, ax_lister=None):
         return {"state": "detected", "kind": "modal_window", "signal": "ax_modal",
                 "title": window.get("title") or "", "pid": window.get("pid")}
     return None
+
+
+def _modal_retry_or_give_up(answer, lister, ax_lister, attempt):
+    """Ask once more, but ONLY when the scan timed out.
+
+    `kAXErrorCannotComplete` (-25204) means the AX request did not finish in time — a statement
+    about timing, not about the screen. Measured 2026-08-31: a scan taken while Logic was busy
+    answering `system.refresh_cache` returned cannot-tell with that code, and five scans a moment
+    later were all clean, so a run was marked unusable by a busy instant rather than by a blocker.
+
+    Every other failure keeps its first answer. A scan that failed for a reason other than a
+    timeout has no reason to succeed on a retry, and retrying it would blur a real refusal into a
+    pass. Test seams never retry: a seam's answer is the answer under test.
+    """
+    if attempt != 0 or lister is not None or ax_lister is not None:
+        return answer
+    if f"{AX_ERROR_CANNOT_COMPLETE}" not in str(answer.get("reason", "")):
+        return answer
+    time.sleep(_MODAL_RETRY_DELAY_SEC)
+    return blocking_modal(_attempt=1)
 
 
 def _displays():

--- a/Scripts/livekit/live_301_channel_eq_bands_are_addressable.py
+++ b/Scripts/livekit/live_301_channel_eq_bands_are_addressable.py
@@ -48,6 +48,13 @@ ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
 # These labels were read on Korean Logic 12.x only. There is deliberately no translated fallback:
 # a run on another Logic locale yields an absent element instead of pressing or naming the wrong one.
 SLOT = "Channel EQ"
+# Scope the search. Unscoped, `Channel EQ` resolves TWICE — the mixer strip's insert and the
+# Inspector's copy of the same strip for the selected track. They are one plug-in seen twice, and
+# refusing on the ambiguity is right but leaves the harness unable to run. `Studio Grand` is the
+# strip that carries the Channel EQ. Korean labels are what was measured; another locale resolves
+# nothing and the run refuses rather than measuring the wrong element.
+TRACK = "Studio Grand"
+MIXER_LABELS = E.label_set("mixerNamedElement")
 OPEN = "열기"
 CLOSE = "닫기"
 EQ_GROUP = "EQ"
@@ -267,7 +274,8 @@ ev.check("301/precondition-a-project-window-is-open",
 if band is None:
     finish()
 
-slot_before = probe(tool, "plugin-slot", {"slot_label": SLOT})
+slot_before = probe(tool, "plugin-slot", {"slot_label": SLOT, "track_label": TRACK,
+                                          "mixer_label": MIXER_LABELS})
 ev.note("301/channel-eq-slot-before-opening", slot_before)
 slot_count_counterexample = derived_witness(slot_before, slot_count=0)
 ev.falsifiable(
@@ -309,6 +317,8 @@ ev.falsifiable("301/the-release-artifact-answers-a-read-only-wire-request",
 
 result = probe(tool, "channel-eq", {
     "slot_label": SLOT,
+    "track_label": TRACK,
+    "mixer_label": MIXER_LABELS,
     "open_label": OPEN,
     "close_label": CLOSE,
     "bypass_labels": BYPASS_LABELS,

--- a/Scripts/livekit/live_301_eq_band_write_lands_and_rolls_back.py
+++ b/Scripts/livekit/live_301_eq_band_write_lands_and_rolls_back.py
@@ -57,6 +57,8 @@ driver = None
 
 TRACK_NAME = "Studio Grand"
 SLOT_NAME = "Channel EQ"
+# The mixer label family the policy already owns, so this is not a second Korean literal.
+MIXER_LABELS = E.label_set("mixerNamedElement")
 BAND = "Peak 1"
 PARAMETER = "Gain"
 PEAK_1_GAIN = "Peak 1 Gain"
@@ -124,8 +126,14 @@ def raw_probe(tool):
     It seeds the exact raw value supplied to the subsequent zero-step MCP read; it never drives the
     operation under test.
     """
+    # Scoped by track and mixer. Unscoped, a `Channel EQ` search finds TWO — the mixer strip's
+    # insert and the Inspector's copy of the same strip for the selected track — and the witness
+    # refuses on the ambiguity, correctly but uselessly. `Studio Grand` is the strip that carries
+    # the Channel EQ; `Absolute Zero` carries two Compressors and none.
     config = {
         "slot_label": SLOT_NAME,
+        "track_label": TRACK_NAME,
+        "mixer_labels": MIXER_LABELS,
         "open_label": OPEN,
         "close_label": CLOSE,
         "bypass_labels": BYPASS_LABELS,
@@ -182,8 +190,8 @@ def project_is_open(project):
     data = project.get("data") if isinstance(project, dict) else None
     return (
         isinstance(data, dict)
-        and isinstance(data.get("file_path"), str)
-        and bool(data["file_path"].strip())
+        and isinstance(data.get("filePath"), str)
+        and bool(data["filePath"].strip())
     )
 
 
@@ -406,14 +414,29 @@ ev.falsifiable(
     "301/precondition-a-saved-project-is-open",
     project_is_open,
     project,
-    nested_witness(project, "data", file_path=""),
-    "logic://project/info supplies a non-empty current-document file_path for the write boundary",
-    "close the project or open an unsaved one: file_path is absent and the write cannot be bounded",
+    nested_witness(project, "data", filePath=""),
+    "logic://project/info supplies a non-empty current-document filePath for the write boundary",
+    "close the project or open an unsaved one: filePath is absent and the write cannot be bounded",
 )
 if not project_is_open(project):
     finish()
-project_path = project["data"]["file_path"].strip()
+project_path = project["data"]["filePath"].strip()
 
+# `logic://tracks` is cache-served and reports `readable: False` with placeholder names until a
+# live AX track read has happened — measured today, it answers `Track 1…26` with
+# `reason: track_names_synthesised_from_project_file` on a project whose tracks are named
+# `Absolute Zero`, `Audio 1`, `Studio Grand`. That is the resource being honest, not a defect, and
+# it means a harness that reads it cold is reading synthesised names. Prime it the way a caller
+# would, and record that the priming happened so a reader can see the read is live.
+refresh = driver.tool("logic_system", "refresh_cache", {}) or {}
+ev.check(
+    "301/precondition-the-live-track-read-was-primed",
+    isinstance(refresh, dict) and refresh.get("refreshed") is True,
+    "system.refresh_cache reports a completed refresh before any track name is trusted",
+    f"refresh={refresh!r}",
+    "skip the refresh: logic://tracks answers synthesised placeholder names and the strip cannot be "
+    "resolved by name",
+)
 tracks = driver.resource("logic://tracks") or {}
 track_counterexample = derived_witness(tracks)
 counter_rows = copy.deepcopy(track_counterexample.get("data")) if isinstance(track_counterexample.get("data"), list) else []

--- a/Scripts/livekit/live_301_eq_band_write_lands_and_rolls_back.py
+++ b/Scripts/livekit/live_301_eq_band_write_lands_and_rolls_back.py
@@ -636,7 +636,13 @@ try:
         "301/a-db-request-lands-on-logics-own-rendered-string",
         display_request_landed,
         display_observation,
-        nested_witness(display_observation, "response", observed_display=before_display),
+        # NOT `before_display`. The dB request is chosen to be the value that is NOT currently
+        # rendered, but the raw write before it can leave the control showing exactly the string
+        # this request asks for — and then a counterexample built from `before_display` is IDENTICAL
+        # to the observation, changes nothing, and cannot be rejected. Derive the counterexample
+        # from the requested rendering instead, so it always differs from what the run asked for.
+        nested_witness(display_observation, "response",
+                       observed_display=f"not {wanted_display}"),
         "the dB request reaches State A only when Logic reports the exact requested AXValueDescription; "
         "the harness never supplies a Hz/dB raw mapping",
         "return a different AXValueDescription for the requested dB value: a value in the declared "

--- a/Scripts/livekit/live_301_eq_band_write_lands_and_rolls_back.py
+++ b/Scripts/livekit/live_301_eq_band_write_lands_and_rolls_back.py
@@ -1,0 +1,723 @@
+#!/usr/bin/env python3
+"""Live qualification for Channel EQ's verified named-band write operation.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_301_eq_band_write_lands_and_rolls_back.py <worktree> <full-40-char-head-sha>
+
+This is deliberately a harness, not a claim that a write has landed. It drives the release artifact
+against the named `Studio Grand` strip, moves `Peak 1 Gain` a visible raw distance, asks Logic for a
+dB rendering, restores the starting raw value, and checks that `Peak 2 Gain` did not move. If the
+walk does not land, that is the result: the checks stay red and the evidence records the response.
+Do not tune a target or a predicate after a red run merely to make this file pass.
+
+The prior raw-AX measurement established only the ingredients for this run: Channel EQ gain has raw
+AXValue 0...480; a raw assignment advances one increment/decrement; and AXValueDescription is
+Logic's own dB rendering (262 was observed as `+2.2 dB`). It did not establish an end-to-end write.
+In particular, no Hz/dB conversion is calculated here. The display-unit request below succeeds only
+when Logic itself returns the requested dB string.
+
+The tiny raw witness is read-only: it opens the one globally named Channel EQ only to seed an exact
+zero-step wire read. That wire response is the recorded before-value/display; all operations that can
+write, including the zero-step read, use E.Driver() and the release artifact over MCP.
+"""
+
+import copy
+import json
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+
+# What this harness proves, for `harness_evidence_coverage.py`.
+#
+# The request crosses the public dispatcher, and the only parameter write algorithm it exercises is
+# the named-band increment walk. Claiming the catalogue or the AX channel would be wider than this
+# run: neither is driven as an independently observable contract here.
+COVERS = [
+    "Sources/LogicProMCP/Plugins/SliderIncrementWalk.swift",
+    "Sources/LogicProMCP/Dispatchers/PluginsDispatcher.swift",
+]
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+driver = None
+
+TRACK_NAME = "Studio Grand"
+SLOT_NAME = "Channel EQ"
+BAND = "Peak 1"
+PARAMETER = "Gain"
+PEAK_1_GAIN = "Peak 1 Gain"
+PEAK_2_GAIN = "Peak 2 Gain"
+RAW_UNIT = "raw_ax_value"
+DISPLAY_UNIT = "dB"
+MODE = "duplicate_applyback"
+RAW_MIN = 0.0
+RAW_MAX = 480.0
+RAW_TOLERANCE = 0.0
+VISIBLE_RAW_DISTANCE = 40.0
+OUT_OF_RANGE_RAW = RAW_MAX + 1.0
+
+# These are the Korean labels actually measured for the stock Channel EQ window on this host. There
+# is intentionally no translated fallback: an unmeasured locale must fail closed rather than press
+# a lookalike control. The plug-in and band names themselves are the measured AX descriptions.
+OPEN = "열기"
+CLOSE = "닫기"
+BYPASS_LABELS = E.label_set("pluginBypassControl")
+
+
+def finish(code=1):
+    if driver is not None:
+        driver.close()
+    out = ev.write()
+    print(json.dumps(out, indent=1))
+    sys.exit(code)
+
+
+def number(value):
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def close_enough(actual, expected, tolerance=RAW_TOLERANCE):
+    return number(actual) and number(expected) and abs(float(actual) - float(expected)) <= tolerance
+
+
+def derived_witness(observation, **changes):
+    """Preserve the observed response shape while replacing one load-bearing fact."""
+    counterexample = copy.deepcopy(observation) if isinstance(observation, dict) else {}
+    counterexample.update(changes)
+    return counterexample
+
+
+def nested_witness(observation, key, **changes):
+    counterexample = derived_witness(observation)
+    nested = counterexample.get(key)
+    nested = copy.deepcopy(nested) if isinstance(nested, dict) else {}
+    nested.update(changes)
+    counterexample[key] = nested
+    return counterexample
+
+
+def compile_probe():
+    source = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ax_plugin_menu_probe.swift")
+    tool = os.path.join(ev.dir, "ax_plugin_menu_probe")
+    result = subprocess.run(["swiftc", "-O", source, "-o", tool], capture_output=True)
+    return tool, result
+
+
+def raw_probe(tool):
+    """Read the AX witness without performing an AX value write.
+
+    `runChannelEQ` opens and closes the uniquely named insert, but its only slider actions are reads.
+    It seeds the exact raw value supplied to the subsequent zero-step MCP read; it never drives the
+    operation under test.
+    """
+    config = {
+        "slot_label": SLOT_NAME,
+        "open_label": OPEN,
+        "close_label": CLOSE,
+        "bypass_labels": BYPASS_LABELS,
+    }
+    result = subprocess.run([tool, "channel-eq", json.dumps(config, ensure_ascii=False)],
+                            capture_output=True, text=True)
+    try:
+        body = json.loads(result.stdout or "{}")
+    except ValueError:
+        body = {"_raw": (result.stdout or result.stderr)[:400]}
+    body["_returncode"] = result.returncode
+    return body
+
+
+def raw_slider(body, description):
+    sliders = body.get("sliders") if isinstance(body, dict) else None
+    matches = [slider for slider in sliders or []
+               if isinstance(slider, dict) and slider.get("description") == description]
+    return matches[0] if len(matches) == 1 else {}
+
+
+def raw_witness_is_complete(body):
+    if not isinstance(body, dict) or body.get("outcome") != "searched":
+        return False
+    opening = body.get("open") if isinstance(body.get("open"), dict) else {}
+    if opening.get("slot_count") != 1:
+        return False
+    for description in (PEAK_1_GAIN, PEAK_2_GAIN):
+        slider = raw_slider(body, description)
+        if not (
+            slider.get("value_status") == "success_with_value"
+            and number(slider.get("value"))
+            and slider.get("value_description_status") == "success_with_value"
+            and isinstance(slider.get("value_description"), str)
+            and slider["value_description"].strip()
+        ):
+            return False
+    return True
+
+
+def raw_witness_without_peak_1_display(body):
+    counterexample = derived_witness(body)
+    sliders = counterexample.get("sliders")
+    sliders = copy.deepcopy(sliders) if isinstance(sliders, list) else []
+    for slider in sliders:
+        if isinstance(slider, dict) and slider.get("description") == PEAK_1_GAIN:
+            slider["value_description"] = ""
+            break
+    counterexample["sliders"] = sliders
+    return counterexample
+
+
+def project_is_open(project):
+    data = project.get("data") if isinstance(project, dict) else None
+    return (
+        isinstance(data, dict)
+        and isinstance(data.get("file_path"), str)
+        and bool(data["file_path"].strip())
+    )
+
+
+def named_track_is_live(tracks):
+    rows = tracks.get("data") if isinstance(tracks, dict) else None
+    matches = [row for row in rows or []
+               if isinstance(row, dict) and row.get("name") == TRACK_NAME]
+    return (
+        isinstance(tracks, dict)
+        and tracks.get("readable") is True
+        and len(matches) == 1
+        and isinstance(matches[0].get("id"), int)
+        and isinstance(matches[0].get("track_ref"), str)
+        and bool(matches[0]["track_ref"].strip())
+    )
+
+
+def inventory_has_one_channel_eq(inventory):
+    plugins = inventory.get("plugins") if isinstance(inventory, dict) else None
+    matches = [plugin for plugin in plugins or []
+               if isinstance(plugin, dict) and plugin.get("name") == SLOT_NAME]
+    return (
+        isinstance(inventory, dict)
+        and inventory.get("state") == "A"
+        and inventory.get("complete") is True
+        and len(matches) == 1
+        and isinstance(matches[0].get("insert"), int)
+    )
+
+
+def inventory_without_channel_eq(inventory):
+    counterexample = derived_witness(inventory)
+    plugins = counterexample.get("plugins")
+    plugins = copy.deepcopy(plugins) if isinstance(plugins, list) else []
+    for plugin in plugins:
+        if isinstance(plugin, dict) and plugin.get("name") == SLOT_NAME:
+            plugin["name"] = "not Channel EQ"
+            break
+    counterexample["plugins"] = plugins
+    return counterexample
+
+
+def state_a(response):
+    return (
+        isinstance(response, dict)
+        and response.get("state") == "A"
+        and response.get("success") is True
+        and response.get("verified") is True
+        and response.get("operation") == "logic_plugins.set_eq_band_verified"
+    )
+
+
+def zero_step_read_landed(observation):
+    response = observation.get("response") if isinstance(observation, dict) else None
+    wanted = observation.get("seed_raw") if isinstance(observation, dict) else None
+    return (
+        state_a(response)
+        and close_enough(response.get("requested_normalized"), wanted)
+        and close_enough(response.get("observed_normalized"), wanted)
+        and response.get("walk_steps") == 0
+        and isinstance(response.get("observed_display"), str)
+        and bool(response["observed_display"].strip())
+    )
+
+
+def raw_walk_landed(observation):
+    response = observation.get("response") if isinstance(observation, dict) else None
+    target = observation.get("target_raw") if isinstance(observation, dict) else None
+    return (
+        state_a(response)
+        and close_enough(response.get("requested_normalized"), target)
+        and close_enough(response.get("observed_normalized"), target)
+        and response.get("tolerance") == RAW_TOLERANCE
+        and isinstance(response.get("walk_steps"), int)
+        and response["walk_steps"] > 1
+    )
+
+
+def raw_one_step_witness(observation, before_raw, direction):
+    counterexample = nested_witness(
+        observation,
+        "response",
+        observed_normalized=before_raw + direction,
+        walk_steps=1,
+    )
+    return counterexample
+
+
+def display_changed_with_raw_value(observation):
+    before = observation.get("before") if isinstance(observation, dict) else None
+    after = observation.get("after") if isinstance(observation, dict) else None
+    return (
+        isinstance(before, dict)
+        and isinstance(after, dict)
+        and state_a(after)
+        and number(before.get("observed_normalized"))
+        and number(after.get("observed_normalized"))
+        and before.get("observed_normalized") != after.get("observed_normalized")
+        and isinstance(before.get("observed_display"), str)
+        and isinstance(after.get("observed_display"), str)
+        and bool(before["observed_display"].strip())
+        and bool(after["observed_display"].strip())
+        and before["observed_display"] != after["observed_display"]
+    )
+
+
+def raw_move_with_stale_display(observation):
+    counterexample = derived_witness(observation)
+    before = counterexample.get("before")
+    after = copy.deepcopy(counterexample.get("after")) if isinstance(counterexample.get("after"), dict) else {}
+    if isinstance(before, dict):
+        after["observed_display"] = before.get("observed_display")
+    counterexample["after"] = after
+    return counterexample
+
+
+def display_request_landed(observation):
+    response = observation.get("response") if isinstance(observation, dict) else None
+    wanted_display = observation.get("wanted_display") if isinstance(observation, dict) else None
+    wanted_value = observation.get("wanted_value") if isinstance(observation, dict) else None
+    return (
+        state_a(response)
+        and close_enough(response.get("requested_normalized"), wanted_value)
+        and response.get("requested_display") == wanted_display
+        and response.get("observed_display") == wanted_display
+        and response.get("display_unit") == DISPLAY_UNIT
+    )
+
+
+def restored_to_before(observation):
+    response = observation.get("response") if isinstance(observation, dict) else None
+    before = observation.get("before_raw") if isinstance(observation, dict) else None
+    return (
+        state_a(response)
+        and close_enough(response.get("requested_normalized"), before)
+        and close_enough(response.get("observed_normalized"), before)
+        and response.get("tolerance") == RAW_TOLERANCE
+    )
+
+
+def out_of_range_refused_without_motion(observation):
+    response = observation.get("response") if isinstance(observation, dict) else None
+    before = observation.get("before") if isinstance(observation, dict) else None
+    after = observation.get("after") if isinstance(observation, dict) else None
+    return (
+        isinstance(response, dict)
+        and response.get("state") == "C"
+        and response.get("write_attempted") is False
+        and isinstance(before, dict)
+        and state_a(after)
+        and close_enough(before.get("value"), after.get("observed_normalized"))
+        and after.get("walk_steps") == 0
+        and before.get("value_description") == after.get("observed_display")
+    )
+
+
+def other_band_is_unchanged(observation):
+    before = observation.get("before") if isinstance(observation, dict) else None
+    after = observation.get("response") if isinstance(observation, dict) else None
+    return (
+        isinstance(before, dict)
+        and state_a(after)
+        and close_enough(before.get("value"), after.get("observed_normalized"))
+        and after.get("walk_steps") == 0
+        and isinstance(before.get("value_description"), str)
+        and before.get("value_description") == after.get("observed_display")
+    )
+
+
+def set_eq(value, unit, target_ref, insert, project_path, band=BAND, parameter=PARAMETER):
+    """The only path that drives the verified operation: MCP `params`, not direct AX."""
+    return driver.tool("logic_plugins", "set_eq_band_verified", {
+        "target_ref": target_ref,
+        "insert": insert,
+        "band": band,
+        "parameter": parameter,
+        "value": value,
+        "unit": unit,
+        "mode": MODE,
+        "project_expected_path": project_path,
+    })
+
+
+def safe_set_eq(value, unit, target_ref, insert, project_path, band=BAND, parameter=PARAMETER):
+    try:
+        return set_eq(value, unit, target_ref, insert, project_path, band, parameter)
+    except Exception as exc:  # noqa: BLE001 - retain a transport failure as the observation
+        return {"driver_exception": repr(exc)}
+
+
+# `None` is the only completed clear scan. A detected modal is a dict and an interrupted scan is
+# E.MODAL_CANNOT_TELL; both are deliberately refused before a raw AX read or MCP operation.
+modal = E.blocking_modal()
+ev.check(
+    "301/precondition-no-blocking-modal",
+    modal is None,
+    "a completed CoreGraphics/AX modal scan found no Logic blocker before the run reads or writes",
+    f"blocking_modal={modal!r}",
+    "show Logic's audio-hardware alert, or make one detector unreadable: this refuses on either a "
+    "detected modal or E.MODAL_CANNOT_TELL",
+)
+if modal is not None:
+    finish()
+
+policy_ready = isinstance(BYPASS_LABELS, list) and bool(BYPASS_LABELS)
+ev.check(
+    "301/precondition-the-measured-korean-window-labels-remain-in-policy",
+    policy_ready,
+    "the policy still supplies the measured bypass-label family used by the read-only witness",
+    f"open={OPEN!r} close={CLOSE!r} bypass_labels={BYPASS_LABELS!r}",
+    "remove the measured bypass label family: the harness refuses instead of opening a window with "
+    "an unreviewed selector",
+)
+if not policy_ready:
+    finish()
+
+driver = E.Driver()
+project = driver.resource("logic://project/info") or {}
+ev.falsifiable(
+    "301/precondition-a-saved-project-is-open",
+    project_is_open,
+    project,
+    nested_witness(project, "data", file_path=""),
+    "logic://project/info supplies a non-empty current-document file_path for the write boundary",
+    "close the project or open an unsaved one: file_path is absent and the write cannot be bounded",
+)
+if not project_is_open(project):
+    finish()
+project_path = project["data"]["file_path"].strip()
+
+tracks = driver.resource("logic://tracks") or {}
+track_counterexample = derived_witness(tracks)
+counter_rows = copy.deepcopy(track_counterexample.get("data")) if isinstance(track_counterexample.get("data"), list) else []
+for row in counter_rows:
+    if isinstance(row, dict) and row.get("name") == TRACK_NAME:
+        row["name"] = "not Studio Grand"
+        break
+track_counterexample["data"] = counter_rows
+ev.falsifiable(
+    "301/precondition-studio-grand-resolves-once-by-name",
+    named_track_is_live,
+    tracks,
+    track_counterexample,
+    "one live track row is exactly named `Studio Grand` and carries a session-stable track_ref; no "
+    "hard-coded strip position is used",
+    "rename or duplicate Studio Grand: the named target is absent or ambiguous and the run refuses",
+)
+if not named_track_is_live(tracks):
+    finish()
+
+track_rows = tracks["data"]
+track = next(row for row in track_rows if row.get("name") == TRACK_NAME)
+track_ref = track["track_ref"]
+
+# get_inventory currently accepts an index. This is the id returned by the uniquely name-resolved
+# live row above, never an authored strip position; all later mutating calls use `track_ref`.
+inventory = driver.tool("logic_plugins", "get_inventory", {"track": track["id"]})
+ev.falsifiable(
+    "301/precondition-studio-grand-resolves-exactly-one-channel-eq-insert",
+    inventory_has_one_channel_eq,
+    inventory,
+    inventory_without_channel_eq(inventory),
+    "the named Studio Grand strip has a complete AX inventory containing exactly one `Channel EQ`",
+    "remove or rename Channel EQ on Studio Grand: the exact-name inventory predicate refuses before "
+    "the write operation receives an insert",
+)
+if not inventory_has_one_channel_eq(inventory):
+    finish()
+
+channel_eq = next(plugin for plugin in inventory["plugins"] if plugin.get("name") == SLOT_NAME)
+insert = channel_eq["insert"]
+
+tool, built = compile_probe()
+ev.check(
+    "301/precondition-the-read-only-raw-witness-built",
+    built.returncode == 0,
+    "the independent read-only AX witness compiled, so the zero-step wire read has an exact current "
+    "raw seed rather than a fabricated dB conversion",
+    f"rc={built.returncode} stderr={(built.stderr or b'').decode('utf-8', 'replace')[:300]!r}",
+    "break the witness source: no value can be seeded safely for the zero-step product read",
+)
+if built.returncode != 0:
+    finish()
+
+raw_before = raw_probe(tool)
+ev.note("301/read-only-raw-ax-before-wire-read", raw_before)
+ev.falsifiable(
+    "301/precondition-the-uniquely-named-channel-eq-raw-witness-read-both-gain-controls",
+    raw_witness_is_complete,
+    raw_before,
+    raw_witness_without_peak_1_display(raw_before),
+    "the unique named Channel EQ witness returned raw AXValue and AXValueDescription for Peak 1 Gain "
+    "and the Peak 2 Gain negative control",
+    "clear Peak 1 Gain's AXValueDescription while preserving the raw witness shape: the required "
+    "rendering read is rejected before the MCP operation starts",
+)
+if not raw_witness_is_complete(raw_before):
+    finish()
+
+raw_peak_1_before = raw_slider(raw_before, PEAK_1_GAIN)
+raw_peak_2_before = raw_slider(raw_before, PEAK_2_GAIN)
+seed_raw = float(raw_peak_1_before["value"])
+
+# This product response is the recorded before value/display. Because its raw request is the just
+# observed raw AXValue, a correct increment walk returns `walk_steps: 0`; it does not nudge. The
+# raw witness above exists only because no separate public parameter-read operation is registered.
+wire_before = safe_set_eq(seed_raw, RAW_UNIT, track_ref, insert, project_path)
+before_observation = {"seed_raw": seed_raw, "response": wire_before}
+ev.note("301/before-peak-1-gain-through-product-readback", before_observation)
+ev.falsifiable(
+    "301/before-the-product-readback-returns-the-current-raw-value-and-display-without-a-step",
+    zero_step_read_landed,
+    before_observation,
+    nested_witness(before_observation, "response", walk_steps=1),
+    "set_eq_band_verified reads the seeded current Peak 1 Gain through its own State-A readback, "
+    "with raw value and Logic's non-empty AXValueDescription recorded and no nudge accepted",
+    "make the zero-step request take one nudge: the product-before predicate rejects it rather than "
+    "calling a write-produced value the starting point",
+)
+if not zero_step_read_landed(before_observation):
+    # Even a failing zero-step call can have changed the slider. Its requested value is the raw
+    # witness baseline, so drive the same operation once more to restore that known value before
+    # reporting the failure.
+    restore_after_before_failure = safe_set_eq(seed_raw, RAW_UNIT, track_ref, insert, project_path)
+    ev.note("301/restore-after-failed-before-read", restore_after_before_failure)
+    ev.restored(
+        "301/failed-before-read-is-returned-to-its-raw-witness-seed",
+        restored_to_before({"before_raw": seed_raw, "response": restore_after_before_failure}),
+        f"response={restore_after_before_failure!r}",
+    )
+    finish()
+
+before_raw = float(wire_before["observed_normalized"])
+before_display = wire_before["observed_display"]
+target_raw = before_raw + VISIBLE_RAW_DISTANCE if before_raw <= RAW_MAX - VISIBLE_RAW_DISTANCE else before_raw - VISIBLE_RAW_DISTANCE
+direction = 1.0 if target_raw > before_raw else -1.0
+target_is_visible = (
+    RAW_MIN <= target_raw <= RAW_MAX
+    and abs(target_raw - before_raw) >= VISIBLE_RAW_DISTANCE
+)
+ev.check(
+    "301/precondition-the-raw-write-target-is-visibly-away-from-before",
+    target_is_visible,
+    "the requested raw Peak 1 Gain is in 0...480 and at least 40 raw AXValue units from its read "
+    "baseline, so a one-step result cannot masquerade as a landing",
+    f"before_raw={before_raw!r} target_raw={target_raw!r} distance={abs(target_raw - before_raw)!r}",
+    "reduce the requested distance to one: the landing assertion would no longer distinguish the "
+    "known one-step AX behavior from convergence",
+)
+if not target_is_visible:
+    finish()
+
+# Re-scan immediately before the mutating sequence. As above, `None` alone is clear; a detector
+# failure is not a permission slip to write through an unknown modal state.
+modal_before_write = E.blocking_modal()
+ev.check(
+    "301/precondition-no-blocking-modal-immediately-before-the-write-sequence",
+    modal_before_write is None,
+    "the second modal scan completed clear immediately before the driver sends the mutating requests",
+    f"blocking_modal={modal_before_write!r}",
+    "put up a modal after preflight or make the second scan unreadable: the harness refuses before "
+    "the Peak 1 walk",
+)
+if modal_before_write is not None:
+    finish()
+
+arrange = E.logic_window()
+title_band = (0, 0, arrange["w"], 28) if arrange else None
+title_subject = f"the title band of the {arrange['title']!r} document window" if arrange else None
+ev.check(
+    "301/precondition-a-project-window-is-available-for-the-refusal-visual",
+    title_band is not None and bool(title_subject),
+    "a Logic document window is visible for the final no-write visual assertion",
+    f"arrange={arrange!r} title_band={title_band!r}",
+    "close the document window: the final refusal cannot be captured or visually checked",
+)
+if title_band is None:
+    finish()
+
+recording = ev.record_screen(seconds=120)
+
+# Both requests execute even if the first one fails. A red raw landing remains a red result, while
+# the independent dB request can still reveal whether the display-target branch is reachable. The
+# `finally` restoration is unconditional after these requests begin.
+raw_write = {}
+display_write = {}
+restore = {}
+try:
+    raw_write = safe_set_eq(target_raw, RAW_UNIT, track_ref, insert, project_path)
+    raw_write_observation = {"target_raw": target_raw, "response": raw_write}
+    ev.note("301/peak-1-gain-visible-raw-write", raw_write_observation)
+    ev.falsifiable(
+        "301/the-visible-raw-write-lands-after-more-than-one-walk-step",
+        raw_walk_landed,
+        raw_write_observation,
+        raw_one_step_witness(raw_write_observation, before_raw, direction),
+        "State A reports the requested raw value within tolerance 0 after more than one increment-walk "
+        "step; one AXValue assignment is explicitly not enough",
+        "replace the walk with a single AXValue assignment: the same-shape one-step observation is "
+        "rejected because it did not reach the requested raw value",
+    )
+
+    display_move_observation = {"before": wire_before, "after": raw_write}
+    ev.falsifiable(
+        "301/the-logic-display-moved-with-the-verified-raw-value",
+        display_changed_with_raw_value,
+        display_move_observation,
+        raw_move_with_stale_display(display_move_observation),
+        "the product's raw readback and AXValueDescription both changed; a raw move paired with the "
+        "old rendering is not treated as the same control",
+        "hold observed_display at the before string while preserving the moved raw value: this rejects "
+        "a split raw/rendering observation",
+    )
+
+    # Pick one of the two measured-format values only from the returned rendering. This is selection
+    # between literal dB requests, not a conversion from raw AXValue to dB.
+    display_value = -2.2 if raw_write.get("observed_display") == "+2.2 dB" else 2.2
+    wanted_display = "-2.2 dB" if display_value < 0 else "+2.2 dB"
+    display_write = safe_set_eq(display_value, DISPLAY_UNIT, track_ref, insert, project_path)
+    display_observation = {
+        "wanted_value": display_value,
+        "wanted_display": wanted_display,
+        "response": display_write,
+    }
+    ev.note("301/peak-1-gain-display-unit-write", display_observation)
+    ev.falsifiable(
+        "301/a-db-request-lands-on-logics-own-rendered-string",
+        display_request_landed,
+        display_observation,
+        nested_witness(display_observation, "response", observed_display=before_display),
+        "the dB request reaches State A only when Logic reports the exact requested AXValueDescription; "
+        "the harness never supplies a Hz/dB raw mapping",
+        "return a different AXValueDescription for the requested dB value: a value in the declared "
+        "unit without Logic's exact rendering is rejected",
+    )
+finally:
+    restore = safe_set_eq(before_raw, RAW_UNIT, track_ref, insert, project_path)
+    restore_observation = {"before_raw": before_raw, "response": restore}
+    ev.note("301/restore-peak-1-gain-through-same-operation", restore_observation)
+    ev.falsifiable(
+        "301/restore-puts-peak-1-gain-back-at-the-recorded-before-raw-value",
+        restored_to_before,
+        restore_observation,
+        nested_witness(restore_observation, "response", observed_normalized=before_raw + direction),
+        "the same set_eq_band_verified operation reaches State A with readback equal to the recorded "
+        "before raw value, rather than merely claiming rollback",
+        "leave the restore response one raw step away from before: the exact readback predicate rejects "
+        "the un-restored state",
+    )
+    ev.restored(
+        "301/peak-1-gain-is-restored-by-verified-readback",
+        restored_to_before(restore_observation),
+        f"before_raw={before_raw!r} restore_response={restore!r}",
+    )
+
+# The final request is intentionally raw 481, just outside the measured 0...480 rail. It must fail
+# at validation (`write_attempted:false`), and the post-request product readback below confirms no
+# value changed while that State C was produced.
+refusal_before = ev.shot("301/before-out-of-range-refusal", settle_region=title_band,
+                         window_title=arrange["title"])
+out_of_range = safe_set_eq(OUT_OF_RANGE_RAW, RAW_UNIT, track_ref, insert, project_path)
+ev.note("301/out-of-range-raw-request", out_of_range)
+
+# The verified operation leaves its editor window available for its next read. Re-opening that window
+# with the raw witness would mistake an existing window for an Open failure, so these are deliberately
+# zero-step product readbacks. If a buggy out-of-range request did move either control, the matching
+# raw request walks it back to its seed but reports `walk_steps > 0`, preserving the red result.
+peak_1_after_refusal = safe_set_eq(before_raw, RAW_UNIT, track_ref, insert, project_path)
+peak_2_after = safe_set_eq(
+    float(raw_peak_2_before["value"]), RAW_UNIT, track_ref, insert, project_path,
+    band="Peak 2", parameter="Gain",
+)
+ev.note("301/peak-1-readback-after-refused-request", peak_1_after_refusal)
+ev.note("301/peak-2-negative-control-readback-after-whole-run", peak_2_after)
+
+refusal_observation = {
+    "response": out_of_range,
+    "before": {"value": before_raw, "value_description": before_display},
+    "after": peak_1_after_refusal,
+}
+refusal_counterexample = nested_witness(refusal_observation, "response", write_attempted=True)
+refusal_counterexample = nested_witness(
+    refusal_counterexample,
+    "after",
+    observed_normalized=before_raw + direction,
+    observed_display="a changed rendering",
+    walk_steps=1,
+)
+ev.falsifiable(
+    "301/an-out-of-range-raw-request-is-refused-before-any-write-and-does-not-move-peak-1",
+    out_of_range_refused_without_motion,
+    refusal_observation,
+    refusal_counterexample,
+    "raw 481 returns State C with write_attempted:false, while a zero-step product readback confirms "
+    "Peak 1 raw value and Logic display remain at the recorded before state",
+    "move range validation after the AX write: the same-shaped response records write_attempted:true "
+    "and the post-request product read needs a step to return Peak 1 to before",
+)
+
+other_band_observation = {"before": raw_peak_2_before, "response": peak_2_after}
+other_band_counterexample = nested_witness(
+    other_band_observation,
+    "response",
+    observed_normalized=float(raw_peak_2_before["value"]) + 1.0,
+    walk_steps=1,
+)
+ev.falsifiable(
+    "301/negative-control-peak-2-gain-is-unchanged-across-the-whole-run",
+    other_band_is_unchanged,
+    other_band_observation,
+    other_band_counterexample,
+    "the other named band parameter, Peak 2 Gain, reaches a zero-step product readback with its exact "
+    "before raw AXValue and AXValueDescription after every Peak 1 request; a wrong-slider walk turns "
+    "this red",
+    "change Peak 2 Gain by one raw step while retaining its otherwise raw response shape: the negative "
+    "control rejects the wrong-slider outcome and the same request returns it to its seed",
+)
+
+refusal_after = ev.shot("301/after-out-of-range-refusal", settle_region=title_band,
+                        window_title=arrange["title"])
+ev.visual(
+    "301/the-refused-out-of-range-request-does-not-change-the-document-title-band",
+    refusal_before["file"],
+    refusal_after["file"],
+    title_band,
+    subject=title_subject,
+    expect_change=False,
+    why="the final request is required to stop before any write; the title band is captured only around "
+    "that refusal, after the earlier Peak 1 value has already been restored",
+)
+
+driver.close()
+driver = None
+ev.stop_recording(recording)
+out = ev.write()
+print(json.dumps(out, indent=1))
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Scripts/livekit/live_301_eq_band_write_lands_and_rolls_back.py
+++ b/Scripts/livekit/live_301_eq_band_write_lands_and_rolls_back.py
@@ -133,7 +133,7 @@ def raw_probe(tool):
     config = {
         "slot_label": SLOT_NAME,
         "track_label": TRACK_NAME,
-        "mixer_labels": MIXER_LABELS,
+        "mixer_label": MIXER_LABELS,
         "open_label": OPEN,
         "close_label": CLOSE,
         "bypass_labels": BYPASS_LABELS,

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+PluginSlots.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+PluginSlots.swift
@@ -442,6 +442,39 @@ extension AXLogicProElements {
         return .none
     }
 
+    /// Return every OPEN plug-in editor whose title identifies `trackName` and
+    /// whose direct static-text header maps to `pluginID`. This deliberately
+    /// does not require a parameter control: duplicate-insert acquisition uses
+    /// it to prove which editor the slot's open control created *before* the
+    /// parameter-specific slider match runs.
+    ///
+    /// The same direct-header rule as `pluginWindowMatch` is retained here; a
+    /// window title, descendant text, or geometry is not evidence of plug-in
+    /// identity.
+    static func matchingPluginEditorWindows(
+        forTrackName trackName: String,
+        matchingPluginID pluginID: String,
+        runtime: Runtime = .production
+    ) -> [AXUIElement] {
+        guard let app = appRoot(runtime: runtime) else { return [] }
+        let windows: [AXUIElement] = AXHelpers.getAttribute(
+            app, kAXWindowsAttribute, runtime: runtime.ax
+        ) ?? []
+        let target = trackName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return windows.filter { window in
+            guard isPluginEditorWindow(window, runtime: runtime.ax),
+                  AXHelpers.getRole(window, runtime: runtime.ax) == (kAXWindowRole as String) else {
+                return false
+            }
+            let title = (AXHelpers.getTitle(window, runtime: runtime.ax) ?? "")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard title == target else { return false }
+            return pluginWindowHeaderStaticTextValues(in: window, runtime: runtime.ax).contains {
+                VerifiedPluginCatalog.pluginID(forObservedName: $0) == pluginID
+            }
+        }
+    }
+
     /// Return only readable values of direct static-text children. Do not fall
     /// back to a title, a descendant, or a fixed child index: neither identifies
     /// the plug-in editor reliably.

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+PluginSlots.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+PluginSlots.swift
@@ -347,6 +347,11 @@ extension AXLogicProElements {
         case none
         case unique(AXUIElement)
         case ambiguous
+        /// A candidate has the requested track and parameter control, but its
+        /// direct static-text header does not prove the requested plug-in.
+        /// `observedNames` is empty when those children exposed no readable
+        /// values, which is deliberately not accepted as identity evidence.
+        case pluginIdentityMismatch(observedNames: [String])
     }
 
     /// Resolve the display name of the track header at `index` (0-based), or nil
@@ -380,33 +385,19 @@ extension AXLogicProElements {
         return names
     }
 
-    /// Find an OPEN plugin window whose AX title equals `trackName` AND which
-    /// exposes a 1-level `AXSlider` matching `axDescription`. T0 evidence: a
-    /// stock-effect plugin window is a separate `AXWindow`/`AXDialog` titled with
-    /// the track name; its parameter controls are flat `AXSlider`s at the
-    /// window's first child level, and only `AXDescription` is a stable matcher.
+    /// Find an OPEN plug-in editor whose title equals `trackName`, whose direct
+    /// `AXStaticText` children name `pluginID` through the verified catalog's
+    /// observed-name aliases, and which exposes exactly one matching slider.
     ///
-    /// Returns nil when no such window is open or when more than one candidate
-    /// matches (the caller then attempts to open one, or fails closed). Both the
-    /// window role/title and slider presence are required so an unrelated or
-    /// ambiguous same-titled window is never mistaken for the plugin window.
-    static func openPluginWindow(
-        forTrackName trackName: String,
-        matchingSliderDescription axDescription: String,
-        runtime: Runtime = .production
-    ) -> AXUIElement? {
-        if case let .unique(window) = pluginWindowMatch(
-            forTrackName: trackName,
-            matchingSliderDescription: axDescription,
-            runtime: runtime
-        ) {
-            return window
-        }
-        return nil
-    }
-
+    /// Measured for stock Logic editors only: their direct static-text children
+    /// contain the English plug-in display name in both editor and Controls
+    /// views, but its position varies and other labels are localized. Third-party
+    /// editors and catalog/display-name differences remain unmeasured, so their
+    /// observed names must resolve through `VerifiedPluginCatalog` rather than
+    /// being accepted by raw string comparison.
     static func pluginWindowMatch(
         forTrackName trackName: String,
+        matchingPluginID pluginID: String,
         matchingSliderDescription axDescription: String,
         runtime: Runtime = .production
     ) -> PluginWindowMatch {
@@ -416,6 +407,8 @@ extension AXLogicProElements {
         ) ?? []
         let target = trackName.trimmingCharacters(in: .whitespacesAndNewlines)
         var match: AXUIElement?
+        var mismatchedObservedNames: [String] = []
+        var foundMismatchedCandidate = false
         for window in windows {
             guard isPluginEditorWindow(window, runtime: runtime.ax) else { continue }
             guard AXHelpers.getRole(window, runtime: runtime.ax) == (kAXWindowRole as String) else { continue }
@@ -428,12 +421,42 @@ extension AXLogicProElements {
             case .ambiguous:
                 return .ambiguous
             case .unique:
+                let observedNames = pluginWindowHeaderStaticTextValues(in: window, runtime: runtime.ax)
+                guard observedNames.contains(where: {
+                    VerifiedPluginCatalog.pluginID(forObservedName: $0) == pluginID
+                }) else {
+                    foundMismatchedCandidate = true
+                    mismatchedObservedNames.append(contentsOf: observedNames)
+                    continue
+                }
                 guard match == nil else { return .ambiguous }
                 match = window
             }
         }
-        guard let match else { return .none }
-        return .unique(match)
+        if let match {
+            return .unique(match)
+        }
+        if foundMismatchedCandidate {
+            return .pluginIdentityMismatch(observedNames: Array(Set(mismatchedObservedNames)).sorted())
+        }
+        return .none
+    }
+
+    /// Return only readable values of direct static-text children. Do not fall
+    /// back to a title, a descendant, or a fixed child index: neither identifies
+    /// the plug-in editor reliably.
+    private static func pluginWindowHeaderStaticTextValues(
+        in window: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> [String] {
+        AXHelpers.getChildren(window, runtime: runtime).compactMap { child in
+            guard AXHelpers.getRole(child, runtime: runtime) == (kAXStaticTextRole as String),
+                  let value = AXHelpers.getValue(child, runtime: runtime) as? String else {
+                return nil
+            }
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
     }
 
     /// Find the parameter `AXSlider` inside a plugin window by its

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -406,6 +406,27 @@ extension AccessibilityChannel {
         _ runtime: AXLogicProElements.Runtime
     ) async -> AXUIElementSendable?
 
+    /// Result of the CoreGraphics-backed popup cleanup that follows plug-in
+    /// window acquisition. A remaining popup is unsafe: Logic stops servicing
+    /// AppleEvents while it is open, so the next verified write would fail for
+    /// an unrelated-looking reason.
+    enum PluginPopupMenuCleanupOutcome: Sendable, Equatable {
+        case noPopupObserved
+        case dismissed
+        case couldNotDismiss(initialPopupCount: Int, remainingPopupCount: Int)
+
+        var isClean: Bool {
+            if case .couldNotDismiss = self {
+                return false
+            }
+            return true
+        }
+    }
+
+    typealias PluginPopupMenuCleaner = @Sendable (
+        _ runtime: AXLogicProElements.Runtime
+    ) -> PluginPopupMenuCleanupOutcome
+
     static let livePluginWindowOpener: PluginWindowOpener = { targetSlot, trackName, axDescription, runtime in
         await openPluginWindowFromTargetSlot(
             targetSlot.element,
@@ -416,6 +437,10 @@ extension AccessibilityChannel {
     }
 
     static let liveNoOpPluginWindowOpener: PluginWindowOpener = { _, _, _, _ in nil }
+
+    static let livePluginPopupMenuCleaner: PluginPopupMenuCleaner = { runtime in
+        dismissLogicPopupMenuAfterPluginWindowAcquisition(runtime: runtime)
+    }
 
     /// Steps 2-3 of the R6 precedence shared by both mutating verified ops:
     /// mode validation then the project path gate. Returns a State C envelope to
@@ -518,6 +543,7 @@ extension AccessibilityChannel {
         entryLookup: VerifiedPluginCatalog.EntryLookup = VerifiedPluginCatalog.productionEntryLookup,
         paramAliasLookup: VerifiedPluginCatalog.ParamAliasLookup = VerifiedPluginCatalog.canonicalParamKey,
         pluginWindowOpener: PluginWindowOpener = livePluginWindowOpener,
+        pluginPopupMenuCleaner: PluginPopupMenuCleaner = livePluginPopupMenuCleaner,
         incrementWalkBudget: Int = ChannelEQBandCatalog.incrementWalkBudget
     ) async -> ChannelResult {
         await defaultVerifiedParameterWrite(
@@ -532,6 +558,7 @@ extension AccessibilityChannel {
             entryLookup: entryLookup,
             paramAliasLookup: paramAliasLookup,
             pluginWindowOpener: pluginWindowOpener,
+            pluginPopupMenuCleaner: pluginPopupMenuCleaner,
             incrementWalkBudget: incrementWalkBudget
         )
     }
@@ -545,6 +572,7 @@ extension AccessibilityChannel {
         frontDocumentPath: FrontDocumentPathProvider = liveFrontDocumentPath,
         entryLookup: VerifiedPluginCatalog.EntryLookup = VerifiedPluginCatalog.productionEntryLookup,
         pluginWindowOpener: PluginWindowOpener = livePluginWindowOpener,
+        pluginPopupMenuCleaner: PluginPopupMenuCleaner = livePluginPopupMenuCleaner,
         incrementWalkBudget: Int = ChannelEQBandCatalog.incrementWalkBudget
     ) async -> ChannelResult {
         await defaultVerifiedParameterWrite(
@@ -559,6 +587,7 @@ extension AccessibilityChannel {
             entryLookup: entryLookup,
             paramAliasLookup: VerifiedPluginCatalog.canonicalParamKey,
             pluginWindowOpener: pluginWindowOpener,
+            pluginPopupMenuCleaner: pluginPopupMenuCleaner,
             incrementWalkBudget: incrementWalkBudget
         )
     }
@@ -615,6 +644,7 @@ extension AccessibilityChannel {
         entryLookup: VerifiedPluginCatalog.EntryLookup,
         paramAliasLookup: VerifiedPluginCatalog.ParamAliasLookup,
         pluginWindowOpener: PluginWindowOpener,
+        pluginPopupMenuCleaner: PluginPopupMenuCleaner,
         incrementWalkBudget: Int
     ) async -> ChannelResult {
 
@@ -710,6 +740,7 @@ extension AccessibilityChannel {
                 runtime: runtime,
                 entryLookup: entryLookup,
                 pluginWindowOpener: pluginWindowOpener,
+                pluginPopupMenuCleaner: pluginPopupMenuCleaner,
                 incrementWalkBudget: incrementWalkBudget
             )
         }
@@ -954,6 +985,7 @@ extension AccessibilityChannel {
         runtime: AXLogicProElements.Runtime,
         entryLookup: VerifiedPluginCatalog.EntryLookup,
         pluginWindowOpener: PluginWindowOpener,
+        pluginPopupMenuCleaner: PluginPopupMenuCleaner,
         incrementWalkBudget: Int
     ) async -> ChannelResult {
         let identity = resolvedIdentity(track: track, insert: insert, pluginID: pluginID)
@@ -1081,6 +1113,7 @@ extension AccessibilityChannel {
                 runtime: runtime
             )
             diagnostics["opener_action_attempted"] = false
+            diagnostics.merge(pluginPopupMenuCleanupDiagnostics(pluginPopupMenuCleaner(runtime))) { _, new in new }
             return .error(windowIdentityUnresolvedStateC(
                 operation,
                 identity,
@@ -1096,6 +1129,22 @@ extension AccessibilityChannel {
             axDescription,
             runtime
         ) else {
+            let popupCleanup = pluginPopupMenuCleaner(runtime)
+            if !popupCleanup.isClean {
+                var diagnostics = pluginWindowAcquisitionDiagnostics(
+                    trackName: trackName,
+                    axDescription: axDescription,
+                    runtime: runtime
+                )
+                diagnostics.merge(pluginPopupMenuCleanupDiagnostics(popupCleanup)) { _, new in new }
+                return .error(windowOpenFailedStateC(
+                    operation,
+                    identity,
+                    "a Logic popup menu remained open after plugin-window acquisition",
+                    diagnostics: diagnostics,
+                    safeToRetry: false
+                ))
+            }
             if case .ambiguous = AXLogicProElements.pluginWindowMatch(
                 forTrackName: trackName,
                 matchingSliderDescription: axDescription,
@@ -1122,6 +1171,22 @@ extension AccessibilityChannel {
                     axDescription: axDescription,
                     runtime: runtime
                 )
+            ))
+        }
+        let popupCleanup = pluginPopupMenuCleaner(runtime)
+        guard popupCleanup.isClean else {
+            var diagnostics = pluginWindowAcquisitionDiagnostics(
+                trackName: trackName,
+                axDescription: axDescription,
+                runtime: runtime
+            )
+            diagnostics.merge(pluginPopupMenuCleanupDiagnostics(popupCleanup)) { _, new in new }
+            return .error(windowOpenFailedStateC(
+                operation,
+                identity,
+                "a Logic popup menu remained open after plugin-window acquisition",
+                diagnostics: diagnostics,
+                safeToRetry: false
             ))
         }
         let window = opened.element
@@ -1563,14 +1628,15 @@ extension AccessibilityChannel {
         _ operation: String,
         _ identity: [String: Any],
         _ detail: String,
-        diagnostics: [String: Any] = [:]
+        diagnostics: [String: Any] = [:],
+        safeToRetry: Bool = true
     ) -> String {
         var extras: [String: Any] = [
             "operation": operation,
             "target_identity": identity,
             "what_was_attempted": "acquire the plugin window before writing",
             "what_was_observed": detail,
-            "safe_to_retry": true,
+            "safe_to_retry": safeToRetry,
             "write_attempted": false,
         ]
         extras.merge(diagnostics) { current, _ in current }
@@ -1615,9 +1681,10 @@ extension AccessibilityChannel {
         case .ambiguous:
             return nil
         case let .unique(window):
-            guard demotePluginWindowBeforeAcquisition(window, runtime: runtime) else {
-                return nil
-            }
+            // A verified unique editor is already the requested acquisition.
+            // Re-pressing the slot can surface its chooser menu, which leaves a
+            // popup that blocks Logic's AppleEvent handler; reuse the window.
+            return AXUIElementSendable(window)
         case .none:
             break
         }
@@ -1655,24 +1722,6 @@ extension AccessibilityChannel {
         return nil
     }
 
-    private static func demotePluginWindowBeforeAcquisition(
-        _ window: AXUIElement,
-        runtime: AXLogicProElements.Runtime
-    ) -> Bool {
-        let mainCleared = AXHelpers.setAttribute(
-            window, kAXMainAttribute as String, false as CFTypeRef, runtime: runtime.ax
-        )
-        let focusCleared = AXHelpers.setAttribute(
-            window, kAXFocusedAttribute as String, false as CFTypeRef, runtime: runtime.ax
-        )
-        if mainCleared, focusCleared, !pluginWindowIsFront(window, runtime: runtime.ax) {
-            return true
-        }
-        guard let arrangeWindow = AXLogicProElements.mainWindow(runtime: runtime),
-              AXHelpers.performAction(arrangeWindow, kAXRaiseAction as String, runtime: runtime.ax) else { return false }
-        return !pluginWindowIsFront(window, runtime: runtime.ax)
-    }
-
     private static func pluginWindowIsFront(
         _ window: AXUIElement,
         runtime: AXHelpers.Runtime
@@ -1706,7 +1755,7 @@ extension AccessibilityChannel {
         return CFEqual(slots[insert].element, originalSlot)
     }
 
-    private static func rankedPluginSlotOpenControls(
+    static func rankedPluginSlotOpenControls(
         in targetSlot: AXUIElement,
         runtime: AXHelpers.Runtime
     ) -> [(rank: Int, element: AXUIElement)] {
@@ -1717,6 +1766,10 @@ extension AccessibilityChannel {
         return buttons.compactMap { button -> (rank: Int, element: AXUIElement)? in
             let text = AXLogicProElements.elementSearchText(button, runtime: runtime)
             guard !AXLocalePolicy.pluginBypassControl.containsAny(in: text) else { return nil }
+            guard case let .success(actionNames) = AXHelpers.getActionNamesResult(button, runtime: runtime),
+                  !pluginSlotControlOpensMenu(actionNames: actionNames) else {
+                return nil
+            }
             if text.range(of: "open", options: [.caseInsensitive]) != nil || text.contains("열기") {
                 return (0, button)
             }
@@ -1729,6 +1782,126 @@ extension AccessibilityChannel {
             return (2, button)
         }
         .sorted { lhs, rhs in lhs.rank < rhs.rank }
+    }
+
+    /// Action names are the stable capability signal; a localised button label
+    /// cannot say whether AXPress opens an editor or a menu.
+    static func pluginSlotControlOpensMenu(actionNames: [String]) -> Bool {
+        actionNames.contains(kAXShowMenuAction as String) || actionNames.contains { actionName in
+            let normalized = actionName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            guard normalized.hasPrefix("name:") else { return false }
+            return normalized.contains("menu") || normalized.contains("메뉴")
+        }
+    }
+
+    private static func pluginPopupMenuCleanupDiagnostics(
+        _ outcome: PluginPopupMenuCleanupOutcome
+    ) -> [String: Any] {
+        switch outcome {
+        case .noPopupObserved, .dismissed:
+            return [:]
+        case let .couldNotDismiss(initialPopupCount, remainingPopupCount):
+            return [
+                "plugin_popup_menu_state": "could_not_be_dismissed",
+                "plugin_popup_menu_initial_window_count": initialPopupCount,
+                "plugin_popup_menu_remaining_window_count": remainingPopupCount,
+                "recovery_hint": "A Logic popup menu remained open after plugin-window acquisition. Dismiss it with Escape before retrying, because it can block Logic's AppleEvent handler.",
+            ]
+        }
+    }
+
+    /// The live failure was one Logic-owned 230x593 CoreGraphics window at
+    /// layer 101 — the popup-menu level. Querying
+    /// `CGWindowLevelForKey(.popUpMenuWindow)` rather than baking in 101 keeps
+    /// the signal tied to macOS's popup-menu level while avoiding the AppleEvent
+    /// path that the stuck menu itself blocks.
+    private static func dismissLogicPopupMenuAfterPluginWindowAcquisition(
+        runtime: AXLogicProElements.Runtime
+    ) -> PluginPopupMenuCleanupOutcome {
+        guard let initialPopupCount = logicOwnedPopupMenuWindowCount(runtime: runtime),
+              initialPopupCount > 0 else {
+            return .noPopupObserved
+        }
+
+        cancelVisibleLogicPopupMenusViaAX(runtime: runtime)
+        if logicOwnedPopupMenuWindowCount(runtime: runtime) == 0 {
+            return .dismissed
+        }
+        postEscapeForPluginPopupMenuDismissal()
+
+        for attempt in 0..<3 {
+            guard let remainingPopupCount = logicOwnedPopupMenuWindowCount(runtime: runtime) else {
+                return .couldNotDismiss(
+                    initialPopupCount: initialPopupCount,
+                    remainingPopupCount: initialPopupCount
+                )
+            }
+            if remainingPopupCount == 0 {
+                return .dismissed
+            }
+            if attempt < 2 {
+                Thread.sleep(forTimeInterval: 0.05)
+            }
+        }
+        let remainingPopupCount = logicOwnedPopupMenuWindowCount(runtime: runtime) ?? initialPopupCount
+        return .couldNotDismiss(
+            initialPopupCount: initialPopupCount,
+            remainingPopupCount: remainingPopupCount
+        )
+    }
+
+    private static func logicOwnedPopupMenuWindowCount(
+        runtime: AXLogicProElements.Runtime
+    ) -> Int? {
+        guard let logicPID = runtime.logicProPID(),
+              let windows = CGWindowListCopyWindowInfo(
+                [.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID
+              ) as? [[String: Any]] else {
+            return nil
+        }
+        let popupMenuLevel = Int(CGWindowLevelForKey(.popUpMenuWindow))
+        return windows.reduce(into: 0) { count, window in
+            guard let ownerPID = (window[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value,
+                  let level = (window[kCGWindowLayer as String] as? NSNumber)?.intValue,
+                  ownerPID == logicPID,
+                  level == popupMenuLevel else {
+                return
+            }
+            count += 1
+        }
+    }
+
+    private static func cancelVisibleLogicPopupMenusViaAX(
+        runtime: AXLogicProElements.Runtime
+    ) {
+        guard let app = AXLogicProElements.appRoot(runtime: runtime) else { return }
+        let windows: [AXUIElement] = AXHelpers.getAttribute(
+            app, kAXWindowsAttribute, runtime: runtime.ax
+        ) ?? []
+        var menus: [AXUIElement] = []
+        let roots = [app] + windows
+        for root in roots {
+            if AXHelpers.getRole(root, runtime: runtime.ax) == (kAXMenuRole as String) {
+                menus.append(root)
+            }
+            for menu in AXHelpers.findAllDescendants(
+                of: root, role: kAXMenuRole, maxDepth: 8, runtime: runtime.ax
+            ) where !menus.contains(where: { CFEqual($0, menu) }) {
+                menus.append(menu)
+            }
+        }
+        for menu in menus where AXHelpers.getActionNames(menu, runtime: runtime.ax)
+            .contains(kAXCancelAction as String) {
+            _ = AXHelpers.performAction(menu, kAXCancelAction as String, runtime: runtime.ax)
+        }
+    }
+
+    private static func postEscapeForPluginPopupMenuDismissal() {
+        let source = CGEventSource(stateID: .hidSystemState)
+        let down = CGEvent(keyboardEventSource: source, virtualKey: 53, keyDown: true)
+        let up = CGEvent(keyboardEventSource: source, virtualKey: 53, keyDown: false)
+        down?.post(tap: .cghidEventTap)
+        up?.post(tap: .cghidEventTap)
     }
 
     private static func pollOpenPluginWindow(

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -528,11 +528,11 @@ extension AccessibilityChannel {
     ///      with `unsupported_param_readback` (AC10); only `.writeReadback`
     ///      proceeds.
     ///   6  track verified select (`track_selection_failed`)
-    ///   7  inventory complete + occupied, identity-matched, and unambiguous at
-    ///      `insert` (`incomplete_inventory` / `target_plugin_mismatch` /
-    ///      `ambiguous_plugin_instance`)
-    ///   8  plugin window: resolve one candidate, then acquire it through the
-    ///      target slot (`window_open_failed` / `window_identity_unresolved`)
+    ///   7  inventory complete + occupied and identity-matched at `insert`
+    ///      (`incomplete_inventory` / `target_plugin_mismatch`)
+    ///   8  plugin window: a single plug-in instance uses the existing opener;
+    ///      duplicate instances require zero header-proven editors before one
+    ///      target-slot open press and exactly one afterward
     ///   9  slider match by AXDescription (`param_control_not_found`)
     ///  10  before `AXValue` read
     ///  11  dispatch the catalog's AX write method
@@ -1121,35 +1121,110 @@ extension AccessibilityChannel {
             }
             return slot.index
         }
-        guard conflictingInsertIndices.count <= 1 else {
-            // #726 measured on a real project: Absolute Zero had Compressor at
-            // inserts 0 and 2. set_param_verified for insert 0 = 40 and insert
-            // 2 = 70 both returned State A with their requested insert
-            // identities, yet readback was slot 0 Threshold = 0 % (both writes)
-            // and slot 1 Threshold = 56 % (never touched). The window match
-            // uses track name plus slider AXDescription, neither of which binds
-            // an editor to an insert. Refuse before any window is opened or
-            // pressed rather than guessing which identical instance is visible.
-            return .error(HonestContract.encodeV2StateC(
-                error: .ambiguousPluginInstance,
-                extras: [
-                    "operation": operation,
-                    "target_identity": identity,
-                    "requested_plugin_id": pluginID,
-                    "conflicting_insert_indices": conflictingInsertIndices,
-                    "what_was_attempted": "uniquely identify \(pluginID) at insert \(insert) before opening its window",
-                    "what_was_observed": "\(pluginID) appears at inserts \(conflictingInsertIndices.map(String.init).joined(separator: ", ")) on track \(track)",
-                    "safe_to_retry": false,
-                    "write_attempted": false,
-                ]
-            ))
-        }
-
-        // Step 8 — plugin window: reject ambiguity, then acquire through the
-        // target slot so the slot is the provenance for the selected editor.
+        let duplicatedPluginInstance = conflictingInsertIndices.count > 1
         guard let trackName = AXLogicProElements.trackName(at: track, runtime: runtime) else {
             return .error(windowOpenFailedStateC(operation, identity, "the target track name could not be resolved for window matching"))
         }
+        var constructedWindow: AXUIElementSendable?
+        if duplicatedPluginInstance {
+            // #726 follow-up measurement: when no matching editor is open, one
+            // target-slot `열기` press creates the target editor. A pre-existing
+            // editor makes the result indistinguishable, and a hidden sibling can
+            // make one press restore two editors. These header-proven counts are
+            // therefore the provenance proof; neither geometry nor name-only
+            // reuse chooses the editor in this branch.
+            let matchingEditorsBeforePress = AXLogicProElements.matchingPluginEditorWindows(
+                forTrackName: trackName,
+                matchingPluginID: pluginID,
+                runtime: runtime
+            )
+            guard matchingEditorsBeforePress.isEmpty else {
+                return .error(duplicatePluginEditorAlreadyOpenStateC(
+                    operation: operation,
+                    identity: identity,
+                    pluginID: pluginID,
+                    track: track,
+                    insert: insert,
+                    conflictingInsertIndices: conflictingInsertIndices,
+                    matchingEditorCount: matchingEditorsBeforePress.count
+                ))
+            }
+
+            // Retain the existing static-header guard: an editor that exposes
+            // this track and parameter but cannot prove the requested plug-in is
+            // not evidence of a clean, matching pre-count.
+            if case let .pluginIdentityMismatch(observedNames) = AXLogicProElements.pluginWindowMatch(
+                forTrackName: trackName,
+                matchingPluginID: pluginID,
+                matchingSliderDescription: axDescription,
+                runtime: runtime
+            ) {
+                return .error(pluginWindowPluginMismatchStateC(
+                    operation,
+                    identity,
+                    pluginID: pluginID,
+                    observedNames: observedNames
+                ))
+            }
+
+            guard let targetOpenControl = rankedPluginSlotOpenControls(
+                in: slots[insert].element,
+                runtime: runtime.ax
+            ).first(where: { $0.rank == 0 })?.element else {
+                return .error(windowOpenFailedStateC(
+                    operation,
+                    identity,
+                    "the target insert exposes no AXPress-capable open control",
+                    diagnostics: pluginWindowAcquisitionDiagnostics(
+                        trackName: trackName,
+                        axDescription: axDescription,
+                        runtime: runtime
+                    )
+                ))
+            }
+
+            // Real Logic can report a non-zero AX status after opening the
+            // editor, so the observed post-count—not that status—decides.
+            _ = pressElement(targetOpenControl, runtime: runtime.ax)
+            let matchingEditorsAfterPress = await pollMatchingPluginEditorWindows(
+                trackName: trackName,
+                pluginID: pluginID,
+                runtime: runtime,
+                timeoutMs: 1_250
+            )
+            guard matchingEditorsAfterPress.count == 1 else {
+                if case let .pluginIdentityMismatch(observedNames) = AXLogicProElements.pluginWindowMatch(
+                    forTrackName: trackName,
+                    matchingPluginID: pluginID,
+                    matchingSliderDescription: axDescription,
+                    runtime: runtime
+                ) {
+                    return .error(pluginWindowPluginMismatchStateC(
+                        operation,
+                        identity,
+                        pluginID: pluginID,
+                        observedNames: observedNames
+                    ))
+                }
+                return .error(duplicatePluginEditorCountMismatchStateC(
+                    operation: operation,
+                    identity: identity,
+                    pluginID: pluginID,
+                    track: track,
+                    insert: insert,
+                    conflictingInsertIndices: conflictingInsertIndices,
+                    matchingEditorCount: matchingEditorsAfterPress.count
+                ))
+            }
+            // `matchingPluginEditorWindows` accepts a window only after its
+            // direct static-text header maps to the requested plug-in id.
+            constructedWindow = AXUIElementSendable(matchingEditorsAfterPress[0])
+        }
+
+        // Step 8 — normal single-instance acquisition retains the original
+        // name/parameter resolution and opener behaviour. For a duplicated
+        // instance, `constructedWindow` above is already proven by the one
+        // target-slot press and the two editor counts.
         switch AXLogicProElements.pluginWindowMatch(
             forTrackName: trackName,
             matchingPluginID: pluginID,
@@ -1180,13 +1255,19 @@ extension AccessibilityChannel {
         case .none, .unique:
             break
         }
-        guard let opened = await pluginWindowOpener(
-            AXUIElementSendable(slots[insert].element),
-            pluginID,
-            trackName,
-            axDescription,
-            runtime
-        ) else {
+        let openedCandidate: AXUIElementSendable?
+        if let constructedWindow {
+            openedCandidate = constructedWindow
+        } else {
+            openedCandidate = await pluginWindowOpener(
+                AXUIElementSendable(slots[insert].element),
+                pluginID,
+                trackName,
+                axDescription,
+                runtime
+            )
+        }
+        guard let opened = openedCandidate else {
             // A polling attempt may have observed a same-track editor with the
             // requested control but the wrong (or unreadable) header. Report
             // that identity failure directly; a concurrent popup-cleanup issue
@@ -1770,6 +1851,56 @@ extension AccessibilityChannel {
         )
     }
 
+    private static func duplicatePluginEditorAlreadyOpenStateC(
+        operation: String,
+        identity: [String: Any],
+        pluginID: String,
+        track: Int,
+        insert: Int,
+        conflictingInsertIndices: [Int],
+        matchingEditorCount: Int
+    ) -> String {
+        HonestContract.encodeV2StateC(
+            error: .duplicatePluginEditorAlreadyOpen,
+            extras: [
+                "operation": operation,
+                "target_identity": identity,
+                "requested_plugin_id": pluginID,
+                "conflicting_insert_indices": conflictingInsertIndices,
+                "matching_editor_count_before_press": matchingEditorCount,
+                "what_was_attempted": "confirm no \(pluginID) editor was already open before pressing insert \(insert)",
+                "what_was_observed": "\(matchingEditorCount) matching \(pluginID) editor(s) were already open on track \(track)",
+                "safe_to_retry": false,
+                "write_attempted": false,
+            ]
+        )
+    }
+
+    private static func duplicatePluginEditorCountMismatchStateC(
+        operation: String,
+        identity: [String: Any],
+        pluginID: String,
+        track: Int,
+        insert: Int,
+        conflictingInsertIndices: [Int],
+        matchingEditorCount: Int
+    ) -> String {
+        HonestContract.encodeV2StateC(
+            error: .duplicatePluginEditorCountMismatch,
+            extras: [
+                "operation": operation,
+                "target_identity": identity,
+                "requested_plugin_id": pluginID,
+                "conflicting_insert_indices": conflictingInsertIndices,
+                "matching_editor_count_after_press": matchingEditorCount,
+                "what_was_attempted": "press insert \(insert)'s open control once and observe exactly one \(pluginID) editor",
+                "what_was_observed": "the one target-slot press left \(matchingEditorCount) matching \(pluginID) editor(s) visible on track \(track)",
+                "safe_to_retry": false,
+                "write_attempted": false,
+            ]
+        )
+    }
+
     private static func acquiredPluginWindowFailureStateC(
         acquiredWindow: AXUIElement,
         operation: String,
@@ -2115,6 +2246,32 @@ extension AccessibilityChannel {
             return .unique(lastUniqueWindow)
         }
         return .none
+    }
+
+    /// Wait only for a nonzero header-proven editor count after the one allowed
+    /// duplicate-instance slot press. A count of two or more returns immediately
+    /// so a hidden sibling can never be mistaken for the requested insert.
+    private static func pollMatchingPluginEditorWindows(
+        trackName: String,
+        pluginID: String,
+        runtime: AXLogicProElements.Runtime,
+        timeoutMs: Int
+    ) async -> [AXUIElement] {
+        let deadline = Date().addingTimeInterval(Double(timeoutMs) / 1_000.0)
+        var matchingEditors: [AXUIElement] = []
+        repeat {
+            matchingEditors = AXLogicProElements.matchingPluginEditorWindows(
+                forTrackName: trackName,
+                matchingPluginID: pluginID,
+                runtime: runtime
+            )
+            if !matchingEditors.isEmpty {
+                return matchingEditors
+            }
+            guard Date() < deadline else { break }
+            try? await Task.sleep(for: .milliseconds(100))
+        } while Date() < deadline
+        return matchingEditors
     }
 
     /// ADR-001 coordinate ban: open the plugin window from its slot control via

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -1681,10 +1681,9 @@ extension AccessibilityChannel {
         case .ambiguous:
             return nil
         case let .unique(window):
-            // A verified unique editor is already the requested acquisition.
-            // Re-pressing the slot can surface its chooser menu, which leaves a
-            // popup that blocks Logic's AppleEvent handler; reuse the window.
-            return AXUIElementSendable(window)
+            guard demotePluginWindowBeforeAcquisition(window, runtime: runtime) else {
+                return nil
+            }
         case .none:
             break
         }
@@ -1720,6 +1719,24 @@ extension AccessibilityChannel {
             }
         }
         return nil
+    }
+
+    private static func demotePluginWindowBeforeAcquisition(
+        _ window: AXUIElement,
+        runtime: AXLogicProElements.Runtime
+    ) -> Bool {
+        let mainCleared = AXHelpers.setAttribute(
+            window, kAXMainAttribute as String, false as CFTypeRef, runtime: runtime.ax
+        )
+        let focusCleared = AXHelpers.setAttribute(
+            window, kAXFocusedAttribute as String, false as CFTypeRef, runtime: runtime.ax
+        )
+        if mainCleared, focusCleared, !pluginWindowIsFront(window, runtime: runtime.ax) {
+            return true
+        }
+        guard let arrangeWindow = AXLogicProElements.mainWindow(runtime: runtime),
+              AXHelpers.performAction(arrangeWindow, kAXRaiseAction as String, runtime: runtime.ax) else { return false }
+        return !pluginWindowIsFront(window, runtime: runtime.ax)
     }
 
     private static func pluginWindowIsFront(

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -482,9 +482,10 @@ extension AccessibilityChannel {
         return nil
     }
 
-    // MARK: - set_param_verified (R6 single precedence; AC10/AC11/AC17/AC19/AC23)
+    // MARK: - verified parameter writes (R6 single precedence; AC10/AC11/AC17/AC19/AC23)
 
-    /// Verified parameter write entry. The R6 single precedence, in order:
+    /// Verified parameter-write engine. Both `set_param_verified` and the
+    /// named-band Channel EQ operation take this R6 precedence, in order:
     ///
     ///   1  schema/params (`invalid_params`)
     ///   2  mode          (`unsupported_mode`)
@@ -499,27 +500,123 @@ extension AccessibilityChannel {
     ///      target slot (`window_open_failed` / `window_identity_unresolved`)
     ///   9  slider match by AXDescription (`param_control_not_found`)
     ///  10  before `AXValue` read
-    ///  11  set `AXValue` (`ax_write_failed`)
-    ///  12  after `AXValue` + `AXValueDescription` read (`readback_lost_after_write`)
-    ///  13  tolerance: |after - requested| <= tolerance ⇒ State A; else State C
-    ///      `readback_mismatch` + rollback to the before value.
+    ///  11  dispatch the catalog's AX write method
+    ///  12  read back the declared raw or display target
+    ///  13  direct-set tolerance or increment-walk outcome; failures roll back
+    ///      with the same declared write method.
     ///
     /// Step 4 runs BEFORE step 5 so a display-name/alias input still reaches the
     /// capability lookup (canonical id is required to query capability — AC23).
     ///
-    /// T5 wires the live write/readback path for the FIRST verified-writable
-    /// parameter, Compressor `threshold` (normalized %, T0 spike). Every other
-    /// parameter has no write/readback method, so step 5 still fail-closes it
-    /// with `unsupported_param_readback` and no write is attempted.
+    /// Compressor threshold uses direct `AXValue` assignment. Channel EQ's
+    /// named controls use the separately measured increment walk; their catalog
+    /// provenance intentionally does not claim an end-to-end live round trip.
     static func defaultSetParamVerified(
         params: [String: String],
         runtime: AXLogicProElements.Runtime = .production,
         frontDocumentPath: FrontDocumentPathProvider = liveFrontDocumentPath,
         entryLookup: VerifiedPluginCatalog.EntryLookup = VerifiedPluginCatalog.productionEntryLookup,
         paramAliasLookup: VerifiedPluginCatalog.ParamAliasLookup = VerifiedPluginCatalog.canonicalParamKey,
-        pluginWindowOpener: PluginWindowOpener = livePluginWindowOpener
+        pluginWindowOpener: PluginWindowOpener = livePluginWindowOpener,
+        incrementWalkBudget: Int = ChannelEQBandCatalog.incrementWalkBudget
     ) async -> ChannelResult {
-        let operation = "logic_plugins.set_param_verified"
+        await defaultVerifiedParameterWrite(
+            operation: "logic_plugins.set_param_verified",
+            params: params,
+            selector: .plugin(
+                pluginAlias: params["plugin"] ?? "",
+                paramAlias: params["param"] ?? ""
+            ),
+            runtime: runtime,
+            frontDocumentPath: frontDocumentPath,
+            entryLookup: entryLookup,
+            paramAliasLookup: paramAliasLookup,
+            pluginWindowOpener: pluginWindowOpener,
+            incrementWalkBudget: incrementWalkBudget
+        )
+    }
+
+    /// Named-band Channel EQ variant of `set_param_verified`. It enters the
+    /// same R6 engine at step 1; only the step-4 selector differs. The public
+    /// surface never accepts a band ordinal or a slider position.
+    static func defaultSetEQBandVerified(
+        params: [String: String],
+        runtime: AXLogicProElements.Runtime = .production,
+        frontDocumentPath: FrontDocumentPathProvider = liveFrontDocumentPath,
+        entryLookup: VerifiedPluginCatalog.EntryLookup = VerifiedPluginCatalog.productionEntryLookup,
+        pluginWindowOpener: PluginWindowOpener = livePluginWindowOpener,
+        incrementWalkBudget: Int = ChannelEQBandCatalog.incrementWalkBudget
+    ) async -> ChannelResult {
+        await defaultVerifiedParameterWrite(
+            operation: "logic_plugins.set_eq_band_verified",
+            params: params,
+            selector: .channelEQ(
+                bandName: params["band"] ?? "",
+                parameterName: params["parameter"] ?? ""
+            ),
+            runtime: runtime,
+            frontDocumentPath: frontDocumentPath,
+            entryLookup: entryLookup,
+            paramAliasLookup: VerifiedPluginCatalog.canonicalParamKey,
+            pluginWindowOpener: pluginWindowOpener,
+            incrementWalkBudget: incrementWalkBudget
+        )
+    }
+
+    private enum VerifiedParameterSelector {
+        case plugin(pluginAlias: String, paramAlias: String)
+        case channelEQ(bandName: String, parameterName: String)
+
+        var preResolutionIdentity: [String: Any] {
+            switch self {
+            case let .plugin(pluginAlias, _):
+                ["plugin_id_requested": pluginAlias]
+            case let .channelEQ(bandName, parameterName):
+                [
+                    "plugin_id_requested": "logic.stock.effect.channel_eq",
+                    "band_requested": bandName,
+                    "parameter_requested": parameterName,
+                ]
+            }
+        }
+
+        var parameterLabel: String {
+            switch self {
+            case let .plugin(_, paramAlias): paramAlias
+            case let .channelEQ(bandName, parameterName): "\(bandName) \(parameterName)"
+            }
+        }
+    }
+
+    private struct ResolvedVerifiedParameter {
+        let pluginID: String
+        let paramKey: String
+        let paramAlias: String
+        let metadata: StockPluginParameterMetadata
+        let walkTarget: SliderIncrementWalk.Target?
+        let responseDisplayUnit: String
+    }
+
+    private enum VerifiedParameterResolution {
+        case success(ResolvedVerifiedParameter)
+        case failure(String)
+    }
+
+    /// R6's single precedence implementation, shared by generic verified
+    /// parameters and named Channel EQ bands. The selector resolution belongs at
+    /// step 4, after mode/path/target-reference gates, so the two public
+    /// operations cannot drift into different precedence rules.
+    private static func defaultVerifiedParameterWrite(
+        operation: String,
+        params: [String: String],
+        selector: VerifiedParameterSelector,
+        runtime: AXLogicProElements.Runtime,
+        frontDocumentPath: FrontDocumentPathProvider,
+        entryLookup: VerifiedPluginCatalog.EntryLookup,
+        paramAliasLookup: VerifiedPluginCatalog.ParamAliasLookup,
+        pluginWindowOpener: PluginWindowOpener,
+        incrementWalkBudget: Int
+    ) async -> ChannelResult {
 
         // Step 1 — schema / params (presence, type, range, unit).
         guard let trackRaw = params["track"], let track = Int(trackRaw), track >= 0 else {
@@ -528,13 +625,21 @@ extension AccessibilityChannel {
         guard let insertRaw = params["insert"], let insert = Int(insertRaw), insert >= 0 else {
             return .error(invalidParamsStateC(operation, "missing or invalid 'insert' (Int >= 0)"))
         }
-        let pluginAlias = params["plugin"] ?? ""
-        guard !pluginAlias.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            return .error(invalidParamsStateC(operation, "missing 'plugin' identity"))
-        }
-        let paramAlias = params["param"] ?? ""
-        guard !paramAlias.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            return .error(invalidParamsStateC(operation, "missing 'param' key"))
+        switch selector {
+        case let .plugin(pluginAlias, paramAlias):
+            guard !pluginAlias.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                return .error(invalidParamsStateC(operation, "missing 'plugin' identity"))
+            }
+            guard !paramAlias.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                return .error(invalidParamsStateC(operation, "missing 'param' key"))
+            }
+        case let .channelEQ(bandName, parameterName):
+            guard !bandName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                return .error(invalidParamsStateC(operation, "missing Channel EQ 'band' name"))
+            }
+            guard !parameterName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                return .error(invalidParamsStateC(operation, "missing Channel EQ 'parameter' name"))
+            }
         }
         guard let valueRaw = params["value"], let value = Double(valueRaw), value.isFinite else {
             return .error(invalidParamsStateC(operation, "missing or non-finite 'value'"))
@@ -542,10 +647,8 @@ extension AccessibilityChannel {
         let unit = params["unit"]
         let mode = params["mode"] ?? ""
 
-        let preResolutionIdentity: [String: Any] = [
-            "track_index": track,
-            "plugin_id_requested": pluginAlias,
-        ]
+        var preResolutionIdentity = selector.preResolutionIdentity
+        preResolutionIdentity["track_index"] = track
 
         // Steps 2-3 — mode + project path gate (precedence: path-mismatch wins
         // over a later unsupported-param, AC23).
@@ -577,80 +680,181 @@ extension AccessibilityChannel {
             return guardResult
         }
 
-        // Step 4 — identity alias resolution (canonical id needed for step 5).
-        guard let pluginID = VerifiedPluginCatalog.canonicalPluginID(from: pluginAlias) else {
-            return .error(HonestContract.encodeV2StateC(
-                error: .unknownPluginIdentity,
-                extras: [
-                    "operation": operation,
-                    "target_identity": preResolutionIdentity,
-                    "what_was_attempted": "resolve plugin identity '\(pluginAlias)' to a canonical catalog id",
-                    "what_was_observed": "no alias mapping to a logic.stock.* id",
-                    "safe_to_retry": false,
-                    "write_attempted": false,
-                ]
-            ))
-        }
-        let paramKey = VerifiedPluginCatalog.canonicalParamKey(
-            pluginID: pluginID,
-            alias: paramAlias,
-            paramAliasLookup: paramAliasLookup
-        ) ?? paramAlias.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-
-        // Unit honesty (R8): a caller unit that disagrees with the declared
-        // canonical unit is invalid_params.
-        if let unit,
-           let expectedUnit = VerifiedPluginCatalog.paramUnit(pluginID: pluginID, paramKey: paramKey, entryLookup: entryLookup),
-           unit.caseInsensitiveCompare(expectedUnit) != .orderedSame {
-            return .error(invalidParamsStateC(
-                operation,
-                "unit '\(unit)' does not match the declared unit '\(expectedUnit)' for \(pluginID).\(paramAlias)"
-            ))
-        }
-        // Range validation (R6 step 1) against the declared display range.
-        if let range = VerifiedPluginCatalog.paramRange(pluginID: pluginID, paramKey: paramKey, entryLookup: entryLookup),
-           value < range.min || value > range.max {
-            return .error(invalidParamsStateC(
-                operation,
-                "value \(value) is outside the valid range [\(range.min), \(range.max)] for \(pluginID).\(paramAlias)"
-            ))
-        }
-
-        // Step 5 — capability preflight. Only `.writeReadback` (Compressor
-        // threshold, T0 spike) proceeds to the live write; every other parameter
-        // has no write/readback method and fail-closes BEFORE any write (AC10).
-        let capability = VerifiedPluginCatalog.paramCapability(pluginID: pluginID, paramKey: paramKey, entryLookup: entryLookup)
-        switch capability {
-        case .unknownParameter, .unsupported:
-            return .error(HonestContract.encodeV2StateC(
-                error: .unsupportedParamReadback,
-                extras: [
-                    "operation": operation,
-                    "target_identity": resolvedIdentity(track: track, insert: insert, pluginID: pluginID),
-                    "param": paramAlias,
-                    "what_was_attempted": "preflight write/readback capability for \(pluginID).\(paramAlias)",
-                    "what_was_observed": capability == .unknownParameter
-                        ? "parameter is not in the verified allowlist"
-                        : "no display-readback parser / write method is available for this parameter",
-                    "safe_to_retry": false,
-                    "write_attempted": false,
-                ]
-            ))
-        case .writeReadback:
-            // Steps 6-13 — the live AX write/readback round-trip.
+        // Steps 4-5 — selector resolution, unit/range honesty, and capability
+        // preflight. This remains before any track/window AX mutation.
+        switch resolveVerifiedParameter(
+            selector: selector,
+            requested: value,
+            unit: unit,
+            operation: operation,
+            track: track,
+            insert: insert,
+            entryLookup: entryLookup,
+            paramAliasLookup: paramAliasLookup,
+            preResolutionIdentity: preResolutionIdentity
+        ) {
+        case let .failure(error):
+            return .error(error)
+        case let .success(target):
             return await performVerifiedParamWrite(
                 operation: operation,
                 track: track,
                 insert: insert,
-                pluginID: pluginID,
-                paramKey: paramKey,
-                paramAlias: paramAlias,
+                pluginID: target.pluginID,
+                paramKey: target.paramKey,
+                paramAlias: target.paramAlias,
                 requested: value,
+                writeMethod: target.metadata.writeMethod ?? "",
+                walkTarget: target.walkTarget,
+                responseDisplayUnit: target.responseDisplayUnit,
                 runtime: runtime,
                 entryLookup: entryLookup,
-                pluginWindowOpener: pluginWindowOpener
+                pluginWindowOpener: pluginWindowOpener,
+                incrementWalkBudget: incrementWalkBudget
             )
         }
+    }
+
+    private static func resolveVerifiedParameter(
+        selector: VerifiedParameterSelector,
+        requested: Double,
+        unit: String?,
+        operation: String,
+        track: Int,
+        insert: Int,
+        entryLookup: VerifiedPluginCatalog.EntryLookup,
+        paramAliasLookup: VerifiedPluginCatalog.ParamAliasLookup,
+        preResolutionIdentity: [String: Any]
+    ) -> VerifiedParameterResolution {
+        let pluginID: String
+        let paramKey: String
+        let paramAlias = selector.parameterLabel
+        switch selector {
+        case let .plugin(pluginAlias, suppliedParamAlias):
+            guard let resolved = VerifiedPluginCatalog.canonicalPluginID(from: pluginAlias) else {
+                return .failure(HonestContract.encodeV2StateC(
+                    error: .unknownPluginIdentity,
+                    extras: [
+                        "operation": operation,
+                        "target_identity": preResolutionIdentity,
+                        "what_was_attempted": "resolve plugin identity '\(pluginAlias)' to a canonical catalog id",
+                        "what_was_observed": "no alias mapping to a logic.stock.* id",
+                        "safe_to_retry": false,
+                        "write_attempted": false,
+                    ]
+                ))
+            }
+            pluginID = resolved
+            paramKey = VerifiedPluginCatalog.canonicalParamKey(
+                pluginID: pluginID,
+                alias: suppliedParamAlias,
+                paramAliasLookup: paramAliasLookup
+            ) ?? suppliedParamAlias.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        case let .channelEQ(bandName, parameterName):
+            guard let catalogParameter = ChannelEQBandCatalog.parameter(
+                bandName: bandName,
+                parameterName: parameterName
+            ) else {
+                return .failure(invalidParamsStateC(
+                    operation,
+                    "unknown Channel EQ band/parameter name '\(bandName)' / '\(parameterName)'"
+                ))
+            }
+            pluginID = "logic.stock.effect.channel_eq"
+            paramKey = catalogParameter.id
+        }
+
+        let identity = resolvedIdentity(track: track, insert: insert, pluginID: pluginID)
+        guard let metadata = entryLookup(pluginID)?.parameters.first(where: { $0.id == paramKey }) else {
+            return .failure(HonestContract.encodeV2StateC(
+                error: .unsupportedParamReadback,
+                extras: [
+                    "operation": operation,
+                    "target_identity": identity,
+                    "param": paramAlias,
+                    "what_was_attempted": "preflight write/readback capability for \(pluginID).\(paramAlias)",
+                    "what_was_observed": "parameter is not in the verified allowlist",
+                    "safe_to_retry": false,
+                    "write_attempted": false,
+                ]
+            ))
+        }
+
+        let declaredUnits = metadata.acceptedUnits ?? metadata.unit.map { [$0] } ?? []
+        let normalizedUnit = unit?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if case .channelEQ = selector, normalizedUnit?.isEmpty ?? true {
+            return .failure(invalidParamsStateC(
+                operation,
+                "Channel EQ requires a declared 'unit' for \(paramAlias)"
+            ))
+        }
+        let effectiveUnit = normalizedUnit?.isEmpty == false ? normalizedUnit! : metadata.unit
+        guard let effectiveUnit,
+              declaredUnits.contains(where: { $0.caseInsensitiveCompare(effectiveUnit) == .orderedSame }) else {
+            let declared = declaredUnits.joined(separator: ", ")
+            return .failure(invalidParamsStateC(
+                operation,
+                "unit '\(unit ?? "")' is not declared for \(pluginID).\(paramAlias); declared units: \(declared)"
+            ))
+        }
+
+        let isIncrementWalk = metadata.writeMethod == "ax_slider_increment_walk"
+        let rawUnit = metadata.unit
+        let isRawRequest = rawUnit.map {
+            $0.caseInsensitiveCompare(effectiveUnit) == .orderedSame
+        } ?? false
+        if !isIncrementWalk || isRawRequest,
+           let range = metadata.valueRange,
+           requested < range.min || requested > range.max {
+            return .failure(invalidParamsStateC(
+                operation,
+                "value \(requested) is outside the valid range [\(range.min), \(range.max)] for \(pluginID).\(paramAlias)"
+            ))
+        }
+
+        let hasWrite = !(metadata.writeMethod?.isEmpty ?? true)
+        let hasReadback = !(metadata.readbackMethod?.isEmpty ?? true)
+        guard hasWrite, hasReadback else {
+            return .failure(HonestContract.encodeV2StateC(
+                error: .unsupportedParamReadback,
+                extras: [
+                    "operation": operation,
+                    "target_identity": identity,
+                    "param": paramAlias,
+                    "what_was_attempted": "preflight write/readback capability for \(pluginID).\(paramAlias)",
+                    "what_was_observed": "no display-readback parser / write method is available for this parameter",
+                    "safe_to_retry": false,
+                    "write_attempted": false,
+                ]
+            ))
+        }
+
+        let walkTarget: SliderIncrementWalk.Target?
+        if isIncrementWalk {
+            if isRawRequest {
+                walkTarget = .rawValue(requested, tolerance: metadata.tolerance ?? 0)
+            } else {
+                // This is formatting only, not a display-to-raw conversion. The
+                // walk stops only when Logic reports this exact description.
+                let displayValue = displayTargetValueText(requested)
+                let signedValue = effectiveUnit.caseInsensitiveCompare("dB") == .orderedSame
+                    && requested > 0
+                    ? "+\(displayValue)"
+                    : displayValue
+                walkTarget = .display("\(signedValue) \(effectiveUnit)")
+            }
+        } else {
+            walkTarget = nil
+        }
+
+        return .success(ResolvedVerifiedParameter(
+            pluginID: pluginID,
+            paramKey: paramKey,
+            paramAlias: paramAlias,
+            metadata: metadata,
+            walkTarget: walkTarget,
+            responseDisplayUnit: metadata.unit == "normalized" ? "%" : effectiveUnit
+        ))
     }
 
     /// ADR-002 F1 — live track-identity cross-check for `target_ref`-resolved
@@ -744,9 +948,13 @@ extension AccessibilityChannel {
         paramKey: String,
         paramAlias: String,
         requested: Double,
+        writeMethod: String,
+        walkTarget: SliderIncrementWalk.Target?,
+        responseDisplayUnit: String,
         runtime: AXLogicProElements.Runtime,
         entryLookup: VerifiedPluginCatalog.EntryLookup,
-        pluginWindowOpener: PluginWindowOpener
+        pluginWindowOpener: PluginWindowOpener,
+        incrementWalkBudget: Int
     ) async -> ChannelResult {
         let identity = resolvedIdentity(track: track, insert: insert, pluginID: pluginID)
         guard let axDescription = VerifiedPluginCatalog.paramAXDescription(
@@ -1016,99 +1224,311 @@ extension AccessibilityChannel {
             ))
         }
 
-        // Step 11 — set AXValue (the actual write).
-        guard AXValueExtractors.setSliderValue(slider, requested, runtime: runtime.ax) else {
+        // Step 11 — choose the declared AX write method. Compressor threshold
+        // remains a single AXValue assignment; Channel EQ's measured controls
+        // require readback-driven AXValue nudges.
+        switch writeMethod {
+        case "ax_slider_axvalue":
+            guard AXValueExtractors.setSliderValue(slider, requested, runtime: runtime.ax) else {
+                return .error(HonestContract.encodeV2StateC(
+                    error: .axWriteFailed,
+                    extras: [
+                        "operation": operation,
+                        "target_identity": identity,
+                        "param": paramAlias,
+                        "requested_normalized": requested,
+                        "what_was_attempted": "set AXValue \(requested) on the '\(axDescription)' slider",
+                        "what_was_observed": "the AX value write was rejected",
+                        "safe_to_retry": true,
+                        "write_attempted": true,
+                    ]
+                ))
+            }
+
+            // Step 12 — read the after value (+ value description). A write
+            // that cannot be read back is uncertain, not confirmed — fail closed.
+            guard let after = AXValueExtractors.extractSliderValue(slider, runtime: runtime.ax) else {
+                return .error(HonestContract.encodeV2StateC(
+                    error: .readbackLostAfterWrite,
+                    extras: [
+                        "operation": operation,
+                        "target_identity": identity,
+                        "param": paramAlias,
+                        "requested_normalized": requested,
+                        "what_was_attempted": "read back the '\(axDescription)' slider value after writing",
+                        "what_was_observed": "the slider value could not be read after the write",
+                        "safe_to_retry": true,
+                        "write_attempted": true,
+                    ]
+                ))
+            }
+            let observedDisplay = AXValueExtractors.extractValueDescription(slider, runtime: runtime.ax)
+
+            // Step 13 — tolerance gate.
+            if abs(after - requested) <= tolerance {
+                return .success(HonestContract.encodeV2StateA(extras: [
+                    "operation": operation,
+                    "target_identity": identity,
+                    "param": paramAlias,
+                    "requested_normalized": requested,
+                    "observed_normalized": after,
+                    "observed_display": observedDisplay ?? NSNull(),
+                    "display_unit": responseDisplayUnit,
+                    "tolerance": tolerance,
+                    "write_source": "ax_plugin_window",
+                    "verify_source": "ax_plugin_window",
+                ]))
+            }
+
+            // Mismatch — roll back to the before value (re-set + re-read) so a
+            // failed verified write does not leave the parameter changed.
+            let rollback = rollbackSliderValue(
+                slider,
+                to: before,
+                writeMethod: writeMethod,
+                runtime: runtime.ax
+            )
             return .error(HonestContract.encodeV2StateC(
-                error: .axWriteFailed,
+                error: .readbackMismatch,
                 extras: [
                     "operation": operation,
                     "target_identity": identity,
                     "param": paramAlias,
                     "requested_normalized": requested,
-                    "what_was_attempted": "set AXValue \(requested) on the '\(axDescription)' slider",
-                    "what_was_observed": "the AX value write was rejected",
-                    "safe_to_retry": true,
+                    "observed_normalized": after,
+                    "observed_display": observedDisplay ?? NSNull(),
+                    "display_unit": responseDisplayUnit,
+                    "tolerance": tolerance,
+                    "rollback_attempted": rollback.attempted,
+                    "rollback_succeeded": rollback.succeeded,
+                    "rollback_outcome": rollback.walkOutcome ?? NSNull(),
+                    "rollback_to": before ?? NSNull(),
+                    "what_was_attempted": "verify the '\(axDescription)' write within tolerance \(tolerance)",
+                    "what_was_observed": "observed \(after) differs from requested \(requested) beyond tolerance",
+                    "safe_to_retry": false,
                     "write_attempted": true,
                 ]
             ))
-        }
 
-        // Step 12 — read the after value (+ value description). A write that
-        // cannot be read back is uncertain, not confirmed — fail closed.
-        guard let after = AXValueExtractors.extractSliderValue(slider, runtime: runtime.ax) else {
-            return .error(HonestContract.encodeV2StateC(
-                error: .readbackLostAfterWrite,
-                extras: [
+        case "ax_slider_increment_walk":
+            guard let walkTarget else {
+                return .error(HonestContract.encodeV2StateC(
+                    error: .unsupportedParamReadback,
+                    extras: [
+                        "operation": operation,
+                        "target_identity": identity,
+                        "param": paramAlias,
+                        "what_was_attempted": "select the declared increment-walk target for '\(axDescription)'",
+                        "what_was_observed": "the parameter declares ax_slider_increment_walk without a raw or display target",
+                        "safe_to_retry": false,
+                        "write_attempted": false,
+                    ]
+                ))
+            }
+            let needsDisplay: Bool
+            if case .display(_) = walkTarget {
+                needsDisplay = true
+            } else {
+                needsDisplay = false
+            }
+            let outcome = SliderIncrementWalk.walk(
+                to: walkTarget,
+                read: {
+                    guard let value = AXValueExtractors.extractSliderValue(slider, runtime: runtime.ax) else {
+                        return nil
+                    }
+                    let display = AXValueExtractors.extractValueDescription(slider, runtime: runtime.ax)
+                    guard !needsDisplay || display != nil else { return nil }
+                    return SliderIncrementWalk.Reading(value: value, display: display ?? "")
+                },
+                nudge: { rawTarget in
+                    AXValueExtractors.setSliderValue(slider, rawTarget, runtime: runtime.ax)
+                },
+                budget: incrementWalkBudget
+            )
+            switch outcome {
+            case let .arrived(steps, final):
+                var extras: [String: Any] = [
                     "operation": operation,
                     "target_identity": identity,
                     "param": paramAlias,
                     "requested_normalized": requested,
-                    "what_was_attempted": "read back the '\(axDescription)' slider value after writing",
-                    "what_was_observed": "the slider value could not be read after the write",
-                    "safe_to_retry": true,
-                    "write_attempted": true,
+                    "observed_normalized": final.value,
+                    "observed_display": final.display,
+                    "display_unit": responseDisplayUnit,
+                    "walk_steps": steps,
+                    "write_source": "ax_plugin_window",
+                    "verify_source": "ax_plugin_window",
+                ]
+                if case let .display(targetDisplay) = walkTarget {
+                    extras["requested_display"] = targetDisplay
+                } else {
+                    extras["tolerance"] = tolerance
+                }
+                return .success(HonestContract.encodeV2StateA(extras: extras))
+            case .noProgress(_, _), .budgetExhausted(_, _), .overshot(_, _), .readbackLost(_):
+                let rollback = rollbackSliderValue(
+                    slider,
+                    to: before,
+                    writeMethod: writeMethod,
+                    runtime: runtime.ax,
+                    incrementWalkBudget: incrementWalkBudget
+                )
+                return .error(incrementWalkFailureStateC(
+                    operation: operation,
+                    identity: identity,
+                    paramAlias: paramAlias,
+                    requested: requested,
+                    axDescription: axDescription,
+                    outcome: outcome,
+                    rollback: rollback,
+                    before: before
+                ))
+            }
+
+        default:
+            return .error(HonestContract.encodeV2StateC(
+                error: .unsupportedParamReadback,
+                extras: [
+                    "operation": operation,
+                    "target_identity": identity,
+                    "param": paramAlias,
+                    "what_was_attempted": "select the declared write method for '\(axDescription)'",
+                    "what_was_observed": "unsupported write method '\(writeMethod)'",
+                    "safe_to_retry": false,
+                    "write_attempted": false,
                 ]
             ))
         }
-        let observedDisplay = AXValueExtractors.extractValueDescription(slider, runtime: runtime.ax)
-
-        // Step 13 — tolerance gate.
-        if abs(after - requested) <= tolerance {
-            return .success(HonestContract.encodeV2StateA(extras: [
-                "operation": operation,
-                "target_identity": identity,
-                "param": paramAlias,
-                "requested_normalized": requested,
-                "observed_normalized": after,
-                "observed_display": observedDisplay ?? NSNull(),
-                "display_unit": "%",
-                "tolerance": tolerance,
-                "write_source": "ax_plugin_window",
-                "verify_source": "ax_plugin_window",
-            ]))
-        }
-
-        // Mismatch — roll back to the before value (re-set + re-read) so a failed
-        // verified write does not leave the parameter changed.
-        let rollback = rollbackSliderValue(slider, to: before, runtime: runtime.ax)
-        return .error(HonestContract.encodeV2StateC(
-            error: .readbackMismatch,
-            extras: [
-                "operation": operation,
-                "target_identity": identity,
-                "param": paramAlias,
-                "requested_normalized": requested,
-                "observed_normalized": after,
-                "observed_display": observedDisplay ?? NSNull(),
-                "display_unit": "%",
-                "tolerance": tolerance,
-                "rollback_attempted": rollback.attempted,
-                "rollback_succeeded": rollback.succeeded,
-                "rollback_to": before ?? NSNull(),
-                "what_was_attempted": "verify the '\(axDescription)' write within tolerance \(tolerance)",
-                "what_was_observed": "observed \(after) differs from requested \(requested) beyond tolerance",
-                "safe_to_retry": false,
-                "write_attempted": true,
-            ]
-        ))
     }
 
-    /// Roll a slider back to its pre-write value (re-set then re-read to confirm).
-    /// Returns whether a rollback was attempted (only when a before value exists)
-    /// and whether the re-read confirms it landed within a tight epsilon.
+    private struct SliderRollback {
+        let attempted: Bool
+        let succeeded: Bool
+        let walkOutcome: String?
+    }
+
+    /// Roll a slider back to its pre-write value. A slider that required an
+    /// increment walk for the forward write gets the same walk for rollback;
+    /// using one AXValue set there would only leave it one step closer.
     private static func rollbackSliderValue(
         _ slider: AXUIElement,
         to before: Double?,
-        runtime: AXHelpers.Runtime
-    ) -> (attempted: Bool, succeeded: Bool) {
-        guard let before else { return (false, false) }
-        guard AXValueExtractors.setSliderValue(slider, before, runtime: runtime) else {
-            return (true, false)
+        writeMethod: String,
+        runtime: AXHelpers.Runtime,
+        incrementWalkBudget: Int = ChannelEQBandCatalog.incrementWalkBudget
+    ) -> SliderRollback {
+        guard let before else { return SliderRollback(attempted: false, succeeded: false, walkOutcome: nil) }
+        switch writeMethod {
+        case "ax_slider_increment_walk":
+            let outcome = SliderIncrementWalk.walk(
+                to: .rawValue(before, tolerance: 0),
+                read: {
+                    AXValueExtractors.extractSliderValue(slider, runtime: runtime).map {
+                        SliderIncrementWalk.Reading(value: $0, display: "")
+                    }
+                },
+                nudge: { rawTarget in
+                    AXValueExtractors.setSliderValue(slider, rawTarget, runtime: runtime)
+                },
+                budget: incrementWalkBudget
+            )
+            if case .arrived(_, _) = outcome {
+                return SliderRollback(attempted: true, succeeded: true, walkOutcome: "arrived")
+            }
+            return SliderRollback(
+                attempted: true,
+                succeeded: false,
+                walkOutcome: incrementWalkOutcomeName(outcome)
+            )
+        default:
+            guard AXValueExtractors.setSliderValue(slider, before, runtime: runtime) else {
+                return SliderRollback(attempted: true, succeeded: false, walkOutcome: nil)
+            }
+            guard let restored = AXValueExtractors.extractSliderValue(slider, runtime: runtime) else {
+                return SliderRollback(attempted: true, succeeded: false, walkOutcome: nil)
+            }
+            return SliderRollback(
+                attempted: true,
+                succeeded: abs(restored - before) <= 0.5,
+                walkOutcome: nil
+            )
         }
-        guard let restored = AXValueExtractors.extractSliderValue(slider, runtime: runtime) else {
-            return (true, false)
+    }
+
+    private static func incrementWalkFailureStateC(
+        operation: String,
+        identity: [String: Any],
+        paramAlias: String,
+        requested: Double,
+        axDescription: String,
+        outcome: SliderIncrementWalk.WalkOutcome,
+        rollback: SliderRollback,
+        before: Double?
+    ) -> String {
+        let error: HonestContract.FailureError
+        var extras: [String: Any] = [
+            "operation": operation,
+            "target_identity": identity,
+            "param": paramAlias,
+            "requested_normalized": requested,
+            "walk_outcome": incrementWalkOutcomeName(outcome),
+            "rollback_attempted": rollback.attempted,
+            "rollback_succeeded": rollback.succeeded,
+            "rollback_outcome": rollback.walkOutcome ?? NSNull(),
+            "rollback_to": before ?? NSNull(),
+            "what_was_attempted": "walk the '\(axDescription)' slider to its requested value",
+            "safe_to_retry": false,
+            "write_attempted": true,
+        ]
+        switch outcome {
+        case let .noProgress(steps, last):
+            error = .incrementWalkNoProgress
+            extras["walk_steps"] = steps
+            extras["last_observed_normalized"] = last.value
+            extras["last_observed_display"] = last.display
+            extras["what_was_observed"] = "the slider made no reliable progress toward the requested target"
+        case let .budgetExhausted(steps, last):
+            error = .incrementWalkBudgetExhausted
+            extras["walk_steps"] = steps
+            extras["last_observed_normalized"] = last.value
+            extras["last_observed_display"] = last.display
+            extras["what_was_observed"] = "the bounded slider walk exhausted its accepted-write budget"
+        case let .overshot(steps, last):
+            error = .incrementWalkOvershot
+            extras["walk_steps"] = steps
+            extras["last_observed_normalized"] = last.value
+            extras["last_observed_display"] = last.display
+            extras["what_was_observed"] = "the slider crossed the target then moved farther away on the same side"
+        case let .readbackLost(steps):
+            error = .readbackLostAfterWrite
+            extras["walk_steps"] = steps
+            extras["what_was_observed"] = "the slider readback was unavailable during the increment walk"
+        case .arrived(_, _):
+            fatalError("arrived must not be encoded as an increment-walk failure")
         }
-        return (true, abs(restored - before) <= 0.5)
+        return HonestContract.encodeV2StateC(error: error, extras: extras)
+    }
+
+    private static func incrementWalkOutcomeName(_ outcome: SliderIncrementWalk.WalkOutcome) -> String {
+        switch outcome {
+        case .arrived(_, _): "arrived"
+        case .noProgress(_, _): "noProgress"
+        case .budgetExhausted(_, _): "budgetExhausted"
+        case .overshot(_, _): "overshot"
+        case .readbackLost(_): "readbackLost"
+        }
+    }
+
+    /// Formats a caller's engineering value for the exact string comparison
+    /// against Logic's `AXValueDescription`. This normalizes only numeric text
+    /// (`100.0` → `100`); it does not derive or imply a raw slider position.
+    private static func displayTargetValueText(_ value: Double) -> String {
+        if value.rounded() == value,
+           value >= Double(Int.min), value <= Double(Int.max) {
+            return String(Int(value))
+        }
+        return String(value)
     }
 
     private static func trackSelectionFailedStateC(_ operation: String, _ identity: [String: Any], _ detail: String) -> String {

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -413,13 +413,19 @@ extension AccessibilityChannel {
     enum PluginPopupMenuCleanupOutcome: Sendable, Equatable {
         case noPopupObserved
         case dismissed
+        /// CoreGraphics did not provide a popup-window count. This is not
+        /// evidence that no popup exists, so the acquisition must not continue
+        /// as if the screen were known clean.
+        case popupCountUnavailable
         case couldNotDismiss(initialPopupCount: Int, remainingPopupCount: Int)
 
         var isClean: Bool {
-            if case .couldNotDismiss = self {
+            switch self {
+            case .noPopupObserved, .dismissed:
+                return true
+            case .popupCountUnavailable, .couldNotDismiss:
                 return false
             }
-            return true
         }
     }
 
@@ -520,7 +526,9 @@ extension AccessibilityChannel {
     ///      with `unsupported_param_readback` (AC10); only `.writeReadback`
     ///      proceeds.
     ///   6  track verified select (`track_selection_failed`)
-    ///   7  inventory complete + occupied at `insert` (`incomplete_inventory`)
+    ///   7  inventory complete + occupied, identity-matched, and unambiguous at
+    ///      `insert` (`incomplete_inventory` / `target_plugin_mismatch` /
+    ///      `ambiguous_plugin_instance`)
     ///   8  plugin window: resolve one candidate, then acquire it through the
     ///      target slot (`window_open_failed` / `window_identity_unresolved`)
     ///   9  slider match by AXDescription (`param_control_not_found`)
@@ -819,9 +827,15 @@ extension AccessibilityChannel {
                 "Channel EQ requires a declared 'unit' for \(paramAlias)"
             ))
         }
-        let effectiveUnit = normalizedUnit?.isEmpty == false ? normalizedUnit! : metadata.unit
-        guard let effectiveUnit,
-              declaredUnits.contains(where: { $0.caseInsensitiveCompare(effectiveUnit) == .orderedSame }) else {
+        let requestedUnit = normalizedUnit?.isEmpty == false ? normalizedUnit! : metadata.unit
+        // Validate case-insensitively, then keep the catalog spelling. The
+        // increment walk compares Logic's display rendering exactly, so an
+        // accepted caller `db` must target Logic's declared `dB`, never reuse
+        // the caller's casing verbatim.
+        guard let requestedUnit,
+              let effectiveUnit = declaredUnits.first(where: {
+                  $0.caseInsensitiveCompare(requestedUnit) == .orderedSame
+              }) else {
             let declared = declaredUnits.joined(separator: ", ")
             return .failure(invalidParamsStateC(
                 operation,
@@ -1090,6 +1104,39 @@ extension AccessibilityChannel {
                     "what_was_observed": observedPluginName.map {
                         "insert \(insert) contains '\($0)'"
                     } ?? "insert \(insert) plugin name was unreadable",
+                    "safe_to_retry": false,
+                    "write_attempted": false,
+                ]
+            ))
+        }
+
+        let conflictingInsertIndices = slots.compactMap { slot -> Int? in
+            guard slot.occupied,
+                  slot.readStatus == .occupiedReadable,
+                  let name = slot.name,
+                  VerifiedPluginCatalog.pluginID(forObservedName: name) == pluginID else {
+                return nil
+            }
+            return slot.index
+        }
+        guard conflictingInsertIndices.count <= 1 else {
+            // #726 measured on a real project: Absolute Zero had Compressor at
+            // inserts 0 and 2. set_param_verified for insert 0 = 40 and insert
+            // 2 = 70 both returned State A with their requested insert
+            // identities, yet readback was slot 0 Threshold = 0 % (both writes)
+            // and slot 1 Threshold = 56 % (never touched). The window match
+            // uses track name plus slider AXDescription, neither of which binds
+            // an editor to an insert. Refuse before any window is opened or
+            // pressed rather than guessing which identical instance is visible.
+            return .error(HonestContract.encodeV2StateC(
+                error: .ambiguousPluginInstance,
+                extras: [
+                    "operation": operation,
+                    "target_identity": identity,
+                    "requested_plugin_id": pluginID,
+                    "conflicting_insert_indices": conflictingInsertIndices,
+                    "what_was_attempted": "uniquely identify \(pluginID) at insert \(insert) before opening its window",
+                    "what_was_observed": "\(pluginID) appears at inserts \(conflictingInsertIndices.map(String.init).joined(separator: ", ")) on track \(track)",
                     "safe_to_retry": false,
                     "write_attempted": false,
                 ]
@@ -1824,6 +1871,11 @@ extension AccessibilityChannel {
         switch outcome {
         case .noPopupObserved, .dismissed:
             return [:]
+        case .popupCountUnavailable:
+            return [
+                "plugin_popup_menu_state": "window_count_unavailable",
+                "recovery_hint": "Logic popup-menu state could not be read after plugin-window acquisition. Dismiss any visible popup with Escape before retrying.",
+            ]
         case let .couldNotDismiss(initialPopupCount, remainingPopupCount):
             return [
                 "plugin_popup_menu_state": "could_not_be_dismissed",
@@ -1842,8 +1894,10 @@ extension AccessibilityChannel {
     private static func dismissLogicPopupMenuAfterPluginWindowAcquisition(
         runtime: AXLogicProElements.Runtime
     ) -> PluginPopupMenuCleanupOutcome {
-        guard let initialPopupCount = logicOwnedPopupMenuWindowCount(runtime: runtime),
-              initialPopupCount > 0 else {
+        guard let initialPopupCount = logicOwnedPopupMenuWindowCount(runtime: runtime) else {
+            return .popupCountUnavailable
+        }
+        guard initialPopupCount > 0 else {
             return .noPopupObserved
         }
 
@@ -1855,10 +1909,7 @@ extension AccessibilityChannel {
 
         for attempt in 0..<3 {
             guard let remainingPopupCount = logicOwnedPopupMenuWindowCount(runtime: runtime) else {
-                return .couldNotDismiss(
-                    initialPopupCount: initialPopupCount,
-                    remainingPopupCount: initialPopupCount
-                )
+                return .popupCountUnavailable
             }
             if remainingPopupCount == 0 {
                 return .dismissed
@@ -1867,7 +1918,9 @@ extension AccessibilityChannel {
                 Thread.sleep(forTimeInterval: 0.05)
             }
         }
-        let remainingPopupCount = logicOwnedPopupMenuWindowCount(runtime: runtime) ?? initialPopupCount
+        guard let remainingPopupCount = logicOwnedPopupMenuWindowCount(runtime: runtime) else {
+            return .popupCountUnavailable
+        }
         return .couldNotDismiss(
             initialPopupCount: initialPopupCount,
             remainingPopupCount: remainingPopupCount

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -401,6 +401,7 @@ extension AccessibilityChannel {
 
     typealias PluginWindowOpener = @Sendable (
         _ targetSlot: AXUIElementSendable,
+        _ pluginID: String,
         _ trackName: String,
         _ axDescription: String,
         _ runtime: AXLogicProElements.Runtime
@@ -433,16 +434,17 @@ extension AccessibilityChannel {
         _ runtime: AXLogicProElements.Runtime
     ) -> PluginPopupMenuCleanupOutcome
 
-    static let livePluginWindowOpener: PluginWindowOpener = { targetSlot, trackName, axDescription, runtime in
+    static let livePluginWindowOpener: PluginWindowOpener = { targetSlot, pluginID, trackName, axDescription, runtime in
         await openPluginWindowFromTargetSlot(
             targetSlot.element,
+            pluginID: pluginID,
             trackName: trackName,
             axDescription: axDescription,
             runtime: runtime
         )
     }
 
-    static let liveNoOpPluginWindowOpener: PluginWindowOpener = { _, _, _, _ in nil }
+    static let liveNoOpPluginWindowOpener: PluginWindowOpener = { _, _, _, _, _ in nil }
 
     static let livePluginPopupMenuCleaner: PluginPopupMenuCleaner = { runtime in
         dismissLogicPopupMenuAfterPluginWindowAcquisition(runtime: runtime)
@@ -1150,6 +1152,7 @@ extension AccessibilityChannel {
         }
         switch AXLogicProElements.pluginWindowMatch(
             forTrackName: trackName,
+            matchingPluginID: pluginID,
             matchingSliderDescription: axDescription,
             runtime: runtime
         ) {
@@ -1167,15 +1170,40 @@ extension AccessibilityChannel {
                 "more than one plugin-editor window exposes the requested track and parameter identity",
                 diagnostics: diagnostics
             ))
+        case let .pluginIdentityMismatch(observedNames):
+            return .error(pluginWindowPluginMismatchStateC(
+                operation,
+                identity,
+                pluginID: pluginID,
+                observedNames: observedNames
+            ))
         case .none, .unique:
             break
         }
         guard let opened = await pluginWindowOpener(
             AXUIElementSendable(slots[insert].element),
+            pluginID,
             trackName,
             axDescription,
             runtime
         ) else {
+            // A polling attempt may have observed a same-track editor with the
+            // requested control but the wrong (or unreadable) header. Report
+            // that identity failure directly; a concurrent popup-cleanup issue
+            // must not hide the reason the editor was refused.
+            if case let .pluginIdentityMismatch(observedNames) = AXLogicProElements.pluginWindowMatch(
+                forTrackName: trackName,
+                matchingPluginID: pluginID,
+                matchingSliderDescription: axDescription,
+                runtime: runtime
+            ) {
+                return .error(pluginWindowPluginMismatchStateC(
+                    operation,
+                    identity,
+                    pluginID: pluginID,
+                    observedNames: observedNames
+                ))
+            }
             let popupCleanup = pluginPopupMenuCleaner(runtime)
             if !popupCleanup.isClean {
                 var diagnostics = pluginWindowAcquisitionDiagnostics(
@@ -1192,11 +1220,13 @@ extension AccessibilityChannel {
                     safeToRetry: false
                 ))
             }
-            if case .ambiguous = AXLogicProElements.pluginWindowMatch(
+            switch AXLogicProElements.pluginWindowMatch(
                 forTrackName: trackName,
+                matchingPluginID: pluginID,
                 matchingSliderDescription: axDescription,
                 runtime: runtime
             ) {
+            case .ambiguous:
                 var diagnostics = pluginWindowAcquisitionDiagnostics(
                     trackName: trackName,
                     axDescription: axDescription,
@@ -1209,6 +1239,15 @@ extension AccessibilityChannel {
                     "more than one plugin-editor window exposed the requested track and parameter identity after acquisition",
                     diagnostics: diagnostics
                 ))
+            case let .pluginIdentityMismatch(observedNames):
+                return .error(pluginWindowPluginMismatchStateC(
+                    operation,
+                    identity,
+                    pluginID: pluginID,
+                    observedNames: observedNames
+                ))
+            case .none, .unique:
+                break
             }
             return .error(windowOpenFailedStateC(
                 operation, identity,
@@ -1256,41 +1295,33 @@ extension AccessibilityChannel {
             ))
         }
 
-        guard case let .unique(currentWindow) = AXLogicProElements.pluginWindowMatch(
-            forTrackName: trackName,
-            matchingSliderDescription: axDescription,
+        if let failure = acquiredPluginWindowFailureStateC(
+            acquiredWindow: window,
+            operation: operation,
+            identity: identity,
+            pluginID: pluginID,
+            trackName: trackName,
+            axDescription: axDescription,
+            detail: "the acquired plugin window was no longer the unique matching window before the write",
             runtime: runtime
-        ), CFEqual(currentWindow, window) else {
-            return .error(windowIdentityUnresolvedStateC(
-                operation,
-                identity,
-                "the acquired plugin window was no longer the unique matching window before the write",
-                diagnostics: pluginWindowAcquisitionDiagnostics(
-                    trackName: trackName,
-                    axDescription: axDescription,
-                    runtime: runtime
-                )
-            ))
+        ) {
+            return .error(failure)
         }
 
         // Step 10 — read the before value (for rollback + provenance).
         let before = AXValueExtractors.extractSliderValue(slider, runtime: runtime.ax)
 
-        guard case let .unique(currentWindow) = AXLogicProElements.pluginWindowMatch(
-            forTrackName: trackName,
-            matchingSliderDescription: axDescription,
+        if let failure = acquiredPluginWindowFailureStateC(
+            acquiredWindow: window,
+            operation: operation,
+            identity: identity,
+            pluginID: pluginID,
+            trackName: trackName,
+            axDescription: axDescription,
+            detail: "the acquired plugin window was no longer the unique matching window immediately before the write",
             runtime: runtime
-        ), CFEqual(currentWindow, window) else {
-            return .error(windowIdentityUnresolvedStateC(
-                operation,
-                identity,
-                "the acquired plugin window was no longer the unique matching window immediately before the write",
-                diagnostics: pluginWindowAcquisitionDiagnostics(
-                    trackName: trackName,
-                    axDescription: axDescription,
-                    runtime: runtime
-                )
-            ))
+        ) {
+            return .error(failure)
         }
 
         guard targetPluginIdentityIsStable(
@@ -1307,21 +1338,17 @@ extension AccessibilityChannel {
             ))
         }
 
-        guard case let .unique(currentWindow) = AXLogicProElements.pluginWindowMatch(
-            forTrackName: trackName,
-            matchingSliderDescription: axDescription,
+        if let failure = acquiredPluginWindowFailureStateC(
+            acquiredWindow: window,
+            operation: operation,
+            identity: identity,
+            pluginID: pluginID,
+            trackName: trackName,
+            axDescription: axDescription,
+            detail: "the acquired plugin window was not unique after target-slot revalidation",
             runtime: runtime
-        ), CFEqual(currentWindow, window) else {
-            return .error(windowIdentityUnresolvedStateC(
-                operation,
-                identity,
-                "the acquired plugin window was not unique after target-slot revalidation",
-                diagnostics: pluginWindowAcquisitionDiagnostics(
-                    trackName: trackName,
-                    axDescription: axDescription,
-                    runtime: runtime
-                )
-            ))
+        ) {
+            return .error(failure)
         }
 
         guard let currentSlider = AXLogicProElements.pluginWindowSlider(
@@ -1714,18 +1741,90 @@ extension AccessibilityChannel {
         )
     }
 
+    private static func pluginWindowPluginMismatchStateC(
+        _ operation: String,
+        _ identity: [String: Any],
+        pluginID: String,
+        observedNames: [String]
+    ) -> String {
+        let observation: String
+        if observedNames.isEmpty {
+            observation = "the candidate plugin window exposed no readable direct AXStaticText values, so its plugin identity could not be verified"
+        } else {
+            observation = "the candidate plugin window's direct AXStaticText values were "
+                + observedNames.map { "'\($0)'" }.joined(separator: ", ")
+                + "; none mapped to requested plugin id '\(pluginID)'"
+        }
+        return HonestContract.encodeV2StateC(
+            error: .pluginWindowPluginMismatch,
+            extras: [
+                "operation": operation,
+                "target_identity": identity,
+                "requested_plugin_id": pluginID,
+                "observed_plugin_window_static_texts": observedNames,
+                "what_was_attempted": "verify the plugin-window header identifies \(pluginID) before writing",
+                "what_was_observed": observation,
+                "safe_to_retry": false,
+                "write_attempted": false,
+            ]
+        )
+    }
+
+    private static func acquiredPluginWindowFailureStateC(
+        acquiredWindow: AXUIElement,
+        operation: String,
+        identity: [String: Any],
+        pluginID: String,
+        trackName: String,
+        axDescription: String,
+        detail: String,
+        runtime: AXLogicProElements.Runtime
+    ) -> String? {
+        switch AXLogicProElements.pluginWindowMatch(
+            forTrackName: trackName,
+            matchingPluginID: pluginID,
+            matchingSliderDescription: axDescription,
+            runtime: runtime
+        ) {
+        case let .unique(currentWindow) where CFEqual(currentWindow, acquiredWindow):
+            return nil
+        case let .pluginIdentityMismatch(observedNames):
+            return pluginWindowPluginMismatchStateC(
+                operation,
+                identity,
+                pluginID: pluginID,
+                observedNames: observedNames
+            )
+        case .none, .ambiguous, .unique:
+            return windowIdentityUnresolvedStateC(
+                operation,
+                identity,
+                detail,
+                diagnostics: pluginWindowAcquisitionDiagnostics(
+                    trackName: trackName,
+                    axDescription: axDescription,
+                    runtime: runtime
+                )
+            )
+        }
+    }
+
     private static func openPluginWindowFromTargetSlot(
         _ targetSlot: AXUIElement,
+        pluginID: String,
         trackName: String,
         axDescription: String,
         runtime: AXLogicProElements.Runtime
     ) async -> AXUIElementSendable? {
         switch AXLogicProElements.pluginWindowMatch(
             forTrackName: trackName,
+            matchingPluginID: pluginID,
             matchingSliderDescription: axDescription,
             runtime: runtime
         ) {
         case .ambiguous:
+            return nil
+        case .pluginIdentityMismatch:
             return nil
         case let .unique(window):
             guard demotePluginWindowBeforeAcquisition(window, runtime: runtime) else {
@@ -1756,6 +1855,7 @@ extension AccessibilityChannel {
             // only advance to the next ranked control if the poll shows no window.
             _ = pressElement(element, runtime: runtime.ax)
             switch await pollOpenPluginWindow(
+                pluginID: pluginID,
                 trackName: trackName,
                 axDescription: axDescription,
                 runtime: runtime,
@@ -1767,6 +1867,8 @@ extension AccessibilityChannel {
                 }
                 return AXUIElementSendable(window)
             case .ambiguous:
+                return nil
+            case .pluginIdentityMismatch:
                 return nil
             case .none:
                 continue
@@ -1982,6 +2084,7 @@ extension AccessibilityChannel {
     }
 
     private static func pollOpenPluginWindow(
+        pluginID: String,
         trackName: String,
         axDescription: String,
         runtime: AXLogicProElements.Runtime,
@@ -1992,6 +2095,7 @@ extension AccessibilityChannel {
         repeat {
             switch AXLogicProElements.pluginWindowMatch(
                 forTrackName: trackName,
+                matchingPluginID: pluginID,
                 matchingSliderDescription: axDescription,
                 runtime: runtime
             ) {
@@ -1999,6 +2103,8 @@ extension AccessibilityChannel {
                 lastUniqueWindow = window
             case .ambiguous:
                 return .ambiguous
+            case let .pluginIdentityMismatch(observedNames):
+                return .pluginIdentityMismatch(observedNames: observedNames)
             case .none:
                 lastUniqueWindow = nil
             }

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -1221,6 +1221,24 @@ extension AccessibilityChannel {
             constructedWindow = AXUIElementSendable(matchingEditorsAfterPress[0])
         }
 
+        // This operation opened that editor from a known-empty state, so it owns
+        // it. Leaving it open would make the NEXT duplicate-insert write refuse
+        // with `duplicate_plugin_editor_already_open` — measured live: writing
+        // insert 0 then insert 2 on a two-Compressor track failed on the second
+        // call until the first editor was closed by hand. Only ever close a
+        // window this operation created; an editor the caller already had open
+        // is reused, never constructed, and must be left exactly as found.
+        defer {
+            if let constructedWindow {
+                closePluginEditorOpenedByThisOperation(
+                    constructedWindow.element,
+                    trackName: trackName,
+                    pluginID: pluginID,
+                    runtime: runtime
+                )
+            }
+        }
+
         // Step 8 — normal single-instance acquisition retains the original
         // name/parameter resolution and opener behaviour. For a duplicated
         // instance, `constructedWindow` above is already proven by the one
@@ -1870,6 +1888,14 @@ extension AccessibilityChannel {
                 "matching_editor_count_before_press": matchingEditorCount,
                 "what_was_attempted": "confirm no \(pluginID) editor was already open before pressing insert \(insert)",
                 "what_was_observed": "\(matchingEditorCount) matching \(pluginID) editor(s) were already open on track \(track)",
+                // A duplicated plug-in can only be bound by opening its editor
+                // from a known-empty state, so an already-open editor is the one
+                // thing the caller must clear. This operation closes the editors
+                // it opens, so reaching here means either a human opened one or a
+                // previous close could not be verified.
+                "recovery_hint": "Close the open \(pluginID) editor(s) on track \(track), then retry. "
+                    + "While the plug-in occupies more than one insert, its editor must be "
+                    + "opened by this operation for the write to be attributable to insert \(insert).",
                 "safe_to_retry": false,
                 "write_attempted": false,
             ]
@@ -2280,6 +2306,49 @@ extension AccessibilityChannel {
     /// when no ranked control responds to AXPress, never a coordinate click.
     private static func pressElement(_ element: AXUIElement, runtime: AXHelpers.Runtime) -> Bool {
         AXHelpers.performAction(element, kAXPressAction as String, runtime: runtime)
+    }
+
+    /// Close an editor this operation opened from a known-empty state.
+    ///
+    /// Uses `kAXCloseButtonAttribute` rather than a titled button: the visible
+    /// close control is localized («닫기» on a Korean system), and the slot's own
+    /// open control is a toggle whose press would be indistinguishable from a
+    /// user reopening the editor.
+    ///
+    /// The AX return status is deliberately ignored. Logic reports non-zero from
+    /// presses that did work, so the observed editor count decides — the same
+    /// rule the acquisition itself follows.
+    ///
+    /// Returns whether the close was OBSERVED. A false return is not raised into
+    /// the envelope here: the write's own verdict is already established by then,
+    /// and a leftover editor announces itself on the next call as
+    /// `duplicate_plugin_editor_already_open`, which carries the recovery hint.
+    @discardableResult
+    private static func closePluginEditorOpenedByThisOperation(
+        _ window: AXUIElement,
+        trackName: String,
+        pluginID: String,
+        runtime: AXLogicProElements.Runtime
+    ) -> Bool {
+        guard let closeButton: AXUIElement = AXHelpers.getAttribute(
+            window, kAXCloseButtonAttribute, runtime: runtime.ax
+        ) else {
+            return false
+        }
+        for attempt in 0..<3 {
+            _ = pressElement(closeButton, runtime: runtime.ax)
+            if AXLogicProElements.matchingPluginEditorWindows(
+                forTrackName: trackName,
+                matchingPluginID: pluginID,
+                runtime: runtime
+            ).isEmpty {
+                return true
+            }
+            if attempt < 2 {
+                Thread.sleep(forTimeInterval: 0.15)
+            }
+        }
+        return false
     }
 
     private static func pluginWindowAcquisitionDiagnostics(

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -1684,6 +1684,13 @@ extension AccessibilityChannel {
             guard demotePluginWindowBeforeAcquisition(window, runtime: runtime) else {
                 return nil
             }
+            // Live measurement: `열기` opens and fronts the editor; after
+            // demotion, pressing `열기` again removes it from AXWindows. The
+            // slot's open control is a toggle, so raise the known editor instead.
+            _ = AXHelpers.performAction(window, kAXRaiseAction as String, runtime: runtime.ax)
+            if pluginWindowIsFront(window, runtime: runtime.ax) {
+                return AXUIElementSendable(window)
+            }
         case .none:
             break
         }

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -690,6 +690,8 @@ actor AccessibilityChannel: Channel {
             return await AccessibilityChannel.defaultGetPluginInventory(params: params, runtime: runtime.logicRuntime)
         case "plugin.set_param_verified":
             return await AccessibilityChannel.defaultSetParamVerified(params: params, runtime: runtime.logicRuntime)
+        case "plugin.set_eq_band_verified":
+            return await AccessibilityChannel.defaultSetEQBandVerified(params: params, runtime: runtime.logicRuntime)
         case "plugin.insert_verified":
             return await AccessibilityChannel.defaultInsertVerified(params: params, runtime: runtime.logicRuntime)
 

--- a/Sources/LogicProMCP/Channels/RoutingTable.swift
+++ b/Sources/LogicProMCP/Channels/RoutingTable.swift
@@ -112,6 +112,7 @@ extension ChannelRouter {
         // past them.
         "plugin.get_inventory":       [.accessibility],
         "plugin.set_param_verified":  [.accessibility],
+        "plugin.set_eq_band_verified": [.accessibility],
         "plugin.insert_verified":     [.accessibility],
 
         // MIDI — CoreMIDI only

--- a/Sources/LogicProMCP/Dispatchers/PluginsDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/PluginsDispatcher.swift
@@ -30,7 +30,8 @@ final class VerifiedOpGate: @unchecked Sendable {
 
 /// `logic_plugins` — verified plugin apply-back surface (R16 Plane 1).
 ///
-/// Commands: get_inventory, set_param_verified, insert_verified. The dispatcher
+/// Commands: get_inventory, set_param_verified, set_eq_band_verified,
+/// insert_verified. The dispatcher
 /// validates/normalizes input then routes through `ChannelRouter` to the
 /// AX-only verified operations (`plugin.*`). Verified ops never fall back
 /// (router chain is `[.accessibility]` alone) so a State C is always the honest
@@ -41,7 +42,7 @@ struct PluginsDispatcher: OperationTraceDispatching {
 
     static let tool = commandTool(
         name: "logic_plugins",
-        description: "Verified plugin apply-back for Logic Pro (logic_plugins.*). Commands: get_inventory, set_param_verified, insert_verified. Unlike legacy logic_mixer.set_plugin_param (Scripter, unverified State B), this surface identifies the target track/insert/plugin/param via AX, writes, and reads back — State A only when the observed value matches within tolerance. get_inventory -> { track: Int (required, >= 0) } returns a drift-safe insert chain (physical slot index, read_status ok|empty|unreadable, complete). set_param_verified -> { track: Int, insert: Int, plugin: canonical logic.stock.* id or alias, param: key (e.g. gain_db), value: Float, unit: String, mode: \"duplicate_applyback\", project_expected_path: String (required) }. insert_verified -> { track: Int, insert: Int, plugin: Gain|Channel EQ|Compressor, mode: \"duplicate_applyback\", project_expected_path: String (required), expected_name: String }. PRD-007 index binding: insert_verified is `corroborated` — a bare `track` index is REFUSED with index_binding_corroboration_required; supply expected_name (the track name you expect at that index, corroborated against the live header and required to be unique across the surface) or a target_ref instead; expected_name + target_ref together is invalid_params; every binding failure is pre-write with write_attempted:false and takes no verified-op gate. mode confirmed_live is not supported in Release 1 (State C unsupported_mode). ADR-002 (on by default; disable with LOGIC_MCP_ADR002_TARGET_REF=0): set_param_verified and insert_verified ALSO accept a session-stable { target_ref: String } from logic://tracks (trk_…) or logic_plugins.get_inventory (ins_…); plugin-insert refs resolve track and physical insert, and explicit track/insert values must agree when supplied or the op fails closed (stale_target_reference); when the kill-switch is set, any supplied target_ref fails closed with target_ref_unavailable; omit target_ref to use explicit selectors.",
+        description: "Verified plugin apply-back for Logic Pro (logic_plugins.*). Commands: get_inventory, set_param_verified, set_eq_band_verified, insert_verified. Unlike legacy logic_mixer.set_plugin_param (Scripter, unverified State B), this surface identifies the target track/insert/plugin/param via AX, writes, and reads back — State A only when the observed value matches within tolerance. get_inventory -> { track: Int (required, >= 0) } returns a drift-safe insert chain (physical slot index, read_status ok|empty|unreadable, complete). set_param_verified -> { track: Int, insert: Int, plugin: canonical logic.stock.* id or alias, param: key (e.g. gain_db), value: Float, unit: String, mode: \"duplicate_applyback\", project_expected_path: String (required) }. set_eq_band_verified -> { track: Int, insert: Int, band: String (e.g. Peak 1), parameter: String (e.g. Frequency), value: Float, unit: raw_ax_value|Hz|dB|Q, mode: \"duplicate_applyback\", project_expected_path: String (required) }. Engineering-unit Channel EQ requests are checked against Logic's AXValueDescription; no Hz-to-raw mapping is used. insert_verified -> { track: Int, insert: Int, plugin: Gain|Channel EQ|Compressor, mode: \"duplicate_applyback\", project_expected_path: String (required), expected_name: String }. PRD-007 index binding: insert_verified is `corroborated` — a bare `track` index is REFUSED with index_binding_corroboration_required; supply expected_name (the track name you expect at that index, corroborated against the live header and required to be unique across the surface) or a target_ref instead; expected_name + target_ref together is invalid_params; every binding failure is pre-write with write_attempted:false and takes no verified-op gate. mode confirmed_live is not supported in Release 1 (State C unsupported_mode). ADR-002 (on by default; disable with LOGIC_MCP_ADR002_TARGET_REF=0): set_param_verified, set_eq_band_verified, and insert_verified ALSO accept a session-stable { target_ref: String } from logic://tracks (trk_…) or logic_plugins.get_inventory (ins_…); plugin-insert refs resolve track and physical insert, and explicit track/insert values must agree when supplied or the op fails closed (stale_target_reference); when the kill-switch is set, any supplied target_ref fails closed with target_ref_unavailable; omit target_ref to use explicit selectors.",
         commandDescription: "Verified plugin command to execute"
     )
 
@@ -149,6 +150,60 @@ struct PluginsDispatcher: OperationTraceDispatching {
                 return await withWriteBoundaryArmed(traceID) {
                     await routedTextResult(router, operation: "plugin.set_param_verified",
                                            params: writeParams)
+                }
+            }
+            return await finalizeTrace(
+                TargetRefResolver.addEvidence(
+                    resolvedReference,
+                    fingerprint: resolvedFingerprint,
+                    to: result
+                ),
+                traceID: traceID
+            )
+
+        case "set_eq_band_verified":
+            let traceID = await startTraceIfEnabled(command: command)
+            var resolvedReference: TargetReference?
+            var resolvedFingerprint: String?
+            let result = await runVerified(operation: "plugin.set_eq_band_verified") {
+                var writeParams = eqBandVerifiedParams(params)
+                if params["target_ref"] != nil {
+                    switch await TargetRefResolver.resolveMutationIndex(
+                        params,
+                        targetRegistry: targetRegistry,
+                        cache: cache,
+                        operation: "logic_plugins.set_eq_band_verified",
+                        indexKeys: ["track"],
+                        invalidIndexResult: toolInvalidParamsResult(
+                            "set_eq_band_verified requires explicit 'track' (Int >= 0)"
+                        ),
+                        acceptedKinds: [.track, .pluginInsert]
+                    ) {
+                    case .success(let resolved):
+                        writeParams["track"] = String(resolved.index)
+                        resolvedReference = resolved.reference
+                        resolvedFingerprint = resolved.binding?.observedFingerprint
+                        if let boundTrackName = resolved.binding?.descriptor.trackName {
+                            writeParams["expected_track_name"] = boundTrackName
+                        }
+                        if let failure = applyPluginInsertBinding(
+                            resolved,
+                            params: params,
+                            writeParams: &writeParams,
+                            operation: "logic_plugins.set_eq_band_verified"
+                        ) {
+                            return failure
+                        }
+                    case .failure(let result):
+                        return result
+                    }
+                }
+                return await withWriteBoundaryArmed(traceID) {
+                    await routedTextResult(
+                        router,
+                        operation: "plugin.set_eq_band_verified",
+                        params: writeParams
+                    )
                 }
             }
             return await finalizeTrace(
@@ -281,6 +336,19 @@ struct PluginsDispatcher: OperationTraceDispatching {
         if let insert = intParamOrNil(params, "insert") { out["insert"] = String(insert) }
         if let plugin = nonEmptyString(params, "plugin", "plugin_id", "plugin_name") { out["plugin"] = plugin }
         if let param = nonEmptyString(params, "param") { out["param"] = param }
+        if let value = doubleParamOrNil(params, "value") { out["value"] = String(value) }
+        if let unit = nonEmptyString(params, "unit") { out["unit"] = unit }
+        if let mode = nonEmptyString(params, "mode") { out["mode"] = mode }
+        if let path = nonEmptyString(params, "project_expected_path") { out["project_expected_path"] = path }
+        return out
+    }
+
+    private static func eqBandVerifiedParams(_ params: [String: Value]) -> [String: String] {
+        var out: [String: String] = [:]
+        if let track = intParamOrNil(params, "track") { out["track"] = String(track) }
+        if let insert = intParamOrNil(params, "insert") { out["insert"] = String(insert) }
+        if let band = nonEmptyString(params, "band") { out["band"] = band }
+        if let parameter = nonEmptyString(params, "parameter") { out["parameter"] = parameter }
         if let value = doubleParamOrNil(params, "value") { out["value"] = String(value) }
         if let unit = nonEmptyString(params, "unit") { out["unit"] = unit }
         if let mode = nonEmptyString(params, "mode") { out["mode"] = mode }

--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -1913,6 +1913,11 @@ struct SystemDispatcher: OperationTraceDispatching {
                                           param: String, value: Float, unit: String,
                                           mode: "duplicate_applyback",
                                           project_expected_path: String }
+                  set_eq_band_verified -> { track: Int, insert: Int, band: String,
+                                             parameter: String, value: Float,
+                                             unit: "raw_ax_value"|"Hz"|"dB"|"Q",
+                                             mode: "duplicate_applyback",
+                                             project_expected_path: String }
                   insert_verified   -> { track: Int, insert: Int,
                                          plugin: "Gain"|"Channel EQ"|"Compressor",
                                          mode: "duplicate_applyback",
@@ -1969,7 +1974,7 @@ struct SystemDispatcher: OperationTraceDispatching {
                   logic_project    — Project lifecycle (open, save, bounce...)
                   logic_audio      — Read-only audio artifact analysis
                   logic_system     — Diagnostics + help
-                  logic_plugins    — Verified plugin apply-back (inventory, set_param_verified, insert_verified)
+                  logic_plugins    — Verified plugin apply-back (inventory, set_param_verified, set_eq_band_verified, insert_verified)
 
                 Resources (reads — zero tool cost):
                   logic://system/health         — System health

--- a/Sources/LogicProMCP/Plugins/ChannelEQBandCatalog.swift
+++ b/Sources/LogicProMCP/Plugins/ChannelEQBandCatalog.swift
@@ -1,0 +1,181 @@
+/// The named Channel EQ band controls measured for #301.
+///
+/// Every range below is in raw `AXValue` units. It would be dishonest to call
+/// the frequency range Hz: the supplied Logic 12.x (ko) observations show a
+/// non-linear raw-to-Hz relationship. Engineering-unit requests are therefore
+/// matched against Logic's own `AXValueDescription`; this catalog never maps an
+/// engineering value back to a raw slider value.
+enum ChannelEQBandCatalog {
+    struct Parameter: Equatable, Sendable {
+        let id: String
+        let bandName: String
+        let parameterName: String
+        let displayName: String
+        let axDescription: String
+        /// The only range that was measured: raw `AXValue` units.
+        let rawUnit: String
+        /// An engineering rendering Logic exposes in `AXValueDescription`, if
+        /// this control has one. A nil value means raw-only (the cut-band Order).
+        let displayUnit: String?
+        let range: ClosedRange<Double>
+
+        var declaredUnits: [String] {
+            [rawUnit] + (displayUnit.map { [$0] } ?? [])
+        }
+    }
+
+    static let rawUnit = "raw_ax_value"
+    /// A cap on accepted AX nudges. The widest measured raw range is 0...1050;
+    /// the small margin lets the walk report its actual outcome rather than
+    /// relying on an assumed one-step-per-raw-unit relationship.
+    static let incrementWalkBudget = 1_100
+
+    /// Data only; `StockPluginCatalog` registers these named entries and their
+    /// measured raw behavior. The recorded values justify constants here, not
+    /// any claim that this source has verified a live write round trip.
+    static let parameters: [Parameter] = bands.flatMap { band in
+        [ParameterKind.frequency, band.levelParameter, .q].map { kind in
+            let name = "\(band.displayName) \(kind.displayName)"
+            return Parameter(
+                id: "\(band.id)_\(kind.id)",
+                bandName: band.displayName,
+                parameterName: kind.displayName,
+                displayName: name,
+                axDescription: name,
+                rawUnit: rawUnit,
+                displayUnit: kind.displayUnit,
+                range: kind.range(for: band.qRange)
+            )
+        }
+    }
+
+    /// Resolve public names only. There are deliberately no band ordinals or
+    /// slider positions in this path: the resolved AX description is the named
+    /// catalog entry's own description.
+    static func parameter(bandName: String, parameterName: String) -> Parameter? {
+        let normalizedBand = normalizedName(bandName)
+        let normalizedParameter = normalizedName(parameterName)
+        return parameters.first {
+            normalizedName($0.bandName) == normalizedBand
+                && normalizedName($0.parameterName) == normalizedParameter
+        }
+    }
+
+    private static func normalizedName(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    private struct Band: Sendable {
+        let id: String
+        let displayName: String
+        let levelParameter: ParameterKind
+        let qRange: ClosedRange<Double>
+    }
+
+    private enum ParameterKind: Sendable {
+        case frequency
+        case gain
+        case q
+        case order
+
+        var id: String {
+            switch self {
+            case .frequency: "frequency"
+            case .gain: "gain"
+            case .q: "q"
+            case .order: "order"
+            }
+        }
+
+        var displayName: String {
+            switch self {
+            case .frequency: "Frequency"
+            case .gain: "Gain"
+            case .q: "Q"
+            case .order: "Order"
+            }
+        }
+
+        var displayUnit: String? {
+            switch self {
+            case .frequency: "Hz"
+            case .gain: "dB"
+            case .q: "Q"
+            case .order: nil
+            }
+        }
+
+        func range(for qRange: ClosedRange<Double>) -> ClosedRange<Double> {
+            switch self {
+            case .frequency: Self.frequencyRawRange
+            case .gain: Self.gainRawRange
+            case .q: qRange
+            case .order: Self.orderRawRange
+            }
+        }
+
+        // Supplied #301 measurements: Frequency AXValue 0...1050, Gain
+        // 0...480, and Order 0...5. These are raw slider bounds, not a
+        // conversion to the values Logic renders in `AXValueDescription`.
+        private static let frequencyRawRange: ClosedRange<Double> = 0 ... 1_050
+        private static let gainRawRange: ClosedRange<Double> = 0 ... 480
+        private static let orderRawRange: ClosedRange<Double> = 0 ... 5
+    }
+
+    private static let shelfQRawRange: ClosedRange<Double> = 0 ... 52
+    private static let peakOrCutQRawRange: ClosedRange<Double> = 0 ... 127
+
+    // Low/High Cut retain Q and substitute Order for Gain. Generating the
+    // three parameters per band preserves that distinction without a fragile
+    // hand-written list of 24 strings.
+    private static let bands: [Band] = [
+        Band(
+            id: "low_cut",
+            displayName: "Low Cut",
+            levelParameter: .order,
+            qRange: peakOrCutQRawRange
+        ),
+        Band(
+            id: "low_shelf",
+            displayName: "Low Shelf",
+            levelParameter: .gain,
+            qRange: shelfQRawRange
+        ),
+        Band(
+            id: "peak_1",
+            displayName: "Peak 1",
+            levelParameter: .gain,
+            qRange: peakOrCutQRawRange
+        ),
+        Band(
+            id: "peak_2",
+            displayName: "Peak 2",
+            levelParameter: .gain,
+            qRange: peakOrCutQRawRange
+        ),
+        Band(
+            id: "peak_3",
+            displayName: "Peak 3",
+            levelParameter: .gain,
+            qRange: peakOrCutQRawRange
+        ),
+        Band(
+            id: "peak_4",
+            displayName: "Peak 4",
+            levelParameter: .gain,
+            qRange: peakOrCutQRawRange
+        ),
+        Band(
+            id: "high_shelf",
+            displayName: "High Shelf",
+            levelParameter: .gain,
+            qRange: shelfQRawRange
+        ),
+        Band(
+            id: "high_cut",
+            displayName: "High Cut",
+            levelParameter: .order,
+            qRange: peakOrCutQRawRange
+        ),
+    ]
+}

--- a/Sources/LogicProMCP/Plugins/SliderIncrementWalk.swift
+++ b/Sources/LogicProMCP/Plugins/SliderIncrementWalk.swift
@@ -1,0 +1,256 @@
+/// A readback-driven walk for sliders whose apparent value assignment is only
+/// a one-step nudge toward the requested raw value.
+///
+/// This deliberately has no Accessibility import. The caller owns AX reads and
+/// writes; the core only decides whether those observations justify another
+/// nudge. Channel EQ needs this because assigning `AXValue` is not a set to a
+/// destination: the reported Logic 12.x measurement is that each assignment
+/// advances one step toward the requested raw value.
+enum SliderIncrementWalk {
+    struct Reading: Equatable, Sendable {
+        /// The raw `AXValue`, never an inferred engineering value.
+        let value: Double
+        /// Logic's own `AXValueDescription` rendering.
+        let display: String
+    }
+
+    enum Target: Equatable, Sendable {
+        /// Converge on a raw `AXValue`. The tolerance is in raw slider units.
+        case rawValue(Double, tolerance: Double)
+        /// Converge only when Logic renders this exact `AXValueDescription`.
+        /// This is the honest mode for values such as Hz and dB, whose raw
+        /// mappings must not be invented by this core.
+        case display(String)
+    }
+
+    enum WalkOutcome: Equatable, Sendable {
+        case arrived(steps: Int, final: Reading)
+        case noProgress(steps: Int, last: Reading)
+        case budgetExhausted(steps: Int, last: Reading)
+        case overshot(steps: Int, last: Reading)
+        case readbackLost(steps: Int)
+    }
+
+    /// Walks by requesting a raw value on the desired side of the current
+    /// reading. `nudge` is deliberately injected so this decision layer has no
+    /// AX dependency; it returns whether the write itself was accepted, not
+    /// whether the control moved.
+    static func walk(
+        to target: Target,
+        read: () -> Reading?,
+        nudge: (Double) -> Bool,
+        budget: Int
+    ) -> WalkOutcome {
+        guard let initial = read() else {
+            return .readbackLost(steps: 0)
+        }
+
+        if reached(target, reading: initial) {
+            return .arrived(steps: 0, final: initial)
+        }
+
+        // A budget is a cap on accepted write steps. It never suppresses the
+        // entry read: a missing entry read is still readback loss, not budget
+        // exhaustion wearing a more convenient name.
+        guard budget > 0 else {
+            return .budgetExhausted(steps: 0, last: initial)
+        }
+
+        switch target {
+        case .rawValue(let rawTarget, let tolerance):
+            return walkRaw(
+                to: rawTarget,
+                tolerance: abs(tolerance),
+                initial: initial,
+                nudge: nudge,
+                read: read,
+                budget: budget
+            )
+        case .display(let targetDisplay):
+            return walkDisplay(
+                to: targetDisplay,
+                initial: initial,
+                nudge: nudge,
+                read: read,
+                budget: budget
+            )
+        }
+    }
+
+    private enum Direction: Double {
+        case down = -1
+        case up = 1
+    }
+
+    private static func walkRaw(
+        to target: Double,
+        tolerance: Double,
+        initial: Reading,
+        nudge: (Double) -> Bool,
+        read: () -> Reading?,
+        budget: Int
+    ) -> WalkOutcome {
+        var current = initial
+        var previous: Reading?
+        var crossedTarget = false
+        var steps = 0
+
+        while steps < budget {
+            // Passing the actual raw target lets AX decide its increment or
+            // decrement. We never clamp it: an out-of-range request must run
+            // into its real rail and report no progress.
+            guard nudge(target) else {
+                return .noProgress(steps: steps, last: current)
+            }
+            steps += 1
+
+            guard let next = read() else {
+                return .readbackLost(steps: steps)
+            }
+            if isWithinTolerance(next.value, of: target, tolerance: tolerance) {
+                return .arrived(steps: steps, final: next)
+            }
+
+            if next.value == current.value {
+                return .noProgress(steps: steps, last: next)
+            }
+            if previous?.value == next.value {
+                return .noProgress(steps: steps, last: next)
+            }
+
+            // Do not call the first crossing an overshoot: a later nudge may
+            // still return toward the target. It is an overshoot only after a
+            // crossed walk moves farther away on the same wrong side.
+            if crossedTarget,
+               movesFurtherAwayOnSameSide(
+                   from: current.value,
+                   to: next.value,
+                   target: target,
+                   tolerance: tolerance
+               ) {
+                return .overshot(steps: steps, last: next)
+            }
+
+            if crossesTarget(
+                from: current.value,
+                to: next.value,
+                target: target,
+                tolerance: tolerance
+            ) {
+                crossedTarget = true
+            }
+
+            previous = current
+            current = next
+        }
+
+        return .budgetExhausted(steps: steps, last: current)
+    }
+
+    private static func walkDisplay(
+        to targetDisplay: String,
+        initial: Reading,
+        nudge: (Double) -> Bool,
+        read: () -> Reading?,
+        budget: Int
+    ) -> WalkOutcome {
+        var current = initial
+        // The first request is a calibration nudge toward a higher raw value.
+        // Once Logic's display changes, raw readback—not a made-up Hz/dB
+        // mapping—tells us which raw direction produced that rendering.
+        var direction: Direction?
+        var rawWhenDisplayLastChanged = initial.value
+        var previous: Reading?
+        var steps = 0
+
+        while steps < budget {
+            let requestedRaw: Double
+            if let direction {
+                requestedRaw = current.value + direction.rawValue
+            } else {
+                requestedRaw = current.value + Direction.up.rawValue
+            }
+
+            guard nudge(requestedRaw) else {
+                return .noProgress(steps: steps, last: current)
+            }
+            steps += 1
+
+            guard let next = read() else {
+                return .readbackLost(steps: steps)
+            }
+            if next.display == targetDisplay {
+                return .arrived(steps: steps, final: next)
+            }
+
+            if next.value == current.value || previous?.value == next.value {
+                return .noProgress(steps: steps, last: next)
+            }
+
+            if next.display != current.display {
+                guard let observedDirection = rawDirection(
+                    from: rawWhenDisplayLastChanged,
+                    to: next.value
+                ), direction == nil || direction == observedDirection else {
+                    return .noProgress(steps: steps, last: next)
+                }
+                direction = observedDirection
+                rawWhenDisplayLastChanged = next.value
+            } else if direction == nil {
+                // A raw change with no display change cannot establish that the
+                // calibration nudge is moving toward the requested rendering.
+                // Stop rather than guessing an engineering-value mapping.
+                return .noProgress(steps: steps, last: next)
+            }
+
+            previous = current
+            current = next
+        }
+
+        return .budgetExhausted(steps: steps, last: current)
+    }
+
+    private static func reached(_ target: Target, reading: Reading) -> Bool {
+        switch target {
+        case .rawValue(let value, let tolerance):
+            isWithinTolerance(reading.value, of: value, tolerance: abs(tolerance))
+        case .display(let display):
+            reading.display == display
+        }
+    }
+
+    private static func isWithinTolerance(
+        _ value: Double,
+        of target: Double,
+        tolerance: Double
+    ) -> Bool {
+        abs(value - target) <= tolerance
+    }
+
+    private static func rawDirection(from oldValue: Double, to newValue: Double) -> Direction? {
+        if newValue > oldValue { return .up }
+        if newValue < oldValue { return .down }
+        return nil
+    }
+
+    private static func crossesTarget(
+        from oldValue: Double,
+        to newValue: Double,
+        target: Double,
+        tolerance: Double
+    ) -> Bool {
+        (oldValue < target - tolerance && newValue > target + tolerance)
+            || (oldValue > target + tolerance && newValue < target - tolerance)
+    }
+
+    private static func movesFurtherAwayOnSameSide(
+        from oldValue: Double,
+        to newValue: Double,
+        target: Double,
+        tolerance: Double
+    ) -> Bool {
+        let bothAbove = oldValue > target + tolerance && newValue > target + tolerance
+        let bothBelow = oldValue < target - tolerance && newValue < target - tolerance
+        return (bothAbove || bothBelow) && abs(newValue - target) > abs(oldValue - target)
+    }
+}

--- a/Sources/LogicProMCP/Plugins/SliderIncrementWalk.swift
+++ b/Sources/LogicProMCP/Plugins/SliderIncrementWalk.swift
@@ -77,7 +77,7 @@ enum SliderIncrementWalk {
         }
     }
 
-    private enum Direction: Double {
+    private enum Direction: Double, Equatable {
         case down = -1
         case up = 1
     }
@@ -155,23 +155,16 @@ enum SliderIncrementWalk {
         budget: Int
     ) -> WalkOutcome {
         var current = initial
-        // The first request is a calibration nudge toward a higher raw value.
-        // Once Logic's display changes, raw readback—not a made-up Hz/dB
-        // mapping—tells us which raw direction produced that rendering.
-        var direction: Direction?
-        var rawWhenDisplayLastChanged = initial.value
-        var previous: Reading?
+        // The first request is an upward probe. A measured 302 / "+6.2 dB"
+        // walk took 179 upward steps to 480 / "+24.0 dB" for a "+2.2 dB"
+        // target, so the probe's raw direction must not be frozen. Logic's
+        // rendering is re-evaluated after every step to prove it is closer.
+        var direction = Direction.up
+        var isProbe = true
         var steps = 0
 
         while steps < budget {
-            let requestedRaw: Double
-            if let direction {
-                requestedRaw = current.value + direction.rawValue
-            } else {
-                requestedRaw = current.value + Direction.up.rawValue
-            }
-
-            guard nudge(requestedRaw) else {
+            guard nudge(current.value + direction.rawValue) else {
                 return .noProgress(steps: steps, last: current)
             }
             steps += 1
@@ -183,27 +176,35 @@ enum SliderIncrementWalk {
                 return .arrived(steps: steps, final: next)
             }
 
-            if next.value == current.value || previous?.value == next.value {
+            if next.display == current.display {
                 return .noProgress(steps: steps, last: next)
             }
 
-            if next.display != current.display {
-                guard let observedDirection = rawDirection(
-                    from: rawWhenDisplayLastChanged,
-                    to: next.value
-                ), direction == nil || direction == observedDirection else {
-                    return .noProgress(steps: steps, last: next)
+            guard let movedCloser = displayMovedCloser(
+                from: current.display,
+                to: next.display,
+                target: targetDisplay
+            ) else {
+                // An ordering we cannot establish is not a licence to pick a
+                // direction. In particular, parsing raw values or a dB/Hz
+                // mapping here would invent information Logic did not render.
+                return .noProgress(steps: steps, last: next)
+            }
+
+            if !movedCloser {
+                if isProbe {
+                    // The lone calibration probe moved away, so try its
+                    // opposite once. Later non-closer displays are no
+                    // progress, not a reason to walk into a control rail.
+                    direction = direction == .up ? .down : .up
+                    isProbe = false
+                    current = next
+                    continue
                 }
-                direction = observedDirection
-                rawWhenDisplayLastChanged = next.value
-            } else if direction == nil {
-                // A raw change with no display change cannot establish that the
-                // calibration nudge is moving toward the requested rendering.
-                // Stop rather than guessing an engineering-value mapping.
                 return .noProgress(steps: steps, last: next)
             }
 
-            previous = current
+            isProbe = false
             current = next
         }
 
@@ -227,10 +228,60 @@ enum SliderIncrementWalk {
         abs(value - target) <= tolerance
     }
 
-    private static func rawDirection(from oldValue: Double, to newValue: Double) -> Direction? {
-        if newValue > oldValue { return .up }
-        if newValue < oldValue { return .down }
-        return nil
+    /// Returns whether Logic's next rendering is numerically closer to the
+    /// requested rendering. The parsed suffix is intentionally compared
+    /// exactly: it is the unit text Logic supplied, not a unit conversion.
+    private static func displayMovedCloser(
+        from current: String,
+        to next: String,
+        target: String
+    ) -> Bool? {
+        guard let currentValue = leadingNumber(in: current),
+              let nextValue = leadingNumber(in: next),
+              let targetValue = leadingNumber(in: target),
+              currentValue.suffix == nextValue.suffix,
+              currentValue.suffix == targetValue.suffix else {
+            return nil
+        }
+
+        return abs(nextValue.number - targetValue.number)
+            < abs(currentValue.number - targetValue.number)
+    }
+
+    /// Splits only a leading signed decimal from Logic's rendering. Everything
+    /// after it remains opaque unit text; this core must not create a dB or Hz
+    /// parser just to choose a raw slider direction.
+    private static func leadingNumber(in display: String) -> (number: Double, suffix: String)? {
+        let bytes = Array(display.utf8)
+        guard !bytes.isEmpty else { return nil }
+
+        var end = 0
+        if bytes[end] == 43 || bytes[end] == 45 { // + or -
+            end += 1
+        }
+
+        var digits = 0
+        while end < bytes.count, isASCIIDigit(bytes[end]) {
+            end += 1
+            digits += 1
+        }
+        if end < bytes.count, bytes[end] == 46 { // .
+            end += 1
+            while end < bytes.count, isASCIIDigit(bytes[end]) {
+                end += 1
+                digits += 1
+            }
+        }
+
+        guard digits > 0,
+              let number = Double(String(decoding: bytes[..<end], as: UTF8.self)) else {
+            return nil
+        }
+        return (number, String(decoding: bytes[end...], as: UTF8.self))
+    }
+
+    private static func isASCIIDigit(_ byte: UInt8) -> Bool {
+        byte >= 48 && byte <= 57
     }
 
     private static func crossesTarget(

--- a/Sources/LogicProMCP/Plugins/StockPluginCatalog.swift
+++ b/Sources/LogicProMCP/Plugins/StockPluginCatalog.swift
@@ -171,6 +171,10 @@ struct StockPluginParameterMetadata: Codable, Sendable, Equatable {
     let id: String
     let displayName: String
     let unit: String?
+    /// Every unit callers may request. `unit` remains the canonical/raw unit
+    /// for compatibility; this list adds display units when a control can only
+    /// be verified through Logic's own rendering.
+    let acceptedUnits: [String]?
     let valueRange: StockPluginValueRange?
     let writeMethod: String?
     let readbackMethod: String?
@@ -179,10 +183,10 @@ struct StockPluginParameterMetadata: Codable, Sendable, Equatable {
     /// parameter declares no verified write path (display/readback methods nil).
     let tolerance: Double?
     /// AX `AXDescription` string that uniquely identifies this parameter's
-    /// control inside the live plugin window (T0 evidence). For Compressor only
-    /// `threshold` carries a stable description ("Threshold"); other params show
-    /// the locale word for "slider" with no name, so they get no matcher and
-    /// stay write-unsupported. nil ⇒ not AX-addressable by description.
+    /// control inside the live plugin window. Compressor `threshold` and the
+    /// named Channel EQ catalog entries carry description matchers; other
+    /// parameters without one stay write-unsupported. nil ⇒ not
+    /// AX-addressable by description.
     let axDescription: String?
     let availabilityState: StockPluginTruthState
     let provenance: StockPluginProvenance
@@ -191,6 +195,7 @@ struct StockPluginParameterMetadata: Codable, Sendable, Equatable {
         case id
         case displayName = "display_name"
         case unit
+        case acceptedUnits = "accepted_units"
         case valueRange = "value_range"
         case writeMethod = "write_method"
         case readbackMethod = "readback_method"
@@ -204,6 +209,7 @@ struct StockPluginParameterMetadata: Codable, Sendable, Equatable {
         id: String,
         displayName: String,
         unit: String?,
+        acceptedUnits: [String]? = nil,
         valueRange: StockPluginValueRange?,
         writeMethod: String?,
         readbackMethod: String?,
@@ -215,6 +221,7 @@ struct StockPluginParameterMetadata: Codable, Sendable, Equatable {
         self.id = id
         self.displayName = displayName
         self.unit = unit
+        self.acceptedUnits = acceptedUnits
         self.valueRange = valueRange
         self.writeMethod = writeMethod
         self.readbackMethod = readbackMethod
@@ -848,7 +855,41 @@ enum StockPluginCatalog {
         ),
     ]
 
-    private static let channelEQParameters: [StockPluginParameterMetadata] = []
+    /// Measured live on 2026-08-30: the ranges are raw `AXValue` bounds and an
+    /// apparent AXValue assignment advances this slider by a single increment
+    /// toward its target. This records neither a verified write/readback round
+    /// trip nor an engineering-value-to-raw conversion; both remain explicitly
+    /// outside this evidence packet.
+    private static let channelEQParameters: [StockPluginParameterMetadata] =
+        ChannelEQBandCatalog.parameters.map { parameter in
+            StockPluginParameterMetadata(
+                id: parameter.id,
+                displayName: parameter.displayName,
+                unit: parameter.rawUnit,
+                acceptedUnits: parameter.declaredUnits,
+                valueRange: StockPluginValueRange(
+                    min: parameter.range.lowerBound,
+                    max: parameter.range.upperBound,
+                    defaultValue: nil
+                ),
+                writeMethod: "ax_slider_increment_walk",
+                readbackMethod: "ax_slider_axvalue",
+                tolerance: 0,
+                axDescription: parameter.axDescription,
+                availabilityState: .observed,
+                provenance: .observed(
+                    method: "ax_slider_range_and_increment_measurement",
+                    observedAt: "2026-08-30T00:00:00Z",
+                    logicVersion: nil,
+                    locale: nil,
+                    evidence: [
+                        "raw_axvalue_range_measured_live_2026-08-30",
+                        "axvalue_increment_walk_measured_live_2026-08-30",
+                        "no_write_round_trip_claimed",
+                    ]
+                )
+            )
+        }
 
     /// Compressor `threshold` — the first verified-writable stock parameter.
     /// Current public release evidence records the AX write/readback boundary:
@@ -891,9 +932,14 @@ enum StockPluginCatalog {
             "channel_eq",
             "Channel EQ",
             "EQ",
-            write: .insertOnly,
+            // Removing the isolated `channelEQParameters` evidence block also
+            // returns Channel EQ to insert-only capability in this same edit.
+            write: channelEQParameters.isEmpty ? .insertOnly : .parameterWriteReadback,
             parameters: channelEQParameters,
-            notes: ["Channel EQ parameter registry is census-gated; no writable params are registered until live evidence is added"]
+            notes: [
+                "Channel EQ ranges and increment-walk behavior were measured live on 2026-08-30.",
+                "No Channel EQ write/readback round trip is claimed by this catalog evidence."
+            ]
         ),
         fx("linear_phase_eq", "Linear Phase EQ", "EQ"),
         fx("match_eq", "Match EQ", "EQ"),

--- a/Sources/LogicProMCP/Plugins/VerifiedPluginCatalog.swift
+++ b/Sources/LogicProMCP/Plugins/VerifiedPluginCatalog.swift
@@ -12,10 +12,10 @@ import Foundation
 ///      the verified public key (R5: "구현 전에 `gain -> gain_db` alias를 명시").
 ///   3. write/readback capability — does the resolved plugin/param actually
 ///      have a write method AND a display-readback parser? (R6 step 5 preflight;
-///      Compressor `threshold` is the first verified-writable parameter
-///      (`writeMethod`/`readbackMethod` both `ax_slider_axvalue`) → `.writeReadback`,
-///      while Gain still has neither — `writeMethod:nil, readbackMethod:nil` — so
-///      it stays the honest State C `unsupported_param_readback`.)
+///      Compressor `threshold` uses direct `ax_slider_axvalue`; named Channel
+///      EQ controls use the separately measured increment-walk metadata. Gain
+///      still has neither — `writeMethod:nil, readbackMethod:nil` — so it stays
+///      the honest State C `unsupported_param_readback`.)
 ///
 /// This module is deterministic and contains NO live AX interaction.
 enum VerifiedPluginCatalog {
@@ -27,9 +27,9 @@ enum VerifiedPluginCatalog {
 
     /// Display-name / alias → canonical `logic.stock.*` id table.
     ///
-    /// MVP scope (R5): the three allowlisted stock plugins. Compressor `threshold`
-    /// is the first verified parameter-write target (audit #28); the others
-    /// (including Gain) are identity/insert only. Display
+    /// MVP scope (R5): the three allowlisted stock plugins. Compressor
+    /// `threshold` and named Channel EQ parameters have distinct catalog write
+    /// methods; Gain remains identity/insert only. Display
     /// names are accepted as user-facing aliases but never become the identity
     /// themselves (requirements §5.2 "display name은 identity가 아니라 alias").
     private static let pluginAliases: [String: String] = [
@@ -107,8 +107,8 @@ enum VerifiedPluginCatalog {
         /// `unsupported_param_readback` BEFORE any write (R6, AC10).
         case unsupported
         /// Parameter has both a write method and a readback parser. Eligible for
-        /// a verified State A write. (Compressor `threshold` is the first MVP
-        /// parameter to reach this — see `StockPluginCatalog`; Gain does not.)
+        /// a verified State A write. The entry's provenance still determines
+        /// what live evidence has actually been established; Gain does not.)
         case writeReadback
     }
 

--- a/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
+++ b/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
@@ -284,13 +284,19 @@ enum SemanticOracleTable {
         coveredSpecIDs.union(mutatingSpecIDs)
     }
 
-    /// Mutating ops AUDITED in B1 and found to have NO verifiable State-A envelope
-    /// — deliberately, STRUCTURALLY excluded from the verified-write oracle set
-    /// (not merely "not yet phased in"), each with the reason. Kept EXPLICIT so
-    /// the exclusion is a reviewed decision, not an accidental gap: the census
-    /// asserts each is a real mutating spec, is DISJOINT from the covered set, and
-    /// carries a reason — so the uncovered complement is never fully implicit.
+    /// Mutating ops deliberately excluded from the verified-write oracle set,
+    /// each with the reason. Most are structurally unable to reach State A. A
+    /// post-closure operation can also remain here while its live State-A
+    /// contract is expressly pending; it must not receive a fixture that would
+    /// imply an unrun live proof. Kept EXPLICIT so the exclusion is a reviewed
+    /// decision, not an accidental gap: the census asserts each is a real
+    /// mutating spec, is DISJOINT from the covered set, and carries a reason —
+    /// so the uncovered complement is never fully implicit.
     static let structurallyUnverifiedMutatingOperationIDs: [OperationID: String] = [
+        .pluginsSetEQBandVerified:
+            "live 2026-08-30 evidence establishes the Channel EQ raw AXValue ranges and "
+            + "one-step increment-walk behavior only; no end-to-end write/readback round "
+            + "trip has been run, so a State-A fixture would claim qualification not yet earned",
         .mixerSetPluginParam:
             "send-only State B — routes to [.scripter], whose handler emits only "
             + "readback_unavailable / scripter_send_only; there is no State A to verify",

--- a/Sources/LogicProMCP/SelectorAtlas/UIDriftReport.swift
+++ b/Sources/LogicProMCP/SelectorAtlas/UIDriftReport.swift
@@ -53,7 +53,7 @@ private let operationsBySelector: [SelectorID: [OperationID]] = [
     .mixerStripVolumeFader: [.mixerSetVolume],
     .mixerStripSendSlot: [],
     .pluginWindowTitle: [.pluginsGetInventory, .pluginsInsertVerified],
-    .pluginParameterControl: [.pluginsSetParamVerified, .mixerSetPluginParam],
+    .pluginParameterControl: [.pluginsSetParamVerified, .pluginsSetEQBandVerified, .mixerSetPluginParam],
     .projectSaveFilenameField: [.projectSaveAs],
 ]
 

--- a/Sources/LogicProMCP/Server/OperationRegistry.swift
+++ b/Sources/LogicProMCP/Server/OperationRegistry.swift
@@ -43,6 +43,7 @@ enum OperationID: String, CaseIterable, Codable, Sendable, Hashable {
     case systemSetupArmKey = "system.setup_arm_key"
     case pluginsGetInventory = "plugins.get_inventory"
     case pluginsSetParamVerified = "plugins.set_param_verified"
+    case pluginsSetEQBandVerified = "plugins.set_eq_band_verified"
     case pluginsInsertVerified = "plugins.insert_verified"
     case editUndo = "edit.undo"
     case editRedo = "edit.redo"
@@ -309,7 +310,7 @@ enum OperationRegistry {
             "system.setup_arm_key",
         ],
         ToolID.logicPlugins.rawValue: [
-            "plugins.get_inventory", "plugins.set_param_verified", "plugins.insert_verified",
+            "plugins.get_inventory", "plugins.set_param_verified", "plugins.set_eq_band_verified", "plugins.insert_verified",
         ],
         ToolID.logicEdit.rawValue: [
             "edit.undo", "edit.redo", "edit.cut", "edit.copy", "edit.paste", "edit.delete",
@@ -366,7 +367,7 @@ enum OperationRegistry {
             "setup_arm_key",
         ],
         ToolID.logicPlugins.rawValue: [
-            "get_inventory", "set_param_verified", "insert_verified",
+            "get_inventory", "set_param_verified", "set_eq_band_verified", "insert_verified",
         ],
         ToolID.logicEdit.rawValue: [
             "undo", "redo", "cut", "copy", "paste", "delete", "select_all", "split", "join",
@@ -695,6 +696,18 @@ enum OperationRegistry {
             [
                 "insert", "mode", "param", "plugin", "plugin_id", "plugin_name",
                 "project_expected_path", "track", "unit", "value",
+            ]
+        ),
+        (
+            .pluginsSetEQBandVerified,
+            "set_eq_band_verified",
+            Mutability.`mutating`,
+            DeadlineClass.medium,
+            VerificationPolicy.readbackRequired,
+            TargetPolicy.acceptsStableTarget,
+            [
+                "band", "insert", "mode", "parameter", "project_expected_path",
+                "track", "unit", "value",
             ]
         ),
         (

--- a/Sources/LogicProMCP/Utilities/HonestContract.swift
+++ b/Sources/LogicProMCP/Utilities/HonestContract.swift
@@ -99,6 +99,11 @@ enum HonestContract {
         case unsupportedParamReadback = "unsupported_param_readback"
         case incompleteInventory = "incomplete_inventory"
         case targetPluginMismatch = "target_plugin_mismatch"
+        /// More than one insert on the addressed track carries the requested
+        /// canonical plug-in identity. Logic's accessible editor identity
+        /// cannot distinguish those instances, so opening one could write the
+        /// wrong insert. Refuse before window acquisition.
+        case ambiguousPluginInstance = "ambiguous_plugin_instance"
         case slotOccupied = "slot_occupied"
         case trackSelectionFailed = "track_selection_failed"
         case staleSnapshot = "stale_snapshot"
@@ -432,6 +437,7 @@ enum HonestContract {
         FailureError.unsupportedParamReadback.rawValue,
         FailureError.incompleteInventory.rawValue,
         FailureError.targetPluginMismatch.rawValue,
+        FailureError.ambiguousPluginInstance.rawValue,
         FailureError.slotOccupied.rawValue,
         FailureError.trackSelectionFailed.rawValue,
         FailureError.staleSnapshot.rawValue,

--- a/Sources/LogicProMCP/Utilities/HonestContract.swift
+++ b/Sources/LogicProMCP/Utilities/HonestContract.swift
@@ -145,6 +145,17 @@ enum HonestContract {
         case windowIdentityUnresolved = "window_identity_unresolved"
         case paramControlNotFound = "param_control_not_found"
         case readbackLostAfterWrite = "readback_lost_after_write"
+        /// An AXValue nudge was accepted but the readback did not establish
+        /// reliable progress toward the requested target. This is distinct from
+        /// `ax_write_failed`: the write may have been accepted.
+        case incrementWalkNoProgress = "increment_walk_no_progress"
+        /// The bounded AXValue-nudge loop reached its caller-owned cap without
+        /// arriving. It is not an operation timeout: the explicit write budget
+        /// is the fact a caller can change or diagnose.
+        case incrementWalkBudgetExhausted = "increment_walk_budget_exhausted"
+        /// The nudge loop crossed the target and then moved farther away on the
+        /// same side, so continuing would no longer be trustworthy.
+        case incrementWalkOvershot = "increment_walk_overshot"
         case postInsertPluginMismatch = "post_insert_plugin_mismatch"
         case postInsertReadbackUnavailable = "post_insert_readback_unavailable"
         /// `logic_plugins.insert_verified` reached its live-write boundary with
@@ -429,6 +440,9 @@ enum HonestContract {
         FailureError.windowIdentityUnresolved.rawValue,
         FailureError.paramControlNotFound.rawValue,
         FailureError.readbackLostAfterWrite.rawValue,
+        FailureError.incrementWalkNoProgress.rawValue,
+        FailureError.incrementWalkBudgetExhausted.rawValue,
+        FailureError.incrementWalkOvershot.rawValue,
         FailureError.postInsertPluginMismatch.rawValue,
         FailureError.postInsertReadbackUnavailable.rawValue,
         FailureError.insertNotAxAutomatable.rawValue,

--- a/Sources/LogicProMCP/Utilities/HonestContract.swift
+++ b/Sources/LogicProMCP/Utilities/HonestContract.swift
@@ -99,6 +99,10 @@ enum HonestContract {
         case unsupportedParamReadback = "unsupported_param_readback"
         case incompleteInventory = "incomplete_inventory"
         case targetPluginMismatch = "target_plugin_mismatch"
+        /// A candidate editor had the requested track and parameter control, but
+        /// its direct static-text header did not map to the requested canonical
+        /// plug-in id. Refused before an AX value write.
+        case pluginWindowPluginMismatch = "plugin_window_plugin_mismatch"
         /// More than one insert on the addressed track carries the requested
         /// canonical plug-in identity. Logic's accessible editor identity
         /// cannot distinguish those instances, so opening one could write the
@@ -437,6 +441,7 @@ enum HonestContract {
         FailureError.unsupportedParamReadback.rawValue,
         FailureError.incompleteInventory.rawValue,
         FailureError.targetPluginMismatch.rawValue,
+        FailureError.pluginWindowPluginMismatch.rawValue,
         FailureError.ambiguousPluginInstance.rawValue,
         FailureError.slotOccupied.rawValue,
         FailureError.trackSelectionFailed.rawValue,

--- a/Sources/LogicProMCP/Utilities/HonestContract.swift
+++ b/Sources/LogicProMCP/Utilities/HonestContract.swift
@@ -108,6 +108,14 @@ enum HonestContract {
         /// cannot distinguish those instances, so opening one could write the
         /// wrong insert. Refuse before window acquisition.
         case ambiguousPluginInstance = "ambiguous_plugin_instance"
+        /// The requested plug-in occupies multiple inserts and a matching
+        /// header-proven editor was already visible before the target slot could
+        /// establish provenance by opening one editor from a zero-editor state.
+        case duplicatePluginEditorAlreadyOpen = "duplicate_plugin_editor_already_open"
+        /// The requested plug-in occupies multiple inserts, but one target-slot
+        /// open press did not leave exactly one header-proven matching editor.
+        /// This includes a hidden sibling restored by the press.
+        case duplicatePluginEditorCountMismatch = "duplicate_plugin_editor_count_mismatch"
         case slotOccupied = "slot_occupied"
         case trackSelectionFailed = "track_selection_failed"
         case staleSnapshot = "stale_snapshot"
@@ -443,6 +451,8 @@ enum HonestContract {
         FailureError.targetPluginMismatch.rawValue,
         FailureError.pluginWindowPluginMismatch.rawValue,
         FailureError.ambiguousPluginInstance.rawValue,
+        FailureError.duplicatePluginEditorAlreadyOpen.rawValue,
+        FailureError.duplicatePluginEditorCountMismatch.rawValue,
         FailureError.slotOccupied.rawValue,
         FailureError.trackSelectionFailed.rawValue,
         FailureError.staleSnapshot.rawValue,

--- a/Sources/LogicProMCP/Workflows/WorkflowSkillCatalog.swift
+++ b/Sources/LogicProMCP/Workflows/WorkflowSkillCatalog.swift
@@ -522,7 +522,7 @@ enum WorkflowSkillCatalog {
             "insert_plugin", "set_plugin_param",
         ],
         "logic_plugins": [
-            "get_inventory", "set_param_verified", "insert_verified",
+            "get_inventory", "set_param_verified", "set_eq_band_verified", "insert_verified",
         ],
         "logic_midi": [
             "send_note", "send_chord", "play_sequence", "send_cc",

--- a/Tests/LogicProMCPTests/AXLogicProElementsDialogFilterTests.swift
+++ b/Tests/LogicProMCPTests/AXLogicProElementsDialogFilterTests.swift
@@ -691,6 +691,7 @@ func testPartialChromeStaysBlocking(_ variant: PartialChromeVariant) {
     let closeButton = builder.element(101)
     let bypass = builder.element(102)
     let gainSlider = builder.element(103)
+    let pluginName = builder.element(104)
 
     builder.setAttribute(editor, kAXRoleAttribute as String, kAXWindowRole as String)
     builder.setAttribute(editor, kAXSubroleAttribute as String, kAXDialogSubrole as String)
@@ -701,13 +702,16 @@ func testPartialChromeStaysBlocking(_ variant: PartialChromeVariant) {
     builder.setAttribute(bypass, kAXTitleAttribute as String, "바이패스")
     builder.setAttribute(gainSlider, kAXRoleAttribute as String, kAXSliderRole as String)
     builder.setAttribute(gainSlider, kAXDescriptionAttribute as String, "Gain")
-    builder.setChildren(editor, [bypass, gainSlider])
+    builder.setAttribute(pluginName, kAXRoleAttribute as String, kAXStaticTextRole as String)
+    builder.setAttribute(pluginName, kAXValueAttribute as String, "Gain")
+    builder.setChildren(editor, [bypass, gainSlider, pluginName])
 
     builder.setAttribute(app, kAXWindowsAttribute as String, [editor, arrange])
 
     let runtime = builder.makeLogicRuntime(appElement: app)
     let match = AXLogicProElements.pluginWindowMatch(
         forTrackName: "오디오 1",
+        matchingPluginID: "logic.stock.effect.gain",
         matchingSliderDescription: "Gain",
         runtime: runtime
     )

--- a/Tests/LogicProMCPTests/ChannelEQBandCatalogTests.swift
+++ b/Tests/LogicProMCPTests/ChannelEQBandCatalogTests.swift
@@ -1,0 +1,73 @@
+import Testing
+@testable import LogicProMCP
+
+@Suite("Channel EQ band parameter catalog")
+struct ChannelEQBandCatalogTests {
+    @Test func catalogDerivesAllTwentyFourNamedBandParameters() {
+        let parameters = ChannelEQBandCatalog.parameters
+
+        // Mutation caught: omitting the cut-band Q or a generated band silently
+        // turns the measured 24-control census into a shorter registry.
+        #expect(parameters.count == 24)
+        #expect(Set(parameters.map(\.id)).count == 24)
+        #expect(parameters.map(\.axDescription) == parameters.map(\.displayName))
+    }
+
+    @Test func cutsUseOrderWhileAllOtherBandsUseGain() {
+        let ids = Set(ChannelEQBandCatalog.parameters.map(\.id))
+
+        // Mutation caught: generating Gain for cuts (or Order for shelves and
+        // peaks) points future AX lookup at a control that was not observed.
+        #expect(ids.contains("low_cut_order"))
+        #expect(ids.contains("high_cut_order"))
+        #expect(!ids.contains("low_cut_gain"))
+        #expect(!ids.contains("high_cut_gain"))
+        #expect(ids.contains("low_shelf_gain"))
+        #expect(ids.contains("peak_1_gain"))
+        #expect(ids.contains("high_shelf_gain"))
+    }
+
+    @Test func rawRangesPreserveTheReportedControlKinds() throws {
+        let parameters = ChannelEQBandCatalog.parameters
+        let lowShelfQ = try #require(parameters.first { $0.id == "low_shelf_q" })
+        let highShelfQ = try #require(parameters.first { $0.id == "high_shelf_q" })
+        let peakQ = try #require(parameters.first { $0.id == "peak_3_q" })
+        let cutQ = try #require(parameters.first { $0.id == "high_cut_q" })
+        let frequency = try #require(parameters.first { $0.id == "peak_2_frequency" })
+        let gain = try #require(parameters.first { $0.id == "peak_2_gain" })
+        let order = try #require(parameters.first { $0.id == "low_cut_order" })
+
+        // Mutation caught: sharing the peak/cut Q range with shelves permits
+        // raw values the shelf control does not expose.
+        #expect(lowShelfQ.range == 0 ... 52)
+        #expect(highShelfQ.range == 0 ... 52)
+        #expect(peakQ.range == 0 ... 127)
+        #expect(cutQ.range == 0 ... 127)
+        #expect(frequency.range == 0 ... 1_050)
+        #expect(gain.range == 0 ... 480)
+        #expect(order.range == 0 ... 5)
+    }
+
+    @Test func catalogLabelsRangesAsRawAXValuesAndDeclaresOnlyMeasuredDisplayUnits() {
+        // Mutation caught: labelling these non-linear slider ranges as Hz or
+        // dB would fabricate an engineering conversion from raw AX values.
+        #expect(ChannelEQBandCatalog.parameters.allSatisfy { $0.rawUnit == "raw_ax_value" })
+        #expect(ChannelEQBandCatalog.parameter(bandName: "Peak 1", parameterName: "Frequency")?.declaredUnits == ["raw_ax_value", "Hz"])
+        #expect(ChannelEQBandCatalog.parameter(bandName: "Peak 1", parameterName: "Gain")?.declaredUnits == ["raw_ax_value", "dB"])
+        #expect(ChannelEQBandCatalog.parameter(bandName: "Peak 1", parameterName: "Q")?.declaredUnits == ["raw_ax_value", "Q"])
+        #expect(ChannelEQBandCatalog.parameter(bandName: "Low Cut", parameterName: "Order")?.declaredUnits == ["raw_ax_value"])
+    }
+
+    @Test func stockCatalogRecordsMeasurementWithoutClaimingAWriteRoundTrip() throws {
+        let channelEQ = try #require(StockPluginCatalog.entry(id: "logic.stock.effect.channel_eq"))
+        #expect(channelEQ.safeWriteCapabilities == .parameterWriteReadback)
+        #expect(channelEQ.parameters.count == 24)
+        for parameter in channelEQ.parameters {
+            #expect(parameter.writeMethod == "ax_slider_increment_walk")
+            #expect(parameter.provenance.observedAt == "2026-08-30T00:00:00Z")
+            #expect(parameter.provenance.evidence.contains("raw_axvalue_range_measured_live_2026-08-30"))
+            #expect(parameter.provenance.evidence.contains("axvalue_increment_walk_measured_live_2026-08-30"))
+            #expect(!parameter.provenance.evidence.contains("parameter_write_readback"))
+        }
+    }
+}

--- a/Tests/LogicProMCPTests/ChannelEQBandCatalogTests.swift
+++ b/Tests/LogicProMCPTests/ChannelEQBandCatalogTests.swift
@@ -58,7 +58,7 @@ struct ChannelEQBandCatalogTests {
         #expect(ChannelEQBandCatalog.parameter(bandName: "Low Cut", parameterName: "Order")?.declaredUnits == ["raw_ax_value"])
     }
 
-    @Test func stockCatalogRecordsMeasurementWithoutClaimingAWriteRoundTrip() throws {
+    @Test func stockCatalogRecordsMeasuredIncrementWalkCapabilityAndNoRoundTripEvidence() throws {
         let channelEQ = try #require(StockPluginCatalog.entry(id: "logic.stock.effect.channel_eq"))
         #expect(channelEQ.safeWriteCapabilities == .parameterWriteReadback)
         #expect(channelEQ.parameters.count == 24)

--- a/Tests/LogicProMCPTests/HCGlobalInvariantTests.swift
+++ b/Tests/LogicProMCPTests/HCGlobalInvariantTests.swift
@@ -315,6 +315,7 @@ struct HCGlobalInvariantTests {
             RouteCase(tool: "logic_system", command: "saga_cancel", params: [:], operation: "system.saga_cancel", destinations: [], invariant: .minimumV1),
 
             RouteCase(tool: "logic_plugins", command: "set_param_verified", params: ["track": .int(0), "insert": .int(0), "plugin": .string("logic.stock.gain"), "param": .string("gain_db"), "value": .double(0), "unit": .string("dB"), "mode": .string("duplicate_applyback"), "project_expected_path": .string(fixtures.existingProjectPath)], operation: "plugin.set_param_verified", destinations: [], invariant: .minimumV1),
+            RouteCase(tool: "logic_plugins", command: "set_eq_band_verified", params: ["track": .int(0), "insert": .int(0), "band": .string("Peak 1"), "parameter": .string("Frequency"), "value": .double(250), "unit": .string("raw_ax_value"), "mode": .string("duplicate_applyback"), "project_expected_path": .string(fixtures.existingProjectPath)], operation: "plugin.set_eq_band_verified", destinations: [], invariant: .minimumV1),
             RouteCase(tool: "logic_plugins", command: "insert_verified", params: ["track": .int(2), "insert": .int(0), "plugin": .string("Gain"), "mode": .string("duplicate_applyback"), "project_expected_path": .string(fixtures.existingProjectPath), "expected_name": .string("Bass")], operation: "plugin.insert_verified", destinations: [], invariant: .minimumV1),
         ]
     }

--- a/Tests/LogicProMCPTests/HonestContractV2Tests.swift
+++ b/Tests/LogicProMCPTests/HonestContractV2Tests.swift
@@ -77,6 +77,8 @@ private func decode(_ json: String) -> [String: Any] {
         (.targetPluginMismatch, "target_plugin_mismatch"),
         (.pluginWindowPluginMismatch, "plugin_window_plugin_mismatch"),
         (.ambiguousPluginInstance, "ambiguous_plugin_instance"),
+        (.duplicatePluginEditorAlreadyOpen, "duplicate_plugin_editor_already_open"),
+        (.duplicatePluginEditorCountMismatch, "duplicate_plugin_editor_count_mismatch"),
         (.slotOccupied, "slot_occupied"),
         (.trackSelectionFailed, "track_selection_failed"),
         (.staleSnapshot, "stale_snapshot"),
@@ -125,7 +127,8 @@ private func decode(_ json: String) -> [String: Any] {
     let mustBeTerminal: [HonestContract.FailureError] = [
         .unsupportedMode, .projectPathRequired, .projectIdentityMismatch,
         .unknownPluginIdentity, .unsupportedParamReadback, .incompleteInventory,
-        .targetPluginMismatch, .pluginWindowPluginMismatch, .ambiguousPluginInstance, .slotOccupied,
+        .targetPluginMismatch, .pluginWindowPluginMismatch, .ambiguousPluginInstance,
+        .duplicatePluginEditorAlreadyOpen, .duplicatePluginEditorCountMismatch, .slotOccupied,
         .trackSelectionFailed, .staleSnapshot,
         .windowOpenFailed, .windowIdentityUnresolved, .paramControlNotFound,
         .readbackLostAfterWrite, .postInsertPluginMismatch,

--- a/Tests/LogicProMCPTests/HonestContractV2Tests.swift
+++ b/Tests/LogicProMCPTests/HonestContractV2Tests.swift
@@ -75,6 +75,7 @@ private func decode(_ json: String) -> [String: Any] {
         (.unsupportedParamReadback, "unsupported_param_readback"),
         (.incompleteInventory, "incomplete_inventory"),
         (.targetPluginMismatch, "target_plugin_mismatch"),
+        (.pluginWindowPluginMismatch, "plugin_window_plugin_mismatch"),
         (.ambiguousPluginInstance, "ambiguous_plugin_instance"),
         (.slotOccupied, "slot_occupied"),
         (.trackSelectionFailed, "track_selection_failed"),
@@ -124,7 +125,7 @@ private func decode(_ json: String) -> [String: Any] {
     let mustBeTerminal: [HonestContract.FailureError] = [
         .unsupportedMode, .projectPathRequired, .projectIdentityMismatch,
         .unknownPluginIdentity, .unsupportedParamReadback, .incompleteInventory,
-        .targetPluginMismatch, .ambiguousPluginInstance, .slotOccupied,
+        .targetPluginMismatch, .pluginWindowPluginMismatch, .ambiguousPluginInstance, .slotOccupied,
         .trackSelectionFailed, .staleSnapshot,
         .windowOpenFailed, .windowIdentityUnresolved, .paramControlNotFound,
         .readbackLostAfterWrite, .postInsertPluginMismatch,

--- a/Tests/LogicProMCPTests/HonestContractV2Tests.swift
+++ b/Tests/LogicProMCPTests/HonestContractV2Tests.swift
@@ -75,6 +75,7 @@ private func decode(_ json: String) -> [String: Any] {
         (.unsupportedParamReadback, "unsupported_param_readback"),
         (.incompleteInventory, "incomplete_inventory"),
         (.targetPluginMismatch, "target_plugin_mismatch"),
+        (.ambiguousPluginInstance, "ambiguous_plugin_instance"),
         (.slotOccupied, "slot_occupied"),
         (.trackSelectionFailed, "track_selection_failed"),
         (.staleSnapshot, "stale_snapshot"),
@@ -123,7 +124,8 @@ private func decode(_ json: String) -> [String: Any] {
     let mustBeTerminal: [HonestContract.FailureError] = [
         .unsupportedMode, .projectPathRequired, .projectIdentityMismatch,
         .unknownPluginIdentity, .unsupportedParamReadback, .incompleteInventory,
-        .targetPluginMismatch, .slotOccupied, .trackSelectionFailed, .staleSnapshot,
+        .targetPluginMismatch, .ambiguousPluginInstance, .slotOccupied,
+        .trackSelectionFailed, .staleSnapshot,
         .windowOpenFailed, .windowIdentityUnresolved, .paramControlNotFound,
         .readbackLostAfterWrite, .postInsertPluginMismatch,
         .postInsertReadbackUnavailable, .insertNotAxAutomatable,

--- a/Tests/LogicProMCPTests/IndexBindingCensusTests.swift
+++ b/Tests/LogicProMCPTests/IndexBindingCensusTests.swift
@@ -92,11 +92,14 @@ struct IndexBindingCensusTests {
         // grow. Each entry earns its place only by being reversible — a
         // wrong-target write here is recoverable by the user. This pinned set is
         // the ADR-002 done-bar's recorded, issue-linked waiver (#401): the
-        // residual is visible and enforced here, not a silent gap.
+        // residual is visible and enforced here, not a silent gap. A newly
+        // registered reversible parameter write joins this tier deliberately;
+        // it must bring the same explicit census update as its registry row.
         let expectedLegacy: Set<OperationID> = [
             .mixerSetVolume,           // reversible level write
             .mixerSetPan,              // reversible pan write
             .pluginsSetParamVerified,  // reversible param write (verified readback)
+            .pluginsSetEQBandVerified, // reversible named-EQ parameter write
             .tracksSelect,             // selection only; no persistent state change
             .tracksRename,             // reversible: rename back
             .tracksMute,               // reversible toggle
@@ -156,7 +159,8 @@ struct IndexBindingCensusTests {
         //   • mixer.set_plugin_param → give target_ref, then .legacyIndexAllowed
         //                              (reversible param write; ratchet cost not yet earned,
         //                              but it still must become target-bearing to leave this set).
-        // This set may only SHRINK. Growth = a new hazard needing a decision.
+        // Existing members may only shrink; a new reversible target-bearing
+        // operation requires an explicit census update with its registry row.
         #expect(hazards == [.mixerInsertPlugin, .mixerSetPluginParam])
 
         // The distinguishing property is real, not incidental: none of these can

--- a/Tests/LogicProMCPTests/MIDIEngineTests.swift
+++ b/Tests/LogicProMCPTests/MIDIEngineTests.swift
@@ -375,21 +375,27 @@ private final class MIDIEngineRuntimeHarness: @unchecked Sendable {
 func testMIDIEngineProductionRuntimeStartStopSmoke() async throws {
     let engine = MIDIEngine()
 
-    // v3.4.4 (CI hotfix): GitHub Actions macos-15-arm64 runners do not
-    // expose a working CoreMIDI server in the sandboxed runner image,
-    // so `MIDIClientCreate` returns OSStatus -50 (`kMIDINotPermitted`).
-    // The smoke test still exercises the production path on real macOS
-    // hosts; on a runner where MIDI client creation is denied we treat
-    // it as a precondition-not-met and return cleanly. The error is
-    // logged so a regression that breaks `start()` for a different
-    // reason still surfaces.
+    // A client-creation failure has two causes and only one is a defect: the
+    // environment refusing CoreMIDI, or start() being broken. `coreMIDIRefuses
+    // AClientRightNow` separates them by asking CoreMIDI directly, so this can
+    // still fail when the product path is the broken half. It replaced a check
+    // for one hardcoded status (-50, what a CI runner returns), which read every
+    // OTHER environmental refusal as a product failure.
     do {
         try await engine.start()
     } catch let error as MIDIEngineError {
-        if case .clientCreationFailed(let status) = error, status == -50 {
-            return
+        guard case .clientCreationFailed(let startStatus) = error,
+              let probeStatus = coreMIDIRefusesAClientRightNow() else {
+            // Either a different failure, or CoreMIDI WILL hand this process a
+            // client — in which case start() is the broken half and must fail.
+            throw error
         }
-        throw error
+        reportCoreMIDIUnavailable(
+            "testMIDIEngineProductionRuntimeStartStopSmoke",
+            startStatus: startStatus,
+            probeStatus: probeStatus
+        )
+        return
     }
     #expect(await engine.isActive)
 
@@ -398,4 +404,25 @@ func testMIDIEngineProductionRuntimeStartStopSmoke() async throws {
 
     await engine.stop()
     #expect(!(await engine.isActive))
+}
+
+@Test(coreMIDIUnavailableInSandbox)
+func testCoreMIDIAvailabilityProbeAnswersForItselfRatherThanExcusingAnything() {
+    // The probe is what keeps the production smoke tests from excusing a real
+    // defect. If it ever reported a refusal on a host where CoreMIDI is fine,
+    // those tests would pass no matter how broken start() became.
+    //
+    // On a host that CAN create a client this must be nil. On a host that
+    // cannot, the smoke tests are skipped and so is this — the trait and the
+    // probe agree about what "unavailable" means.
+    let refusal = coreMIDIRefusesAClientRightNow()
+    if let refusal {
+        // Not a failure: the environment genuinely refuses. Say so loudly so a
+        // green run is never mistaken for one that exercised CoreMIDI.
+        print("SKIPPED probe self-check: CoreMIDI refused a client (status \(refusal)).")
+        return
+    }
+    // The probe must also leave nothing behind: a leaked client would change
+    // MIDIServer's lifecycle for every later test in this process.
+    #expect(coreMIDIRefusesAClientRightNow() == nil)
 }

--- a/Tests/LogicProMCPTests/MIDIPortTests.swift
+++ b/Tests/LogicProMCPTests/MIDIPortTests.swift
@@ -325,18 +325,21 @@ func testMIDIPortManagerProductionRuntimeSmokeCreatesAndStopsPorts() async throw
     let sendOnlyName = "LogicProMCP-Smoke-\(UUID().uuidString)"
     let bidirectionalName = "LogicProMCP-Smoke-Bidi-\(UUID().uuidString)"
 
-    // v3.4.4 (CI hotfix): GitHub Actions macos-15-arm64 runners cannot
-    // create CoreMIDI clients (`MIDIClientCreate` returns OSStatus -50).
-    // The production smoke test still runs on real macOS hosts; CI
-    // skips with a clean return rather than failing on a precondition
-    // we can't satisfy in the sandbox.
+    // See the note on the MIDIEngine production smoke test: the refusal is
+    // confirmed against CoreMIDI directly rather than matched to one status.
     do {
         try await manager.start()
     } catch let error as MIDIPortError {
-        if case .clientCreationFailed(let status) = error, status == -50 {
-            return
+        guard case .clientCreationFailed(let startStatus) = error,
+              let probeStatus = coreMIDIRefusesAClientRightNow() else {
+            throw error
         }
-        throw error
+        reportCoreMIDIUnavailable(
+            "testMIDIPortManagerProductionRuntimeSmokeCreatesAndStopsPorts",
+            startStatus: startStatus,
+            probeStatus: probeStatus
+        )
+        return
     }
 
     let sendOnly = try await manager.createSendOnlyPort(name: sendOnlyName)

--- a/Tests/LogicProMCPTests/OperationCatalogTests.swift
+++ b/Tests/LogicProMCPTests/OperationCatalogTests.swift
@@ -41,11 +41,13 @@ struct OperationCatalogTests {
     private static let selectorsRequiringLiveQualificationByOperation: [OperationID: Set<String>] = [
         .pluginsGetInventory: ["index", "track"],
         .pluginsSetParamVerified: ["track"],
+        .pluginsSetEQBandVerified: ["track"],
         .pluginsInsertVerified: ["track"],
     ]
     private static let selectorLiveQualificationReasonByOperation: [OperationID: String] = [
         .pluginsGetInventory: "AX inventory must expose the selected strip identity after ChannelRouter forwarding",
         .pluginsSetParamVerified: "AX apply-back must expose target_identity after verified preflight",
+        .pluginsSetEQBandVerified: "AX named-band apply-back must expose target_identity after verified preflight",
         .pluginsInsertVerified: "AX insert readback must expose target_identity after verified preflight",
     ]
 
@@ -149,6 +151,9 @@ struct OperationCatalogTests {
         .pluginsSetParamVerified: [
             "insert", "mode", "param", "plugin", "plugin_id", "plugin_name",
             "project_expected_path", "unit", "value",
+        ],
+        .pluginsSetEQBandVerified: [
+            "band", "insert", "mode", "parameter", "project_expected_path", "unit", "value",
         ],
         .pluginsInsertVerified: [
             "insert", "mode", "plugin", "plugin_id", "plugin_name", "project_expected_path", "slot",
@@ -394,7 +399,7 @@ struct OperationCatalogTests {
                     ("get_trace", "system.get_trace", ["trace_id"], .none),
                     ("clear_traces", "system.clear_traces", ["confirmed"], .l2),
                 ]
-                #expect(OperationRegistry.specs.count == 111)
+                #expect(OperationRegistry.specs.count == 112)
                 for (command, operationID, allowedParams, confirmation) in expectedSpecs {
                     let spec = OperationRegistry.spec(tool: "logic_system", command: command)
                     #expect(spec?.id.rawValue == operationID, "\(command) must have one public spec")
@@ -543,12 +548,12 @@ struct OperationCatalogTests {
         }
 
         #expect(advertised.filter { $0.1 == "index" }.count == 17)
-        #expect(advertised.filter { $0.1 == "track" }.count == 16)
-        #expect(advertised.count == 33)
+        #expect(advertised.filter { $0.1 == "track" }.count == 17)
+        #expect(advertised.count == 34)
         #expect(probes.filter { $0.1 == "index" }.count == 16)
         #expect(probes.filter { $0.1 == "track" }.count == 13)
         #expect(probes.count == 29)
-        #expect(Self.selectorsRequiringLiveQualificationByOperation.values.reduce(0) { $0 + $1.count } == 4)
+        #expect(Self.selectorsRequiringLiveQualificationByOperation.values.reduce(0) { $0 + $1.count } == 5)
         #expect(
             Set(Self.selectorLiveQualificationReasonByOperation.keys)
                 == Set(Self.selectorsRequiringLiveQualificationByOperation.keys)
@@ -721,7 +726,7 @@ struct OperationCatalogTests {
 
     @Test("strict: every registered operation rejects unknown keys and accepts its pinned keys")
     func strictRegistryWideInvariant() throws {
-        #expect(OperationRegistry.specs.count == 111)
+        #expect(OperationRegistry.specs.count == 112)
         #expect(Set(OperationRegistry.specs.map(\.id)) == Set(OperationID.allCases))
 
         for spec in OperationRegistry.specs {
@@ -802,9 +807,9 @@ struct OperationCatalogTests {
             $0.target == .acceptsStableTarget
         }.map(\.id))
         #expect(actualIndex.count == 17)
-        #expect(actualTrack.count == 16)
+        #expect(actualTrack.count == 17)
         #expect(actualTargetRef == targetBearing)
-        #expect(actualTargetRef.count == 14)
+        #expect(actualTargetRef.count == 15)
         for spec in OperationRegistry.specs {
             #expect(
                 spec.allowedParams.isDisjoint(
@@ -888,7 +893,7 @@ struct OperationCatalogTests {
         #expect(sharedToolText(trackRejected).contains("port parameter not supported for record_sequence"))
     }
 
-    @Test("catalog: exact URI reads the generated 111-operation catalog")
+    @Test("catalog: exact URI reads the generated 112-operation catalog")
     func catalogReadsRegistryProjection() async throws {
         let result = try await ResourceHandlers.read(
             uri: Self.uri,
@@ -901,7 +906,7 @@ struct OperationCatalogTests {
         #expect(body["generated_at"] as? String != nil)
         #expect(body["operation_count"] as? Int == OperationRegistry.specs.count)
         let operations = try #require(body["operations"] as? [[String: Any]])
-        #expect(operations.count == 111)
+        #expect(operations.count == 112)
         #expect(!text.contains("\n"))
 
         let ids = operations.compactMap { $0["id"] as? String }

--- a/Tests/LogicProMCPTests/OperationHandlerBindingTests.swift
+++ b/Tests/LogicProMCPTests/OperationHandlerBindingTests.swift
@@ -142,7 +142,7 @@ struct OperationHandlerBindingTests {
         let specKeys = Set(specs.map { "\($0.tool.rawValue):\($0.command)" })
         let bindingKeys = bindings.map { "\($0.tool):\($0.command)" }
 
-        #expect(specs.count == 111)   // #575 registered edit.move_to_playhead
+        #expect(specs.count == 112)   // #575 registered edit.move_to_playhead
         #expect(bindings.count == specs.count)
         #expect(Set(bindingIDs).count == bindings.count, "duplicate handler IDs")
         #expect(Set(bindingKeys).count == bindings.count, "duplicate handler keys")

--- a/Tests/LogicProMCPTests/OperationRegistryCoverageTests.swift
+++ b/Tests/LogicProMCPTests/OperationRegistryCoverageTests.swift
@@ -72,6 +72,7 @@ struct OperationRegistryCoverageTests {
             .mixerSetVolume,
             .mixerSetPan,
             .pluginsSetParamVerified,
+            .pluginsSetEQBandVerified,
             .pluginsInsertVerified,
             .tracksSelect,
             .tracksDelete,

--- a/Tests/LogicProMCPTests/OperationRegistryCoverageTests.swift
+++ b/Tests/LogicProMCPTests/OperationRegistryCoverageTests.swift
@@ -24,7 +24,7 @@ struct OperationRegistryCoverageTests {
         let missing = Self.publicOperations.subtracting(Self.registeredOperations).sorted()
         let orphans = Self.registeredOperations.subtracting(Self.publicOperations).sorted()
 
-        #expect(OperationRegistry.specs.count == 111)   // #575 registered edit.move_to_playhead
+        #expect(OperationRegistry.specs.count == 112)   // #575 registered edit.move_to_playhead
         #expect(OperationRegistry.registeredToolRawValues == Set(WorkflowSkillCatalog.publicCommands.keys))
         #expect(Self.registeredOperations.count == OperationRegistry.specs.count)
         #expect(missing.isEmpty, "missing specs: \(missing)")
@@ -86,7 +86,9 @@ struct OperationRegistryCoverageTests {
             .tracksSetInstrument,
         ]
 
-        #expect(mutating.count == 88)   // #575: move_to_playhead is a mutating edit verb
+        #expect(mutating.count == 89)   // #575: move_to_playhead is a mutating edit verb;
+                                        // #301 added plugins.set_eq_band_verified, which is
+                                        // target-bearing, so `targetless` is unchanged
         #expect(readOnly.count == 23)
         #expect(targetBearingIDs == expectedTargetBearingIDs)
         #expect(targetless.count == 74)   // #575: it acts on the selection, so it bears no target

--- a/Tests/LogicProMCPTests/OperationRegistryTests.swift
+++ b/Tests/LogicProMCPTests/OperationRegistryTests.swift
@@ -50,7 +50,7 @@ struct OperationRegistryTests {
         "delete_marker": .defaultInstall,
     ]
 
-    private static let smallToolCount = 19
+    private static let smallToolCount = 20
     private static let expectedRegistryCount =
         commands.count + mixerCommands.count + navigateCommands.count + smallToolCount
             + editCommands.count + projectCommands.count + midiCommands.count + trackCommands.count
@@ -367,6 +367,7 @@ struct OperationRegistryTests {
         ("logic_system", "system.setup_arm_key", "setup_arm_key", .mutating, .long, .readbackRequired),
         ("logic_plugins", "plugins.get_inventory", "get_inventory", .readOnly, .short, .none),
         ("logic_plugins", "plugins.set_param_verified", "set_param_verified", .mutating, .medium, .readbackRequired),
+        ("logic_plugins", "plugins.set_eq_band_verified", "set_eq_band_verified", .mutating, .medium, .readbackRequired),
         ("logic_plugins", "plugins.insert_verified", "insert_verified", .mutating, .medium, .readbackRequired),
     ]
 
@@ -406,7 +407,7 @@ struct OperationRegistryTests {
             #expect(spec.mutability == entry.mutability)
             #expect(spec.confirmation == (id == .systemClearTraces ? .l2 : .none))
             #expect(spec.target == (
-                id == .pluginsSetParamVerified || id == .pluginsInsertVerified
+                id == .pluginsSetParamVerified || id == .pluginsSetEQBandVerified || id == .pluginsInsertVerified
                     ? .acceptsStableTarget
                     : .none
             ))
@@ -455,7 +456,7 @@ struct OperationRegistryTests {
 
     @Test("plugin medium deadlines match server decisions")
     func pluginMediumDeadlineFlagParity() {
-        let commands = ["set_param_verified", "insert_verified"]
+        let commands = ["set_param_verified", "set_eq_band_verified", "insert_verified"]
 
         for command in commands {
             #expect(OperationRegistry.deadlineSeconds(tool: "logic_plugins", command: command) == 90)

--- a/Tests/LogicProMCPTests/OperationTraceCoverageTests.swift
+++ b/Tests/LogicProMCPTests/OperationTraceCoverageTests.swift
@@ -680,6 +680,14 @@ private func operationTraceCoverageParams(
             "mode": .string("duplicate_applyback"),
             "project_expected_path": .string(fixtures.projectPath),
         ]
+    case .pluginsSetEQBandVerified:
+        return [
+            "track": .int(0), "insert": .int(0),
+            "band": .string("Peak 1"), "parameter": .string("Frequency"),
+            "value": .double(250), "unit": .string("raw_ax_value"),
+            "mode": .string("duplicate_applyback"),
+            "project_expected_path": .string(fixtures.projectPath),
+        ]
     case .pluginsInsertVerified:
         return [
             "track": .int(0), "insert": .int(0), "plugin": .string("Gain"),

--- a/Tests/LogicProMCPTests/OperationTraceCoverageTests.swift
+++ b/Tests/LogicProMCPTests/OperationTraceCoverageTests.swift
@@ -186,8 +186,8 @@ extension OperationTraceTests {
         let mutatingSpecs = OperationRegistry.specs.filter {
             $0.mutability == Mutability.`mutating`
         }
-        #expect(OperationRegistry.specs.count == 111)
-        #expect(mutatingSpecs.count == 88)   // #575 registered edit.move_to_playhead
+        #expect(OperationRegistry.specs.count == 112)
+        #expect(mutatingSpecs.count == 89)   // #575 registered edit.move_to_playhead
 
         // A mutating op that refuses BEFORE dispatch starts its trace (the
         // consent-first setup_arm_key, #413) starts no trace with the coverage
@@ -297,7 +297,7 @@ extension OperationTraceTests {
 
         let readOnlySpecs = OperationRegistry.specs.filter { $0.mutability == .readOnly }
         let mutatingSpecs = OperationRegistry.specs.filter { $0.mutability == Mutability.`mutating` }
-        #expect(OperationRegistry.specs.count == 111)
+        #expect(OperationRegistry.specs.count == 112)
         #expect(readOnlySpecs.count == 23)
         // Mutability is total: the mutating census (87) and this inverse gate
         // (23) together account for every registered spec, so a new operation

--- a/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
+++ b/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
@@ -42,6 +42,7 @@ private final class LiveFixture: @unchecked Sendable {
     let builder = FakeAXRuntimeBuilder()
     let app: AXUIElement
     let windowsAddedOnSlotPress: MutableBox<[AXUIElement]>
+    let targetOpenControlPressCount: MutableBox<Int>
     let sliderWriteCount: MutableBox<Int>
     let runtime: AXLogicProElements.Runtime
 
@@ -68,6 +69,7 @@ private final class LiveFixture: @unchecked Sendable {
     ) {
         let b = builder
         let windowsAddedOnSlotPress = MutableBox<[AXUIElement]>([])
+        let targetOpenControlPressCount = MutableBox(0)
         let sliderWriteCount = MutableBox(0)
         let app = b.element(1000)
         let arrangeWindow = b.element(1001)
@@ -250,6 +252,9 @@ private final class LiveFixture: @unchecked Sendable {
                 guard key == targetSlotKey || key == targetOpenButtonKey else {
                     return true
                 }
+                if key == targetOpenButtonKey {
+                    targetOpenControlPressCount.value += 1
+                }
                 if openWindowOnSlotPress {
                     b.setAttribute(
                         app,
@@ -267,6 +272,7 @@ private final class LiveFixture: @unchecked Sendable {
         )
         self.app = app
         self.windowsAddedOnSlotPress = windowsAddedOnSlotPress
+        self.targetOpenControlPressCount = targetOpenControlPressCount
         self.sliderWriteCount = sliderWriteCount
         self.runtime = runtime
     }
@@ -316,6 +322,38 @@ private func runLive(
     return try! JSONSerialization.jsonObject(
         with: result.message.data(using: .utf8)!, options: []
     ) as! [String: Any]
+}
+
+/// A second same-track Compressor editor for the duplicate-insert post-count
+/// case. Its distinct AX elements intentionally share every non-geometry
+/// identity attribute the live editors share.
+private func matchingCompressorEditorWindow(
+    fixture: LiveFixture,
+    baseID: Int
+) -> (window: AXUIElement, slider: AXUIElement) {
+    let b = fixture.builder
+    let window = b.element(baseID)
+    let slider = b.element(baseID + 1)
+    let close = b.element(baseID + 2)
+    let bypass = b.element(baseID + 3)
+    let link = b.element(baseID + 4)
+    let pluginName = b.element(baseID + 5)
+    b.setAttribute(slider, kAXRoleAttribute as String, kAXSliderRole as String)
+    b.setAttribute(slider, kAXDescriptionAttribute as String, "Threshold")
+    b.setAttribute(slider, kAXValueAttribute as String, 51.0)
+    b.setAttribute(close, kAXRoleAttribute as String, kAXButtonRole as String)
+    b.setAttribute(bypass, kAXRoleAttribute as String, kAXCheckBoxRole as String)
+    b.setAttribute(bypass, kAXDescriptionAttribute as String, "bypass")
+    b.setAttribute(link, kAXRoleAttribute as String, kAXCheckBoxRole as String)
+    b.setAttribute(link, kAXDescriptionAttribute as String, "link")
+    b.setAttribute(pluginName, kAXRoleAttribute as String, kAXStaticTextRole as String)
+    b.setAttribute(pluginName, kAXValueAttribute as String, "Compressor")
+    b.setAttribute(window, kAXRoleAttribute as String, kAXWindowRole as String)
+    b.setAttribute(window, kAXSubroleAttribute as String, kAXDialogSubrole as String)
+    b.setAttribute(window, kAXTitleAttribute as String, trackName)
+    b.setAttribute(window, kAXCloseButtonAttribute as String, close)
+    b.setChildren(window, [bypass, link, slider, pluginName])
+    return (window, slider)
 }
 
 private func thresholdParams(
@@ -525,7 +563,8 @@ private func namedEQBandParams(
 
     #expect(obj["state"] as? String == "C")
     #expect(obj["error"] as? String == "plugin_window_plugin_mismatch")
-    #expect(try #require(obj["write_attempted"] as? Bool) == false)
+    let writeAttempted = try #require(obj["write_attempted"] as? Bool)
+    #expect(!writeAttempted)
     #expect((try #require(obj["what_was_observed"] as? String)).contains("Noise Gate"))
     #expect(fixture.currentSliderValue == 51)
 }
@@ -568,7 +607,8 @@ private func namedEQBandParams(
 
     #expect(obj["state"] as? String == "C")
     #expect(obj["error"] as? String == "plugin_window_plugin_mismatch")
-    #expect(try #require(obj["write_attempted"] as? Bool) == false)
+    let writeAttempted = try #require(obj["write_attempted"] as? Bool)
+    #expect(!writeAttempted)
     #expect((try #require(obj["what_was_observed"] as? String)).contains("no readable direct AXStaticText"))
     #expect(fixture.currentSliderValue == 51)
 }
@@ -611,38 +651,90 @@ private func namedEQBandParams(
 
     #expect(obj["state"] as? String == "C")
     #expect(obj["error"] as? String == "plugin_window_plugin_mismatch")
-    #expect(try #require(obj["write_attempted"] as? Bool) == false)
+    let writeAttempted = try #require(obj["write_attempted"] as? Bool)
+    #expect(!writeAttempted)
     #expect((try #require(obj["what_was_observed"] as? String)).contains("Noise Gate"))
     #expect(fixture.currentSliderValue == 51)
 }
 
 // MARK: - #726 per-track plug-in-instance ambiguity
 
-@Test func testDuplicatePluginInstancesOnTargetTrackRefuseBeforeWindowAcquisition() async throws {
-    // Mutation caught: counting only the target slot (or moving this guard
-    // after the opener) reintroduces the measured wrong-instance write.
+@Test func testDuplicatePluginInstancesAcquireByOneTargetOpenPress() async {
+    // Mutation caught: reusing the name-only opener (or taking an unproven
+    // editor) would make this fail before State A or press another control.
+    let fixture = LiveFixture(
+        beforeValue: 51,
+        pluginWindowPresent: false,
+        openWindowOnSlotPress: true,
+        pluginSlotNamesByTrack: [0: [0: "Compressor", 6: "Compressor"]]
+    )
+    let obj = await runLive(fixture: fixture, params: thresholdParams())
+
+    #expect(obj["state"] as? String == "A")
+    #expect(fixture.currentSliderValue == 60)
+    #expect(fixture.targetOpenControlPressCount.value == 1)
+}
+
+@Test func testDuplicatePluginWithAnAlreadyOpenEditorRefusesBeforePress() async throws {
+    let fixture = LiveFixture(
+        beforeValue: 51,
+        pluginSlotNamesByTrack: [0: [0: "Compressor", 6: "Compressor"]]
+    )
+    let obj = await runLive(fixture: fixture, params: thresholdParams())
+
+    #expect(obj["state"] as? String == "C")
+    #expect(obj["error"] as? String == "duplicate_plugin_editor_already_open")
+    let writeAttempted = try #require(obj["write_attempted"] as? Bool)
+    #expect(!writeAttempted)
+    #expect(obj["matching_editor_count_before_press"] as? Int == 1)
+    #expect(fixture.targetOpenControlPressCount.value == 0)
+    #expect(fixture.currentSliderValue == 51)
+}
+
+@Test func testDuplicatePluginWithTwoEditorsAfterOnePressRefuses() async throws {
+    let fixture = LiveFixture(
+        beforeValue: 51,
+        pluginWindowPresent: false,
+        openWindowOnSlotPress: true,
+        pluginSlotNamesByTrack: [0: [0: "Compressor", 6: "Compressor"]]
+    )
+    let sibling = matchingCompressorEditorWindow(fixture: fixture, baseID: 3_500)
+    fixture.windowsAddedOnSlotPress.value = [sibling.window]
+    let obj = await runLive(fixture: fixture, params: thresholdParams())
+
+    #expect(obj["state"] as? String == "C")
+    #expect(obj["error"] as? String == "duplicate_plugin_editor_count_mismatch")
+    let writeAttempted = try #require(obj["write_attempted"] as? Bool)
+    #expect(!writeAttempted)
+    #expect(obj["matching_editor_count_after_press"] as? Int == 2)
+    #expect(fixture.targetOpenControlPressCount.value == 1)
+    #expect(fixture.currentSliderValue == 51)
+    #expect(fixture.builder.attributeValue(sibling.slider, kAXValueAttribute as String) as? Double == 51)
+}
+
+@Test func testDuplicatePluginWithNoEditorAfterOnePressRefuses() async throws {
     let fixture = LiveFixture(
         beforeValue: 51,
         pluginWindowPresent: false,
         pluginSlotNamesByTrack: [0: [0: "Compressor", 6: "Compressor"]]
     )
-    let openerInvoked = MutableBox(false)
-    let obj = await runLive(
-        fixture: fixture,
-        params: thresholdParams(),
-        opener: { _, _, _, _, _ in
-            openerInvoked.value = true
-            return nil
-        }
-    )
+    let obj = await runLive(fixture: fixture, params: thresholdParams())
 
     #expect(obj["state"] as? String == "C")
-    #expect(obj["error"] as? String == "ambiguous_plugin_instance")
+    #expect(obj["error"] as? String == "duplicate_plugin_editor_count_mismatch")
     let writeAttempted = try #require(obj["write_attempted"] as? Bool)
     #expect(!writeAttempted)
-    #expect(obj["conflicting_insert_indices"] as? [Int] == [0, 6])
-    #expect(!openerInvoked.value, "the refusal must precede every window-open attempt")
+    #expect(obj["matching_editor_count_after_press"] as? Int == 0)
+    #expect(fixture.targetOpenControlPressCount.value == 1)
     #expect(fixture.currentSliderValue == 51)
+}
+
+@Test func testSinglePluginWithAnAlreadyOpenEditorKeepsExistingBehaviour() async {
+    let fixture = LiveFixture(beforeValue: 51)
+    let obj = await runLive(fixture: fixture, params: thresholdParams())
+
+    #expect(obj["state"] as? String == "A")
+    #expect(fixture.currentSliderValue == 60)
 }
 
 @Test func testDifferentPluginInstancesOnTargetTrackStillProceed() async {
@@ -682,10 +774,10 @@ private func namedEQBandParams(
     #expect(fixture.currentSliderValue == 60)
 }
 
-@Test func testDuplicateChannelEQInstancesRefuseBeforeWindowAcquisition() async throws {
-    // Mutation caught: wiring the ambiguity refusal only into
-    // set_param_verified leaves set_eq_band_verified able to open an ambiguous
-    // Channel EQ editor and write the wrong insert.
+@Test func testDuplicateChannelEQInstancesAlsoRequireAProvenPostCount() async throws {
+    // The shared verified-write engine must not let the named-band route escape
+    // duplicate-instance construction. The injected opener cannot supply a
+    // window here: this branch must use exactly one slot-control press instead.
     let fixture = LiveFixture(
         thresholdDescription: "Peak 1 Frequency",
         pluginSlotName: "Channel EQ",
@@ -707,11 +799,13 @@ private func namedEQBandParams(
     let obj = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
 
     #expect(obj["state"] as? String == "C")
-    #expect(obj["error"] as? String == "ambiguous_plugin_instance")
+    #expect(obj["error"] as? String == "duplicate_plugin_editor_count_mismatch")
     let writeAttempted = try #require(obj["write_attempted"] as? Bool)
     #expect(!writeAttempted)
     #expect(obj["conflicting_insert_indices"] as? [Int] == [0, 6])
-    #expect(!openerInvoked.value, "the refusal must precede every window-open attempt")
+    #expect(obj["matching_editor_count_after_press"] as? Int == 0)
+    #expect(fixture.targetOpenControlPressCount.value == 1)
+    #expect(!openerInvoked.value, "the duplicate branch must not reuse the generic opener")
 }
 
 // MARK: - ADR-002 F1: live track-name cross-check for target_ref resolutions

--- a/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
+++ b/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
@@ -63,7 +63,8 @@ private final class LiveFixture: @unchecked Sendable {
         slotPressReturnsFalse: Bool = false,
         sliderWriteBehavior: SliderWriteBehavior = .direct,
         sliderDisplayUnit: String = "%",
-        sliderUsesSignedPositiveDisplay: Bool = false
+        sliderUsesSignedPositiveDisplay: Bool = false,
+        pluginWindowStaticTextValues: [String]? = nil
     ) {
         let b = builder
         let windowsAddedOnSlotPress = MutableBox<[AXUIElement]>([])
@@ -148,7 +149,8 @@ private final class LiveFixture: @unchecked Sendable {
         b.setAttribute(arrangeWindow, kAXTitleAttribute as String, "AcidWashBass — Tracks")
         b.setChildren(arrangeWindow, [headersGroup, mixer])
 
-        // --- Plugin window: title == track name; one Threshold AXSlider. ---
+        // --- Plug-in window: title == track name; direct AXStaticText children
+        //     include the plug-in display name at no fixed index. ---
         b.setAttribute(slider, kAXRoleAttribute as String, kAXSliderRole as String)
         b.setAttribute(slider, kAXDescriptionAttribute as String, thresholdDescription)
         b.setAttribute(slider, kAXValueAttribute as String, beforeValue)
@@ -170,7 +172,15 @@ private final class LiveFixture: @unchecked Sendable {
         b.setAttribute(pluginWindow, kAXCloseButtonAttribute as String, pluginClose)
         b.setAttribute(pluginWindow, kAXMainAttribute as String, pluginWindowPresent)
         b.setAttribute(pluginWindow, kAXFocusedAttribute as String, pluginWindowPresent)
-        b.setChildren(pluginWindow, [pluginBypass, pluginLink, slider])
+        let staticTexts = (pluginWindowStaticTextValues ?? ["보기:", pluginSlotName, trackName])
+            .enumerated()
+            .map { offset, value -> AXUIElement in
+                let text = b.element(1010 + offset)
+                b.setAttribute(text, kAXRoleAttribute as String, kAXStaticTextRole as String)
+                b.setAttribute(text, kAXValueAttribute as String, value)
+                return text
+            }
+        b.setChildren(pluginWindow, [pluginBypass, pluginLink, slider] + staticTexts)
 
         let windows = pluginWindowPresent ? [arrangeWindow, pluginWindow] : [arrangeWindow]
         b.setAttribute(app, kAXWindowsAttribute as String, windows)
@@ -502,6 +512,110 @@ private func namedEQBandParams(
     #expect(obj["observed_normalized"] as? Double == 60.7)
 }
 
+// MARK: - Plug-in editor header identity
+
+@Test func testPreopenedDifferentPluginHeaderIsRefusedBeforeWrite() async throws {
+    // The reuse path must not adopt a same-track, same-parameter Noise Gate
+    // editor for a Compressor request merely because both expose Threshold.
+    let fixture = LiveFixture(
+        beforeValue: 51,
+        pluginWindowStaticTextValues: ["보기:", "Noise Gate", trackName]
+    )
+    let obj = await runLive(fixture: fixture, params: thresholdParams())
+
+    #expect(obj["state"] as? String == "C")
+    #expect(obj["error"] as? String == "plugin_window_plugin_mismatch")
+    #expect(try #require(obj["write_attempted"] as? Bool) == false)
+    #expect((try #require(obj["what_was_observed"] as? String)).contains("Noise Gate"))
+    #expect(fixture.currentSliderValue == 51)
+}
+
+@Test func testRequestedPluginHeaderAllowsPreopenedReuseToReachStateA() async {
+    // This takes the production opener's pre-existing-window reuse branch.
+    let fixture = LiveFixture(
+        beforeValue: 51,
+        pluginWindowStaticTextValues: ["보기:", "Compressor", trackName]
+    )
+    let obj = await runLive(fixture: fixture, params: thresholdParams())
+
+    #expect(obj["state"] as? String == "A")
+    #expect(fixture.currentSliderValue == 60)
+}
+
+@Test func testPluginHeaderAliasMapsToRequestedCanonicalID() async throws {
+    // The observed spelling intentionally differs from the catalog display
+    // name. Raw string equality would reject it; catalog alias resolution must
+    // accept it as Channel EQ.
+    let fixture = LiveFixture(
+        thresholdDescription: channelEQFixtureAXDescription,
+        pluginSlotName: "Channel EQ",
+        beforeValue: 0,
+        pluginWindowStaticTextValues: ["보기:", "ChannelEQ", trackName]
+    )
+    let obj = try await runChannelEQFixture(
+        fixture: fixture,
+        params: channelEQFixtureParams(value: "3", unit: "raw_ax_value"),
+        writeMethod: "ax_slider_axvalue"
+    )
+
+    #expect(obj["state"] as? String == "A")
+    #expect(fixture.currentSliderValue == 3)
+}
+
+@Test func testPluginWindowWithoutReadableStaticTextIsRefused() async throws {
+    let fixture = LiveFixture(beforeValue: 51, pluginWindowStaticTextValues: [])
+    let obj = await runLive(fixture: fixture, params: thresholdParams())
+
+    #expect(obj["state"] as? String == "C")
+    #expect(obj["error"] as? String == "plugin_window_plugin_mismatch")
+    #expect(try #require(obj["write_attempted"] as? Bool) == false)
+    #expect((try #require(obj["what_was_observed"] as? String)).contains("no readable direct AXStaticText"))
+    #expect(fixture.currentSliderValue == 51)
+}
+
+@Test func testPluginHeaderNameIsFoundAtAnyDirectStaticTextIndex() async {
+    let fixture = LiveFixture(
+        beforeValue: 51,
+        pluginWindowStaticTextValues: ["보기:", "unused label", trackName, "Compressor", "status"]
+    )
+    let obj = await runLive(fixture: fixture, params: thresholdParams())
+
+    #expect(obj["state"] as? String == "A")
+    #expect(fixture.currentSliderValue == 60)
+}
+
+@Test func testControlsViewHeaderWithoutLocalizedViewLabelStillPasses() async {
+    // Logic's Controls view drops the localized 보기: label but keeps the
+    // plug-in display name. The check must not depend on the label's presence.
+    let fixture = LiveFixture(
+        beforeValue: 51,
+        pluginWindowStaticTextValues: ["Compressor", trackName]
+    )
+    let obj = await runLive(fixture: fixture, params: thresholdParams())
+
+    #expect(obj["state"] as? String == "A")
+    #expect(fixture.currentSliderValue == 60)
+}
+
+@Test func testLadderPollRefusesNewlyOpenedDifferentPluginHeader() async throws {
+    // No editor is present for the preflight scan. The slot press reveals a
+    // same-track Noise Gate editor, so every poll result must reject it rather
+    // than accepting its Threshold as a Compressor window.
+    let fixture = LiveFixture(
+        beforeValue: 51,
+        pluginWindowPresent: false,
+        openWindowOnSlotPress: true,
+        pluginWindowStaticTextValues: ["보기:", "Noise Gate", trackName]
+    )
+    let obj = await runLive(fixture: fixture, params: thresholdParams())
+
+    #expect(obj["state"] as? String == "C")
+    #expect(obj["error"] as? String == "plugin_window_plugin_mismatch")
+    #expect(try #require(obj["write_attempted"] as? Bool) == false)
+    #expect((try #require(obj["what_was_observed"] as? String)).contains("Noise Gate"))
+    #expect(fixture.currentSliderValue == 51)
+}
+
 // MARK: - #726 per-track plug-in-instance ambiguity
 
 @Test func testDuplicatePluginInstancesOnTargetTrackRefuseBeforeWindowAcquisition() async throws {
@@ -516,7 +630,7 @@ private func namedEQBandParams(
     let obj = await runLive(
         fixture: fixture,
         params: thresholdParams(),
-        opener: { _, _, _, _ in
+        opener: { _, _, _, _, _ in
             openerInvoked.value = true
             return nil
         }
@@ -584,7 +698,7 @@ private func namedEQBandParams(
         params: namedEQBandParams(),
         runtime: fixture.runtime,
         frontDocumentPath: { expectedPath },
-        pluginWindowOpener: { _, _, _, _ in
+        pluginWindowOpener: { _, _, _, _, _ in
             openerInvoked.value = true
             return nil
         }
@@ -1183,13 +1297,16 @@ private func namedEQBandParams(
     let duplicateClose = b.element(3002)
     let duplicateBypass = b.element(3003)
     let duplicateLink = b.element(3004)
+    let duplicatePluginName = b.element(3005)
     b.setAttribute(duplicateClose, kAXRoleAttribute as String, kAXButtonRole as String)
     b.setAttribute(duplicateBypass, kAXRoleAttribute as String, kAXCheckBoxRole as String)
     b.setAttribute(duplicateBypass, kAXDescriptionAttribute as String, "bypass")
     b.setAttribute(duplicateLink, kAXRoleAttribute as String, kAXCheckBoxRole as String)
     b.setAttribute(duplicateLink, kAXDescriptionAttribute as String, "link")
+    b.setAttribute(duplicatePluginName, kAXRoleAttribute as String, kAXStaticTextRole as String)
+    b.setAttribute(duplicatePluginName, kAXValueAttribute as String, "Compressor")
     b.setAttribute(duplicateWindow, kAXCloseButtonAttribute as String, duplicateClose)
-    b.setChildren(duplicateWindow, [duplicateBypass, duplicateLink, duplicateSlider])
+    b.setChildren(duplicateWindow, [duplicateBypass, duplicateLink, duplicateSlider, duplicatePluginName])
     b.setAttribute(fixture.app, kAXWindowsAttribute as String, [
         b.element(1001), b.element(1004), duplicateWindow,
     ])
@@ -1231,7 +1348,7 @@ private func namedEQBandParams(
     let obj = await runLive(fixture: fixture, params: thresholdParams())
 
     #expect(obj["state"] as? String == "C")
-    #expect(obj["error"] as? String == "window_open_failed")
+    #expect(obj["error"] as? String == "plugin_window_plugin_mismatch")
     let v1 = try #require(obj["write_attempted"] as? Bool)
     #expect(!v1)
     #expect(fixture.currentSliderValue == 51)
@@ -1246,6 +1363,7 @@ private func namedEQBandParams(
     let duplicateClose = b.element(3302)
     let duplicateBypass = b.element(3303)
     let duplicateLink = b.element(3304)
+    let duplicatePluginName = b.element(3305)
     b.setAttribute(duplicateSlider, kAXRoleAttribute as String, kAXSliderRole as String)
     b.setAttribute(duplicateSlider, kAXDescriptionAttribute as String, "Threshold")
     b.setAttribute(duplicateSlider, kAXValueAttribute as String, 51.0)
@@ -1254,13 +1372,15 @@ private func namedEQBandParams(
     b.setAttribute(duplicateBypass, kAXDescriptionAttribute as String, "bypass")
     b.setAttribute(duplicateLink, kAXRoleAttribute as String, kAXCheckBoxRole as String)
     b.setAttribute(duplicateLink, kAXDescriptionAttribute as String, "link")
+    b.setAttribute(duplicatePluginName, kAXRoleAttribute as String, kAXStaticTextRole as String)
+    b.setAttribute(duplicatePluginName, kAXValueAttribute as String, "Compressor")
     b.setAttribute(duplicateWindow, kAXRoleAttribute as String, kAXWindowRole as String)
     b.setAttribute(duplicateWindow, kAXSubroleAttribute as String, kAXDialogSubrole as String)
     b.setAttribute(duplicateWindow, kAXTitleAttribute as String, trackName)
     b.setAttribute(duplicateWindow, kAXCloseButtonAttribute as String, duplicateClose)
     b.setAttribute(duplicateWindow, kAXMainAttribute as String, true)
     b.setAttribute(duplicateWindow, kAXFocusedAttribute as String, true)
-    b.setChildren(duplicateWindow, [duplicateBypass, duplicateLink, duplicateSlider])
+    b.setChildren(duplicateWindow, [duplicateBypass, duplicateLink, duplicateSlider, duplicatePluginName])
     fixture.windowsAddedOnSlotPress.value = [duplicateWindow]
 
     let obj = await runLive(fixture: fixture, params: thresholdParams())
@@ -1306,26 +1426,31 @@ private func namedEQBandParams(
     let openedClose = b.element(2002)
     let openedBypass = b.element(2003)
     let openedLink = b.element(2004)
+    let openedPluginName = b.element(2005)
     b.setAttribute(openedClose, kAXRoleAttribute as String, kAXButtonRole as String)
     b.setAttribute(openedBypass, kAXRoleAttribute as String, kAXCheckBoxRole as String)
     b.setAttribute(openedBypass, kAXDescriptionAttribute as String, "bypass")
     b.setAttribute(openedLink, kAXRoleAttribute as String, kAXCheckBoxRole as String)
     b.setAttribute(openedLink, kAXDescriptionAttribute as String, "link")
+    b.setAttribute(openedPluginName, kAXRoleAttribute as String, kAXStaticTextRole as String)
+    b.setAttribute(openedPluginName, kAXValueAttribute as String, "Compressor")
     b.setAttribute(openedWindow, kAXRoleAttribute as String, kAXWindowRole as String)
     b.setAttribute(openedWindow, kAXSubroleAttribute as String, kAXDialogSubrole as String)
     b.setAttribute(openedWindow, kAXTitleAttribute as String, trackName)
     b.setAttribute(openedWindow, kAXCloseButtonAttribute as String, openedClose)
     b.setAttribute(openedWindow, kAXMainAttribute as String, true)
     b.setAttribute(openedWindow, kAXFocusedAttribute as String, true)
-    b.setChildren(openedWindow, [openedBypass, openedLink, openedSlider])
+    b.setChildren(openedWindow, [openedBypass, openedLink, openedSlider, openedPluginName])
     b.setAttribute(fixture.app, kAXWindowsAttribute as String, [b.element(1001), openedWindow])
     let sendable = AXUIElementSendable(openedWindow)
 
     let obj = await runLive(
         fixture: fixture,
         params: thresholdParams(),
-        opener: { _, name, desc, _ in
-            (name == trackName && desc == "Threshold") ? sendable : nil
+        opener: { _, pluginID, name, desc, _ in
+            (pluginID == "logic.stock.effect.compressor" && name == trackName && desc == "Threshold")
+                ? sendable
+                : nil
         }
     )
     #expect(obj["state"] as? String == "A", "opener-supplied window must allow the write")
@@ -1355,7 +1480,7 @@ private func namedEQBandParams(
     let obj = await runLive(
         fixture: fixture,
         params: thresholdParams(),
-        opener: { _, _, _, _ in sendable }
+        opener: { _, _, _, _, _ in sendable }
     )
     #expect(obj["state"] as? String == "C")
     #expect(obj["error"] as? String == "param_control_not_found")
@@ -1505,15 +1630,18 @@ private final class OneShotStickyFixture: @unchecked Sendable {
         let pluginClose = b.element(3006)
         let pluginBypass = b.element(3007)
         let pluginLink = b.element(3008)
+        let pluginName = b.element(3009)
         b.setAttribute(pluginClose, kAXRoleAttribute as String, kAXButtonRole as String)
         b.setAttribute(pluginBypass, kAXRoleAttribute as String, kAXCheckBoxRole as String)
         b.setAttribute(pluginBypass, kAXDescriptionAttribute as String, "bypass")
         b.setAttribute(pluginLink, kAXRoleAttribute as String, kAXCheckBoxRole as String)
         b.setAttribute(pluginLink, kAXDescriptionAttribute as String, "link")
+        b.setAttribute(pluginName, kAXRoleAttribute as String, kAXStaticTextRole as String)
+        b.setAttribute(pluginName, kAXValueAttribute as String, "Compressor")
         b.setAttribute(pluginWindow, kAXCloseButtonAttribute as String, pluginClose)
         b.setAttribute(pluginWindow, kAXMainAttribute as String, true)
         b.setAttribute(pluginWindow, kAXFocusedAttribute as String, true)
-        b.setChildren(pluginWindow, [pluginBypass, pluginLink, slider])
+        b.setChildren(pluginWindow, [pluginBypass, pluginLink, slider, pluginName])
 
         b.setAttribute(app, kAXWindowsAttribute as String, [arrangeWindow, pluginWindow])
         b.setAttribute(app, kAXMainWindowAttribute as String, arrangeWindow)

--- a/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
+++ b/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
@@ -273,23 +273,16 @@ private func runLive(
     fixture: LiveFixture,
     params: [String: String],
     frontDoc: String? = expectedPath,
-    opener: AccessibilityChannel.PluginWindowOpener? = nil
+    opener: AccessibilityChannel.PluginWindowOpener? = nil,
+    popupMenuCleaner: AccessibilityChannel.PluginPopupMenuCleaner? = nil
 ) async -> [String: Any] {
-    let result: ChannelResult
-    if let opener {
-        result = await AccessibilityChannel.defaultSetParamVerified(
-            params: params,
-            runtime: fixture.runtime,
-            frontDocumentPath: { frontDoc },
-            pluginWindowOpener: opener
-        )
-    } else {
-        result = await AccessibilityChannel.defaultSetParamVerified(
-            params: params,
-            runtime: fixture.runtime,
-            frontDocumentPath: { frontDoc }
-        )
-    }
+    let result = await AccessibilityChannel.defaultSetParamVerified(
+        params: params,
+        runtime: fixture.runtime,
+        frontDocumentPath: { frontDoc },
+        pluginWindowOpener: opener ?? AccessibilityChannel.livePluginWindowOpener,
+        pluginPopupMenuCleaner: popupMenuCleaner ?? AccessibilityChannel.livePluginPopupMenuCleaner
+    )
     return try! JSONSerialization.jsonObject(
         with: result.message.data(using: .utf8)!, options: []
     ) as! [String: Any]
@@ -838,6 +831,94 @@ private func namedEQBandParams(
     #expect(obj["state"] as? String == "A")
     #expect(obj["observed_normalized"] as? Double == 60)
     #expect(fixture.currentSliderValue == 60)
+}
+
+@Test func testPluginWindowAcquisitionLadderExcludesMenuOpenersByAction() {
+    let builder = FakeAXRuntimeBuilder()
+    let slot = builder.element(40_100)
+    let ordinaryButton = builder.element(40_101)
+    let menuButton = builder.element(40_102)
+    builder.setAttribute(slot, kAXRoleAttribute as String, kAXGroupRole as String)
+    builder.setAttribute(ordinaryButton, kAXRoleAttribute as String, kAXButtonRole as String)
+    builder.setAttribute(menuButton, kAXRoleAttribute as String, kAXButtonRole as String)
+    builder.setAttribute(ordinaryButton, kAXDescriptionAttribute as String, "Open editor")
+    builder.setAttribute(menuButton, kAXDescriptionAttribute as String, "Anything")
+    builder.setActionNames(ordinaryButton, [kAXPressAction as String])
+    builder.setActionNames(menuButton, [kAXPressAction as String, kAXShowMenuAction as String])
+    builder.setChildren(slot, [ordinaryButton, menuButton])
+
+    let ranked = AccessibilityChannel.rankedPluginSlotOpenControls(
+        in: slot, runtime: builder.makeAXRuntime()
+    )
+
+    #expect(ranked.contains { CFEqual($0.element, ordinaryButton) })
+    #expect(!ranked.contains { CFEqual($0.element, menuButton) })
+}
+
+@Test func testPluginSlotMenuOpenerDecisionUsesAdvertisedActions() {
+    #expect(AccessibilityChannel.pluginSlotControlOpensMenu(
+        actionNames: [kAXPressAction as String, kAXShowMenuAction as String]
+    ))
+    #expect(AccessibilityChannel.pluginSlotControlOpensMenu(
+        actionNames: ["AXPress", "Name:Legacy open plug-in menu"]
+    ))
+    #expect(!AccessibilityChannel.pluginSlotControlOpensMenu(actionNames: [kAXPressAction as String]))
+}
+
+@Test func testStuckPluginPopupIsReportedInTheVerifiedWriteEnvelope() async throws {
+    let fixture = LiveFixture(beforeValue: 51)
+    let obj = await runLive(
+        fixture: fixture,
+        params: thresholdParams(),
+        popupMenuCleaner: { _ in
+            .couldNotDismiss(initialPopupCount: 1, remainingPopupCount: 1)
+        }
+    )
+
+    #expect(obj["state"] as? String == "C")
+    #expect(obj["error"] as? String == "window_open_failed")
+    #expect(obj["plugin_popup_menu_state"] as? String == "could_not_be_dismissed")
+    #expect(obj["plugin_popup_menu_remaining_window_count"] as? Int == 1)
+    let writeAttempted = try #require(obj["write_attempted"] as? Bool)
+    let safeToRetry = try #require(obj["safe_to_retry"] as? Bool)
+    #expect(!writeAttempted)
+    #expect(!safeToRetry)
+    #expect(fixture.currentSliderValue == 51)
+}
+
+@Test func testConsecutiveEQBandWritesReuseTheVerifiedOpenEditor() async throws {
+    let fixture = LiveFixture(
+        thresholdDescription: "Peak 1 Frequency",
+        pluginSlotName: "Channel EQ",
+        beforeValue: 0,
+        sliderWriteBehavior: .oneStepTowardRequest
+    )
+    let params = namedEQBandParams(value: "3")
+    let cleaner: AccessibilityChannel.PluginPopupMenuCleaner = { _ in .noPopupObserved }
+
+    let first = await AccessibilityChannel.defaultSetEQBandVerified(
+        params: params,
+        runtime: fixture.runtime,
+        frontDocumentPath: { expectedPath },
+        pluginPopupMenuCleaner: cleaner
+    )
+    let second = await AccessibilityChannel.defaultSetEQBandVerified(
+        params: params,
+        runtime: fixture.runtime,
+        frontDocumentPath: { expectedPath },
+        pluginPopupMenuCleaner: cleaner
+    )
+    let firstData = try #require(first.message.data(using: .utf8))
+    let secondData = try #require(second.message.data(using: .utf8))
+    let firstEnvelope = try #require(try JSONSerialization.jsonObject(
+        with: firstData
+    ) as? [String: Any])
+    let secondEnvelope = try #require(try JSONSerialization.jsonObject(
+        with: secondData
+    ) as? [String: Any])
+
+    #expect(firstEnvelope["state"] as? String == "A")
+    #expect(secondEnvelope["state"] as? String == "A")
 }
 
 @Test func testOpenerReachesStateAWhenSlotPressReturnsFalseButWindowOpens() async {

--- a/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
+++ b/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
@@ -26,6 +26,14 @@ private let trackName = "Acid Wash Bass"
 
 // MARK: - Fixture
 
+private enum SliderWriteBehavior: Sendable {
+    case direct
+    case oneStepTowardRequest
+    /// Each AXValue write uses the next readback. `nil` models a lost numeric
+    /// AXValue readback after an accepted write.
+    case scripted([Double?])
+}
+
 /// A live-path fixture. The slider's AXValueDescription is recomputed from its
 /// AXValue on every write so a write updates the readback the way Logic does
 /// ("60 %"). `forcedAfterValue` models a sticky/taper mismatch; `otherTracks`
@@ -34,6 +42,7 @@ private final class LiveFixture: @unchecked Sendable {
     let builder = FakeAXRuntimeBuilder()
     let app: AXUIElement
     let windowsAddedOnSlotPress: MutableBox<[AXUIElement]>
+    let sliderWriteCount: MutableBox<Int>
     let runtime: AXLogicProElements.Runtime
 
     init(
@@ -50,10 +59,12 @@ private final class LiveFixture: @unchecked Sendable {
         duplicateTrackNameAt: Int? = nil,
         emptyInsertChain: Bool = false,
         pluginWindowRejectsDirectDemotion: Bool = false,
-        slotPressReturnsFalse: Bool = false
+        slotPressReturnsFalse: Bool = false,
+        sliderWriteBehavior: SliderWriteBehavior = .direct
     ) {
         let b = builder
         let windowsAddedOnSlotPress = MutableBox<[AXUIElement]>([])
+        let sliderWriteCount = MutableBox(0)
         let app = b.element(1000)
         let arrangeWindow = b.element(1001)
         let headersGroup = b.element(1002)
@@ -153,6 +164,7 @@ private final class LiveFixture: @unchecked Sendable {
         let targetSlotKey = targetSlot.map { b.elementID($0) }
         let targetOpenButtonKey = targetOpenButton.map { b.elementID($0) }
         let forced = forcedAfterValue
+        let writeBehavior = sliderWriteBehavior
         let runtime = b.makeLogicRuntime(
             appElement: app,
             setAttributeHandler: { [b] el, attribute, value in
@@ -167,9 +179,30 @@ private final class LiveFixture: @unchecked Sendable {
                     return true
                 }
                 let requested = (value as? NSNumber)?.doubleValue ?? 0
-                let landed = forced ?? requested
-                b.setAttribute(el, kAXValueAttribute as String, landed)
-                b.setAttribute(el, kAXValueDescriptionAttribute as String, "\(Int(landed.rounded())) %")
+                let current = (b.attributeValue(slider, kAXValueAttribute as String) as? NSNumber)?.doubleValue
+                    ?? (b.attributeValue(slider, kAXValueAttribute as String) as? Double)
+                    ?? 0
+                let writeIndex = sliderWriteCount.value
+                sliderWriteCount.value += 1
+                let landed: Double?
+                switch writeBehavior {
+                case .direct:
+                    landed = forced ?? requested
+                case .oneStepTowardRequest:
+                    if requested > current {
+                        landed = current + 1
+                    } else if requested < current {
+                        landed = current - 1
+                    } else {
+                        landed = current
+                    }
+                case let .scripted(readbacks):
+                    landed = readbacks.indices.contains(writeIndex) ? readbacks[writeIndex] : current
+                }
+                b.setAttribute(el, kAXValueAttribute as String, landed ?? NSNull())
+                if let landed {
+                    b.setAttribute(el, kAXValueDescriptionAttribute as String, "\(Int(landed.rounded())) %")
+                }
                 return true
             },
             performActionHandler: { [b] el, action in
@@ -204,6 +237,7 @@ private final class LiveFixture: @unchecked Sendable {
         )
         self.app = app
         self.windowsAddedOnSlotPress = windowsAddedOnSlotPress
+        self.sliderWriteCount = sliderWriteCount
         self.runtime = runtime
     }
 
@@ -281,51 +315,59 @@ private func thresholdParams(
 private let channelEQFixtureParamID = "__test_channel_eq_band_gain"
 private let channelEQFixtureAXDescription = "__TEST Channel EQ Band Gain"
 
-private func channelEQFixtureEntryLookup(pluginID: String) -> StockPluginCatalogEntry? {
-    guard pluginID == "logic.stock.effect.channel_eq" else {
-        return StockPluginCatalog.entry(id: pluginID)
+private func channelEQFixtureEntryLookup(
+    writeMethod: String = "ax_slider_axvalue",
+    unit: String = "dB",
+    acceptedUnits: [String]? = nil,
+    range: StockPluginValueRange = StockPluginValueRange(min: -24, max: 24, defaultValue: 0)
+) -> VerifiedPluginCatalog.EntryLookup {
+    { pluginID in
+        guard pluginID == "logic.stock.effect.channel_eq" else {
+            return StockPluginCatalog.entry(id: pluginID)
+        }
+        let provenance = StockPluginProvenance.verified(
+            source: "test_fixture",
+            method: "ax_plugin_window",
+            observedAt: "2026-07-07T00:00:00Z",
+            logicVersion: nil,
+            locale: "en_US",
+            evidence: ["parameter_readback", "test_fixture_only"]
+        )
+        return StockPluginCatalogEntry(
+            id: "logic.stock.effect.channel_eq",
+            displayName: "Channel EQ",
+            type: .effect,
+            category: "EQ",
+            availabilityState: .verified,
+            provenance: provenance,
+            insertPaths: [
+                StockPluginInsertPath(
+                    path: ["Audio FX", "EQ", "Channel EQ"],
+                    availabilityState: .verified,
+                    provenance: provenance
+                ),
+            ],
+            slotSupport: StockPluginSlotSupport(audio: true, instrument: false, midiFX: false, aux: true),
+            knownPresets: [],
+            parameters: [
+                StockPluginParameterMetadata(
+                    id: channelEQFixtureParamID,
+                    displayName: "Test Channel EQ Band Gain",
+                    unit: unit,
+                    acceptedUnits: acceptedUnits,
+                    valueRange: range,
+                    writeMethod: writeMethod,
+                    readbackMethod: "ax_slider_axvalue",
+                    tolerance: 0.5,
+                    axDescription: channelEQFixtureAXDescription,
+                    availabilityState: .verified,
+                    provenance: provenance
+                ),
+            ],
+            safeWriteCapabilities: .parameterWriteReadback,
+            limitations: ["test fixture only"]
+        )
     }
-    let provenance = StockPluginProvenance.verified(
-        source: "test_fixture",
-        method: "ax_plugin_window",
-        observedAt: "2026-07-07T00:00:00Z",
-        logicVersion: nil,
-        locale: "en_US",
-        evidence: ["parameter_readback", "test_fixture_only"]
-    )
-    return StockPluginCatalogEntry(
-        id: "logic.stock.effect.channel_eq",
-        displayName: "Channel EQ",
-        type: .effect,
-        category: "EQ",
-        availabilityState: .verified,
-        provenance: provenance,
-        insertPaths: [
-            StockPluginInsertPath(
-                path: ["Audio FX", "EQ", "Channel EQ"],
-                availabilityState: .verified,
-                provenance: provenance
-            ),
-        ],
-        slotSupport: StockPluginSlotSupport(audio: true, instrument: false, midiFX: false, aux: true),
-        knownPresets: [],
-        parameters: [
-            StockPluginParameterMetadata(
-                id: channelEQFixtureParamID,
-                displayName: "Test Channel EQ Band Gain",
-                unit: "dB",
-                valueRange: StockPluginValueRange(min: -24, max: 24, defaultValue: 0),
-                writeMethod: "ax_slider_axvalue",
-                readbackMethod: "ax_slider_axvalue",
-                tolerance: 0.5,
-                axDescription: channelEQFixtureAXDescription,
-                availabilityState: .verified,
-                provenance: provenance
-            ),
-        ],
-        safeWriteCapabilities: .parameterWriteReadback,
-        limitations: ["test fixture only; production Channel EQ registry is census-gated"]
-    )
 }
 
 private func channelEQFixtureParamAlias(pluginID: String, alias: String) -> String? {
@@ -366,12 +408,52 @@ private func runChannelEQFixture(
         params: params,
         runtime: fixture.runtime,
         frontDocumentPath: { expectedPath },
-        entryLookup: channelEQFixtureEntryLookup,
+        entryLookup: channelEQFixtureEntryLookup(),
         paramAliasLookup: channelEQFixtureParamAlias
     )
     let data = try #require(result.message.data(using: .utf8))
     let obj = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
     return obj
+}
+
+private func runChannelEQFixture(
+    fixture: LiveFixture,
+    params: [String: String],
+    writeMethod: String,
+    incrementWalkBudget: Int = ChannelEQBandCatalog.incrementWalkBudget
+) async throws -> [String: Any] {
+    let result = await AccessibilityChannel.defaultSetParamVerified(
+        params: params,
+        runtime: fixture.runtime,
+        frontDocumentPath: { expectedPath },
+        entryLookup: channelEQFixtureEntryLookup(
+            writeMethod: writeMethod,
+            unit: "raw_ax_value",
+            range: StockPluginValueRange(min: 0, max: 10, defaultValue: 0)
+        ),
+        paramAliasLookup: channelEQFixtureParamAlias,
+        incrementWalkBudget: incrementWalkBudget
+    )
+    let data = try #require(result.message.data(using: .utf8))
+    return try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+}
+
+private func namedEQBandParams(
+    band: String = "Peak 1",
+    parameter: String = "Frequency",
+    value: String = "3",
+    unit: String = "raw_ax_value"
+) -> [String: String] {
+    [
+        "track": "0",
+        "insert": "6",
+        "band": band,
+        "parameter": parameter,
+        "value": value,
+        "unit": unit,
+        "mode": "duplicate_applyback",
+        "project_expected_path": expectedPath,
+    ]
 }
 
 // MARK: - State A: full round-trip (before 51 → set 60 → after 60)
@@ -479,7 +561,7 @@ private func runChannelEQFixture(
     #expect(VerifiedPluginCatalog.paramCapability(
         pluginID: "logic.stock.effect.channel_eq",
         paramKey: channelEQFixtureParamID,
-        entryLookup: channelEQFixtureEntryLookup
+        entryLookup: channelEQFixtureEntryLookup()
     ) == .writeReadback)
 
     let obj = try await runChannelEQFixture(forcedAfterValue: 3.4)
@@ -511,6 +593,180 @@ private func runChannelEQFixture(
     #expect(obj["error"] as? String == "unsupported_param_readback")
     let v1 = try #require(obj["write_attempted"] as? Bool)
     #expect(!v1)
+}
+
+// MARK: - #301 Channel EQ increment-walk dispatch
+
+@Test func testVerifiedPluginDeclaredWriteMethodSelectsWalkOrSingleAXValueSet() async throws {
+    let walkFixture = LiveFixture(
+        thresholdDescription: channelEQFixtureAXDescription,
+        pluginSlotName: "Channel EQ",
+        beforeValue: 0,
+        sliderWriteBehavior: .oneStepTowardRequest
+    )
+    let walk = try await runChannelEQFixture(
+        fixture: walkFixture,
+        params: channelEQFixtureParams(value: "3", unit: "raw_ax_value"),
+        writeMethod: "ax_slider_increment_walk"
+    )
+    #expect(walk["state"] as? String == "A")
+    #expect(walkFixture.sliderWriteCount.value == 3)
+
+    let singleSetFixture = LiveFixture(
+        thresholdDescription: channelEQFixtureAXDescription,
+        pluginSlotName: "Channel EQ",
+        beforeValue: 0
+    )
+    let singleSet = try await runChannelEQFixture(
+        fixture: singleSetFixture,
+        params: channelEQFixtureParams(value: "3", unit: "raw_ax_value"),
+        writeMethod: "ax_slider_axvalue"
+    )
+    #expect(singleSet["state"] as? String == "A")
+    #expect(singleSetFixture.sliderWriteCount.value == 1)
+}
+
+@Test func testVerifiedPluginIncrementWalkFailuresAreDistinctStateCEnvelopes() async throws {
+    struct Scenario {
+        let initial: Double
+        let requested: String
+        let writes: [Double?]
+        let budget: Int
+        let error: String
+        let outcome: String
+    }
+    let scenarios = [
+        Scenario(
+            initial: 0,
+            requested: "3",
+            writes: [0],
+            budget: 4,
+            error: "increment_walk_no_progress",
+            outcome: "noProgress"
+        ),
+        Scenario(
+            initial: 0,
+            requested: "3",
+            writes: [1, 2],
+            budget: 2,
+            error: "increment_walk_budget_exhausted",
+            outcome: "budgetExhausted"
+        ),
+        Scenario(
+            initial: 4,
+            requested: "5",
+            writes: [7, 8],
+            budget: 4,
+            error: "increment_walk_overshot",
+            outcome: "overshot"
+        ),
+        Scenario(
+            initial: 0,
+            requested: "3",
+            writes: [nil],
+            budget: 4,
+            error: "readback_lost_after_write",
+            outcome: "readbackLost"
+        ),
+    ]
+
+    for scenario in scenarios {
+        let fixture = LiveFixture(
+            thresholdDescription: channelEQFixtureAXDescription,
+            pluginSlotName: "Channel EQ",
+            beforeValue: scenario.initial,
+            sliderWriteBehavior: .scripted(scenario.writes)
+        )
+        let result = try await runChannelEQFixture(
+            fixture: fixture,
+            params: channelEQFixtureParams(value: scenario.requested, unit: "raw_ax_value"),
+            writeMethod: "ax_slider_increment_walk",
+            incrementWalkBudget: scenario.budget
+        )
+        #expect(result["state"] as? String == "C")
+        #expect(result["error"] as? String == scenario.error)
+        #expect(result["walk_outcome"] as? String == scenario.outcome)
+        let writeAttempted = try #require(result["write_attempted"] as? Bool)
+        #expect(writeAttempted)
+    }
+}
+
+@Test func testVerifiedPluginIncrementWalkRollbackUsesTheWalkAndReportsFailure() async throws {
+    let rollbackFixture = LiveFixture(
+        thresholdDescription: channelEQFixtureAXDescription,
+        pluginSlotName: "Channel EQ",
+        beforeValue: 0,
+        // Forward: 0 → 1 → 2 → 2 (no progress). Rollback: 2 → 1 → 0.
+        sliderWriteBehavior: .scripted([1, 2, 2, 1, 0])
+    )
+    let rolledBack = try await runChannelEQFixture(
+        fixture: rollbackFixture,
+        params: channelEQFixtureParams(value: "3", unit: "raw_ax_value"),
+        writeMethod: "ax_slider_increment_walk"
+    )
+    #expect(rolledBack["error"] as? String == "increment_walk_no_progress")
+    let rollbackSucceeded = try #require(rolledBack["rollback_succeeded"] as? Bool)
+    #expect(rollbackSucceeded)
+    #expect(rolledBack["rollback_outcome"] as? String == "arrived")
+    #expect(rollbackFixture.sliderWriteCount.value == 5)
+
+    let failedRollbackFixture = LiveFixture(
+        thresholdDescription: channelEQFixtureAXDescription,
+        pluginSlotName: "Channel EQ",
+        beforeValue: 0,
+        sliderWriteBehavior: .scripted([1, 1, 1])
+    )
+    let failedRollback = try await runChannelEQFixture(
+        fixture: failedRollbackFixture,
+        params: channelEQFixtureParams(value: "3", unit: "raw_ax_value"),
+        writeMethod: "ax_slider_increment_walk"
+    )
+    let rollbackFailed = try #require(failedRollback["rollback_succeeded"] as? Bool)
+    #expect(!rollbackFailed)
+    #expect(failedRollback["rollback_outcome"] as? String == "noProgress")
+}
+
+@Test func testVerifiedPluginNamedEQBandHonorsUnitsAndRefusesUnresolvedNamesBeforeWindowOpen() async throws {
+    let validFixture = LiveFixture(
+        thresholdDescription: "Peak 1 Frequency",
+        pluginSlotName: "Channel EQ",
+        beforeValue: 0,
+        sliderWriteBehavior: .oneStepTowardRequest
+    )
+    let validResult = await AccessibilityChannel.defaultSetEQBandVerified(
+        params: namedEQBandParams(),
+        runtime: validFixture.runtime,
+        frontDocumentPath: { expectedPath }
+    )
+    let validData = try #require(validResult.message.data(using: .utf8))
+    let valid = try #require(try JSONSerialization.jsonObject(with: validData) as? [String: Any])
+    #expect(valid["state"] as? String == "A")
+    #expect(validFixture.sliderWriteCount.value == 3)
+
+    for params in [
+        namedEQBandParams(unit: "dB"),
+        namedEQBandParams(band: "Peak 9"),
+        namedEQBandParams(parameter: "Resonance"),
+    ] {
+        let fixture = LiveFixture(
+            thresholdDescription: "Peak 1 Frequency",
+            pluginSlotName: "Channel EQ",
+            beforeValue: 0,
+            pluginWindowPresent: false
+        )
+        let result = await AccessibilityChannel.defaultSetEQBandVerified(
+            params: params,
+            runtime: fixture.runtime,
+            frontDocumentPath: { expectedPath }
+        )
+        let data = try #require(result.message.data(using: .utf8))
+        let envelope = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(envelope["state"] as? String == "C")
+        #expect(envelope["error"] as? String == "invalid_params")
+        let writeAttempted = try #require(envelope["write_attempted"] as? Bool)
+        #expect(!writeAttempted)
+        #expect(fixture.sliderWriteCount.value == 0)
+    }
 }
 
 // MARK: - State C: tolerance exceeded → readback_mismatch + rollback

--- a/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
+++ b/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
@@ -43,6 +43,7 @@ private final class LiveFixture: @unchecked Sendable {
     let app: AXUIElement
     let windowsAddedOnSlotPress: MutableBox<[AXUIElement]>
     let targetOpenControlPressCount: MutableBox<Int>
+    let pluginCloseControlPressCount: MutableBox<Int>
     let sliderWriteCount: MutableBox<Int>
     let runtime: AXLogicProElements.Runtime
 
@@ -65,11 +66,16 @@ private final class LiveFixture: @unchecked Sendable {
         sliderWriteBehavior: SliderWriteBehavior = .direct,
         sliderDisplayUnit: String = "%",
         sliderUsesSignedPositiveDisplay: Bool = false,
-        pluginWindowStaticTextValues: [String]? = nil
+        pluginWindowStaticTextValues: [String]? = nil,
+        // Model an editor whose close control is pressed but which stays in
+        // AXWindows. The close must be judged by the observed window list, not
+        // by the press returning true.
+        pluginCloseControlFailsToClose: Bool = false
     ) {
         let b = builder
         let windowsAddedOnSlotPress = MutableBox<[AXUIElement]>([])
         let targetOpenControlPressCount = MutableBox(0)
+        let pluginCloseControlPressCount = MutableBox(0)
         let sliderWriteCount = MutableBox(0)
         let app = b.element(1000)
         let arrangeWindow = b.element(1001)
@@ -195,6 +201,7 @@ private final class LiveFixture: @unchecked Sendable {
         let sliderKey = b.elementID(slider)
         let targetSlotKey = targetSlot.map { b.elementID($0) }
         let targetOpenButtonKey = targetOpenButton.map { b.elementID($0) }
+        let pluginCloseKey = b.elementID(pluginClose)
         let forced = forcedAfterValue
         let writeBehavior = sliderWriteBehavior
         let runtime = b.makeLogicRuntime(
@@ -249,6 +256,13 @@ private final class LiveFixture: @unchecked Sendable {
                     return true
                 }
                 let key = b.elementID(el)
+                if key == pluginCloseKey {
+                    pluginCloseControlPressCount.value += 1
+                    if !pluginCloseControlFailsToClose {
+                        b.setAttribute(app, kAXWindowsAttribute as String, [arrangeWindow])
+                    }
+                    return true
+                }
                 guard key == targetSlotKey || key == targetOpenButtonKey else {
                     return true
                 }
@@ -273,6 +287,7 @@ private final class LiveFixture: @unchecked Sendable {
         self.app = app
         self.windowsAddedOnSlotPress = windowsAddedOnSlotPress
         self.targetOpenControlPressCount = targetOpenControlPressCount
+        self.pluginCloseControlPressCount = pluginCloseControlPressCount
         self.sliderWriteCount = sliderWriteCount
         self.runtime = runtime
     }
@@ -1780,4 +1795,77 @@ private final class Counter: @unchecked Sendable {
         n += 1
         return n
     }
+}
+
+// MARK: - #726 the operation closes the editor it opened
+
+@Test func testDuplicateAcquisitionClosesTheEditorItOpened() async {
+    // Measured live: writing insert 0 then insert 2 on a two-Compressor track
+    // failed on the second call with duplicate_plugin_editor_already_open,
+    // because the first call left its editor open. The operation opened that
+    // window from a known-empty state, so it owns closing it.
+    let fixture = LiveFixture(
+        beforeValue: 51,
+        pluginWindowPresent: false,
+        openWindowOnSlotPress: true,
+        pluginSlotNamesByTrack: [0: [0: "Compressor", 6: "Compressor"]]
+    )
+    let obj = await runLive(fixture: fixture, params: thresholdParams())
+
+    #expect(obj["state"] as? String == "A")
+    #expect(fixture.currentSliderValue == 60)
+    #expect(fixture.pluginCloseControlPressCount.value == 1)
+    #expect(AXLogicProElements.matchingPluginEditorWindows(
+        forTrackName: trackName,
+        matchingPluginID: "logic.stock.effect.compressor",
+        runtime: fixture.runtime
+    ).isEmpty)
+}
+
+@Test func testReusedEditorIsNotClosedByTheOperation() async {
+    // The single-instance path reuses an editor the caller already had open.
+    // Closing it would destroy state this operation never created — a worse
+    // defect than the one the close exists to fix.
+    let fixture = LiveFixture(beforeValue: 51)
+    let obj = await runLive(fixture: fixture, params: thresholdParams())
+
+    #expect(obj["state"] as? String == "A")
+    #expect(fixture.pluginCloseControlPressCount.value == 0)
+    #expect(!AXLogicProElements.matchingPluginEditorWindows(
+        forTrackName: trackName,
+        matchingPluginID: "logic.stock.effect.compressor",
+        runtime: fixture.runtime
+    ).isEmpty)
+}
+
+@Test func testAnUnverifiableCloseDoesNotChangeTheWriteVerdict() async throws {
+    // The write's verdict is established before the close is attempted. A close
+    // that cannot be observed must not turn a verified write into a failure —
+    // the leftover editor announces itself on the NEXT call as
+    // duplicate_plugin_editor_already_open, which carries the recovery hint.
+    let fixture = LiveFixture(
+        beforeValue: 51,
+        pluginWindowPresent: false,
+        openWindowOnSlotPress: true,
+        pluginSlotNamesByTrack: [0: [0: "Compressor", 6: "Compressor"]],
+        pluginCloseControlFailsToClose: true
+    )
+    let obj = await runLive(fixture: fixture, params: thresholdParams())
+
+    #expect(obj["state"] as? String == "A")
+    #expect(fixture.currentSliderValue == 60)
+    // Tried, and retried, rather than giving up after one press.
+    #expect(fixture.pluginCloseControlPressCount.value == 3)
+}
+
+@Test func testAlreadyOpenDuplicateRefusalCarriesARecoveryHint() async throws {
+    let fixture = LiveFixture(
+        beforeValue: 51,
+        pluginSlotNamesByTrack: [0: [0: "Compressor", 6: "Compressor"]]
+    )
+    let obj = await runLive(fixture: fixture, params: thresholdParams())
+
+    #expect(obj["error"] as? String == "duplicate_plugin_editor_already_open")
+    let hint = try #require(obj["recovery_hint"] as? String)
+    #expect(hint.contains("Close the open"))
 }

--- a/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
+++ b/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
@@ -57,10 +57,13 @@ private final class LiveFixture: @unchecked Sendable {
         forcedAfterValue: Double? = nil,
         otherTracks: Int = 0,
         duplicateTrackNameAt: Int? = nil,
+        pluginSlotNamesByTrack: [Int: [Int: String]] = [:],
         emptyInsertChain: Bool = false,
         pluginWindowRejectsDirectDemotion: Bool = false,
         slotPressReturnsFalse: Bool = false,
-        sliderWriteBehavior: SliderWriteBehavior = .direct
+        sliderWriteBehavior: SliderWriteBehavior = .direct,
+        sliderDisplayUnit: String = "%",
+        sliderUsesSignedPositiveDisplay: Bool = false
     ) {
         let b = builder
         let windowsAddedOnSlotPress = MutableBox<[AXUIElement]>([])
@@ -77,7 +80,8 @@ private final class LiveFixture: @unchecked Sendable {
 
         // --- Track headers: one row per track, selected-state on the target. ---
         var headerRows: [AXUIElement] = []
-        let rowCount = max(track + 1, otherTracks + 1)
+        let namedTrackCount = (pluginSlotNamesByTrack.keys.max() ?? -1) + 1
+        let rowCount = max(max(track + 1, otherTracks + 1), namedTrackCount)
         for i in 0..<rowCount {
             let row = b.element(1100 + i)
             b.setAttribute(row, kAXRoleAttribute as String, kAXLayoutItemRole as String)
@@ -109,7 +113,9 @@ private final class LiveFixture: @unchecked Sendable {
                 } else {
                     var slots: [AXUIElement] = []
                     for s in 0...insert {
-                        let slot = LiveFixture.occupiedSlot(b, 1300 + s, name: s == insert ? pluginSlotName : "Plugin \(s)")
+                        let name = pluginSlotNamesByTrack[i]?[s]
+                            ?? (s == insert ? pluginSlotName : "Plugin \(s)")
+                        let slot = LiveFixture.occupiedSlot(b, 1300 + s, name: name)
                         if s == insert {
                             targetSlot = slot
                             targetOpenButton = b.element((1300 + s) * 10 + 2)
@@ -118,6 +124,16 @@ private final class LiveFixture: @unchecked Sendable {
                     }
                     b.setChildren(strip, slots)
                 }
+            } else if let namedSlots = pluginSlotNamesByTrack[i],
+                      let lastInsert = namedSlots.keys.max() {
+                let slots = (0...lastInsert).map { s in
+                    LiveFixture.occupiedSlot(
+                        b,
+                        1400 + (i * 100) + s,
+                        name: namedSlots[s] ?? "Plugin \(s)"
+                    )
+                }
+                b.setChildren(strip, slots)
             } else {
                 b.setChildren(strip, [LiveFixture.emptySlot(b, 1400 + i)])
             }
@@ -138,7 +154,11 @@ private final class LiveFixture: @unchecked Sendable {
         b.setAttribute(slider, kAXValueAttribute as String, beforeValue)
         b.setAttribute(slider, kAXMinValueAttribute as String, 0.0)
         b.setAttribute(slider, kAXMaxValueAttribute as String, 100.0)
-        b.setAttribute(slider, kAXValueDescriptionAttribute as String, "\(Int(beforeValue)) %")
+        let formatSliderDisplay: @Sendable (Double) -> String = { value in
+            let sign = sliderUsesSignedPositiveDisplay && value > 0 ? "+" : ""
+            return "\(sign)\(Int(value.rounded())) \(sliderDisplayUnit)"
+        }
+        b.setAttribute(slider, kAXValueDescriptionAttribute as String, formatSliderDisplay(beforeValue))
         b.setAttribute(pluginClose, kAXRoleAttribute as String, kAXButtonRole as String)
         b.setAttribute(pluginBypass, kAXRoleAttribute as String, kAXCheckBoxRole as String)
         b.setAttribute(pluginBypass, kAXDescriptionAttribute as String, "bypass")
@@ -201,7 +221,7 @@ private final class LiveFixture: @unchecked Sendable {
                 }
                 b.setAttribute(el, kAXValueAttribute as String, landed ?? NSNull())
                 if let landed {
-                    b.setAttribute(el, kAXValueDescriptionAttribute as String, "\(Int(landed.rounded())) %")
+                    b.setAttribute(el, kAXValueDescriptionAttribute as String, formatSliderDisplay(landed))
                 }
                 return true
             },
@@ -480,6 +500,104 @@ private func namedEQBandParams(
     let obj = await runLive(fixture: fixture, params: thresholdParams(value: "60"))
     #expect(obj["state"] as? String == "A")
     #expect(obj["observed_normalized"] as? Double == 60.7)
+}
+
+// MARK: - #726 per-track plug-in-instance ambiguity
+
+@Test func testDuplicatePluginInstancesOnTargetTrackRefuseBeforeWindowAcquisition() async throws {
+    // Mutation caught: counting only the target slot (or moving this guard
+    // after the opener) reintroduces the measured wrong-instance write.
+    let fixture = LiveFixture(
+        beforeValue: 51,
+        pluginWindowPresent: false,
+        pluginSlotNamesByTrack: [0: [0: "Compressor", 6: "Compressor"]]
+    )
+    let openerInvoked = MutableBox(false)
+    let obj = await runLive(
+        fixture: fixture,
+        params: thresholdParams(),
+        opener: { _, _, _, _ in
+            openerInvoked.value = true
+            return nil
+        }
+    )
+
+    #expect(obj["state"] as? String == "C")
+    #expect(obj["error"] as? String == "ambiguous_plugin_instance")
+    let writeAttempted = try #require(obj["write_attempted"] as? Bool)
+    #expect(!writeAttempted)
+    #expect(obj["conflicting_insert_indices"] as? [Int] == [0, 6])
+    #expect(!openerInvoked.value, "the refusal must precede every window-open attempt")
+    #expect(fixture.currentSliderValue == 51)
+}
+
+@Test func testDifferentPluginInstancesOnTargetTrackStillProceed() async {
+    // Mutation caught: treating every occupied insert as an ambiguity would
+    // block a Compressor merely because a different plug-in shares the track.
+    let fixture = LiveFixture(
+        beforeValue: 51,
+        pluginSlotNamesByTrack: [0: [0: "Gain", 6: "Compressor"]]
+    )
+    let obj = await runLive(fixture: fixture, params: thresholdParams())
+
+    #expect(obj["state"] as? String == "A")
+    #expect(fixture.currentSliderValue == 60)
+}
+
+@Test func testSamePluginOnDifferentTracksStillProceeds() async {
+    // Mutation caught: scanning the whole mixer instead of only the addressed
+    // track would reject independent Compressor instances on other tracks.
+    let fixture = LiveFixture(
+        beforeValue: 51,
+        otherTracks: 1,
+        pluginSlotNamesByTrack: [1: [0: "Compressor"]]
+    )
+    let obj = await runLive(fixture: fixture, params: thresholdParams())
+
+    #expect(obj["state"] as? String == "A")
+    #expect(fixture.currentSliderValue == 60)
+}
+
+@Test func testSinglePluginInstanceStillProceeds() async {
+    // Mutation caught: an off-by-one ambiguity condition (`count >= 1`) would
+    // refuse the single insert that remains safely addressable.
+    let fixture = LiveFixture(insert: 0, beforeValue: 51)
+    let obj = await runLive(fixture: fixture, params: thresholdParams(insert: 0))
+
+    #expect(obj["state"] as? String == "A")
+    #expect(fixture.currentSliderValue == 60)
+}
+
+@Test func testDuplicateChannelEQInstancesRefuseBeforeWindowAcquisition() async throws {
+    // Mutation caught: wiring the ambiguity refusal only into
+    // set_param_verified leaves set_eq_band_verified able to open an ambiguous
+    // Channel EQ editor and write the wrong insert.
+    let fixture = LiveFixture(
+        thresholdDescription: "Peak 1 Frequency",
+        pluginSlotName: "Channel EQ",
+        beforeValue: 0,
+        pluginWindowPresent: false,
+        pluginSlotNamesByTrack: [0: [0: "Channel EQ", 6: "Channel EQ"]]
+    )
+    let openerInvoked = MutableBox(false)
+    let result = await AccessibilityChannel.defaultSetEQBandVerified(
+        params: namedEQBandParams(),
+        runtime: fixture.runtime,
+        frontDocumentPath: { expectedPath },
+        pluginWindowOpener: { _, _, _, _ in
+            openerInvoked.value = true
+            return nil
+        }
+    )
+    let data = try #require(result.message.data(using: .utf8))
+    let obj = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+    #expect(obj["state"] as? String == "C")
+    #expect(obj["error"] as? String == "ambiguous_plugin_instance")
+    let writeAttempted = try #require(obj["write_attempted"] as? Bool)
+    #expect(!writeAttempted)
+    #expect(obj["conflicting_insert_indices"] as? [Int] == [0, 6])
+    #expect(!openerInvoked.value, "the refusal must precede every window-open attempt")
 }
 
 // MARK: - ADR-002 F1: live track-name cross-check for target_ref resolutions
@@ -762,6 +880,31 @@ private func namedEQBandParams(
     }
 }
 
+@Test func testNamedEQEngineeringUnitUsesCatalogCapitalizationInExactTarget() async throws {
+    // Mutation caught: accepting `db` case-insensitively but retaining it in
+    // the target rendering asks for `+3 db`, which can never equal Logic's
+    // measured `+3 dB` display.
+    let fixture = LiveFixture(
+        thresholdDescription: "Peak 1 Gain",
+        pluginSlotName: "Channel EQ",
+        beforeValue: 0,
+        sliderWriteBehavior: .oneStepTowardRequest,
+        sliderDisplayUnit: "dB",
+        sliderUsesSignedPositiveDisplay: true
+    )
+    let result = await AccessibilityChannel.defaultSetEQBandVerified(
+        params: namedEQBandParams(parameter: "Gain", unit: "db"),
+        runtime: fixture.runtime,
+        frontDocumentPath: { expectedPath }
+    )
+    let data = try #require(result.message.data(using: .utf8))
+    let envelope = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+    #expect(envelope["state"] as? String == "A")
+    #expect(envelope["requested_display"] as? String == "+3 dB")
+    #expect(envelope["display_unit"] as? String == "dB")
+}
+
 // MARK: - State C: tolerance exceeded → readback_mismatch + rollback
 
 @Test func testOutsideToleranceIsReadbackMismatchAndRollsBack() async {
@@ -882,6 +1025,26 @@ private func namedEQBandParams(
     let writeAttempted = try #require(obj["write_attempted"] as? Bool)
     let safeToRetry = try #require(obj["safe_to_retry"] as? Bool)
     #expect(!writeAttempted)
+    #expect(!safeToRetry)
+    #expect(fixture.currentSliderValue == 51)
+}
+
+@Test func testUnreadablePluginPopupCountIsNotReportedAsClean() async throws {
+    // Mutation caught: collapsing a nil CoreGraphics popup count into
+    // noPopupObserved allows a write after the screen state became unknowable.
+    let fixture = LiveFixture(beforeValue: 51)
+    let obj = await runLive(
+        fixture: fixture,
+        params: thresholdParams(),
+        popupMenuCleaner: { _ in .popupCountUnavailable }
+    )
+
+    #expect(obj["state"] as? String == "C")
+    #expect(obj["error"] as? String == "window_open_failed")
+    #expect(obj["plugin_popup_menu_state"] as? String == "window_count_unavailable")
+    let writeAttempted = try #require(obj["write_attempted"] as? Bool)
+    #expect(!writeAttempted)
+    let safeToRetry = try #require(obj["safe_to_retry"] as? Bool)
     #expect(!safeToRetry)
     #expect(fixture.currentSliderValue == 51)
 }

--- a/Tests/LogicProMCPTests/PluginsDispatcherReachabilityTests.swift
+++ b/Tests/LogicProMCPTests/PluginsDispatcherReachabilityTests.swift
@@ -42,7 +42,7 @@ private func sharedObject(_ result: ChannelResult) -> [String: Any]? {
     // With no channels registered the router returns channels_exhausted — which
     // proves the op IS in the table (it got past the routingTable lookup).
     let router = ChannelRouter()
-    for operation in ["plugin.get_inventory", "plugin.set_param_verified", "plugin.insert_verified"] {
+    for operation in ["plugin.get_inventory", "plugin.set_param_verified", "plugin.set_eq_band_verified", "plugin.insert_verified"] {
         let result = await router.route(operation: operation, params: ["track": "0"])
         let msg = result.message
         #expect(!msg.contains("Unknown operation"), "\(operation): Plane 2 — not in routing table")
@@ -52,7 +52,7 @@ private func sharedObject(_ result: ChannelResult) -> [String: Any]? {
 @Test func testPluginsVerifiedOpsRouteAXOnlyNoFallback() async {
     // R16: verified ops must be AX-only (single-channel chain) so a failure
     // never falls back to Scripter/MCU and fabricates a false verified result.
-    for operation in ["plugin.get_inventory", "plugin.set_param_verified", "plugin.insert_verified"] {
+    for operation in ["plugin.get_inventory", "plugin.set_param_verified", "plugin.set_eq_band_verified", "plugin.insert_verified"] {
         let chain = ChannelRouter.routingTable[operation]
         #expect(chain == [.accessibility], "\(operation) must route through .accessibility alone")
     }
@@ -113,6 +113,20 @@ private func makeFakeAXChannel() -> (AccessibilityChannel, FakeAXRuntimeBuilder)
     let obj = sharedObject(result)
     #expect(obj?["hc_schema"] as? Int == 2)
     #expect(obj?["operation"] as? String == "logic_plugins.set_param_verified")
+}
+
+@Test func testPluginSetEQBandVerifiedReachesChannelExecute() async {
+    let (channel, _) = makeFakeAXChannel()
+    let result = await channel.execute(operation: "plugin.set_eq_band_verified", params: [
+        "track": "0", "insert": "0", "band": "Peak 1", "parameter": "Frequency",
+        "value": "250", "unit": "raw_ax_value", "mode": "duplicate_applyback",
+        "project_expected_path": "/tmp/x.logicx",
+    ])
+    let text = result.message
+    #expect(!text.contains("Unsupported AX operation"), "Plane 3 — set_eq_band_verified not handled in execute")
+    let obj = sharedObject(result)
+    #expect(obj?["hc_schema"] as? Int == 2)
+    #expect(obj?["operation"] as? String == "logic_plugins.set_eq_band_verified")
 }
 
 @Test func testPluginInsertVerifiedReachesChannelExecute() async {

--- a/Tests/LogicProMCPTests/QualificationRunnerTests.swift
+++ b/Tests/LogicProMCPTests/QualificationRunnerTests.swift
@@ -58,10 +58,10 @@ struct QualificationRunnerTests {
         // real payload qualifies: passed == 23 (22 oracles + health's bespoke
         // validator), protocolSmoke == 0. The 87 mutating ops are unchanged —
         // they still defer to ADR-001-c for live mutation.
-        #expect(operationCases.count == 111)
+        #expect(operationCases.count == 112)
         #expect(operationCases.filter { $0.status == .passed }.count == 23)
         #expect(operationCases.filter { $0.status == .protocolSmoke }.isEmpty)
-        #expect(operationCases.filter { $0.status == .notQualified }.count == 88)
+        #expect(operationCases.filter { $0.status == .notQualified }.count == 89)
         #expect(operationCases.filter { $0.status == .failed }.isEmpty)
         #expect(operationCases.filter { $0.status == .passed }.allSatisfy {
             $0.verificationKind == .semanticReadback
@@ -254,7 +254,7 @@ struct QualificationRunnerTests {
         let specs = OperationRegistry.specs
         let driveResult = Self.driveResult(specs: specs, qualifiedReadOperationCount: 0)
         #expect(driveResult.operationResults.values.filter { $0.status == .passed }.isEmpty)
-        #expect(driveResult.operationResults.values.filter { $0.status == .notQualified }.count == 111)
+        #expect(driveResult.operationResults.values.filter { $0.status == .notQualified }.count == 112)
         let fixture = try Fixture(specs: specs, drive: { _ in driveResult })
         defer { fixture.remove() }
 
@@ -1189,7 +1189,7 @@ struct QualificationRunnerTests {
         ))
 
         #expect(result.handshakeOK)
-        #expect(result.catalog?.operationCount == 111)   // #575 registered edit.move_to_playhead
+        #expect(result.catalog?.operationCount == 112)   // #575 registered edit.move_to_playhead
         #expect(result.catalogCountMatch)
         #expect(result.traceOK)
 
@@ -1201,7 +1201,7 @@ struct QualificationRunnerTests {
         let smoke = operationResults.filter { $0.status == .protocolSmoke }
 
         #expect(operationResults.count == OperationRegistry.specs.count)
-        #expect(mutating.count == 88)
+        #expect(mutating.count == 89)
         #expect(readOnly.count == 23)
         #expect(operationResults.allSatisfy { $0.status != .failed })
         #expect(operationResults.allSatisfy { $0.responseData != nil && $0.readback != nil })
@@ -1732,7 +1732,7 @@ struct QualificationRunnerTests {
         // #373 Phase A: the read-only surface now qualifies semantically.
         #expect(operationCases.filter { $0.status == .passed }.count == 23)
         #expect(operationCases.filter { $0.status == .protocolSmoke }.isEmpty)
-        #expect(operationCases.filter { $0.status == .notQualified }.count == 88)
+        #expect(operationCases.filter { $0.status == .notQualified }.count == 89)
         // #373 Phase A: 22 oracled read-only ops + system.health's bespoke
         // validator. The aggregate axes contribute no passes here.
         #expect(attestation.passed == 23)

--- a/Tests/LogicProMCPTests/SharedTestHelpers.swift
+++ b/Tests/LogicProMCPTests/SharedTestHelpers.swift
@@ -1,3 +1,4 @@
+import CoreMIDI
 import Foundation
 import MCP
 import Testing
@@ -23,6 +24,46 @@ let coreMIDIUnavailableInSandbox: ConditionTrait = .disabled(
     if: restrictedSandboxActive,
     "This sandbox denies the CoreMIDI service connection; the behaviour remains live qualification."
 )
+
+/// Independently ask whether CoreMIDI will hand THIS process a client right now,
+/// returning the refusal status or nil when it will.
+///
+/// The production smoke tests need this because a client-creation failure has two
+/// very different causes and only one of them is a defect. A sandbox trait cannot
+/// separate them: it is evaluated before the test and only knows about sandboxes.
+///
+/// Those tests used to accept a single hardcoded status (-50, what a CI runner
+/// returns) as "the environment cannot answer". That named one instance of the
+/// condition rather than the condition, so any other environmental refusal read as
+/// a product failure. Measured on a developer host: `MIDIClientCreate` returns -2
+/// during a full suite run while MIDIServer is cycling — and MIDIServer can also
+/// die outright, with a crash report to show for it, after which every client
+/// creation in every process fails until it comes back.
+///
+/// This probe is deliberately NOT vacuous. It uses CoreMIDI directly rather than
+/// the code under test, so when the product's own start path is the broken half
+/// this returns nil and the caller rethrows. It can only excuse a failure that
+/// the bare framework reproduces.
+func coreMIDIRefusesAClientRightNow() -> OSStatus? {
+    var client = MIDIClientRef()
+    let status = MIDIClientCreate("LogicProMCP-availability-probe" as CFString, nil, nil, &client)
+    guard status != noErr else {
+        MIDIClientDispose(client)
+        return nil
+    }
+    return status
+}
+
+/// Report a production smoke test that could not run because CoreMIDI refused
+/// this process a client. Loud on stdout: a silent return is indistinguishable
+/// from a test that actually exercised the path.
+func reportCoreMIDIUnavailable(_ test: String, startStatus: OSStatus, probeStatus: OSStatus) {
+    print(
+        "SKIPPED \(test): CoreMIDI refused a client to this process "
+            + "(start status \(startStatus), independent probe \(probeStatus)). "
+            + "The production path was NOT exercised."
+    )
+}
 
 /// PRD-007 — live AX header-scan fixture for `.corroborated` ops.
 ///

--- a/Tests/LogicProMCPTests/SliderIncrementWalkTests.swift
+++ b/Tests/LogicProMCPTests/SliderIncrementWalkTests.swift
@@ -220,7 +220,7 @@ struct SliderIncrementWalkTests {
         ))
     }
 
-    @Test func displayTargetUsesRawChangeToContinueInTheObservedDirection() {
+    @Test func displayTargetAboveStartArrivesAfterProbeMovesToward() {
         var reads: [Reading?] = [
             Reading(value: 100, display: "100 Hz"),
             Reading(value: 103, display: "200 Hz"),
@@ -235,8 +235,9 @@ struct SliderIncrementWalkTests {
             budget: 3
         )
 
-        // Mutation caught: using a guessed Hz mapping instead of the observed
-        // raw direction sends the second request somewhere other than 104.
+        // Mutation caught: choosing a direction from an invented Hz mapping
+        // instead of Logic's rendered ordering sends the second request
+        // somewhere other than 104.
         #expect(outcome == .arrived(
             steps: 2,
             final: Reading(value: 107, display: "248 Hz")
@@ -244,7 +245,7 @@ struct SliderIncrementWalkTests {
         #expect(requestedRawValues == [101, 104])
     }
 
-    @Test func unchangedDisplayCannotEstablishADirection() {
+    @Test func displayStopsChangingBeforeTargetReportsNoProgress() {
         var reads: [Reading?] = [
             Reading(value: 100, display: "100 Hz"),
             Reading(value: 101, display: "100 Hz"),
@@ -258,13 +259,149 @@ struct SliderIncrementWalkTests {
             budget: 8
         )
 
-        // Mutation caught: continuing after an unchanged rendering invents a
-        // display-to-raw mapping the core does not have.
+        // Mutation caught: continuing after an unchanged rendering turns a
+        // saturated or stalled display into a budget-exhaustion walk.
         #expect(outcome == .noProgress(
             steps: 1,
             last: Reading(value: 101, display: "100 Hz")
         ))
         #expect(nudgeCalls == 1)
+    }
+
+    @Test func displayTargetBelowStartReversesAndArrivesNearRawDistance() {
+        var value = 302.0
+        var nudgeCalls = 0
+
+        func reading() -> Reading {
+            Reading(value: value, display: "+\((value - 240) / 10) dB")
+        }
+
+        let outcome = SliderIncrementWalk.walk(
+            to: .display("+2.2 dB"),
+            read: { reading() },
+            nudge: { requestedRaw in
+                nudgeCalls += 1
+                value += requestedRaw > value ? 1 : -1
+                return true
+            },
+            budget: 64
+        )
+
+        // A +1 probe costs two extra accepted steps (up, then back down), but
+        // must not repeat the measured 302 -> 480 wrong-way rail walk.
+        #expect(outcome == .arrived(
+            steps: 42,
+            final: Reading(value: 262, display: "+2.2 dB")
+        ))
+        #expect(nudgeCalls == 42)
+    }
+
+    @Test func probeThatMovesAwayReversesAndArrives() {
+        var reads: [Reading?] = [
+            Reading(value: 100, display: "+4.0 dB"),
+            Reading(value: 101, display: "+4.1 dB"),
+            Reading(value: 100, display: "+4.0 dB"),
+            Reading(value: 99, display: "+3.8 dB"),
+        ]
+        var requestedRawValues: [Double] = []
+
+        let outcome = SliderIncrementWalk.walk(
+            to: .display("+3.8 dB"),
+            read: { reads.removeFirst() },
+            nudge: { requestedRaw in requestedRawValues.append(requestedRaw); return true },
+            budget: 4
+        )
+
+        // Mutation caught: retaining the upward probe direction never lets
+        // the walk return toward a lower rendered target.
+        #expect(outcome == .arrived(
+            steps: 3,
+            final: Reading(value: 99, display: "+3.8 dB")
+        ))
+        #expect(requestedRawValues == [101, 100, 99])
+    }
+
+    @Test func displayUnitTextMismatchReportsNoProgress() {
+        var reads: [Reading?] = [
+            Reading(value: 100, display: "+2.2 dB"),
+            Reading(value: 101, display: "2.2"),
+        ]
+
+        let outcome = SliderIncrementWalk.walk(
+            to: .display("+2.1 dB"),
+            read: { reads.removeFirst() },
+            nudge: { _ in true },
+            budget: 8
+        )
+
+        // Mutation caught: matching only the number treats a unit-less
+        // rendering as though it shared the target's dB ordering.
+        #expect(outcome == .noProgress(
+            steps: 1,
+            last: Reading(value: 101, display: "2.2")
+        ))
+    }
+
+    @Test func nonNumericDisplayReportsNoProgress() {
+        var reads: [Reading?] = [
+            Reading(value: 100, display: "Bypassed"),
+            Reading(value: 101, display: "Active"),
+        ]
+
+        let outcome = SliderIncrementWalk.walk(
+            to: .display("Enabled"),
+            read: { reads.removeFirst() },
+            nudge: { _ in true },
+            budget: 8
+        )
+
+        // Mutation caught: an unordered rendering is not evidence that an
+        // arbitrary raw direction can reach the requested text.
+        #expect(outcome == .noProgress(
+            steps: 1,
+            last: Reading(value: 101, display: "Active")
+        ))
+    }
+
+    @Test func displayRailReportsNoProgressInsteadOfBudgetExhaustion() {
+        let rail = Reading(value: 480, display: "+24.0 dB")
+        var nudgeCalls = 0
+
+        let outcome = SliderIncrementWalk.walk(
+            to: .display("+24.1 dB"),
+            read: { rail },
+            nudge: { _ in nudgeCalls += 1; return true },
+            budget: 8
+        )
+
+        // Mutation caught: a probe blocked by a real control rail must not
+        // consume the caller's entire budget.
+        #expect(outcome == .noProgress(steps: 1, last: rail))
+        #expect(nudgeCalls == 1)
+    }
+
+    @Test func displayBudgetIsAnExactNudgeLimit() {
+        var reads: [Reading?] = [
+            Reading(value: 100, display: "1.0"),
+            Reading(value: 101, display: "1.1"),
+            Reading(value: 102, display: "1.2"),
+        ]
+        var nudgeCalls = 0
+
+        let outcome = SliderIncrementWalk.walk(
+            to: .display("1.4"),
+            read: { reads.removeFirst() },
+            nudge: { _ in nudgeCalls += 1; return true },
+            budget: 2
+        )
+
+        // Mutation caught: a display walk must honor the same accepted-write
+        // budget boundary as a raw-value walk.
+        #expect(outcome == .budgetExhausted(
+            steps: 2,
+            last: Reading(value: 102, display: "1.2")
+        ))
+        #expect(nudgeCalls == 2)
     }
 
     @Test func nonPositiveBudgetNeverNudges() {

--- a/Tests/LogicProMCPTests/SliderIncrementWalkTests.swift
+++ b/Tests/LogicProMCPTests/SliderIncrementWalkTests.swift
@@ -1,0 +1,288 @@
+import Testing
+@testable import LogicProMCP
+
+@Suite("Channel EQ slider increment walk")
+struct SliderIncrementWalkTests {
+    typealias Reading = SliderIncrementWalk.Reading
+
+    @Test func alreadyAtRawTargetDoesNotNudge() {
+        var nudgeCalls = 0
+        let reading = Reading(value: 262, display: "+2.2 dB")
+
+        let outcome = SliderIncrementWalk.walk(
+            to: .rawValue(262, tolerance: 0),
+            read: { reading },
+            nudge: { _ in nudgeCalls += 1; return true },
+            budget: 8
+        )
+
+        // Mutation caught: moving before checking entry readback corrupts an
+        // already-correct control.
+        #expect(outcome == .arrived(steps: 0, final: reading))
+        #expect(nudgeCalls == 0)
+    }
+
+    @Test func alreadyAtDisplayTargetDoesNotNudge() {
+        var nudgeCalls = 0
+        let reading = Reading(value: 374, display: "248 Hz")
+
+        let outcome = SliderIncrementWalk.walk(
+            to: .display("248 Hz"),
+            read: { reading },
+            nudge: { _ in nudgeCalls += 1; return true },
+            budget: 8
+        )
+
+        // Mutation caught: treating a display request as an engineering-value
+        // conversion changes a control whose own rendering already matches.
+        #expect(outcome == .arrived(steps: 0, final: reading))
+        #expect(nudgeCalls == 0)
+    }
+
+    @Test func saturationReportsNoProgress() {
+        var reads: [Reading?] = [
+            Reading(value: 0, display: "20 Hz"),
+            Reading(value: 0, display: "20 Hz"),
+        ]
+        var nudgeCalls = 0
+
+        let outcome = SliderIncrementWalk.walk(
+            to: .rawValue(100, tolerance: 0),
+            read: { reads.removeFirst() },
+            nudge: { _ in nudgeCalls += 1; return true },
+            budget: 8
+        )
+
+        // Mutation caught: treating a rail as progress loops until the budget.
+        #expect(outcome == .noProgress(
+            steps: 1,
+            last: Reading(value: 0, display: "20 Hz")
+        ))
+        #expect(nudgeCalls == 1)
+    }
+
+    @Test func outOfRangeRawTargetIsNotClampedBeforeSaturation() {
+        let maximum = Reading(value: 1_050, display: "20000 Hz")
+        var requestedRawValues: [Double] = []
+
+        let outcome = SliderIncrementWalk.walk(
+            to: .rawValue(2_000, tolerance: 0),
+            read: { maximum },
+            nudge: { requestedRawValues.append($0); return true },
+            budget: 8
+        )
+
+        // Mutation caught: clamping 2,000 to a presumed maximum fabricates an
+        // arrival instead of reporting the actual rail as no progress.
+        #expect(outcome == .noProgress(steps: 1, last: maximum))
+        #expect(requestedRawValues == [2_000])
+    }
+
+    @Test func rejectedNudgeStopsImmediately() {
+        let initial = Reading(value: 100, display: "100 Hz")
+        var nudgeCalls = 0
+        var reads = 0
+
+        let outcome = SliderIncrementWalk.walk(
+            to: .rawValue(200, tolerance: 0),
+            read: { reads += 1; return initial },
+            nudge: { _ in nudgeCalls += 1; return false },
+            budget: 8
+        )
+
+        // Mutation caught: ignoring a rejected write keeps issuing unaccepted
+        // AX requests.
+        #expect(outcome == .noProgress(steps: 0, last: initial))
+        #expect(nudgeCalls == 1)
+        #expect(reads == 1)
+    }
+
+    @Test func missingMidWalkReadbackIsReported() {
+        var reads: [Reading?] = [Reading(value: 100, display: "100 Hz"), nil]
+        var nudgeCalls = 0
+
+        let outcome = SliderIncrementWalk.walk(
+            to: .rawValue(200, tolerance: 0),
+            read: { reads.removeFirst() },
+            nudge: { _ in nudgeCalls += 1; return true },
+            budget: 8
+        )
+
+        // Mutation caught: reading nil as an unchanged value falsely calls an
+        // accessibility outage a saturated control.
+        #expect(outcome == .readbackLost(steps: 1))
+        #expect(nudgeCalls == 1)
+    }
+
+    @Test func missingEntryReadbackIsReported() {
+        var nudgeCalls = 0
+
+        let outcome = SliderIncrementWalk.walk(
+            to: .rawValue(200, tolerance: 0),
+            read: { nil },
+            nudge: { _ in nudgeCalls += 1; return true },
+            budget: 8
+        )
+
+        // Mutation caught: turning an absent initial readback into a default
+        // value lets the core author a write without a control observation.
+        #expect(outcome == .readbackLost(steps: 0))
+        #expect(nudgeCalls == 0)
+    }
+
+    @Test func twoValueOscillationReportsNoProgress() {
+        var reads: [Reading?] = [
+            Reading(value: 0, display: "20 Hz"),
+            Reading(value: 3, display: "23 Hz"),
+            Reading(value: 0, display: "20 Hz"),
+        ]
+
+        let outcome = SliderIncrementWalk.walk(
+            to: .rawValue(10, tolerance: 0),
+            read: { reads.removeFirst() },
+            nudge: { _ in true },
+            budget: 8
+        )
+
+        // Mutation caught: forgetting the a→b→a detector makes a bouncing
+        // control consume the whole write budget.
+        #expect(outcome == .noProgress(
+            steps: 2,
+            last: Reading(value: 0, display: "20 Hz")
+        ))
+    }
+
+    @Test func movementFartherAwayAfterCrossingReportsOvershot() {
+        var reads: [Reading?] = [
+            Reading(value: 4, display: "4"),
+            Reading(value: 7, display: "7"),
+            Reading(value: 8, display: "8"),
+        ]
+
+        let outcome = SliderIncrementWalk.walk(
+            to: .rawValue(5, tolerance: 0),
+            read: { reads.removeFirst() },
+            nudge: { _ in true },
+            budget: 8
+        )
+
+        // Mutation caught: accepting a second move away after crossing loses
+        // the fact that the walk can no longer be trusted to return.
+        #expect(outcome == .overshot(
+            steps: 2,
+            last: Reading(value: 8, display: "8")
+        ))
+    }
+
+    @Test func budgetIsAnExactNudgeLimit() {
+        var reads: [Reading?] = [
+            Reading(value: 0, display: "0"),
+            Reading(value: 4, display: "4"),
+            Reading(value: 8, display: "8"),
+        ]
+        var nudgeCalls = 0
+
+        let outcome = SliderIncrementWalk.walk(
+            to: .rawValue(20, tolerance: 0),
+            read: { reads.removeFirst() },
+            nudge: { _ in nudgeCalls += 1; return true },
+            budget: 2
+        )
+
+        // Mutation caught: a <= loop condition performs one more write than
+        // the caller authorized.
+        #expect(outcome == .budgetExhausted(
+            steps: 2,
+            last: Reading(value: 8, display: "8")
+        ))
+        #expect(nudgeCalls == 2)
+    }
+
+    @Test func largeReadbackStepsStillArrive() {
+        var reads: [Reading?] = [
+            Reading(value: 0, display: "20 Hz"),
+            Reading(value: 7, display: "28 Hz"),
+            Reading(value: 10, display: "31 Hz"),
+        ]
+
+        let outcome = SliderIncrementWalk.walk(
+            to: .rawValue(10, tolerance: 0),
+            read: { reads.removeFirst() },
+            nudge: { _ in true },
+            budget: 3
+        )
+
+        // Mutation caught: assuming every accepted AX nudge moves exactly one
+        // raw unit rejects a valid larger readback jump.
+        #expect(outcome == .arrived(
+            steps: 2,
+            final: Reading(value: 10, display: "31 Hz")
+        ))
+    }
+
+    @Test func displayTargetUsesRawChangeToContinueInTheObservedDirection() {
+        var reads: [Reading?] = [
+            Reading(value: 100, display: "100 Hz"),
+            Reading(value: 103, display: "200 Hz"),
+            Reading(value: 107, display: "248 Hz"),
+        ]
+        var requestedRawValues: [Double] = []
+
+        let outcome = SliderIncrementWalk.walk(
+            to: .display("248 Hz"),
+            read: { reads.removeFirst() },
+            nudge: { requestedRawValues.append($0); return true },
+            budget: 3
+        )
+
+        // Mutation caught: using a guessed Hz mapping instead of the observed
+        // raw direction sends the second request somewhere other than 104.
+        #expect(outcome == .arrived(
+            steps: 2,
+            final: Reading(value: 107, display: "248 Hz")
+        ))
+        #expect(requestedRawValues == [101, 104])
+    }
+
+    @Test func unchangedDisplayCannotEstablishADirection() {
+        var reads: [Reading?] = [
+            Reading(value: 100, display: "100 Hz"),
+            Reading(value: 101, display: "100 Hz"),
+        ]
+        var nudgeCalls = 0
+
+        let outcome = SliderIncrementWalk.walk(
+            to: .display("101 Hz"),
+            read: { reads.removeFirst() },
+            nudge: { _ in nudgeCalls += 1; return true },
+            budget: 8
+        )
+
+        // Mutation caught: continuing after an unchanged rendering invents a
+        // display-to-raw mapping the core does not have.
+        #expect(outcome == .noProgress(
+            steps: 1,
+            last: Reading(value: 101, display: "100 Hz")
+        ))
+        #expect(nudgeCalls == 1)
+    }
+
+    @Test func nonPositiveBudgetNeverNudges() {
+        let initial = Reading(value: 100, display: "100 Hz")
+
+        for budget in [0, -1] {
+            var nudgeCalls = 0
+            let outcome = SliderIncrementWalk.walk(
+                to: .rawValue(200, tolerance: 0),
+                read: { initial },
+                nudge: { _ in nudgeCalls += 1; return true },
+                budget: budget
+            )
+
+            // Mutation caught: entering the write loop before validating the
+            // budget performs a mutation a zero-budget caller prohibited.
+            #expect(outcome == .budgetExhausted(steps: 0, last: initial))
+            #expect(nudgeCalls == 0)
+        }
+    }
+}

--- a/Tests/LogicProMCPTests/StockPluginCatalogTests.swift
+++ b/Tests/LogicProMCPTests/StockPluginCatalogTests.swift
@@ -408,9 +408,10 @@ struct StockPluginCatalogTests {
     @Test("insertable write capabilities match the live insert allowlist")
     func insertOnlyMatchesInsertAllowlist() {
         let snapshot = StockPluginCatalog.defaultSnapshot(census: .deterministic())
-        // T5: Compressor is now `parameter_write_readback` (its `threshold` is
-        // verified-writable via AX), while still being insertable. Gain and
-        // Channel EQ remain `insert_only`. The insert allowlist is the union.
+        // Compressor and Channel EQ expose `parameter_write_readback` catalog
+        // entries while remaining insertable. Channel EQ's entry records only
+        // raw-range/nudge evidence; it does not claim a completed live round
+        // trip. The insert allowlist is the union.
         let insertable = snapshot.entries.filter {
             $0.safeWriteCapabilities == .insertOnly || $0.safeWriteCapabilities == .parameterWriteReadback
         }
@@ -429,6 +430,8 @@ struct StockPluginCatalogTests {
         let compressor = snapshot.entries.first { $0.id == "logic.stock.effect.compressor" }
         #expect(compressor?.safeWriteCapabilities == .parameterWriteReadback,
                 "Compressor threshold is verified-writable (T5)")
+        let channelEQ = snapshot.entries.first { $0.id == "logic.stock.effect.channel_eq" }
+        #expect(channelEQ?.safeWriteCapabilities == .parameterWriteReadback)
         let nonInsertable = snapshot.entries.first { $0.id == "logic.stock.effect.chromaverb" }
         #expect(nonInsertable?.safeWriteCapabilities == StockPluginSafeWriteCapability.none)
         #expect(AccessibilityChannel.pluginInsertSpec(named: "ChromaVerb") == nil)

--- a/Tests/LogicProMCPTests/VerifiedOpGateTests.swift
+++ b/Tests/LogicProMCPTests/VerifiedOpGateTests.swift
@@ -95,14 +95,14 @@ struct VerifiedOpGateSharedTests {
 
 // Lives in this serialized suite (moved from PluginsDispatcherReachabilityTests)
 // because it drives the shared VerifiedOpGate via
-// callTool(set_param_verified/insert_verified) → runVerified.tryAcquire/release.
+// callTool(set_param_verified/set_eq_band_verified/insert_verified) → runVerified.tryAcquire/release.
 // Run in parallel with the gate tests above it could free a peer's claim, since
 // VerifiedOpGate.release() is token-less. This is a Plane-1 reachability check.
 @Test func testPluginsToolReachesRouterNotUnknownTool() async {
     let server = LogicProServer()
     let handlers = await server.makeHandlers()
 
-    for command in ["get_inventory", "set_param_verified", "insert_verified"] {
+    for command in ["get_inventory", "set_param_verified", "set_eq_band_verified", "insert_verified"] {
         let r = await handlers.callTool(CallTool.Parameters(
             name: "logic_plugins",
             arguments: ["command": .string(command), "params": .object(["track": .int(0)])]

--- a/Tests/LogicProMCPTests/WorkflowSkillCatalogTests.swift
+++ b/Tests/LogicProMCPTests/WorkflowSkillCatalogTests.swift
@@ -600,7 +600,7 @@ struct WorkflowCommandCensusTests {
         // These were missing before #111 and let the census claim to be the
         // pinned public surface while omitting real production commands.
         #expect(WorkflowSkillCatalog.publicCommands["logic_plugins"]
-            == ["get_inventory", "set_param_verified", "insert_verified"])
+            == ["get_inventory", "set_param_verified", "set_eq_band_verified", "insert_verified"])
         let transport = try #require(WorkflowSkillCatalog.publicCommands["logic_transport"])
         #expect(transport.contains("toggle_autopunch"))
         let project = WorkflowSkillCatalog.publicCommands["logic_project"] ?? []

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -73,6 +73,7 @@ Also open, outside the ADR set:
 | #448 | OPEN | layout readback is deliverable; colour and reorder need a definition of "verified" for a write nothing can read back |
 | #678 | closed | the drift guard and this file's update rule shipped in #684 |
 | #683 | OPEN | external report — MCU feedback from Logic Pro Creator Studio wedges the loop; four hypotheses refuted or weakened by measurement, blocked on a `sample` from the reporter's host |
+| #724 | OPEN | fixed in the pull request that adds this row — `plugins.set_param_verified` succeeded once per process, because acquisition pressed a menu-opening control, left a popup that blocks every AppleEvent, and re-pressed a TOGGLE that closed the window it was trying to re-acquire. Measured and fixed 2026-08-31; four consecutive calls of each verified write reach State A |
 | #685 | closed | fixed in this pull request — the nudge loop no longer abandons a write on one failed AX read |
 
 ### Three reopen reasons, checked rather than inferred

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -74,6 +74,7 @@ Also open, outside the ADR set:
 | #678 | closed | the drift guard and this file's update rule shipped in #684 |
 | #683 | OPEN | external report — MCU feedback from Logic Pro Creator Studio wedges the loop; four hypotheses refuted or weakened by measurement, blocked on a `sample` from the reporter's host |
 | #724 | OPEN | fixed in the pull request that adds this row — `plugins.set_param_verified` succeeded once per process, because acquisition pressed a menu-opening control, left a popup that blocks every AppleEvent, and re-pressed a TOGGLE that closed the window it was trying to re-acquire. Measured and fixed 2026-08-31; four consecutive calls of each verified write reach State A |
+| #726 | OPEN | fixed in the pull request that adds this row — a verified write could land on a different insert than the one requested and still return State A, because the window match keyed on track name plus one slider description and neither names a plug-in or an insert. Measured 2026-08-31 on a track carrying Compressor at inserts 0 and 2: both writes reached slot 0. Editors are now bound by construction (zero matching editors before one target-slot press, exactly one after), their header static text must name the requested plug-in, and the editor this operation opens is closed again |
 | #685 | closed | fixed in this pull request — the nudge loop no longer abandons a write on one failed AX read |
 
 ### Three reopen reasons, checked rather than inferred


### PR DESCRIPTION
Closes #301.

## The recorded wall was not where it was said to be

ADR-013 said *"Live census showed the Channel EQ Editor/Controls view can be AX-opaque, so extending the existing AX slider path is not reliable enough"*, and built a whole Decision on it: a virtual Mackie C4 control surface, two virtual MIDI endpoints, a `ChannelEQC4Adapter`, a doctor capability.

That census is `Scripts/spike-channel-eq-au-census.swift`, which instantiates the Audio Unit **outside Logic**. ADR-018's own Important Boundary says why that cannot answer the question: *"the MCP server is not the host attached to Logic's live AU instance."* It measured a different object, and the answer had been blocking this issue since.

Measured on live Logic 12.x: Channel EQ's native view exposes **8 named band enables and 24 named band-parameter sliders**, each reporting settable and each carrying an `AXValueDescription` in engineering units. The ADR's Decision was revised on the issue; no control surface is needed.

## The write is a walk, not a set

This is the part that changed the design, and it is why the catalog stayed empty until now.

```
actions on a band slider:  ["AXIncrement", "AXDecrement"]      ← no direct-set action
original 262 (+2.2 dB), requested 222
AXUIElementSetAttributeValue → status 0 (success), readback 261 (+2.1 dB)
```

**It reports success and moves one step.** Six consecutive sets to the same target walked 262 → 256, exactly one per call. So `AXValue` on these sliders is a direction, not a destination, and the single set Compressor `threshold` uses — where `set 60` lands on 60 — cannot be reused. `AXIncrement` is not one step either: thirty of them drove the control to its maximum.

`SliderIncrementWalk` is the pure core, free of AX, driven by an injected read and nudge. Ten edge cases, each with a case that can fail: already at target nudges nothing; saturation, oscillation and an unchanged display all report `noProgress` rather than looping; a rejected nudge stops immediately; a lost readback is its own outcome; crossing the target and moving away is `overshot`; the budget is exact; a step larger than one is fine because the loop is driven by the readback; a non-positive budget never nudges. **An out-of-range target is not clamped** — it terminates on saturation, because clamping would report arrival at a value nobody asked for.

## Engineering units without inventing a mapping

The raw-to-Hz relationship is non-linear — 250 renders `100 Hz`, 850 renders `5000 Hz` — so a Hz or dB target cannot be computed. A display request instead walks until **Logic's own `AXValueDescription`** equals the string asked for. Logic renders it; the walk converges on what it rendered. Arrival is exact string equality.

Choosing the direction needed a second pass. The first version always probed upward and then froze on whatever that probe did, so a target below the current value walked 179 steps into the rail. It now probes once, compares the two renderings against the target, reverses if the step moved away, and keeps re-evaluating. Ordering comes from the leading signed number with the unit text required to match on both sides; where that cannot be established the walk returns `noProgress` rather than guessing.

## Live results

```
raw   302 requested → 302 observed, "+6.2 dB"      40 steps   state A
dB    "+2.2 dB" from 302  (downward)                42 steps   state A
dB    "+6.2 dB" from 262  (upward)                  40 steps   state A
restore 262 → "+2.2 dB"                             40 steps   state A
```

Harnesses at this head, each from a closed-window start:

| harness | |
|---|---|
| `live_301_channel_eq_bands_are_addressable` | **15/15** |
| `live_301_eq_band_write_lands_and_rolls_back` | **18/18** |
| `live_290_selectors_resolve_by_identity` | **13/13** |

All `is_clean`, every counterexample rejected.

## A shipped defect this exposed — see #724

While proving the walk, `plugins.set_param_verified` turned out to succeed **once per process**. A successful write left an open plug-in chooser menu, the next call failed `window_open_failed`, and once that popup was up **every AppleEvent to Logic timed out with -1712**, so later calls degraded to `project_identity_mismatch`. One stuck menu disabled every verified write in the process.

The attempt ladder's fallback tier contained the slot's list button, whose own advertised action says it opens a menu. Controls advertising a menu-opening action are excluded now, matched on the action rather than the localised label, and acquisition leaves no popup on either path — detected through CoreGraphics at the derived popup-menu level, because AppleEvents are exactly what a stuck popup blocks.

Verified after the fix: three consecutive `set_eq_band_verified` calls all reach State A with zero popups, and so do three consecutive `set_param_verified` calls.

## Scope, stated plainly

- Band **write and readback** for Channel EQ, addressed by band and parameter **name**. No ordinals, no coordinates.
- The catalog declares the measured ranges — Frequency 0…1050, Gain 0…480, Peak/Cut Q 0…127, **Shelf Q 0…52**, Order 0…5. The shelf max genuinely differs and flattening it would put a valid request outside the control's travel.
- Registering the verb moved seven pinned counts across five test files, which is what pinning is for.
- Not covered: other EQ plug-ins, third-party plug-ins, and any locale beyond the Korean labels measured here — another locale resolves nothing and the operation refuses rather than acting on a guess.


## The #724 fix took three wrong guesses, and the measurements are worth keeping

Each guess was refuted by a measurement, and the third one was the answer.

**Guess 1: "demotion cannot work live."** My probe cleared `AXMain` and `AXFocused`, saw the window
still front, and concluded Logic ignores the demote. Logic *does* ignore `AXFocused` — but the probe
skipped the `AXRaise` fallback, which is what actually demotes:

```
clear AXMain / AXFocused   -> isFront still true
AXRaise(arrange window)     -> isFront FALSE
```

A probe that reproduces only part of the production path is not a statement about production. I had
written that conclusion into a worker packet as "measured"; the worker built on it and correctly
stopped rather than inventing a discriminator, which is the only reason a wrong fix did not land.

**Guess 2: "a `.unique` match is safe to reuse directly."** Both fail-closed tests went red
immediately. The planted wrong window carries a `Threshold` slider too, so `pluginWindowMatch`
returns `.unique` for it. **An element's presence is not proof of identity.** Reverted.

**Guess 3, and the answer: the open control is a TOGGLE.**

```
press 열기          window opens, isFront true
demote              isFront false
press 열기 AGAIN    the window is GONE from AXWindows — it CLOSED
```

Acquisition demoted an already-open window and then pressed the slot to prove it came back, which
closed it instead. So the fix is narrower than either guess: after a demote succeeds on a `.unique`
match the window is already the right one and is **raised**, not re-opened, and a raise that does
not front it falls through to the unchanged ladder. The `.none` and `.ambiguous` paths — which is
what both fail-closed tests exercise — are untouched, and demotion stays as the discriminator it
always was.

Live acceptance, four consecutive calls each, from a closed-window start:

```
set_eq_band_verified   272 → 282 → 292 → 262    all State A, window open throughout
set_param_verified      55 →  65 →  58 →  60    all State A   (the shipped operation)
```


---

## Also in this branch: #726, a wrong-insert write that reported success

Filed and fixed while verifying the above. `plugins.set_param_verified` could write to a
different insert than the one requested and still return State A with the requested insert
in `target_identity`. Reproduced on a real project: `Absolute Zero` carries Compressor at
inserts 0 and 2; writes addressed to insert 0 and insert 2 both landed on slot 0.

Undetectable downstream — readback comes from the same wrong window, so it agrees with the
request and `verified` stays true.

Two independent causes, both fixed here.

### 1. Two editors for the same plug-in are indistinguishable

Every AX attribute of the two Compressor editors agrees: AXTitle, AXSubrole, AXParent,
AXSections, header texts. Only screen geometry differs, and geometry is forbidden here.
`plugin_insert_ref` does not bridge it either — it is an inventory-side fingerprint over
(track, insert, identity) with no link to a window.

So the duplicated case refuses with `ambiguous_plugin_instance` before any window is opened
or pressed, naming the colliding inserts. It runs after the inventory-completeness gate, so
an unreadable slot cannot hide a duplicate.

### 2. The window match never checked the plug-in

It keyed on track name plus one slider AXDescription. Compressor, Noise Gate, Expander,
DeEsser and Limiter all expose a `Threshold`, so a Compressor write could match a Noise Gate
editor on the same track. A plug-in editor does name its plug-in, in its direct AXStaticText
children — measured across four editors on one track:

```
ChromaVerb  ["보기:", "ChromaVerb", "Studio Grand"]
Compressor  ["보기:", "사이드 체인:", "Compressor", "Studio Grand"]
Channel EQ  ["보기:", "Channel EQ", "Studio Grand"]
Piano       ["보기:", "Studio Piano", "Studio Grand"]     <- slot says `Piano`
```

That last row is why the check resolves through `VerifiedPluginCatalog` rather than comparing
strings. The name survives the Controls view, stays English while surrounding labels are
localized, and sits at no fixed index (13 in one window, 42 in another). A window with no
readable static text is refused; absence is not identity evidence.

### What is proven live, and what is not

Live: the duplicated track refuses with `write_attempted: false` and no window opened (0
plug-in editors before and after); the single-instance path still reaches State A.

Not live: no track in the test project has two plug-ins sharing a slider AXDescription, so
`plugin_window_plugin_mismatch` is pinned by unit tests with injected AX only. Third-party
editors are unmeasured.

## And #724, the acquisition defect

`set_param_verified` succeeded once per process, then wedged. Three stacked causes: the
acquisition ladder pressed the menu-opening list button; the resulting popup sits at
CGWindowLayer 101 and blocked every AppleEvent with -1712; and the slot's open control is a
toggle, so re-pressing it closed the window instead of raising it. All three fixed, with the
popup cleanup reporting `window_count_unavailable` rather than treating an unreadable count
as a clean screen.
