### PR TITLE
docs(roadmap): mark #724 and #726 closed

### DIFF
--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -73,8 +73,8 @@ Also open, outside the ADR set:
 | #448 | OPEN | layout readback is deliverable; colour and reorder need a definition of "verified" for a write nothing can read back |
 | #678 | closed | the drift guard and this file's update rule shipped in #684 |
 | #683 | OPEN | external report — MCU feedback from Logic Pro Creator Studio wedges the loop; four hypotheses refuted or weakened by measurement, blocked on a `sample` from the reporter's host |
-| #724 | OPEN | fixed in the pull request that adds this row — `plugins.set_param_verified` succeeded once per process, because acquisition pressed a menu-opening control, left a popup that blocks every AppleEvent, and re-pressed a TOGGLE that closed the window it was trying to re-acquire. Measured and fixed 2026-08-31; four consecutive calls of each verified write reach State A |
-| #726 | OPEN | fixed in the pull request that adds this row — a verified write could land on a different insert than the one requested and still return State A, because the window match keyed on track name plus one slider description and neither names a plug-in or an insert. Measured 2026-08-31 on a track carrying Compressor at inserts 0 and 2: both writes reached slot 0. Editors are now bound by construction (zero matching editors before one target-slot press, exactly one after), their header static text must name the requested plug-in, and the editor this operation opens is closed again |
+| #724 | closed | |
+| #726 | closed | |
 | #685 | closed | fixed in this pull request — the nudge loop no longer abandons a write on one failed AX read |
 
 ### Three reopen reasons, checked rather than inferred


### PR DESCRIPTION
Marks **#724** and **#726** closed. Two table cells, one commit.

## What shipped, and how it was checked

**#724** — `set_param_verified` succeeded once per process, then wedged. Three stacked causes: acquisition pressed a menu-opening control; the resulting popup sits at `CGWindowLayer 101` and blocked every AppleEvent while the modal detector, looking only at level 8, reported the screen clean; and the slot's open control is a **toggle**, so re-pressing closed the window it was trying to re-acquire.

```
four consecutive verified writes, one process:   A 57 · A 58 · A 59 · A 56
```

**#726** — a verified write could land on a different insert and still report State A.

- the editor's own header must name the requested plug-in, **excluding the window title and the caller-resolved track name** — the track name is among those static texts, so on a track *named* `Compressor` a Noise Gate editor would otherwise pass
- a duplicated plug-in is acquired **by construction**: zero matching editors before one press of the target slot, exactly one *new* one after
- the operation **attempts** to close the editor it opened, retrying up to three times, keeping State A and reporting `editor_still_open` when the close cannot be observed

```
insert 0 <- 44  A   insert 2 <- 88  A   insert 0 <- 56  A   insert 2 <- 56  A
independent raw-AX readback:  slot#0 = 56 %   slot#1 = 56 %
plug-in editors left open: 0
```

The readback is taken outside the product's own window — the half the original defect could not fail.

Both notes are left empty. That is one of two forms this file already uses for a closed row (four of twelve are empty, six carry an explanation), and it is the right one here because the issues carry the full account.

## What this PR no longer contains

An earlier attempt also rewrote the **#302** and **#369** rows as "corrections to recorded blockers". Two rounds of adversarial review rejected it. It is not in this branch — the branch was squashed so the false commit message cannot reach `main` through a merge commit.

**The table already said both things.** #302 has recorded since 2026-08-29 that `kAXColumns` returns eight columns and that the header's sort buttons carry the names the collector binds. #369 has recorded since 2026-08-30 that the menu path is reachable and enabled. That attempt quoted the **issue bodies'** stale STATUS lines, never read the table, and presented two-day-old conclusions as new findings.

**And it contradicted the repository.** It asserted the export settings panel "remains unmeasured" while `docs/tickets/issue-369-per-track-stem-export/T1-drive-the-export-panel.md` records a real export completed on 2026-08-19 — 394,922 bytes of audio, analysed and verified — driven with Accessibility only and no coordinates.

**It also disabled the guard meant to check it.** An added `previously:` cell omitted the closing pipe, and `check-roadmap-blockers-cite-measurements.py` skips any line that does not end in one. Four rows went unparsed; the scan covered 13 OPEN rows instead of 15.

On this revision both roadmap guards pass and the citation guard reports all 15 OPEN rows. Corrections were posted to #302 and #369.
