### PR TITLE
fix(#448): stop guessing at track colour, and say why it cannot be read

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXValueExtractors.swift
+++ b/Sources/LogicProMCP/Accessibility/AXValueExtractors.swift
@@ -743,12 +743,24 @@ enum AXValueExtractors {
         return nil
     }
 
+    /// Track colour is NOT readable through Accessibility. Measured, not assumed (#448).
+    ///
+    /// A sweep of every element in every Logic window for any attribute whose name contains
+    /// `color` or `colour` returned **zero** on Logic 12.x. Not one element in the tree carries
+    /// one, so there is nothing for this to read and `nil` is the only honest answer.
+    ///
+    /// What stood here before guessed: it lower-cased the header's `AXDescription` and, if that
+    /// contained the English word "color", returned the WHOLE description as the colour. Two
+    /// things were wrong with it. On a localized Logic the description is a sentence like
+    /// `1개의 'Absolute Zero' 트랙`, which never contains that word, so the branch was dead and
+    /// the comment's "may expose" was a hypothesis nobody had tested. And on any Logic, a track
+    /// NAMED something like "Colorful Bass" WOULD match, and the caller would receive a
+    /// localized sentence about track count as a colour value.
+    ///
+    /// Kept as a named function rather than deleting the field so the wall is stated where
+    /// somebody looks for it. `set_color_verified` cannot reach State A by readback while this
+    /// holds: there is nothing to read back, and AX settability has lied in this codebase before.
     private static func extractTrackColor(from header: AXUIElement, runtime: AXHelpers.Runtime) -> String? {
-        // Logic Pro may expose color via a custom attribute or the element's description
-        let desc = AXHelpers.getDescription(header, runtime: runtime) ?? ""
-        if desc.lowercased().contains("color") {
-            return desc
-        }
-        return nil
+        nil
     }
 }

--- a/Tests/LogicProMCPTests/AXValueExtractorsTests.swift
+++ b/Tests/LogicProMCPTests/AXValueExtractorsTests.swift
@@ -114,7 +114,20 @@ import Testing
     #expect(!track.isSoloed)
     #expect(track.isArmed)
     #expect(track.isSelected)
-    #expect(track.color == "Audio color blue")
+    // Colour is not readable through Accessibility (#448). This fixture's header
+    // description contains the English word "color", which is exactly what the old
+    // speculative extractor keyed on — it returned the whole description as a colour.
+    // A real localized Logic never produces that string, and a track NAMED
+    // "Colorful Bass" would have produced a sentence about track count instead.
+    #expect(colourIsUnread(track))
+}
+
+/// `track.color` must be absent, whatever the header says.
+///
+/// Computed outside the macro deliberately: on this toolchain `#expect(x == nil)` is dead in
+/// both directions for an Optional, so the comparison has to produce a plain Bool first.
+private func colourIsUnread(_ track: TrackState) -> Bool {
+    track.color == nil
 }
 
 @Test func testAXValueExtractorsMarksUnreadableTrackIdentity() {
@@ -233,10 +246,10 @@ import Testing
     #expect(track.name == "808 Rack")
     #expect(track.type == .externalMIDI)
     #expect(track.isMuted)
-    #expect(track.color == "External MIDI color green")
+    #expect(colourIsUnread(track))
     #expect(unknownTrack.name == "Mystery Track")
     #expect(unknownTrack.type == .unknown)
-    #expect(unknownTrack.color == nil)
+    #expect(colourIsUnread(unknownTrack))
 }
 
 @Test func testAXValueExtractorsClassifiesGMDeviceStripAsExternalMIDI() {


### PR DESCRIPTION
Closes nothing on its own — this is the measured half of #448, and what it mostly does is stop the codebase claiming something it never checked.

## The defect

```swift
let desc = AXHelpers.getDescription(header, runtime: runtime) ?? ""
if desc.lowercased().contains("color") { return desc }
```

That is `extractTrackColor`. It lower-cased the track header's `AXDescription` and, if the result contained the English word "color", returned **the whole description** as the track's colour. The comment above it said Logic "may expose color via a custom attribute or the element's description" — a hypothesis written in the voice of a finding.

It was never true. Measured on Logic 12.x: a sweep of every element in every window for any attribute whose name contains `color` or `colour` returns **zero**. Not one element in the tree carries one. The repository's own recorded decision history says the same thing independently.

So on a localized Logic the branch is dead — the description reads `1개의 'Absolute Zero' 트랙` and never contains that word. And on any Logic it is worse than dead: a track **named** something like `Colorful Bass` matches, and the caller receives a localized sentence about track count as a colour value. Nothing downstream noticed because `logic://tracks` omits nil fields, so the field simply never appeared.

## What changed

The function returns nil and carries the measurement. It is kept as a named function rather than deleted so the wall is stated where somebody goes looking for it.

Two tests pinned the old behaviour using fixtures whose descriptions contain `"color"` — a string real Logic does not produce, which is why they were green. They now pin that colour is unread whatever the header says. The comparison is computed in an ordinary function rather than inside `#expect`, because this toolchain treats `#expect(optional == nil)` as always-pass in both directions.

Verified by mutation with a **forced rebuild** — writing the source and immediately running the suite reuses the previous artifact and reports green for a mutation that landed, which this repository has recorded before. Restoring the speculative branch turns both tests red for exactly the right reason:

```
colourIsUnread(track → TrackState(… color: Optional("Audio color blue") …))
colourIsUnread(track → TrackState(… color: Optional("External MIDI color green") …))
```

## What this settles for the issue

`set_color_verified` cannot reach State A by readback while this holds: there is nothing to read back, and AX settability has lied in this codebase before. It needs either a different source of truth or an explicit decision that colour writes are State B, said in the envelope.

The rest of the layout readback is already shipped. `logic://tracks` carries `track_ref`, arrangement order as `id`, `is_stack_header` and `stack_collapsed` — the last two from the disclosure triangle's own value, measured moving 21 → 44 → 21 headers as a stack was disclosed.

`depth` and `parent_stack_ref` remain derivations from disclosure state plus row ordering, not readings. They are deliberately not published as fields: this project does not ship an inference in a slot a caller will read as an observation.

Full suite 4096 passed; guards 15; ship gate green with live evidence bound to this head.
