### PR TITLE
fix: ten review findings, and the live check that should have caught them

### DIFF
--- a/Scripts/check-falsifiable-adoption.py
+++ b/Scripts/check-falsifiable-adoption.py
@@ -37,7 +37,7 @@ import sys
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # The measured floor. Raise it when a harness converts; never lower it to make a branch pass.
-FLOOR = 6
+FLOOR = 7
 _FALSIFIABLE_PARAMETERS = (
     "tag", "predicate", "observation", "counterexample", "expected", "mutation", "modal_snapshot",
 )

--- a/Scripts/livekit/ax_plugin_menu_probe.swift
+++ b/Scripts/livekit/ax_plugin_menu_probe.swift
@@ -349,6 +349,10 @@ func configuredOptionalString(_ key: String) -> String? {
     config[key] as? String
 }
 
+func configuredInt(_ key: String) -> Int? {
+    config[key] as? Int
+}
+
 func configuredStrings(_ key: String) -> [String] {
     config[key] as? [String] ?? []
 }
@@ -652,6 +656,12 @@ func openPlugin(
     openLabel: String,
     trackLabel: String? = nil,
     mixerLabels: [String]? = nil,
+    // Pick one of several identically named slots by AX child order within the
+    // named strip. This is the ordering the product's own `insert` parameter
+    // uses; it is NOT a screen coordinate. Only a harness that must BUILD a
+    // duplicate-instance state should pass it — leaving it nil keeps the
+    // refuse-on-ambiguity behaviour every other caller relies on.
+    slotOrdinal: Int? = nil,
     beforePress: ((AXUIElement) -> Void)? = nil
 ) -> (JSON, AXUIElement?, AXUIElement?) {
     let search = pluginSlotSearch(
@@ -667,9 +677,15 @@ func openPlugin(
         "open_press_status": NSNull(),
         "opened_windows": [],
     ]) { _, new in new }
-    guard slots.count == 1 else { return (result, nil, nil) }
-
-    let slot = slots[0]
+    let chosen: AXUIElement?
+    if let slotOrdinal {
+        result["slot_ordinal_requested"] = slotOrdinal
+        result["slot_ordinal_available"] = slots.count
+        chosen = slotOrdinal < slots.count ? slots[slotOrdinal] : nil
+    } else {
+        chosen = slots.count == 1 ? slots[0] : nil
+    }
+    guard let slot = chosen else { return (result, nil, nil) }
     // The caller can take a negative-control reading before this helper mutates anything. In #301
     // that is the bypass value: reading it after the Open press would not catch an Open path that
     // toggled it and toggled it back before the witness looked.
@@ -990,11 +1006,72 @@ func runExportMenu() {
     emit(result)
 }
 
+/// Count Logic's open plug-in editor windows, with the direct static-text values
+/// that identify each.
+///
+/// #726 needs this from OUTSIDE the product. The invariant is that
+/// `set_param_verified` leaves behind no editor it opened, on every exit path
+/// INCLUDING its refusals — and the product cannot witness that about itself,
+/// because it is the thing under test. Measured 2026-08-31: the count-mismatch
+/// refusal left two editors open, and no unit test saw it because the assertion
+/// lived on the same side as the bug.
+func runPluginEditors() {
+    var editors: [JSON] = []
+    for window in windows() {
+        let subrole = stringValue(attr(window, kAXSubroleAttribute as String), attribute: kAXSubroleAttribute as String)
+        guard subrole == "AXDialog" else { continue }
+        let texts = childElements(window).compactMap { child -> String? in
+            let role = stringValue(attr(child, kAXRoleAttribute as String), attribute: kAXRoleAttribute as String)
+            guard role == (kAXStaticTextRole as String) else { return nil }
+            let value = stringValue(attr(child, kAXValueAttribute as String), attribute: kAXValueAttribute as String)
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+        // A plug-in editor is an AXDialog carrying direct static text. An alert
+        // is an AXDialog too, so the text requirement is what separates them.
+        guard !texts.isEmpty else { continue }
+        editors.append([
+            "title": stringValue(attr(window, kAXTitleAttribute as String), attribute: kAXTitleAttribute as String),
+            "static_texts": texts,
+        ])
+    }
+    emit(["outcome": "searched", "editor_count": editors.count, "editors": editors])
+}
+
+/// Open ONE insert slot's editor and leave it open.
+///
+/// The #726 cleanup harness needs a plug-in editor it did not obtain through the
+/// product, because the product now closes the editors it opens. Without this the
+/// hidden-sibling state cannot be built at all, and a harness that cannot build
+/// its own precondition passes vacuously — measured: a "hiding empties the AX
+/// list" check read 0 == 0 when nothing had been open to hide.
+func runOpenPluginEditor() {
+    let slotName = configuredString("slot_label")
+    let openLabel = configuredString("open_label")
+    let trackLabel = configuredOptionalString("track_label")
+    let mixerLabels = configuredStrings("mixer_label")
+    let before = windows().count
+    let (openResult, slot, opened) = openPlugin(
+        slotName: slotName,
+        openLabel: openLabel,
+        trackLabel: trackLabel,
+        mixerLabels: mixerLabels.isEmpty ? nil : mixerLabels,
+        slotOrdinal: configuredInt("slot_ordinal")
+    )
+    var result: JSON = ["open": openResult, "windows_before": before, "windows_after": windows().count]
+    result["slot_found"] = slot != nil
+    result["editor_opened"] = opened != nil
+    result["outcome"] = opened != nil ? "opened" : (openResult["outcome"] ?? "not_found")
+    emit(result)
+}
+
 switch mode {
 case "channel-eq": runChannelEQ()
 case "compressor": runCompressor()
 case "plugin-slot": runPluginSlot()
 case "export-menu": runExportMenu()
+case "plugin-editors": runPluginEditors()
+case "open-plugin-editor": runOpenPluginEditor()
 default:
     emit(["error": "unknown mode: \(mode)"])
     exit(2)

--- a/Scripts/livekit/live_726_a_refusal_leaves_no_editor_open.py
+++ b/Scripts/livekit/live_726_a_refusal_leaves_no_editor_open.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""#726: a verified-plugin call must leave behind no editor it opened — refusals included.
+
+Why this exists, stated plainly: the defect it pins was found by an outside reviewer, not by
+this repository's tests, and the reason is that every assertion about cleanup lived on the same
+side as the bug. The unit test for the count-mismatch refusal reached the exact state and never
+asked what was left on screen.
+
+Measured 2026-08-31 against the code before the fix:
+
+    hide all plug-in windows      -> AX reports 0 matching editors
+    set_param_verified insert 2   -> C duplicate_plugin_editor_count_mismatch
+    editors left open             -> 2          (the operation opened them and walked away)
+
+A leftover editor is not cosmetic. The next duplicate-insert write refuses with
+`duplicate_plugin_editor_already_open`, which reads as an unrelated failure, and the run after
+that inherits the state — the same shape as three other stale-state failures recorded this week.
+
+The editor count is taken by an independent AX probe, never by the product: the product is the
+thing under test and cannot witness this about itself.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+
+# What this harness proves, for `harness_evidence_coverage.py`.
+#
+# The acquisition and cleanup contract lives in the verified-plugin channel, and the request
+# reaches it through the public dispatcher. It does not exercise the catalogue or the walk.
+COVERS = [
+    "Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift",
+    "Sources/LogicProMCP/Dispatchers/PluginsDispatcher.swift",
+]
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"])
+driver = None
+
+# The project fixture: a track carrying the SAME plug-in at two inserts, which is the only
+# state that reaches the by-construction acquisition path at all.
+PROJECT = "/Users/isaac/Music/Logic/lpm-606-warm.logicx"
+TRACK = "0"
+DUPLICATED_PLUGIN = "Compressor"
+FIRST_INSERT = "0"
+SECOND_INSERT = "2"
+TRACK_LABEL = "Absolute Zero"
+# Localized labels the repository already owns; not new literals.
+OPEN_LABEL = "열기"
+MIXER_LABELS = ["Mixer", "믹서", "ミキサー"]
+
+
+def finish(code=1):
+    out = ev.write()
+    print(json.dumps(out, indent=1))
+    sys.exit(code)
+
+
+def compile_probe():
+    source = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ax_plugin_menu_probe.swift")
+    tool = os.path.join(ev.dir, "ax_plugin_menu_probe")
+    result = subprocess.run(["swiftc", "-O", source, "-o", tool], capture_output=True)
+    return tool, result
+
+
+def open_one_editor(tool, ordinal):
+    """Open ONE of the duplicated plug-in's editors, by AX child order in the strip.
+
+    The product now closes the editors it opens, so the harness cannot build a
+    pre-existing-editor state through the product. It has to open one itself, and
+    it has to name WHICH of the two, since both carry the same name.
+    """
+    config = {
+        "slot_label": DUPLICATED_PLUGIN,
+        "open_label": OPEN_LABEL,
+        "track_label": TRACK_LABEL,
+        "mixer_label": MIXER_LABELS,
+        "slot_ordinal": ordinal,
+    }
+    result = subprocess.run([tool, "open-plugin-editor", json.dumps(config, ensure_ascii=False)],
+                            capture_output=True, text=True)
+    try:
+        return json.loads(result.stdout or "{}")
+    except ValueError:
+        return {"_raw": (result.stdout or result.stderr)[:400]}
+
+
+def editors(tool):
+    """Every open plug-in editor, read by AX rather than by the product."""
+    result = subprocess.run([tool, "plugin-editors", "{}"], capture_output=True, text=True)
+    try:
+        body = json.loads(result.stdout or "{}")
+    except ValueError:
+        body = {"_raw": (result.stdout or result.stderr)[:400]}
+    body["_returncode"] = result.returncode
+    return body
+
+
+def write_call(insert, value):
+    return driver.tool("logic_plugins", "set_param_verified", {
+        "track": TRACK,
+        "insert": insert,
+        "plugin": DUPLICATED_PLUGIN,
+        "param": "threshold",
+        "value": str(value),
+        "unit": "normalized",
+        "mode": "duplicate_applyback",
+        "project_expected_path": PROJECT,
+    }) or {}
+
+
+probe_tool, build = compile_probe()
+ev.check("726/precondition-the-independent-editor-reader-builds",
+         build.returncode == 0,
+         "the AX probe that counts editors compiles",
+         f"swiftc returncode {build.returncode}: {build.stderr.decode()[:200]}",
+         "break the probe source and this precondition fails before any verdict is recorded")
+if build.returncode != 0:
+    finish()
+
+# --- Evidence requires the run to have LOOKED, driven, and recorded. These are not
+# --- decoration: a harness that asserts only through its own probe cannot show that
+# --- the screen matched what the probe said.
+arrange_window = E.logic_window()
+ev.check("726/precondition-an-arrange-window-is-visible-for-the-recording",
+         isinstance(arrange_window, dict) and bool(arrange_window.get("title")),
+         "a visible Logic arrange window supplies the recorded visual control",
+         json.dumps(arrange_window, ensure_ascii=False)[:200],
+         "close the arrange window: the recording has no defined subject and this turns red")
+if not (isinstance(arrange_window, dict) and arrange_window.get("title")):
+    finish()
+
+band, band_subject = ev.located_band("Control Bar", "--min-width", "1000")
+ev.check("726/precondition-the-visual-band-is-named-by-the-ui",
+         band is not None and isinstance(band_subject, str) and bool(band_subject.strip()),
+         "an unambiguous region the UI itself names, so the visual assertion has a subject",
+         json.dumps({"band": band, "subject": band_subject}, ensure_ascii=False)[:200],
+         "make the Control Bar lookup ambiguous: no anonymous rectangle is substituted")
+if band is None or not (isinstance(band_subject, str) and band_subject.strip()):
+    finish()
+
+recording = ev.record_screen(seconds=90)
+
+driver = E.Driver()
+driver.tool("logic_system", "refresh_cache", {})
+
+# --- Baseline: nothing open before the run, or nothing later means anything. ---
+start = editors(probe_tool)
+ev.check("726/precondition-no-plugin-editor-is-open-before-the-run",
+         start.get("editor_count") == 0,
+         "zero plug-in editors before the first call",
+         json.dumps(start, ensure_ascii=False)[:300],
+         "leave an editor open before the run and every later count is inherited, not caused")
+if start.get("editor_count") != 0:
+    finish()
+
+# --- 1. A SUCCESSFUL duplicate write closes the editor it opened. ---
+ok = write_call(FIRST_INSERT, 56)
+after_success = editors(probe_tool)
+ev.falsifiable(
+    "726/a-successful-duplicate-write-leaves-no-editor-open",
+    lambda obs: obs.get("state") == "A" and obs.get("editors", {}).get("editor_count") == 0,
+    {"state": ok.get("state"), "error": ok.get("error"), "editors": after_success},
+    {"state": "A", "error": None, "editors": {"editor_count": 1, "editors": [{"title": TRACK}]}},
+    "State A and zero editors left open",
+    mutation="remove the cleanup defer and this observes State A with one editor still open",
+)
+
+# --- 2. A REFUSAL closes it too. This is the half that was missing. ---
+#
+# The count-mismatch refusal is reached by hiding the editors first: AX then reports zero, one
+# press restores BOTH, the post-count is two, and the call correctly refuses. What it must also
+# do is put back what it disturbed.
+opened = open_one_editor(probe_tool, 0)
+present = editors(probe_tool)
+ev.check("726/precondition-one-sibling-editor-is-actually-open-before-hiding",
+         opened.get("editor_count") is None and present.get("editor_count") == 1,
+         "exactly one editor is open before the hide, so the hide has something to hide",
+         json.dumps({"open": opened.get("outcome"), "editors": present}, ensure_ascii=False)[:300],
+         "an earlier version skipped this and read 0 == 0 after hiding nothing, which passed "
+         "vacuously and let the refusal case never be reached")
+if present.get("editor_count") != 1:
+    driver.close()
+    finish()
+
+subprocess.run(["osascript", "-e",
+                'tell application "System Events" to tell process "Logic Pro" to click menu item '
+                '"모든 플러그인 윈도우" of menu 1 of menu bar item "윈도우" of menu bar 1'],
+               capture_output=True)
+time.sleep(1.5)
+hidden = editors(probe_tool)
+ev.check("726/precondition-hiding-makes-the-open-editor-invisible-to-ax",
+         hidden.get("editor_count") == 0,
+         "AX reports zero editors although one IS open, which is what makes a zero pre-count "
+         "insufficient on its own",
+         json.dumps(hidden, ensure_ascii=False)[:300],
+         "if hiding did not empty the AX list this precondition fails and the case below is "
+         "not the one it claims to be")
+if hidden.get("editor_count") != 0:
+    driver.close()
+    finish()
+
+refused = write_call(SECOND_INSERT, 70)
+after_refusal = editors(probe_tool)
+ev.falsifiable(
+    "726/a-refused-duplicate-write-leaves-no-editor-open",
+    lambda obs: (obs.get("write_attempted") is False
+                 and obs.get("editors", {}).get("editor_count") == 0),
+    {"state": refused.get("state"),
+     "error": refused.get("error"),
+     "write_attempted": refused.get("write_attempted"),
+     "editors": after_refusal},
+    {"state": "C", "error": "duplicate_plugin_editor_count_mismatch", "write_attempted": False,
+     "editors": {"editor_count": 2, "editors": [{"title": "x"}, {"title": "x"}]}},
+    "the refusal attempted no write AND left no editor open",
+    mutation="register the cleanup after the count-mismatch return and this observes two "
+            "editors still open, which is exactly what was measured before the fix",
+)
+
+# --- 3. The project is where it started. A cleanup check must not itself drift the session. ---
+final = write_call(FIRST_INSERT, 56)
+ev.check("726/the-run-restored-the-parameter-it-moved",
+         final.get("state") == "A" and final.get("observed_normalized") == 56,
+         "the duplicated plug-in is back at 56 and the restore was read back, not assumed",
+         json.dumps({"state": final.get("state"),
+                     "observed": final.get("observed_normalized")}, ensure_ascii=False),
+         "skip the restore and this observes a different value than the one the run started from")
+
+before_shot = ev.shot("726/before-comparison", settle_region=band,
+                      window_title=arrange_window["title"])
+
+end = editors(probe_tool)
+ev.check("726/the-run-left-no-editor-open",
+         end.get("editor_count") == 0,
+         "zero plug-in editors when the harness ends",
+         json.dumps(end, ensure_ascii=False)[:300],
+         "leave one open and the next run inherits it, which is how three stale-state failures "
+         "started this week")
+
+driver.close()
+
+# The Control Bar is the visual control, not the witness for cleanup: the editors
+# this harness opens and closes are separate windows and never overlap this band.
+# What it establishes is that the run did not disturb the arrangement while doing
+# all of the above — a cleanup check that silently moved the transport would be a
+# worse instrument than none.
+after_shot = ev.shot("726/after-comparison", settle_region=band,
+                     window_title=arrange_window["title"])
+ev.visual(
+    "726/opening-and-closing-plugin-editors-does-not-disturb-the-arrangement",
+    before_shot["file"], after_shot["file"], band, expect_change=False, subject=band_subject,
+    why="the harness opened, hid and closed plug-in editors and wrote one parameter twice; the "
+        "Control Bar is not part of any of that and must be byte-identical across it",
+)
+ev.stop_recording(recording)
+
+out = ev.write()
+print(json.dumps(out, indent=1))
+sys.exit(0 if E.is_clean(out) else 1)

--- a/Scripts/roadmap-table-matches-github.py
+++ b/Scripts/roadmap-table-matches-github.py
@@ -179,7 +179,9 @@ def main():
         print(f"  #{number}: open on GitHub, absent from the table")
     for number in will_close_but_says_open:
         print(f"  #{number}: this pull request closes it, but the row still says OPEN. "
-              f"Merging would close the issue and leave the row, failing main.")
+              f"This guard assumes GitHub is configured to automatically close linked issues "
+              f"when pull requests merge; with that repository setting disabled, OPEN is correct. "
+              f"Enable automatic issue closing or remove the closing keyword before changing the row.")
     print("\nThe table is the source of truth for what is open. Update it in this PR.")
     return DRIFT
 

--- a/Scripts/test-roadmap-table-guard.sh
+++ b/Scripts/test-roadmap-table-guard.sh
@@ -116,6 +116,19 @@ expect_exit 1 "the closing PR must still list the issue"  "$TMP/roadmap-dropped.
 expect_exit 1 "a row this PR closes may not stay OPEN"    "$TMP/roadmap-ok.md" "$TMP/issues-ok.json" \
   "Closes #284"
 
+# GitHub can disable automatic closing of linked issues. The guard may enforce
+# this repository's convention, but its failure must say why an OPEN row can be
+# correct when that setting is off; otherwise maintainers get a false direction.
+OUT="$(python3 "$GUARD" --roadmap "$TMP/roadmap-ok.md" --issues-json "$TMP/issues-ok.json" \
+      --pr 1 --pr-body 'Closes #284' 2>&1)" || true
+if printf '%s' "$OUT" | grep -q 'automatically close linked issues'; then
+  printf 'ok    %-46s names the auto-close assumption\n' "auto-close setting disclosure"
+else
+  printf 'FAIL  %-46s did not name the auto-close assumption:\n%s\n' \
+    "auto-close setting disclosure" "$OUT"
+  FAILURES=$((FAILURES + 1))
+fi
+
 # The failing cases must name the issue they are about, or the report is unusable in CI.
 OUT="$(python3 "$GUARD" --roadmap "$TMP/roadmap-ok.md" --issues-json "$TMP/issues-extra-open.json" 2>&1)" || true
 if printf '%s' "$OUT" | grep -q '#683'; then

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+PluginSlots.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+PluginSlots.swift
@@ -386,15 +386,18 @@ extension AXLogicProElements {
     }
 
     /// Find an OPEN plug-in editor whose title equals `trackName`, whose direct
-    /// `AXStaticText` children name `pluginID` through the verified catalog's
-    /// observed-name aliases, and which exposes exactly one matching slider.
+    /// `AXStaticText` children contain a plug-in name for `pluginID` through the
+    /// verified catalog's observed-name aliases, and which exposes exactly one
+    /// matching slider.
     ///
     /// Measured for stock Logic editors only: their direct static-text children
     /// contain the English plug-in display name in both editor and Controls
-    /// views, but its position varies and other labels are localized. Third-party
-    /// editors and catalog/display-name differences remain unmeasured, so their
-    /// observed names must resolve through `VerifiedPluginCatalog` rather than
-    /// being accepted by raw string comparison.
+    /// views, but its position varies and other labels are localized. The AX
+    /// title and one direct static-text value are the *track* name, so that
+    /// value is excluded before catalog lookup. Third-party editors and
+    /// catalog/display-name differences remain unmeasured, so their observed
+    /// names must resolve through `VerifiedPluginCatalog` rather than being
+    /// accepted by raw string comparison.
     static func pluginWindowMatch(
         forTrackName trackName: String,
         matchingPluginID pluginID: String,
@@ -422,9 +425,12 @@ extension AXLogicProElements {
                 return .ambiguous
             case .unique:
                 let observedNames = pluginWindowHeaderStaticTextValues(in: window, runtime: runtime.ax)
-                guard observedNames.contains(where: {
-                    VerifiedPluginCatalog.pluginID(forObservedName: $0) == pluginID
-                }) else {
+                guard pluginWindowHeaderNames(
+                    observedNames,
+                    containPluginID: pluginID,
+                    excludingTrackName: title,
+                    callerTrackName: target
+                ) else {
                     foundMismatchedCandidate = true
                     mismatchedObservedNames.append(contentsOf: observedNames)
                     continue
@@ -450,7 +456,8 @@ extension AXLogicProElements {
     ///
     /// The same direct-header rule as `pluginWindowMatch` is retained here; a
     /// window title, descendant text, or geometry is not evidence of plug-in
-    /// identity.
+    /// identity. The direct static-text value equal to the window title is the
+    /// track name and is explicitly not a plug-in-name candidate.
     static func matchingPluginEditorWindows(
         forTrackName trackName: String,
         matchingPluginID pluginID: String,
@@ -469,9 +476,59 @@ extension AXLogicProElements {
             let title = (AXHelpers.getTitle(window, runtime: runtime.ax) ?? "")
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             guard title == target else { return false }
-            return pluginWindowHeaderStaticTextValues(in: window, runtime: runtime.ax).contains {
-                VerifiedPluginCatalog.pluginID(forObservedName: $0) == pluginID
-            }
+            return pluginWindowHeaderNames(
+                pluginWindowHeaderStaticTextValues(in: window, runtime: runtime.ax),
+                containPluginID: pluginID,
+                excludingTrackName: title,
+                callerTrackName: target
+            )
+        }
+    }
+
+    /// Every currently open plug-in editor window. Duplicate-instance
+    /// acquisition snapshots this before it presses an insert control, then
+    /// requires its accepted candidate to be a newly observed AX element.
+    static func pluginEditorWindows(runtime: Runtime = .production) -> [AXUIElement] {
+        guard let app = appRoot(runtime: runtime) else { return [] }
+        let windows: [AXUIElement] = AXHelpers.getAttribute(
+            app, kAXWindowsAttribute, runtime: runtime.ax
+        ) ?? []
+        return windows.filter {
+            isPluginEditorWindow($0, runtime: runtime.ax)
+                && AXHelpers.getRole($0, runtime: runtime.ax) == (kAXWindowRole as String)
+        }
+    }
+
+    /// Whether the exact AX window element remains in the application's
+    /// observed window list. `nil` means the list itself could not be read, so
+    /// a caller must not claim that a close was observed.
+    static func pluginEditorWindowIsOpen(
+        _ window: AXUIElement,
+        runtime: Runtime = .production
+    ) -> Bool? {
+        guard let app = appRoot(runtime: runtime),
+              let windows: [AXUIElement] = AXHelpers.getAttribute(
+                  app, kAXWindowsAttribute, runtime: runtime.ax
+              ) else {
+            return nil
+        }
+        return windows.contains { CFEqual($0, window) }
+    }
+
+    private static func pluginWindowHeaderNames(
+        _ observedNames: [String],
+        containPluginID pluginID: String,
+        excludingTrackName title: String,
+        callerTrackName target: String
+    ) -> Bool {
+        observedNames.contains { observedName in
+            // Logic exposes the track name in both AXTitle and a direct static
+            // text child. A track called "Compressor" must not authenticate a
+            // Noise Gate window as Compressor merely because both have a
+            // Threshold slider. Keep both values here: the caller-resolved
+            // track name is a second defense if Logic normalizes AXTitle.
+            guard observedName != title, observedName != target else { return false }
+            return VerifiedPluginCatalog.pluginID(forObservedName: observedName) == pluginID
         }
     }
 

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -1126,6 +1126,48 @@ extension AccessibilityChannel {
             return .error(windowOpenFailedStateC(operation, identity, "the target track name could not be resolved for window matching"))
         }
         var constructedWindow: AXUIElementSendable?
+        // Set immediately after the target-slot press observes windows. It is
+        // deliberately outside the success-only branch: a hidden sibling can
+        // make acquisition fail with two editors, and every newly observed
+        // editor from that failed attempt still needs best-effort cleanup.
+        var constructedWindowsNeedingCleanup: [AXUIElement] = []
+        defer {
+            if !constructedWindowsNeedingCleanup.isEmpty {
+                _ = closePluginEditorsOpenedByThisOperation(
+                    constructedWindowsNeedingCleanup,
+                    trackName: trackName,
+                    pluginID: pluginID,
+                    runtime: runtime
+                )
+            }
+        }
+
+        /// A write may be fully verified before this operation's editor closes.
+        /// Keep State A for the established write verdict, while making a
+        /// failed observed close actionable rather than deferring that surprise
+        /// to the next duplicate-instance call.
+        func verifiedWriteEnvelope(extras: [String: Any]) -> String {
+            var completedExtras = extras
+            guard !constructedWindowsNeedingCleanup.isEmpty else {
+                return HonestContract.encodeV2StateA(extras: completedExtras)
+            }
+            let closeObserved = closePluginEditorsOpenedByThisOperation(
+                constructedWindowsNeedingCleanup,
+                trackName: trackName,
+                pluginID: pluginID,
+                runtime: runtime
+            )
+            // The explicit attempt above owns cleanup for the successful
+            // envelope. Prevent `defer` from pressing close controls again.
+            constructedWindowsNeedingCleanup.removeAll()
+            completedExtras["editor_close_observed"] = closeObserved
+            if !closeObserved {
+                completedExtras["editor_still_open"] = true
+                completedExtras["recovery_hint"] = "The \(pluginID) editor opened for this write is still visible on track \(track). Close it before another duplicate-instance write."
+            }
+            return HonestContract.encodeV2StateA(extras: completedExtras)
+        }
+
         if duplicatedPluginInstance {
             // #726 follow-up measurement: when no matching editor is open, one
             // target-slot `열기` press creates the target editor. A pre-existing
@@ -1184,7 +1226,15 @@ extension AccessibilityChannel {
             }
 
             // Real Logic can report a non-zero AX status after opening the
-            // editor, so the observed post-count—not that status—decides.
+            // editor, so that status cannot authenticate the action. Instead,
+            // retain the complete pre-press editor set and require the accepted
+            // candidate to be a new AX element. This is the strongest evidence
+            // AX exposes here: we rely on Logic UI actions being serialized for
+            // this operation. AX has no causal event token, so a concurrent
+            // human or other automation opening the same-track sibling between
+            // the snapshot and poll remains unprovable; the one-new-window rule
+            // makes that uncertainty refuse rather than reuse an old editor.
+            let pluginEditorWindowsBeforePress = AXLogicProElements.pluginEditorWindows(runtime: runtime)
             _ = pressElement(targetOpenControl, runtime: runtime.ax)
             let matchingEditorsAfterPress = await pollMatchingPluginEditorWindows(
                 trackName: trackName,
@@ -1192,7 +1242,16 @@ extension AccessibilityChannel {
                 runtime: runtime,
                 timeoutMs: 1_250
             )
-            guard matchingEditorsAfterPress.count == 1 else {
+            let newlyObservedMatchingEditors = matchingEditorsAfterPress.filter { candidate in
+                !pluginEditorWindowsBeforePress.contains { CFEqual($0, candidate) }
+            }
+            // A target press may have restored a hidden sibling as well. These
+            // are newly observed during this operation's acquisition window;
+            // install best-effort cleanup before any mismatch return can leave
+            // an editor that this attempt may have opened behind.
+            constructedWindowsNeedingCleanup = newlyObservedMatchingEditors
+            guard matchingEditorsAfterPress.count == 1,
+                  newlyObservedMatchingEditors.count == 1 else {
                 if case let .pluginIdentityMismatch(observedNames) = AXLogicProElements.pluginWindowMatch(
                     forTrackName: trackName,
                     matchingPluginID: pluginID,
@@ -1213,30 +1272,13 @@ extension AccessibilityChannel {
                     track: track,
                     insert: insert,
                     conflictingInsertIndices: conflictingInsertIndices,
-                    matchingEditorCount: matchingEditorsAfterPress.count
+                    matchingEditorCount: matchingEditorsAfterPress.count,
+                    newlyObservedMatchingEditorCount: newlyObservedMatchingEditors.count
                 ))
             }
             // `matchingPluginEditorWindows` accepts a window only after its
             // direct static-text header maps to the requested plug-in id.
-            constructedWindow = AXUIElementSendable(matchingEditorsAfterPress[0])
-        }
-
-        // This operation opened that editor from a known-empty state, so it owns
-        // it. Leaving it open would make the NEXT duplicate-insert write refuse
-        // with `duplicate_plugin_editor_already_open` — measured live: writing
-        // insert 0 then insert 2 on a two-Compressor track failed on the second
-        // call until the first editor was closed by hand. Only ever close a
-        // window this operation created; an editor the caller already had open
-        // is reused, never constructed, and must be left exactly as found.
-        defer {
-            if let constructedWindow {
-                closePluginEditorOpenedByThisOperation(
-                    constructedWindow.element,
-                    trackName: trackName,
-                    pluginID: pluginID,
-                    runtime: runtime
-                )
-            }
+            constructedWindow = AXUIElementSendable(newlyObservedMatchingEditors[0])
         }
 
         // Step 8 — normal single-instance acquisition retains the original
@@ -1504,7 +1546,7 @@ extension AccessibilityChannel {
 
             // Step 13 — tolerance gate.
             if abs(after - requested) <= tolerance {
-                return .success(HonestContract.encodeV2StateA(extras: [
+                return .success(verifiedWriteEnvelope(extras: [
                     "operation": operation,
                     "target_identity": identity,
                     "param": paramAlias,
@@ -1603,7 +1645,7 @@ extension AccessibilityChannel {
                 } else {
                     extras["tolerance"] = tolerance
                 }
-                return .success(HonestContract.encodeV2StateA(extras: extras))
+                return .success(verifiedWriteEnvelope(extras: extras))
             case .noProgress(_, _), .budgetExhausted(_, _), .overshot(_, _), .readbackLost(_):
                 let rollback = rollbackSliderValue(
                     slider,
@@ -1909,7 +1951,8 @@ extension AccessibilityChannel {
         track: Int,
         insert: Int,
         conflictingInsertIndices: [Int],
-        matchingEditorCount: Int
+        matchingEditorCount: Int,
+        newlyObservedMatchingEditorCount: Int
     ) -> String {
         HonestContract.encodeV2StateC(
             error: .duplicatePluginEditorCountMismatch,
@@ -1919,8 +1962,9 @@ extension AccessibilityChannel {
                 "requested_plugin_id": pluginID,
                 "conflicting_insert_indices": conflictingInsertIndices,
                 "matching_editor_count_after_press": matchingEditorCount,
-                "what_was_attempted": "press insert \(insert)'s open control once and observe exactly one \(pluginID) editor",
-                "what_was_observed": "the one target-slot press left \(matchingEditorCount) matching \(pluginID) editor(s) visible on track \(track)",
+                "new_matching_editor_count_after_press": newlyObservedMatchingEditorCount,
+                "what_was_attempted": "press insert \(insert)'s open control once and observe exactly one newly created \(pluginID) editor",
+                "what_was_observed": "the one target-slot press left \(matchingEditorCount) matching \(pluginID) editor(s), \(newlyObservedMatchingEditorCount) newly observed, visible on track \(track)",
                 "safe_to_retry": false,
                 "write_attempted": false,
             ]
@@ -2316,13 +2360,12 @@ extension AccessibilityChannel {
     /// user reopening the editor.
     ///
     /// The AX return status is deliberately ignored. Logic reports non-zero from
-    /// presses that did work, so the observed editor count decides — the same
-    /// rule the acquisition itself follows.
+    /// presses that did work, so the exact window element's absence from
+    /// `AXWindows` decides — the same observed-state rule used for acquisition.
     ///
-    /// Returns whether the close was OBSERVED. A false return is not raised into
-    /// the envelope here: the write's own verdict is already established by then,
-    /// and a leftover editor announces itself on the next call as
-    /// `duplicate_plugin_editor_already_open`, which carries the recovery hint.
+    /// Returns whether the close was OBSERVED. A false return leaves the write
+    /// verdict alone, but successful verified-write envelopes disclose the
+    /// leftover editor and tell the caller how to recover.
     @discardableResult
     private static func closePluginEditorOpenedByThisOperation(
         _ window: AXUIElement,
@@ -2337,11 +2380,7 @@ extension AccessibilityChannel {
         }
         for attempt in 0..<3 {
             _ = pressElement(closeButton, runtime: runtime.ax)
-            if AXLogicProElements.matchingPluginEditorWindows(
-                forTrackName: trackName,
-                matchingPluginID: pluginID,
-                runtime: runtime
-            ).isEmpty {
+            if AXLogicProElements.pluginEditorWindowIsOpen(window, runtime: runtime) == false {
                 return true
             }
             if attempt < 2 {
@@ -2349,6 +2388,31 @@ extension AccessibilityChannel {
             }
         }
         return false
+    }
+
+    /// Best-effort cleanup for every editor element newly observed after this
+    /// operation's duplicate-instance slot press. The normal success path has
+    /// one element; the count-mismatch path can have the target plus a hidden
+    /// sibling restored by the same press. Return true only if each exact
+    /// element was observed to leave AXWindows.
+    private static func closePluginEditorsOpenedByThisOperation(
+        _ windows: [AXUIElement],
+        trackName: String,
+        pluginID: String,
+        runtime: AXLogicProElements.Runtime
+    ) -> Bool {
+        var everyCloseObserved = true
+        for window in windows {
+            if !closePluginEditorOpenedByThisOperation(
+                window,
+                trackName: trackName,
+                pluginID: pluginID,
+                runtime: runtime
+            ) {
+                everyCloseObserved = false
+            }
+        }
+        return everyCloseObserved
     }
 
     private static func pluginWindowAcquisitionDiagnostics(

--- a/Sources/LogicProMCP/Channels/MCUChannel.swift
+++ b/Sources/LogicProMCP/Channels/MCUChannel.swift
@@ -8,6 +8,11 @@ protocol MCUTransportProtocol: Actor {
         onReceive: @escaping @Sendable (MIDIFeedback.Event) -> Void,
         onIngressDrop: @escaping @Sendable (UInt64) -> Void
     ) async throws
+    func start(
+        onReceive: @escaping @Sendable (MIDIFeedback.Event) -> Void,
+        onIngressDrop: @escaping @Sendable (UInt64) -> Void,
+        onCallbackWorkBudgetDrop: @escaping @Sendable (UInt64) -> Void
+    ) async throws
     func stop() async
 }
 
@@ -22,6 +27,19 @@ extension MCUTransportProtocol {
         _ = onIngressDrop
         try await start(onReceive: onReceive)
     }
+
+    /// A valid event list can exceed one callback's bounded work budget. That
+    /// is lossy and must be reported, but unlike malformed packet structure it
+    /// must not finish the MCU ingress. Test transports retain their original
+    /// two-sink implementation unless they need to model this distinction.
+    func start(
+        onReceive: @escaping @Sendable (MIDIFeedback.Event) -> Void,
+        onIngressDrop: @escaping @Sendable (UInt64) -> Void,
+        onCallbackWorkBudgetDrop: @escaping @Sendable (UInt64) -> Void
+    ) async throws {
+        _ = onCallbackWorkBudgetDrop
+        try await start(onReceive: onReceive, onIngressDrop: onIngressDrop)
+    }
 }
 
 /// Snapshot of the MCU callback-to-actor hand-off.
@@ -30,10 +48,18 @@ extension MCUTransportProtocol {
 /// CoreMIDI callback must be able to reject an overload without awaiting an
 /// actor or touching a JSON-RPC-owned queue.
 struct MCUFeedbackIngressSnapshot: Sendable, Equatable {
+    /// Every parsed or declared event that could not reach the ingress.
     let droppedEventCount: UInt64
+    /// Subset of `droppedEventCount` omitted solely to keep one CoreMIDI
+    /// callback bounded. This is observable but not fatal to the channel.
+    let callbackWorkBudgetDroppedEventCount: UInt64
     let overflowed: Bool
 
-    static let empty = MCUFeedbackIngressSnapshot(droppedEventCount: 0, overflowed: false)
+    static let empty = MCUFeedbackIngressSnapshot(
+        droppedEventCount: 0,
+        callbackWorkBudgetDroppedEventCount: 0,
+        overflowed: false
+    )
 }
 
 /// Bounded, callback-safe ingress for MCU feedback.
@@ -56,6 +82,7 @@ final class MCUFeedbackIngress: @unchecked Sendable {
     private let lock = NSLock()
     private var state: State = .active
     private var droppedEventCount: UInt64 = 0
+    private var callbackWorkBudgetDroppedEventCount: UInt64 = 0
 
     init(capacity: Int = 256) {
         let (stream, continuation) = AsyncStream<MIDIFeedback.Event>.makeStream(
@@ -74,16 +101,18 @@ final class MCUFeedbackIngress: @unchecked Sendable {
         case .dropped:
             recordDrop(count: 1)
         case .terminated:
-            break
+            // A stream terminated by its first overflow has already rejected
+            // this event. Count it too; otherwise every later callback event
+            // disappears from the health total.
+            recordDrop(count: 1)
         @unknown default:
             recordDrop(count: 1)
         }
     }
 
-    /// Called by the CoreMIDI transport when a packet list's declared shape is
-    /// beyond the callback's fixed work budget. The packet is intentionally not
-    /// traversed: an untrusted `wordCount` must never be used to advance a raw
-    /// pointer merely to preserve feedback.
+    /// Called for malformed ingress or a bounded-stream overflow. These are
+    /// fatal because continuing would either traverse untrusted packet memory
+    /// or silently run a lossy feedback channel.
     func recordDrop(count: UInt64) {
         guard count > 0 else { return }
         lock.lock()
@@ -100,6 +129,19 @@ final class MCUFeedbackIngress: @unchecked Sendable {
         }
     }
 
+    /// Record events omitted only because a valid CoreMIDI list exceeded this
+    /// callback's work allowance. The callback still processes its bounded
+    /// prefix and the ingress stays active for later callbacks.
+    func recordCallbackWorkBudgetDrop(count: UInt64) {
+        guard count > 0 else { return }
+        lock.lock()
+        if state != .stopped {
+            droppedEventCount &+= count
+            callbackWorkBudgetDroppedEventCount &+= count
+        }
+        lock.unlock()
+    }
+
     func finish() {
         lock.lock()
         if state == .active {
@@ -114,6 +156,7 @@ final class MCUFeedbackIngress: @unchecked Sendable {
         defer { lock.unlock() }
         return MCUFeedbackIngressSnapshot(
             droppedEventCount: droppedEventCount,
+            callbackWorkBudgetDroppedEventCount: callbackWorkBudgetDroppedEventCount,
             overflowed: state == .overflowed
         )
     }
@@ -314,10 +357,13 @@ actor MCUChannel: Channel {
 
         // The transport invokes this sink synchronously on its CoreMIDI receive
         // thread. `yield` neither awaits an actor nor waits for the consumer;
-        // on overflow it records the drop and finishes the bounded ingress.
+        // a malformed packet or ingress overflow records a fatal drop and
+        // finishes the bounded ingress. A valid callback that exceeds its
+        // work budget records the omitted suffix without killing MCU.
         try await transport.start(
             onReceive: { event in ingress.yield(event) },
-            onIngressDrop: { count in ingress.recordDrop(count: count) }
+            onIngressDrop: { count in ingress.recordDrop(count: count) },
+            onCallbackWorkBudgetDrop: { count in ingress.recordCallbackWorkBudgetDrop(count: count) }
         )
 
         // Handshake: send Device Query
@@ -397,11 +443,15 @@ actor MCUChannel: Channel {
                     + "MCU is unavailable until the server restarts"
             )
         }
+        let workBudgetDetail = ingress.callbackWorkBudgetDroppedEventCount > 0
+            ? "; callback work budget dropped \(ingress.callbackWorkBudgetDroppedEventCount) event(s)"
+            : ""
         let conn = await cache.getMCUConnection()
         if !conn.isConnected {
             let portName = conn.portName.isEmpty ? "LogicProMCP-MCU-Internal" : conn.portName
             return .unavailable(
                 "MCU feedback not detected. Register '\(portName)' in Logic Pro > Control Surfaces > Setup"
+                    + workBudgetDetail
             )
         }
         let age = conn.lastFeedbackAt.map { Date().timeIntervalSince($0) } ?? .infinity
@@ -410,7 +460,7 @@ actor MCUChannel: Channel {
         let detail = stale
             ? "MCU \(registered), feedback stale (\(Int(age))s)"
             : "MCU \(registered), feedback active"
-        return .healthy(latencyMs: nil, detail: detail)
+        return .healthy(latencyMs: nil, detail: detail + workBudgetDetail)
     }
 
     /// Handle incoming feedback event (called from tests or transport callback).

--- a/Sources/LogicProMCP/Server/LogicProServer.swift
+++ b/Sources/LogicProMCP/Server/LogicProServer.swift
@@ -1381,40 +1381,64 @@ actor LogicProServer {
 /// Real MIDI transport for MCU channel using MIDIPortManager.
 actor ProductionMCUTransport: MCUTransportProtocol {
     /// A callback must finish promptly even if a source presents a large valid
-    /// event list.  This is a work bound, not a performance throttle: normal
-    /// MCU traffic is one packet per callback and the #683 harness sends 142
-    /// packets over 1.42 seconds. Exceeding it fails MCU closed and is reported
-    /// by `logic_system.health` through `MCUFeedbackIngressSnapshot`.
+    /// event list. This is a work bound, not malformed input: normal MCU
+    /// traffic is one packet per callback and the #683 harness sends 142
+    /// packets over 1.42 seconds. A valid list above this count delivers its
+    /// bounded prefix and reports only its omitted suffix; malformed packet
+    /// structure still fails MCU closed through `MCUFeedbackIngressSnapshot`.
     private static let maximumPacketsPerReceiveCallback = 64
     private static let maximumWordsPerPacket = 64
 
-    // v3.8.0 (P1 restart fix) — the CURRENT feedback sink, held in a stable
+    // v3.8.0 (P1 restart fix) — the CURRENT callback sinks, held in a stable
     // lock-guarded box rather than captured by value inside the CoreMIDI
     // callback. `MIDIPortManager.createBidirectionalPort` REUSES an existing
     // destination on restart WITHOUT re-registering the callback, so the
     // closure installed by the FIRST start() is the one CoreMIDI keeps firing.
-    // If that closure captured the sink by value it would forever yield into
+    // If that closure captured any sink by value it would forever route into
     // the first (now-finished) AsyncStream continuation — every feedback event
-    // after any stop→start silently dropped. Holding the sink in a box that
-    // the callback dereferences per event lets a restart's fresh continuation
-    // yield be picked up by the reused callback. The box is read on the
+    // or ingress-drop report after any stop→start silently dropped. Holding
+    // every callback output in a box that the callback dereferences per event
+    // lets a restart's fresh continuation and health sink be picked up by the
+    // reused callback. The box is read on the
     // CoreMIDI real-time thread, so access is NSLock-guarded and lock-light:
     // the lock spans only the pointer read/write, never the delivery call.
     private final class FeedbackSink: @unchecked Sendable {
         private let lock = NSLock()
-        private var sink: (@Sendable (MIDIFeedback.Event) -> Void)?
+        private var eventSink: (@Sendable (MIDIFeedback.Event) -> Void)?
+        private var ingressDropSink: (@Sendable (UInt64) -> Void)?
+        private var callbackWorkBudgetDropSink: (@Sendable (UInt64) -> Void)?
 
-        func set(_ newSink: (@Sendable (MIDIFeedback.Event) -> Void)?) {
+        func set(
+            onReceive: (@Sendable (MIDIFeedback.Event) -> Void)?,
+            onIngressDrop: (@Sendable (UInt64) -> Void)?,
+            onCallbackWorkBudgetDrop: (@Sendable (UInt64) -> Void)?
+        ) {
             lock.lock()
-            sink = newSink
+            eventSink = onReceive
+            ingressDropSink = onIngressDrop
+            callbackWorkBudgetDropSink = onCallbackWorkBudgetDrop
             lock.unlock()
         }
 
         func deliver(_ event: MIDIFeedback.Event) {
             lock.lock()
-            let current = sink
+            let current = eventSink
             lock.unlock()
             current?(event)
+        }
+
+        func recordIngressDrop(_ count: UInt64) {
+            lock.lock()
+            let current = ingressDropSink
+            lock.unlock()
+            current?(count)
+        }
+
+        func recordCallbackWorkBudgetDrop(_ count: UInt64) {
+            lock.lock()
+            let current = callbackWorkBudgetDropSink
+            lock.unlock()
+            current?(count)
         }
     }
 
@@ -1441,20 +1465,40 @@ actor ProductionMCUTransport: MCUTransportProtocol {
     }
 
     func start(onReceive: @escaping @Sendable (MIDIFeedback.Event) -> Void) async throws {
-        try await start(onReceive: onReceive, onIngressDrop: { _ in })
+        try await start(
+            onReceive: onReceive,
+            onIngressDrop: { _ in },
+            onCallbackWorkBudgetDrop: { _ in }
+        )
     }
 
     func start(
         onReceive: @escaping @Sendable (MIDIFeedback.Event) -> Void,
         onIngressDrop: @escaping @Sendable (UInt64) -> Void
     ) async throws {
+        try await start(
+            onReceive: onReceive,
+            onIngressDrop: onIngressDrop,
+            onCallbackWorkBudgetDrop: { _ in }
+        )
+    }
+
+    func start(
+        onReceive: @escaping @Sendable (MIDIFeedback.Event) -> Void,
+        onIngressDrop: @escaping @Sendable (UInt64) -> Void,
+        onCallbackWorkBudgetDrop: @escaping @Sendable (UInt64) -> Void
+    ) async throws {
         // Publish the new sink BEFORE (re)creating the port so a reused
         // destination's already-registered callback immediately routes feedback
         // into this start()'s AsyncStream continuation.
-        feedbackSink.set(onReceive)
-        // Capture the stable box (NOT `onReceive` by value, NOT `self`): the
-        // callback registered here may be reused verbatim across restarts, so
-        // it must dereference whatever sink is current at delivery time.
+        feedbackSink.set(
+            onReceive: onReceive,
+            onIngressDrop: onIngressDrop,
+            onCallbackWorkBudgetDrop: onCallbackWorkBudgetDrop
+        )
+        // Capture the stable box (NOT callback closures by value, NOT `self`):
+        // the callback registered here may be reused verbatim across restarts,
+        // so it must dereference whichever sinks are current at delivery time.
         let sink = feedbackSink
         do {
             port = try await portManager.createBidirectionalPort(name: "LogicProMCP-MCU-Internal") { eventList, _ in
@@ -1463,21 +1507,17 @@ actor ProductionMCUTransport: MCUTransportProtocol {
                 let declaredPackets = Int(eventList.pointee.numPackets)
                 guard declaredPackets > 0 else { return }
                 let packetsToRead = min(declaredPackets, Self.maximumPacketsPerReceiveCallback)
-                if declaredPackets > packetsToRead {
-                    onIngressDrop(UInt64(declaredPackets - packetsToRead))
-                    return
-                }
                 var packetPtr = UnsafeRawPointer(eventList)
                     .advanced(by: MemoryLayout.offset(of: \MIDIEventList.packet)!)
                     .assumingMemoryBound(to: MIDIEventPacket.self)
-                for _ in 0..<packetsToRead {
+                for packetIndex in 0..<packetsToRead {
                     let declaredWords = Int(packetPtr.pointee.wordCount)
                     // Do not call MIDIEventPacketNext after a word-count
                     // violation: that macro advances by the untrusted declared
-                    // count. Reporting the drop and returning is bounded and
-                    // leaves the JSON-RPC loop independent of this callback.
+                    // count. Every unprocessed declared packet is actually
+                    // lost, so report that exact suffix rather than one token.
                     guard declaredWords <= Self.maximumWordsPerPacket else {
-                        onIngressDrop(1)
+                        sink.recordIngressDrop(UInt64(declaredPackets - packetIndex))
                         return
                     }
                     let wordCount = declaredWords
@@ -1499,7 +1539,16 @@ actor ProductionMCUTransport: MCUTransportProtocol {
                             sink.deliver(event)
                         }
                     }
-                    packetPtr = UnsafePointer(MIDIEventPacketNext(packetPtr))
+                    if packetIndex + 1 < packetsToRead {
+                        packetPtr = UnsafePointer(MIDIEventPacketNext(packetPtr))
+                    }
+                }
+                if declaredPackets > packetsToRead {
+                    // The list's declared shape was valid enough to traverse a
+                    // bounded prefix. Its suffix is intentionally omitted to
+                    // keep this callback finite, reported non-fatally as the
+                    // exact number of events that did not reach the ingress.
+                    sink.recordCallbackWorkBudgetDrop(UInt64(declaredPackets - packetsToRead))
                 }
             }
         } catch {
@@ -1512,7 +1561,7 @@ actor ProductionMCUTransport: MCUTransportProtocol {
         // Clear the sink first so any packet delivered on a reused destination
         // after stop() reads nil and is dropped (post-stop-ignored contract),
         // then release the port reference.
-        feedbackSink.set(nil)
+        feedbackSink.set(onReceive: nil, onIngressDrop: nil, onCallbackWorkBudgetDrop: nil)
         port = nil
     }
 }

--- a/Sources/LogicProMCP/Utilities/HonestContract.swift
+++ b/Sources/LogicProMCP/Utilities/HonestContract.swift
@@ -103,11 +103,6 @@ enum HonestContract {
         /// its direct static-text header did not map to the requested canonical
         /// plug-in id. Refused before an AX value write.
         case pluginWindowPluginMismatch = "plugin_window_plugin_mismatch"
-        /// More than one insert on the addressed track carries the requested
-        /// canonical plug-in identity. Logic's accessible editor identity
-        /// cannot distinguish those instances, so opening one could write the
-        /// wrong insert. Refuse before window acquisition.
-        case ambiguousPluginInstance = "ambiguous_plugin_instance"
         /// The requested plug-in occupies multiple inserts and a matching
         /// header-proven editor was already visible before the target slot could
         /// establish provenance by opening one editor from a zero-editor state.
@@ -450,7 +445,6 @@ enum HonestContract {
         FailureError.incompleteInventory.rawValue,
         FailureError.targetPluginMismatch.rawValue,
         FailureError.pluginWindowPluginMismatch.rawValue,
-        FailureError.ambiguousPluginInstance.rawValue,
         FailureError.duplicatePluginEditorAlreadyOpen.rawValue,
         FailureError.duplicatePluginEditorCountMismatch.rawValue,
         FailureError.slotOccupied.rawValue,

--- a/Tests/LogicProMCPTests/HonestContractV2Tests.swift
+++ b/Tests/LogicProMCPTests/HonestContractV2Tests.swift
@@ -76,7 +76,6 @@ private func decode(_ json: String) -> [String: Any] {
         (.incompleteInventory, "incomplete_inventory"),
         (.targetPluginMismatch, "target_plugin_mismatch"),
         (.pluginWindowPluginMismatch, "plugin_window_plugin_mismatch"),
-        (.ambiguousPluginInstance, "ambiguous_plugin_instance"),
         (.duplicatePluginEditorAlreadyOpen, "duplicate_plugin_editor_already_open"),
         (.duplicatePluginEditorCountMismatch, "duplicate_plugin_editor_count_mismatch"),
         (.slotOccupied, "slot_occupied"),
@@ -99,6 +98,13 @@ private func decode(_ json: String) -> [String: Any] {
     for (err, raw) in expected {
         #expect(err.rawValue == raw)
     }
+}
+
+@Test func testRetiredAmbiguousPluginInstanceErrorCannotBeDecoded() {
+    // The duplicate-editor outcomes replaced this pre-acquisition error.
+    // Keeping its raw value would make an unproducible error externally visible.
+    let retired = HonestContract.FailureError(rawValue: "ambiguous_plugin_instance")
+    #expect(retired == nil)
 }
 
 // MARK: - Detector / router compatibility (AC13)
@@ -127,7 +133,7 @@ private func decode(_ json: String) -> [String: Any] {
     let mustBeTerminal: [HonestContract.FailureError] = [
         .unsupportedMode, .projectPathRequired, .projectIdentityMismatch,
         .unknownPluginIdentity, .unsupportedParamReadback, .incompleteInventory,
-        .targetPluginMismatch, .pluginWindowPluginMismatch, .ambiguousPluginInstance,
+        .targetPluginMismatch, .pluginWindowPluginMismatch,
         .duplicatePluginEditorAlreadyOpen, .duplicatePluginEditorCountMismatch, .slotOccupied,
         .trackSelectionFailed, .staleSnapshot,
         .windowOpenFailed, .windowIdentityUnresolved, .paramControlNotFound,

--- a/Tests/LogicProMCPTests/Issue683MCUFeedbackLivenessTests.swift
+++ b/Tests/LogicProMCPTests/Issue683MCUFeedbackLivenessTests.swift
@@ -96,11 +96,15 @@ struct Issue683MCUFeedbackLivenessTests {
         let ingress = MCUFeedbackIngress(capacity: 1)
         ingress.yield(.noteOn(channel: 0, note: 0x12, velocity: 0x7F))
         ingress.yield(.pitchBend(channel: 0, value: 8192))
+        // Once the second yield overflows and finishes the stream, every later
+        // parsed event gets `.terminated`. It was still lost and must count.
+        ingress.yield(.noteOff(channel: 0, note: 0x12, velocity: 0))
         ingress.recordDrop(count: 3)
 
         let snapshot = ingress.snapshot()
         #expect(snapshot.overflowed)
-        #expect(snapshot.droppedEventCount == 4)
+        #expect(snapshot.droppedEventCount == 5)
+        #expect(snapshot.callbackWorkBudgetDroppedEventCount == 0)
     }
 
     @Test("MCU health exposes CoreMIDI callback drops")
@@ -111,7 +115,11 @@ struct Issue683MCUFeedbackLivenessTests {
 
         let snapshot = await channel.feedbackIngressSnapshot()
         let health = await channel.healthCheck()
-        #expect(snapshot == MCUFeedbackIngressSnapshot(droppedEventCount: 3, overflowed: true))
+        #expect(snapshot == MCUFeedbackIngressSnapshot(
+            droppedEventCount: 3,
+            callbackWorkBudgetDroppedEventCount: 0,
+            overflowed: true
+        ))
         #expect(!health.available)
         #expect(health.detail.contains("dropped 3 event(s)"))
     }

--- a/Tests/LogicProMCPTests/LogicProServerTransportTests.swift
+++ b/Tests/LogicProMCPTests/LogicProServerTransportTests.swift
@@ -14,9 +14,11 @@ private func withTestMIDIEventList(
     _ body: (UnsafePointer<MIDIEventList>) -> Void
 ) {
     let packetOffset = MemoryLayout<MIDIEventList>.offset(of: \MIDIEventList.packet) ?? 0
+    let packetWordsOffset = MemoryLayout<MIDIEventPacket>.offset(of: \MIDIEventPacket.words) ?? 0
     let wordCount = Int(wordCountOverride ?? UInt32((bytes.count + 3) / 4))
     let paddedByteCount = max(0, wordCount * MemoryLayout<UInt32>.size)
-    let bufferSize = packetOffset + MemoryLayout<MIDIEventPacket>.size + max(0, paddedByteCount - MemoryLayout<UInt32>.size)
+    let packetSize = packetWordsOffset + paddedByteCount
+    let bufferSize = packetOffset + Int(numPackets) * packetSize
     let raw = UnsafeMutableRawPointer.allocate(
         byteCount: max(bufferSize, MemoryLayout<MIDIEventList>.size),
         alignment: MemoryLayout<MIDIEventList>.alignment
@@ -28,16 +30,20 @@ private func withTestMIDIEventList(
     list.pointee.numPackets = numPackets
 
     if numPackets > 0 {
-        let packet = raw.advanced(by: packetOffset).assumingMemoryBound(to: MIDIEventPacket.self)
-        packet.pointee.wordCount = UInt32(wordCount)
         var padded = bytes
         if padded.count < paddedByteCount {
             padded.append(contentsOf: repeatElement(0, count: paddedByteCount - padded.count))
         }
-        padded.withUnsafeBytes { source in
-            raw.advanced(
-                by: packetOffset + (MemoryLayout<MIDIEventPacket>.offset(of: \MIDIEventPacket.words) ?? 0)
-            ).copyMemory(from: source.baseAddress!, byteCount: paddedByteCount)
+        for packetIndex in 0..<Int(numPackets) {
+            let packetBase = raw.advanced(by: packetOffset + packetIndex * packetSize)
+            let packet = packetBase.assumingMemoryBound(to: MIDIEventPacket.self)
+            packet.pointee.wordCount = UInt32(wordCount)
+            padded.withUnsafeBytes { source in
+                packetBase.advanced(by: packetWordsOffset).copyMemory(
+                    from: source.baseAddress!,
+                    byteCount: paddedByteCount
+                )
+            }
         }
     }
 
@@ -351,11 +357,32 @@ func testProductionKeyCmdTransportDefaultPacketSinkSmoke() async throws {
     // pointer. The production callback must reject this structure before it
     // traverses it, then report the drop to MCU health.
     await manager.emitBidirectionalBytes([0x90, 0x40, 0x7F], wordCountOverride: 65)
-    // Likewise, the event-list count is checked before the callback derives
-    // the first packet pointer, so a malformed oversized list has fixed work.
+
+    #expect(drops.snapshot() == [1])
+}
+
+@Test func testProductionMCUTransportBoundsLargeValidPacketListWithoutFailingIngress() async throws {
+    let manager = MockServerPortManager()
+    let events = FeedbackEventRecorder()
+    let malformedDrops = IngressDropRecorder()
+    let workBudgetDrops = IngressDropRecorder()
+    let transport = ProductionMCUTransport(portManager: manager)
+
+    try await transport.start(
+        onReceive: { event in Task { await events.record(event) } },
+        onIngressDrop: { count in malformedDrops.record(count) },
+        onCallbackWorkBudgetDrop: { count in workBudgetDrops.record(count) }
+    )
+    // This allocates and initializes every declared packet. It is a valid list
+    // of 65 one-word note-ons, not the prior one-packet buffer with a forged
+    // count. The callback may process only 64, but it must keep the ingress
+    // alive and report exactly the one event it did not process.
     await manager.emitBidirectionalBytes([0x90, 0x40, 0x7F], numPackets: 65)
 
-    #expect(drops.snapshot() == [1, 1])
+    let observed = await waitForFeedbackEvents(events, expectedCount: 64)
+    #expect(observed.count == 64)
+    #expect(malformedDrops.snapshot().isEmpty)
+    #expect(workBudgetDrops.snapshot() == [1])
 }
 
 @Test func testProductionMCUTransportSendUsesPacketSinkAfterStart() async throws {

--- a/Tests/LogicProMCPTests/MCURestartFeedbackTests.swift
+++ b/Tests/LogicProMCPTests/MCURestartFeedbackTests.swift
@@ -64,6 +64,17 @@ private actor ReusingPortManager: VirtualPortManaging {
         list.packet.words.0 = word
         withUnsafePointer(to: &list) { installedCallback($0, nil) }
     }
+
+    /// The transport must refuse this before calling `MIDIEventPacketNext`, so
+    /// the one-word backing storage is sufficient to drive the malformed-input
+    /// callback path without traversing untrusted packet memory.
+    func fireOversizedWordCount() {
+        guard let installedCallback else { return }
+        var list = MIDIEventList()
+        list.numPackets = 1
+        list.packet.wordCount = 65
+        withUnsafePointer(to: &list) { installedCallback($0, nil) }
+    }
 }
 
 /// Thread-safe recorder for the pitch-bend values a sink observed — the sink is
@@ -80,6 +91,26 @@ private final class SinkRecorder: @unchecked Sendable {
     }
 
     var pitchBends: [UInt16] {
+        lock.lock()
+        defer { lock.unlock() }
+        return values
+    }
+}
+
+/// Thread-safe recorder for malformed-ingress drops routed from the CoreMIDI
+/// callback. It deliberately shares no state with the event sink so a stale
+/// callback capture cannot accidentally look current through normal feedback.
+private final class DropSinkRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [UInt64] = []
+
+    func record(_ count: UInt64) {
+        lock.lock()
+        values.append(count)
+        lock.unlock()
+    }
+
+    var drops: [UInt64] {
         lock.lock()
         defer { lock.unlock() }
         return values
@@ -115,6 +146,33 @@ private final class SinkRecorder: @unchecked Sendable {
     #expect(secondSink.pitchBends == [8000])
     // And the stale sink must NOT receive the post-restart event.
     #expect(firstSink.pitchBends == [4000])
+
+    await transport.stop()
+}
+
+@Test func testRestartReusedPortRoutesIngressDropsToFreshSink() async throws {
+    let portManager = ReusingPortManager()
+    let transport = ProductionMCUTransport(portManager: portManager)
+    let firstDrops = DropSinkRecorder()
+    let secondDrops = DropSinkRecorder()
+
+    try await transport.start(
+        onReceive: { _ in },
+        onIngressDrop: { firstDrops.record($0) }
+    )
+    await transport.stop()
+    try await transport.start(
+        onReceive: { _ in },
+        onIngressDrop: { secondDrops.record($0) }
+    )
+
+    // The fake retains the FIRST callback. A by-value onIngressDrop capture
+    // reports to the stopped session; the stable sink box must instead route
+    // this malformed packet's loss to the fresh session.
+    await portManager.fireOversizedWordCount()
+
+    #expect(firstDrops.drops.isEmpty)
+    #expect(secondDrops.drops == [1])
 
     await transport.stop()
 }

--- a/Tests/LogicProMCPTests/MIDIEngineTests.swift
+++ b/Tests/LogicProMCPTests/MIDIEngineTests.swift
@@ -376,24 +376,33 @@ func testMIDIEngineProductionRuntimeStartStopSmoke() async throws {
     let engine = MIDIEngine()
 
     // A client-creation failure has two causes and only one is a defect: the
-    // environment refusing CoreMIDI, or start() being broken. `coreMIDIRefuses
-    // AClientRightNow` separates them by asking CoreMIDI directly, so this can
-    // still fail when the product path is the broken half. It replaced a check
-    // for one hardcoded status (-50, what a CI runner returns), which read every
-    // OTHER environmental refusal as a product failure.
+    // environment already refusing CoreMIDI, or start() being broken. Keep a
+    // direct preflight probe, then compare it with a post-failure probe; asking
+    // only after start() could excuse a product path that poisoned MIDIServer.
+    // This replaced a check for one hardcoded status (-50, what a CI runner
+    // returns), which read every OTHER environmental refusal as a product
+    // failure.
+    let preflightProbeStatus = coreMIDIRefusesAClientRightNow()
     do {
         try await engine.start()
     } catch let error as MIDIEngineError {
+        let postFailureProbeStatus = coreMIDIRefusesAClientRightNow()
         guard case .clientCreationFailed(let startStatus) = error,
-              let probeStatus = coreMIDIRefusesAClientRightNow() else {
-            // Either a different failure, or CoreMIDI WILL hand this process a
-            // client — in which case start() is the broken half and must fail.
+              let preflightProbeStatus,
+              let postFailureProbeStatus,
+              coreMIDIRefusalPredatedProductStart(
+                  before: preflightProbeStatus,
+                  after: postFailureProbeStatus
+              ) else {
+            // A different failure, healthy preflight, or recovered post-failure
+            // probe leaves the product start as the failing path.
             throw error
         }
         reportCoreMIDIUnavailable(
             "testMIDIEngineProductionRuntimeStartStopSmoke",
             startStatus: startStatus,
-            probeStatus: probeStatus
+            preflightProbeStatus: preflightProbeStatus,
+            postFailureProbeStatus: postFailureProbeStatus
         )
         return
     }
@@ -404,6 +413,16 @@ func testMIDIEngineProductionRuntimeStartStopSmoke() async throws {
 
     await engine.stop()
     #expect(!(await engine.isActive))
+}
+
+@Test func testCoreMIDIRefusalMustPredateProductStartToExcuseSmokeFailure() {
+    let unavailableBeforeAndAfter = coreMIDIRefusalPredatedProductStart(before: -2, after: -2)
+    let healthyBeforeThenUnavailable = coreMIDIRefusalPredatedProductStart(before: nil, after: -2)
+
+    #expect(unavailableBeforeAndAfter)
+    // This is the mutation guard: accepting a post-failure probe by itself
+    // makes a broken product start on a healthy host silently pass.
+    #expect(!healthyBeforeThenUnavailable)
 }
 
 @Test(coreMIDIUnavailableInSandbox)

--- a/Tests/LogicProMCPTests/MIDIPortTests.swift
+++ b/Tests/LogicProMCPTests/MIDIPortTests.swift
@@ -325,19 +325,28 @@ func testMIDIPortManagerProductionRuntimeSmokeCreatesAndStopsPorts() async throw
     let sendOnlyName = "LogicProMCP-Smoke-\(UUID().uuidString)"
     let bidirectionalName = "LogicProMCP-Smoke-Bidi-\(UUID().uuidString)"
 
-    // See the note on the MIDIEngine production smoke test: the refusal is
-    // confirmed against CoreMIDI directly rather than matched to one status.
+    // See the MIDIEngine smoke test: only a refusal seen before AND after this
+    // product path is environmental. A post-start probe alone could describe a
+    // service this very start() call broke.
+    let preflightProbeStatus = coreMIDIRefusesAClientRightNow()
     do {
         try await manager.start()
     } catch let error as MIDIPortError {
+        let postFailureProbeStatus = coreMIDIRefusesAClientRightNow()
         guard case .clientCreationFailed(let startStatus) = error,
-              let probeStatus = coreMIDIRefusesAClientRightNow() else {
+              let preflightProbeStatus,
+              let postFailureProbeStatus,
+              coreMIDIRefusalPredatedProductStart(
+                  before: preflightProbeStatus,
+                  after: postFailureProbeStatus
+              ) else {
             throw error
         }
         reportCoreMIDIUnavailable(
             "testMIDIPortManagerProductionRuntimeSmokeCreatesAndStopsPorts",
             startStatus: startStatus,
-            probeStatus: probeStatus
+            preflightProbeStatus: preflightProbeStatus,
+            postFailureProbeStatus: postFailureProbeStatus
         )
         return
     }

--- a/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
+++ b/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
@@ -50,6 +50,7 @@ private final class LiveFixture: @unchecked Sendable {
     init(
         track: Int = 0,
         insert: Int = 6,
+        trackDisplayName: String = trackName,
         trackSelected: Bool = true,
         thresholdDescription: String = "Threshold",
         pluginSlotName: String = "Compressor",
@@ -67,6 +68,11 @@ private final class LiveFixture: @unchecked Sendable {
         sliderDisplayUnit: String = "%",
         sliderUsesSignedPositiveDisplay: Bool = false,
         pluginWindowStaticTextValues: [String]? = nil,
+        // An already-visible editor whose title becomes the target track only
+        // after the slot press. This models an existing AX element being
+        // retargeted by an unrelated UI transition; duplicate acquisition must
+        // refuse it because the press did not create a new window element.
+        pluginWindowTitleBeforeSlotPress: String? = nil,
         // Model an editor whose close control is pressed but which stays in
         // AXWindows. The close must be judged by the observed window list, not
         // by the press returning true.
@@ -96,7 +102,7 @@ private final class LiveFixture: @unchecked Sendable {
             b.setAttribute(row, kAXRoleAttribute as String, kAXLayoutItemRole as String)
             // Track name is surfaced via the header's AXDescription (quoted),
             // matching how extractTrackName reads live Logic headers.
-            let name = i == track || i == duplicateTrackNameAt ? trackName : "Other \(i)"
+            let name = i == track || i == duplicateTrackNameAt ? trackDisplayName : "Other \(i)"
             b.setAttribute(row, kAXDescriptionAttribute as String, "1개의 ‘\(name)’ 트랙")
             b.setAttribute(row, kAXSelectedAttribute as String, (i == track && trackSelected))
             headerRows.append(row)
@@ -176,11 +182,15 @@ private final class LiveFixture: @unchecked Sendable {
         b.setAttribute(pluginLink, kAXDescriptionAttribute as String, "link")
         b.setAttribute(pluginWindow, kAXRoleAttribute as String, kAXWindowRole as String)
         b.setAttribute(pluginWindow, kAXSubroleAttribute as String, kAXDialogSubrole as String)
-        b.setAttribute(pluginWindow, kAXTitleAttribute as String, trackName)
+        b.setAttribute(
+            pluginWindow,
+            kAXTitleAttribute as String,
+            pluginWindowTitleBeforeSlotPress ?? trackDisplayName
+        )
         b.setAttribute(pluginWindow, kAXCloseButtonAttribute as String, pluginClose)
         b.setAttribute(pluginWindow, kAXMainAttribute as String, pluginWindowPresent)
         b.setAttribute(pluginWindow, kAXFocusedAttribute as String, pluginWindowPresent)
-        let staticTexts = (pluginWindowStaticTextValues ?? ["보기:", pluginSlotName, trackName])
+        let staticTexts = (pluginWindowStaticTextValues ?? ["보기:", pluginSlotName, trackDisplayName])
             .enumerated()
             .map { offset, value -> AXUIElement in
                 let text = b.element(1010 + offset)
@@ -269,6 +279,9 @@ private final class LiveFixture: @unchecked Sendable {
                 if key == targetOpenButtonKey {
                     targetOpenControlPressCount.value += 1
                 }
+                if pluginWindowTitleBeforeSlotPress != nil {
+                    b.setAttribute(pluginWindow, kAXTitleAttribute as String, trackDisplayName)
+                }
                 if openWindowOnSlotPress {
                     b.setAttribute(
                         app,
@@ -332,7 +345,10 @@ private func runLive(
         runtime: fixture.runtime,
         frontDocumentPath: { frontDoc },
         pluginWindowOpener: opener ?? AccessibilityChannel.livePluginWindowOpener,
-        pluginPopupMenuCleaner: popupMenuCleaner ?? AccessibilityChannel.livePluginPopupMenuCleaner
+        // These are AX-tree fixtures, not a live CoreGraphics qualification.
+        // Keep their default deterministic; popup-cleanup regressions inject
+        // the exact non-clean outcome they need to exercise.
+        pluginPopupMenuCleaner: popupMenuCleaner ?? { _ in .noPopupObserved }
     )
     return try! JSONSerialization.jsonObject(
         with: result.message.data(using: .utf8)!, options: []
@@ -485,7 +501,8 @@ private func runChannelEQFixture(
         runtime: fixture.runtime,
         frontDocumentPath: { expectedPath },
         entryLookup: channelEQFixtureEntryLookup(),
-        paramAliasLookup: channelEQFixtureParamAlias
+        paramAliasLookup: channelEQFixtureParamAlias,
+        pluginPopupMenuCleaner: { _ in .noPopupObserved }
     )
     let data = try #require(result.message.data(using: .utf8))
     let obj = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
@@ -508,6 +525,7 @@ private func runChannelEQFixture(
             range: StockPluginValueRange(min: 0, max: 10, defaultValue: 0)
         ),
         paramAliasLookup: channelEQFixtureParamAlias,
+        pluginPopupMenuCleaner: { _ in .noPopupObserved },
         incrementWalkBudget: incrementWalkBudget
     )
     let data = try #require(result.message.data(using: .utf8))
@@ -591,7 +609,6 @@ private func namedEQBandParams(
         pluginWindowStaticTextValues: ["보기:", "Compressor", trackName]
     )
     let obj = await runLive(fixture: fixture, params: thresholdParams())
-
     #expect(obj["state"] as? String == "A")
     #expect(fixture.currentSliderValue == 60)
 }
@@ -654,13 +671,16 @@ private func namedEQBandParams(
 
 @Test func testLadderPollRefusesNewlyOpenedDifferentPluginHeader() async throws {
     // No editor is present for the preflight scan. The slot press reveals a
-    // same-track Noise Gate editor, so every poll result must reject it rather
-    // than accepting its Threshold as a Compressor window.
+    // Noise Gate editor on a track NAMED Compressor. The title and its matching
+    // direct static-text value are the track, not the plug-in, so every poll
+    // result must reject the shared Threshold slider. This would write State A
+    // before the header check excludes the track name.
     let fixture = LiveFixture(
+        trackDisplayName: "Compressor",
         beforeValue: 51,
         pluginWindowPresent: false,
         openWindowOnSlotPress: true,
-        pluginWindowStaticTextValues: ["보기:", "Noise Gate", trackName]
+        pluginWindowStaticTextValues: ["보기:", "Noise Gate", "Compressor"]
     )
     let obj = await runLive(fixture: fixture, params: thresholdParams())
 
@@ -725,6 +745,38 @@ private func namedEQBandParams(
     #expect(fixture.targetOpenControlPressCount.value == 1)
     #expect(fixture.currentSliderValue == 51)
     #expect(fixture.builder.attributeValue(sibling.slider, kAXValueAttribute as String) as? Double == 51)
+    // Count-mismatch is an early return, but both editors were newly observed
+    // after this operation's press and must not be stranded for the next call.
+    #expect(fixture.pluginCloseControlPressCount.value == 1)
+    #expect(AXLogicProElements.matchingPluginEditorWindows(
+        forTrackName: trackName,
+        matchingPluginID: "logic.stock.effect.compressor",
+        runtime: fixture.runtime
+    ).isEmpty)
+}
+
+@Test func testDuplicateAcquisitionRejectsAnExistingEditorThatOnlyBecomesAMatchAfterPress() async throws {
+    // The pre-press AX window list already contains this editor, but it does
+    // not identify the target track until the target control is pressed. A
+    // count-only implementation accepts it and writes; provenance requires a
+    // newly observed AX element as well as exactly one matching editor.
+    let fixture = LiveFixture(
+        beforeValue: 51,
+        pluginWindowPresent: true,
+        pluginSlotNamesByTrack: [0: [0: "Compressor", 6: "Compressor"]],
+        pluginWindowTitleBeforeSlotPress: "Other Track"
+    )
+    let obj = await runLive(fixture: fixture, params: thresholdParams())
+
+    #expect(obj["state"] as? String == "C")
+    #expect(obj["error"] as? String == "duplicate_plugin_editor_count_mismatch")
+    #expect(obj["matching_editor_count_after_press"] as? Int == 1)
+    #expect(obj["new_matching_editor_count_after_press"] as? Int == 0)
+    let writeAttempted = try #require(obj["write_attempted"] as? Bool)
+    #expect(!writeAttempted)
+    #expect(fixture.targetOpenControlPressCount.value == 1)
+    #expect(fixture.currentSliderValue == 51)
+    #expect(fixture.pluginCloseControlPressCount.value == 0)
 }
 
 @Test func testDuplicatePluginWithNoEditorAfterOnePressRefuses() async throws {
@@ -1070,7 +1122,8 @@ private func namedEQBandParams(
     let validResult = await AccessibilityChannel.defaultSetEQBandVerified(
         params: namedEQBandParams(),
         runtime: validFixture.runtime,
-        frontDocumentPath: { expectedPath }
+        frontDocumentPath: { expectedPath },
+        pluginPopupMenuCleaner: { _ in .noPopupObserved }
     )
     let validData = try #require(validResult.message.data(using: .utf8))
     let valid = try #require(try JSONSerialization.jsonObject(with: validData) as? [String: Any])
@@ -1118,7 +1171,8 @@ private func namedEQBandParams(
     let result = await AccessibilityChannel.defaultSetEQBandVerified(
         params: namedEQBandParams(parameter: "Gain", unit: "db"),
         runtime: fixture.runtime,
-        frontDocumentPath: { expectedPath }
+        frontDocumentPath: { expectedPath },
+        pluginPopupMenuCleaner: { _ in .noPopupObserved }
     )
     let data = try #require(result.message.data(using: .utf8))
     let envelope = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
@@ -1161,7 +1215,8 @@ private func namedEQBandParams(
     let result = await AccessibilityChannel.defaultSetParamVerified(
         params: thresholdParams(value: "60"),
         runtime: fixture.runtime,
-        frontDocumentPath: { expectedPath }
+        frontDocumentPath: { expectedPath },
+        pluginPopupMenuCleaner: { _ in .noPopupObserved }
     )
     let obj = try! JSONSerialization.jsonObject(with: result.message.data(using: .utf8)!) as! [String: Any]
     #expect(obj["error"] as? String == "readback_mismatch")
@@ -1799,7 +1854,7 @@ private final class Counter: @unchecked Sendable {
 
 // MARK: - #726 the operation closes the editor it opened
 
-@Test func testDuplicateAcquisitionClosesTheEditorItOpened() async {
+@Test func testDuplicateAcquisitionClosesTheEditorItOpened() async throws {
     // Measured live: writing insert 0 then insert 2 on a two-Compressor track
     // failed on the second call with duplicate_plugin_editor_already_open,
     // because the first call left its editor open. The operation opened that
@@ -1814,6 +1869,8 @@ private final class Counter: @unchecked Sendable {
 
     #expect(obj["state"] as? String == "A")
     #expect(fixture.currentSliderValue == 60)
+    let closeObserved = try #require(obj["editor_close_observed"] as? Bool)
+    #expect(closeObserved)
     #expect(fixture.pluginCloseControlPressCount.value == 1)
     #expect(AXLogicProElements.matchingPluginEditorWindows(
         forTrackName: trackName,
@@ -1854,6 +1911,12 @@ private final class Counter: @unchecked Sendable {
 
     #expect(obj["state"] as? String == "A")
     #expect(fixture.currentSliderValue == 60)
+    let closeObserved = try #require(obj["editor_close_observed"] as? Bool)
+    let editorStillOpen = try #require(obj["editor_still_open"] as? Bool)
+    #expect(!closeObserved)
+    #expect(editorStillOpen)
+    let recoveryHint = try #require(obj["recovery_hint"] as? String)
+    #expect(recoveryHint.contains("Close it before another duplicate-instance write"))
     // Tried, and retried, rather than giving up after one press.
     #expect(fixture.pluginCloseControlPressCount.value == 3)
 }

--- a/Tests/LogicProMCPTests/SharedTestHelpers.swift
+++ b/Tests/LogicProMCPTests/SharedTestHelpers.swift
@@ -40,10 +40,10 @@ let coreMIDIUnavailableInSandbox: ConditionTrait = .disabled(
 /// die outright, with a crash report to show for it, after which every client
 /// creation in every process fails until it comes back.
 ///
-/// This probe is deliberately NOT vacuous. It uses CoreMIDI directly rather than
-/// the code under test, so when the product's own start path is the broken half
-/// this returns nil and the caller rethrows. It can only excuse a failure that
-/// the bare framework reproduces.
+/// A post-failure probe alone is not independent causation: a broken product
+/// start can poison the shared service and make that immediate probe fail too.
+/// Production smoke tests therefore retain this result *before* their product
+/// path and compare it with a second probe after a client-creation failure.
 func coreMIDIRefusesAClientRightNow() -> OSStatus? {
     var client = MIDIClientRef()
     let status = MIDIClientCreate("LogicProMCP-availability-probe" as CFString, nil, nil, &client)
@@ -54,14 +54,30 @@ func coreMIDIRefusesAClientRightNow() -> OSStatus? {
     return status
 }
 
+/// An environmental refusal may excuse a smoke-test client-creation failure
+/// only when a CoreMIDI refusal was already observable before the product start
+/// ran and remains observable after it. A healthy preflight that turns into a
+/// refusal is never excused: the product path may have caused it (or the host
+/// changed underneath it), and either way the smoke test did not establish a
+/// pre-existing environmental limitation.
+func coreMIDIRefusalPredatedProductStart(before: OSStatus?, after: OSStatus?) -> Bool {
+    before != nil && after != nil
+}
+
 /// Report a production smoke test that could not run because CoreMIDI refused
 /// this process a client. Loud on stdout: a silent return is indistinguishable
 /// from a test that actually exercised the path.
-func reportCoreMIDIUnavailable(_ test: String, startStatus: OSStatus, probeStatus: OSStatus) {
+func reportCoreMIDIUnavailable(
+    _ test: String,
+    startStatus: OSStatus,
+    preflightProbeStatus: OSStatus,
+    postFailureProbeStatus: OSStatus
+) {
     print(
         "SKIPPED \(test): CoreMIDI refused a client to this process "
-            + "(start status \(startStatus), independent probe \(probeStatus)). "
-            + "The production path was NOT exercised."
+            + "before and after the product path (preflight \(preflightProbeStatus), "
+            + "start status \(startStatus), post-failure probe \(postFailureProbeStatus)). "
+            + "The path could not be qualified on this host."
     )
 }
 


### PR DESCRIPTION
Fixes ten defects an independent adversarial review found in #725 and #727, plus the live check that should have caught the worst of them here rather than after merge.

Nothing was dismissed as a non-defect. The first five were confirmed against the merged code before anything was changed.

## The one that matters most

The plug-in identity check accepted the **track** name.

```swift
observedNames.contains { pluginID(forObservedName: $0) == pluginID }
```

`observedNames` is every direct `AXStaticText` of the editor window, and the track name is one of them — measured, and written into the commit message that introduced the check:

```
Channel EQ on «Studio Grand»  ->  ["보기:", "Channel EQ", "Studio Grand"]
                                                          ^^^^^^^^^^^^ the track
```

So on a track **named** `Compressor`, a Noise Gate editor reads `["보기:", "Noise Gate", "Compressor"]`, the last value maps to the requested id, and a Compressor write lands in the Noise Gate and returns State A — the exact defect the check was added to prevent.

The refutation was already in my own notes. `contains` asks whether SOME value matches; what was needed is which value IS the plug-in name. The value equal to the window title, and the caller-resolved track name, are now excluded. Reverting that exclusion turns the new regression red with State A.

## The rest

| | |
|---|---|
| Causation | zero-before/one-after were snapshots and the press result was discarded, so anything opening the sibling during the 1.25 s poll satisfied both. Pre-press editor **elements** are retained now and the accepted window must not be among them. The residual concurrent-UI limit is written down rather than implied away. |
| Cleanup placement | the `defer` was registered after the count-mismatch return, so the hidden-sibling refusal — the case that branch exists for — left **both** editors open. |
| Close result | discarded, so a close that never happened looked identical to one that did, and surfaced on the next call as an unrelated refusal. State A now discloses it, with a recovery hint. |
| Oversized MCU list | a **valid** 65-packet list processed zero packets, reported a drop of one, and finished the ingress — MCU dead until restart. It now processes the bounded prefix and reports the omitted suffix non-fatally. |
| Post-overflow drops | returned `.terminated` and went uncounted, understating the loss. |
| Restart | the reused CoreMIDI callback still held the FIRST start's drop sink, so an oversized list after a restart was reported by nothing. |
| CoreMIDI test probe | established contemporaneous global failure, not causation: a regression that crashed MIDIServer during its own start would make the bare probe fail too and excuse itself. Refusal is now required both **before** and after the product path. |
| Roadmap guard | assumed automatic issue closing is enabled; GitHub lets that be turned off, and then an OPEN row is correct. The failure states the assumption. |
| Dead error | `ambiguous_plugin_instance` was emitted by nothing after the narrowing. Removed. |

## One severity correction, established live

The oversized-list branch is **not reachable from the wire** on this macOS. One `MIDIPacketList` of 65, 200 and 800 packets all arrived chunked and never entered it, with the control (a normal MCU frame run) showing `MCU device registration confirmed, feedback active` throughout. The accounting was still wrong and a work bound should bound work rather than destroy the channel, but this is hardening, not a live-reachable failure.

## Why a live harness had to come with it

The cleanup defect reached the exact broken state in a unit test that never asked what was left on screen. Every assertion about cleanup lived on the same side as the bug.

`live_726_a_refusal_leaves_no_editor_open.py` counts editors with an independent AX probe, never with the product. Measured before the fix:

```
open one sibling editor, hide all plug-in windows  ->  AX reports 0 editors
set_param_verified insert 2                        ->  C count_mismatch
editors left open                                  ->  2
```

and 0 after. That is a negative control across two code versions.

Writing it produced its own lesson worth keeping: the first version hid the windows *after* a successful write had already closed everything, so its "hiding empties the AX list" precondition read `0 == 0` with nothing hidden, the refusal case was never reached, and the harness reported a false disagreement. It now asserts that exactly one editor **is** open before the hide.

Full suite 4096 passed; guards 15; both live harnesses clean at this head.
