### PR TITLE
feat(#306): build the Controls-view manifest producer, and make every unreadable read refuse

### DIFF
--- a/Scripts/livekit/live_726_a_refusal_leaves_no_editor_open.py
+++ b/Scripts/livekit/live_726_a_refusal_leaves_no_editor_open.py
@@ -199,9 +199,17 @@ if present.get("editor_count") != 1:
     driver.close()
     finish()
 
+# Logic REWRITES this item's title with its own state — it reads
+# «모든 플러그인 윈도우 가리기» (hide) when windows are showing and
+# «모든 플러그인 윈도우 보기» (show) when they are hidden. A fixed string
+# matches in one state and raises -1728 in the other, and the harness then
+# hid nothing while believing it had. Resolve by the stable stem instead.
 subprocess.run(["osascript", "-e",
-                'tell application "System Events" to tell process "Logic Pro" to click menu item '
-                '"모든 플러그인 윈도우" of menu 1 of menu bar item "윈도우" of menu bar 1'],
+                'tell application "System Events" to tell process "Logic Pro"\n'
+                '  set m to first menu item of menu 1 of menu bar item "윈도우" of menu bar 1 '
+                'whose name contains "모든 플러그인 윈도우"\n'
+                '  click m\n'
+                'end tell'],
                capture_output=True)
 time.sleep(1.5)
 hidden = editors(probe_tool)

--- a/Sources/LogicProMCP/Accessibility/AXHelpers.swift
+++ b/Sources/LogicProMCP/Accessibility/AXHelpers.swift
@@ -7,6 +7,9 @@ enum AXHelpers {
     struct Runtime: @unchecked Sendable {
         let axApp: @Sendable (pid_t) -> AXUIElement
         let attributeValue: @Sendable (AXUIElement, String) -> AnyObject?
+        /// Whether AX reports an attribute as settable. This is an observed
+        /// claim, not a successful set operation.
+        let attributeIsSettable: @Sendable (AXUIElement, String) -> Bool?
         let setAttributeValue: @Sendable (AXUIElement, String, CFTypeRef) -> Bool
         let children: @Sendable (AXUIElement) -> [AXUIElement]
         let performAction: @Sendable (AXUIElement, String) -> Bool
@@ -32,6 +35,7 @@ enum AXHelpers {
         init(
             axApp: @escaping @Sendable (pid_t) -> AXUIElement,
             attributeValue: @escaping @Sendable (AXUIElement, String) -> AnyObject?,
+            attributeIsSettable: @escaping @Sendable (AXUIElement, String) -> Bool? = { _, _ in nil },
             setAttributeValue: @escaping @Sendable (AXUIElement, String, CFTypeRef) -> Bool,
             children: @escaping @Sendable (AXUIElement) -> [AXUIElement],
             performAction: @escaping @Sendable (AXUIElement, String) -> Bool,
@@ -44,6 +48,7 @@ enum AXHelpers {
         ) {
             self.axApp = axApp
             self.attributeValue = attributeValue
+            self.attributeIsSettable = attributeIsSettable
             self.setAttributeValue = setAttributeValue
             self.children = children
             self.performAction = performAction
@@ -70,6 +75,17 @@ enum AXHelpers {
                 let result = AXUIElementCopyAttributeValue(element, attribute as CFString, &value)
                 guard result == .success else { return nil }
                 return value
+            },
+            attributeIsSettable: { element, attribute in
+                var isSettable: DarwinBoolean = false
+                guard AXUIElementIsAttributeSettable(
+                    element,
+                    attribute as CFString,
+                    &isSettable
+                ) == .success else {
+                    return nil
+                }
+                return isSettable.boolValue
             },
             setAttributeValue: { element, attribute, value in
                 AXUIElementSetAttributeValue(element, attribute as CFString, value) == .success
@@ -209,6 +225,16 @@ enum AXHelpers {
         runtime: Runtime = .production
     ) -> Bool {
         runtime.setAttributeValue(element, attribute, value)
+    }
+
+    /// Read AX's claim about whether an attribute is settable without
+    /// attempting to change it. A failed status remains unknown (`nil`).
+    static func isAttributeSettable(
+        _ element: AXUIElement,
+        _ attribute: String,
+        runtime: Runtime = .production
+    ) -> Bool? {
+        runtime.attributeIsSettable(element, attribute)
     }
 
     /// Get the children of an AX element.

--- a/Sources/LogicProMCP/HostParameters/ControlsViewParameterEnumerator.swift
+++ b/Sources/LogicProMCP/HostParameters/ControlsViewParameterEnumerator.swift
@@ -1,0 +1,749 @@
+import ApplicationServices
+import CryptoKit
+import Foundation
+
+/// Reads Logic's host-provided Controls view. This is deliberately
+/// observation-only: it never treats AX settable state as a successful
+/// write/readback round trip.
+///
+/// No operation calls this producer yet. Wiring must attach to an owner that
+/// already resolves one plug-in editor window, selects and confirms Controls
+/// view, and can decide whether exposing an unapproved, display-name-only
+/// manifest belongs on that operation's public contract. This component does
+/// not make that reachability decision or add a public operation itself.
+enum ControlsViewParameterEnumerator {
+    enum PluginNameSource: String, Codable, Equatable, Sendable {
+        case directWindowStaticText
+    }
+
+    /// Evidence retained beside the manifest because the display name is not a
+    /// canonical plug-in identity. Controls view exposes these AX facts, but it
+    /// exposes no measured canonical AU/component identifier.
+    struct IdentityEvidence: Codable, Equatable, Sendable {
+        let pluginName: String
+        let pluginNameSource: PluginNameSource
+        let windowTitle: String
+        let directStaticTextValues: [String]
+        let observedWindowAXIdentifier: String?
+        let canonicalPluginIdentifier: String?
+    }
+
+    enum RowClassification: Equatable, Sendable {
+        /// A labelled row whose AXCell contains exactly one supported control.
+        /// The value readability is retained so an addressable control with no
+        /// readable value is never misrepresented as readback-capable.
+        case parameter(
+            controlRole: GenericParameterControlRole,
+            valueIsReadable: Bool
+        )
+        /// No supported control shares a cell with a row label.
+        case refusedNoControl
+        /// A row maps to more than one supported control, so selecting one
+        /// would inherit AX traversal order rather than an address.
+        case refusedAmbiguousControl(roles: [String])
+        /// The label and the supported control occurred in different cells.
+        case refusedUnpairedLabelAndControl
+        /// An empty label cannot form a stable row address.
+        case refusedEmptyLabel
+        /// Logic's inactive placeholder label cannot form a stable row address.
+        case refusedPlaceholderLabel
+        /// Multiple label candidates make the row address ambiguous.
+        case refusedAmbiguousLabel
+
+        fileprivate var signatureState: String {
+            switch self {
+            case .parameter(let role, true):
+                return "parameter_readable_\(role.rawValue)"
+            case .parameter(let role, false):
+                return "parameter_unreadable_\(role.rawValue)"
+            case .refusedNoControl:
+                return "refused_no_control"
+            case .refusedAmbiguousControl(let roles):
+                return "refused_ambiguous_control_\(roles.joined(separator: ","))"
+            case .refusedUnpairedLabelAndControl:
+                return "refused_unpaired_label_and_control"
+            case .refusedEmptyLabel:
+                return "refused_empty_label"
+            case .refusedPlaceholderLabel:
+                return "refused_placeholder_label"
+            case .refusedAmbiguousLabel:
+                return "refused_ambiguous_label"
+            }
+        }
+    }
+
+    struct RowObservation: Equatable, Sendable {
+        let rowIndex: Int
+        let observedLabel: String?
+        /// Every supported role found in the row's AXCells, including roles
+        /// on rows refused for their label. This makes the read observation
+        /// auditable without pretending an unaddressable row is writable.
+        let controlRoles: [String]
+        let valueDescription: String?
+        let valueIsSettable: Bool?
+        let classification: RowClassification
+    }
+
+    struct Result: Equatable, Sendable {
+        let manifest: PluginCapabilityManifest
+        let rowObservations: [RowObservation]
+        let identityEvidence: IdentityEvidence
+    }
+
+    /// Enumerate the measured Controls-view table in an already-open plug-in
+    /// editor. The caller supplies the host/build fingerprint because the
+    /// measured AX tree contains no trustworthy plug-in build identity.
+    static func enumerate(
+        in editorWindow: AXUIElement,
+        buildFingerprint: String,
+        runtime: AXHelpers.Runtime = .production
+    ) -> Result? {
+        let trimmedBuildFingerprint = buildFingerprint.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        )
+        guard !trimmedBuildFingerprint.isEmpty,
+              role(of: editorWindow, runtime: runtime) == (kAXWindowRole as String),
+              let identityEvidence = identityEvidence(
+                  for: editorWindow,
+                  runtime: runtime
+              ),
+              let table = controlsTable(in: editorWindow, runtime: runtime),
+              let rows = rows(in: table, runtime: runtime),
+              controlsViewStateIsBound(rows: rows, runtime: runtime) else {
+            return nil
+        }
+
+        var parameters: [GenericPluginParameter] = []
+        var observations: [RowObservation] = []
+        var rowSignatures: [RowSignature] = []
+
+        for (rowIndex, row) in rows.enumerated() {
+            // A failed AXValue read for a label has neither established an
+            // empty label nor a stable UI signature. Refuse the whole
+            // manifest: hashing `nil` would alias distinct unreadable labels.
+            guard let rowRead = readRow(row, runtime: runtime) else {
+                return nil
+            }
+
+            let classification: RowClassification
+            let label: String?
+            let parameterControl: ControlObservation?
+
+            if rowRead.labels.count > 1 {
+                label = nil
+                parameterControl = nil
+                classification = .refusedAmbiguousLabel
+            } else if let candidate = rowRead.pairedCandidates.only {
+                label = candidate.label
+                parameterControl = candidate.control
+                classification = classify(
+                    for: candidate.label,
+                    control: candidate.control
+                )
+            } else if let onlyLabel = rowRead.labels.only {
+                label = onlyLabel
+                parameterControl = nil
+                classification = classificationForUnpairedRow(rowRead, label: onlyLabel)
+            } else {
+                label = nil
+                parameterControl = nil
+                classification = .refusedEmptyLabel
+            }
+
+            let observedRoleStrings = rowRead.controls.map { $0.role.rawValue }.sorted()
+            let controlForObservation = parameterControl ?? rowRead.controls.only
+            observations.append(RowObservation(
+                rowIndex: rowIndex,
+                observedLabel: label,
+                controlRoles: observedRoleStrings,
+                valueDescription: controlForObservation?.valueDescription,
+                valueIsSettable: controlForObservation?.valueIsSettable,
+                classification: classification
+            ))
+            rowSignatures.append(RowSignature(
+                label: label,
+                controlRoles: observedRoleStrings,
+                refusalState: classification.signatureState
+            ))
+
+            guard case let .parameter(controlRole, valueIsReadable) = classification,
+                  let label,
+                  parameterControl != nil else {
+                continue
+            }
+
+            let parameterName = colonStrippedParameterName(label)
+            guard !parameterName.isEmpty else {
+                // `classification(for:)` handles a blank direct label. This
+                // protects the colon-only spelling without turning it into a
+                // parameter after the fact.
+                continue
+            }
+            parameters.append(GenericPluginParameter(
+                parameterRef: TargetReference(rawValue: "controls_view_row_\(rowIndex)"),
+                name: parameterName,
+                // AX's settable claim is not a write/readback round trip. A
+                // readable value supports only readback; unreadable values are
+                // retained as addressable but unsupported observations.
+                valueKind: valueIsReadable ? .normalizedReadbackOnly : .unsupported,
+                controlRole: controlRole,
+                page: 0,
+                // Preserve the table's physical row offset. In particular,
+                // refusing '-' rows must never renumber later parameters.
+                index: rowIndex
+            ))
+        }
+
+        // This covers row label changes AND every observed trait that changes
+        // whether a row is a parameter: paired control roles, readable-value
+        // state, and the explicit refusal state. Values themselves are not
+        // hashed: they move during ordinary plug-in use.
+        let uiSignatureFingerprint = fingerprint(UISignature(orderedRows: rowSignatures))
+        let manifestFingerprint = fingerprint(ManifestFingerprintInput(
+            provider: .controlsViewAX,
+            pluginName: identityEvidence.pluginName,
+            buildFingerprint: trimmedBuildFingerprint,
+            uiSignatureFingerprint: uiSignatureFingerprint,
+            parameters: parameters,
+            approved: false,
+            identityEvidence: identityEvidence
+        ))
+        let manifest = PluginCapabilityManifest(
+            provider: .controlsViewAX,
+            pluginName: identityEvidence.pluginName,
+            buildFingerprint: trimmedBuildFingerprint,
+            uiSignatureFingerprint: uiSignatureFingerprint,
+            parameters: parameters,
+            // A newly observed layout needs explicit human approval before the
+            // existing gate can expose it to a host-verified write path.
+            approved: false,
+            manifestFingerprint: manifestFingerprint
+        )
+        return Result(
+            manifest: manifest,
+            rowObservations: observations,
+            identityEvidence: identityEvidence
+        )
+    }
+
+    /// The manifest-only producer for callers that do not need diagnostic row
+    /// classifications or header-identity evidence.
+    static func manifest(
+        from editorWindow: AXUIElement,
+        buildFingerprint: String,
+        runtime: AXHelpers.Runtime = .production
+    ) -> PluginCapabilityManifest? {
+        enumerate(
+            in: editorWindow,
+            buildFingerprint: buildFingerprint,
+            runtime: runtime
+        )?.manifest
+    }
+
+    private static func controlsTable(
+        in editorWindow: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> AXUIElement? {
+        // The caller may pass only a plug-in AXWindow. A sole AXTable below an
+        // arbitrary element could be a browser, marker list, or another
+        // unrelated table and must not mint a plug-in manifest.
+        guard role(of: editorWindow, runtime: runtime) == (kAXWindowRole as String)
+        else {
+            return nil
+        }
+        guard let scanned = descendants(
+            of: editorWindow,
+            maxDepth: 8,
+            runtime: runtime
+        ) else {
+            return nil
+        }
+        return scanned.filter { $0.role == (kAXTableRole as String) }
+            .map(\.element)
+            .only
+    }
+
+    private static func rows(
+        in table: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> [AXUIElement]? {
+        let candidates: [AXUIElement]
+        switch AXHelpers.getAXUIElementArrayRead(
+            table,
+            kAXRowsAttribute as String,
+            runtime: runtime
+        ) {
+        case .success(.elements(let rows)):
+            candidates = rows
+        case .success(.absent):
+            // AXChildren is an alternate table representation only when every
+            // direct child proves to be an AXRow. It is never a general child
+            // fallback for an unrelated table.
+            switch AXHelpers.childrenResult(table, runtime: runtime) {
+            case .success(let children):
+                candidates = children
+            case .failure:
+                return nil
+            }
+        case .success(.malformed), .failure:
+            return nil
+        }
+        guard !candidates.isEmpty,
+              candidates.allSatisfy({
+                  role(of: $0, runtime: runtime) == (kAXRowRole as String)
+              }) else {
+            return nil
+        }
+        return candidates
+    }
+
+    /// The Controls-view state is structurally bound to the observed AX shape:
+    /// each table row has AXCells and each row contains a supported control in
+    /// one of those cells. The live evidence makes this a Controls-view fact;
+    /// it prevents a bare AXTable with arbitrary children from qualifying.
+    private static func controlsViewStateIsBound(
+        rows: [AXUIElement],
+        runtime: AXHelpers.Runtime
+    ) -> Bool {
+        rows.allSatisfy { row in
+            guard let cells = rowCells(in: row, runtime: runtime), !cells.isEmpty else {
+                return false
+            }
+            var hasControl = false
+            for cell in cells {
+                guard let contents = cellContents(in: cell, runtime: runtime) else {
+                    return false
+                }
+                hasControl = hasControl || !contents.controls.isEmpty
+            }
+            return hasControl
+        }
+    }
+
+    private static func readRow(
+        _ row: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> RowRead? {
+        var labelValues: [String] = []
+        var controlsInRow: [ControlObservation] = []
+        var pairedCandidates: [PairedCandidate] = []
+
+        guard let cells = rowCells(in: row, runtime: runtime) else {
+            return nil
+        }
+        for cell in cells {
+            guard let contents = cellContents(in: cell, runtime: runtime) else {
+                return nil
+            }
+            let cellLabels = contents.labels
+            let cellControls = contents.controls
+            labelValues.append(contentsOf: cellLabels)
+            controlsInRow.append(contentsOf: cellControls)
+            if let label = cellLabels.only, let control = cellControls.only {
+                pairedCandidates.append(PairedCandidate(label: label, control: control))
+            }
+        }
+        return RowRead(
+            labels: labelValues,
+            controls: controlsInRow,
+            pairedCandidates: pairedCandidates
+        )
+    }
+
+    private static func rowCells(
+        in row: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> [AXUIElement]? {
+        descendants(
+            of: row,
+            maxDepth: 3,
+            runtime: runtime
+        )?.compactMap { $0.role == (kAXCellRole as String) ? $0.element : nil }
+    }
+
+    /// Scans the complete cell subtree once, retaining the status of every
+    /// child and role read before either labels or controls can influence row
+    /// classification and the UI signature.
+    private static func cellContents(
+        in cell: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> CellContents? {
+        guard let scanned = descendants(
+            of: cell,
+            maxDepth: 4,
+            runtime: runtime
+        ), case .values(let labels) = labels(in: scanned, runtime: runtime) else {
+            return nil
+        }
+        return CellContents(
+            labels: labels,
+            controls: controls(in: scanned, runtime: runtime)
+        )
+    }
+
+    private static func labels(
+        in descendants: [DescendantRead],
+        runtime: AXHelpers.Runtime
+    ) -> LabelRead {
+        let textElements = descendants.filter {
+            $0.role == (kAXStaticTextRole as String)
+        }.map(\.element)
+        var values: [String] = []
+        for text in textElements {
+            let valueRead: Swift.Result<AnyObject?, AXHelpers.AXStatusError> = AXHelpers.getAttributeResult(
+                text,
+                kAXValueAttribute as String,
+                runtime: runtime
+            )
+            switch valueRead {
+            case .success(.some(let raw)):
+                guard let value = raw as? String else {
+                    return .unreadable
+                }
+                values.append(value.trimmingCharacters(in: .whitespacesAndNewlines))
+            case .success(.none), .failure:
+                return .unreadable
+            }
+        }
+        return .values(values)
+    }
+
+    private static func controls(
+        in descendants: [DescendantRead],
+        runtime: AXHelpers.Runtime
+    ) -> [ControlObservation] {
+        descendants.compactMap { descendant in
+            guard let role = GenericParameterControlRole(rawValue: descendant.role) else {
+                return nil
+            }
+            return ControlObservation(
+                role: role,
+                valueIsReadable: valueIsReadable(on: descendant.element, runtime: runtime),
+                valueDescription: valueDescription(on: descendant.element, runtime: runtime),
+                valueIsSettable: AXHelpers.isAttributeSettable(
+                    descendant.element,
+                    kAXValueAttribute as String,
+                    runtime: runtime
+                )
+            )
+        }
+    }
+
+    private static func valueIsReadable(
+        on control: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> Bool {
+        let valueRead: Swift.Result<AnyObject?, AXHelpers.AXStatusError> = AXHelpers.getAttributeResult(
+            control,
+            kAXValueAttribute as String,
+            runtime: runtime
+        )
+        switch valueRead {
+        case .success(.some):
+            return true
+        case .success(.none), .failure:
+            return valueDescription(on: control, runtime: runtime) != nil
+        }
+    }
+
+    private static func valueDescription(
+        on control: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> String? {
+        let descriptionRead: Swift.Result<AnyObject?, AXHelpers.AXStatusError> = AXHelpers.getAttributeResult(
+            control,
+            kAXValueDescriptionAttribute as String,
+            runtime: runtime
+        )
+        switch descriptionRead {
+        case .success(.some(let raw)):
+            return trimmed(raw as? String)
+        case .success(.none), .failure:
+            return nil
+        }
+    }
+
+    private static func classify(
+        for label: String,
+        control: ControlObservation
+    ) -> RowClassification {
+        if label.isEmpty || colonStrippedParameterName(label).isEmpty {
+            return .refusedEmptyLabel
+        }
+        if label == "-" {
+            return .refusedPlaceholderLabel
+        }
+        return .parameter(
+            controlRole: control.role,
+            valueIsReadable: control.valueIsReadable
+        )
+    }
+
+    private static func classificationForUnpairedRow(
+        _ row: RowRead,
+        label: String
+    ) -> RowClassification {
+        if label.isEmpty || colonStrippedParameterName(label).isEmpty {
+            return .refusedEmptyLabel
+        }
+        if label == "-" {
+            return .refusedPlaceholderLabel
+        }
+        if row.controls.isEmpty {
+            return .refusedNoControl
+        }
+        if row.controls.count > 1 {
+            return .refusedAmbiguousControl(
+                roles: row.controls.map { $0.role.rawValue }.sorted()
+            )
+        }
+        return .refusedUnpairedLabelAndControl
+    }
+
+    private static func identityEvidence(
+        for editorWindow: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> IdentityEvidence? {
+        // A missing, empty, malformed, or unreadable title cannot establish
+        // which direct header text is the track. Refuse rather than weakening
+        // the exclusion and accidentally promoting the track name.
+        let titleRead: Swift.Result<AnyObject?, AXHelpers.AXStatusError> = AXHelpers.getAttributeResult(
+            editorWindow,
+            kAXTitleAttribute as String,
+            runtime: runtime
+        )
+        guard case .success(.some(let rawTitle)) = titleRead,
+              let windowTitle = trimmed(rawTitle as? String) else {
+            return nil
+        }
+        guard case .success(let children) = AXHelpers.childrenResult(
+            editorWindow,
+            runtime: runtime
+        ) else {
+            return nil
+        }
+        var staticTextValues: [String] = []
+        for child in children {
+            guard let childRole = role(of: child, runtime: runtime) else {
+                return nil
+            }
+            guard childRole == (kAXStaticTextRole as String) else {
+                continue
+            }
+            let valueRead: Swift.Result<AnyObject?, AXHelpers.AXStatusError> = AXHelpers.getAttributeResult(
+                child,
+                kAXValueAttribute as String,
+                runtime: runtime
+            )
+            guard case .success(.some(let rawValue)) = valueRead,
+                  let value = trimmed(rawValue as? String) else {
+                return nil
+            }
+            staticTextValues.append(value)
+        }
+        // A view-menu label such as "보기:" is direct header text but not the
+        // plug-in display name. It is recognized structurally by its trailing
+        // colon; the actual name is still read from a direct AXStaticText.
+        let pluginCandidates = staticTextValues.filter { value in
+            value != windowTitle && !value.hasSuffix(":")
+        }
+        guard pluginCandidates.count == 1, let pluginName = pluginCandidates.first else {
+            return nil
+        }
+
+        let identifierRead: Swift.Result<AnyObject?, AXHelpers.AXStatusError> = AXHelpers.getAttributeResult(
+            editorWindow,
+            kAXIdentifierAttribute as String,
+            runtime: runtime
+        )
+        let observedWindowAXIdentifier: String?
+        switch identifierRead {
+        case .success(.none):
+            observedWindowAXIdentifier = nil
+        case .success(.some(let rawIdentifier)):
+            guard let identifier = rawIdentifier as? String else {
+                return nil
+            }
+            observedWindowAXIdentifier = trimmed(identifier)
+        case .failure:
+            return nil
+        }
+
+        return IdentityEvidence(
+            pluginName: pluginName,
+            pluginNameSource: .directWindowStaticText,
+            windowTitle: windowTitle,
+            directStaticTextValues: staticTextValues,
+            observedWindowAXIdentifier: observedWindowAXIdentifier,
+            // The measured AX fields are display/header evidence only. Do not
+            // turn an AX identifier or display string into canonical AU identity.
+            canonicalPluginIdentifier: nil
+        )
+    }
+
+    private static func trimmed(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let result = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return result.isEmpty ? nil : result
+    }
+
+    private static func colonStrippedParameterName(_ label: String) -> String {
+        guard label.hasSuffix(":") else { return label }
+        return String(label.dropLast()).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// A role is a required part of every structural scan in this enumerator.
+    /// Treat failed, absent, malformed, and empty reads alike: any of them
+    /// leaves open the possibility that an unclassified node was a relevant
+    /// table, cell, label, or control.
+    private static func role(
+        of element: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> String? {
+        let roleRead: Swift.Result<AnyObject?, AXHelpers.AXStatusError> = AXHelpers.getAttributeResult(
+            element,
+            kAXRoleAttribute as String,
+            runtime: runtime
+        )
+        guard case .success(.some(let rawRole)) = roleRead,
+              let role = rawRole as? String,
+              !role.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+        return role
+    }
+
+    /// Unlike `findAllDescendants`, this scan preserves AXChildren and AXRole
+    /// failures. A partial traversal cannot prove that a cell has exactly one
+    /// control, nor can it safely contribute a UI signature.
+    private static func descendants(
+        of element: AXUIElement,
+        maxDepth: Int,
+        runtime: AXHelpers.Runtime
+    ) -> [DescendantRead]? {
+        var found: [DescendantRead] = []
+        guard collectDescendants(
+            of: element,
+            maxDepth: maxDepth,
+            runtime: runtime,
+            into: &found
+        ) else {
+            return nil
+        }
+        return found
+    }
+
+    private static func collectDescendants(
+        of element: AXUIElement,
+        maxDepth: Int,
+        runtime: AXHelpers.Runtime,
+        into found: inout [DescendantRead]
+    ) -> Bool {
+        guard maxDepth > 0 else { return true }
+        guard case .success(let children) = AXHelpers.childrenResult(
+            element,
+            runtime: runtime
+        ) else {
+            return false
+        }
+        for child in children {
+            guard let childRole = role(of: child, runtime: runtime) else {
+                return false
+            }
+            found.append(DescendantRead(element: child, role: childRole))
+            guard collectDescendants(
+                of: child,
+                maxDepth: maxDepth - 1,
+                runtime: runtime,
+                into: &found
+            ) else {
+                return false
+            }
+        }
+        return true
+    }
+
+    private static func fingerprint<Value: Encodable>(_ value: Value) -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = try? encoder.encode(value) else {
+            // Every current input is finite strings/integers and encodable. If
+            // that invariant changes, fail closed rather than aliasing a valid
+            // manifest fingerprint to an invented fallback value.
+            return "unencodable:\(UUID().uuidString)"
+        }
+        return SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private enum LabelRead {
+        case values([String])
+        case unreadable
+    }
+
+    private struct DescendantRead {
+        let element: AXUIElement
+        let role: String
+    }
+
+    private struct CellContents {
+        let labels: [String]
+        let controls: [ControlObservation]
+    }
+
+    private struct ControlObservation {
+        let role: GenericParameterControlRole
+        let valueIsReadable: Bool
+        let valueDescription: String?
+        let valueIsSettable: Bool?
+    }
+
+    private struct PairedCandidate {
+        let label: String
+        let control: ControlObservation
+    }
+
+    private struct RowRead {
+        let labels: [String]
+        let controls: [ControlObservation]
+        let pairedCandidates: [PairedCandidate]
+    }
+
+    private struct RowSignature: Encodable {
+        let label: String?
+        let controlRoles: [String]
+        let refusalState: String
+    }
+
+    private struct UISignature: Encodable {
+        let orderedRows: [RowSignature]
+    }
+
+    private struct ManifestFingerprintInput: Encodable {
+        let provider: PluginParameterProvider
+        let pluginName: String
+        let buildFingerprint: String
+        let uiSignatureFingerprint: String
+        let parameters: [GenericPluginParameter]
+        let approved: Bool
+        let identityEvidence: IdentityEvidence
+    }
+}
+
+private extension Array {
+    var only: Element? {
+        count == 1 ? self[0] : nil
+    }
+}
+
+/// Convenience entry point for the manifest-only producer.
+func enumerateControlsViewManifest(
+    from editorWindow: AXUIElement,
+    buildFingerprint: String,
+    runtime: AXHelpers.Runtime = .production
+) -> PluginCapabilityManifest? {
+    ControlsViewParameterEnumerator.manifest(
+        from: editorWindow,
+        buildFingerprint: buildFingerprint,
+        runtime: runtime
+    )
+}

--- a/Sources/LogicProMCP/HostParameters/HostParameterGate.swift
+++ b/Sources/LogicProMCP/HostParameters/HostParameterGate.swift
@@ -22,13 +22,16 @@ func publicParameters(
     else {
         return []
     }
-    return manifest.parameters.filter { $0.valueKind != .unsupported }
+    // A readable normalized value is not a write/readback qualification. Keep
+    // it out of the host-write surface even after a manifest is approved.
+    return manifest.parameters.filter { $0.valueKind == .exactWriteReadback }
 }
 
 enum HostWriteRejection: Equatable, Sendable {
     case manifestNotApproved
     case manifestInvalidated(reason: String)
     case providerNotHostVerified
+    case readbackOnlyParameter(TargetReference)
     case unsupportedParameter(TargetReference)
 }
 
@@ -60,7 +63,12 @@ func validateHostWrite(
     let valueKind = manifest.parameters.first {
         $0.parameterRef == parameterRef
     }?.valueKind
-    if valueKind == nil || valueKind == .unsupported {
+    switch valueKind {
+    case .exactWriteReadback:
+        break
+    case .normalizedReadbackOnly:
+        rejections.append(.readbackOnlyParameter(parameterRef))
+    case .unsupported, nil:
         rejections.append(.unsupportedParameter(parameterRef))
     }
     return rejections

--- a/Sources/LogicProMCP/HostParameters/PluginCapabilityManifest.swift
+++ b/Sources/LogicProMCP/HostParameters/PluginCapabilityManifest.swift
@@ -4,12 +4,41 @@ enum GenericParameterValueKind: String, Codable, Sendable {
     case unsupported
 }
 
+/// The accessibility role observed at the control paired with a Controls-view
+/// row label. This is an addressability fact, not evidence that the control can
+/// be written successfully.
+enum GenericParameterControlRole: String, Codable, Equatable, Sendable {
+    case slider = "AXSlider"
+    case checkBox = "AXCheckBox"
+    case popUpButton = "AXPopUpButton"
+    case radioButton = "AXRadioButton"
+}
+
 struct GenericPluginParameter: Codable, Equatable, Sendable {
     let parameterRef: TargetReference
     let name: String
     let valueKind: GenericParameterValueKind
+    /// Present when a producer has observed the AX role used to address this
+    /// parameter. Older producers did not have that observation.
+    let controlRole: GenericParameterControlRole?
     let page: Int
     let index: Int
+
+    init(
+        parameterRef: TargetReference,
+        name: String,
+        valueKind: GenericParameterValueKind,
+        controlRole: GenericParameterControlRole? = nil,
+        page: Int,
+        index: Int
+    ) {
+        self.parameterRef = parameterRef
+        self.name = name
+        self.valueKind = valueKind
+        self.controlRole = controlRole
+        self.page = page
+        self.index = index
+    }
 }
 
 struct PluginCapabilityManifest: Codable, Equatable, Sendable {

--- a/Tests/LogicProMCPTests/AccessibilityTestSupport.swift
+++ b/Tests/LogicProMCPTests/AccessibilityTestSupport.swift
@@ -5,6 +5,7 @@ import Foundation
 final class FakeAXRuntimeBuilder: @unchecked Sendable {
     private var elements: [Int: AXUIElement] = [:]
     private var attributes: [Int: [String: Any]] = [:]
+    private var settableAttributes: [Int: Set<String>] = [:]
     private var children: [Int: [AXUIElement]] = [:]
     private var actionNames: [Int: [String]] = [:]
     private(set) var setCalls: [(elementID: Int, attribute: String)] = []
@@ -22,6 +23,15 @@ final class FakeAXRuntimeBuilder: @unchecked Sendable {
 
     func setAttribute(_ element: AXUIElement, _ attribute: String, _ value: Any) {
         attributes[key(for: element), default: [:]][attribute] = value
+    }
+
+    func setAttributeSettable(_ element: AXUIElement, _ attribute: String, _ isSettable: Bool) {
+        let elementKey = key(for: element)
+        if isSettable {
+            settableAttributes[elementKey, default: []].insert(attribute)
+        } else {
+            settableAttributes[elementKey, default: []].remove(attribute)
+        }
     }
 
     /// Wires AXParent on each child as well. A real AX tree always has it, and code that walks
@@ -76,6 +86,9 @@ final class FakeAXRuntimeBuilder: @unchecked Sendable {
                     return NSArray()
                 }
                 return bridge(attributes[key(for: element)]?[attribute])
+            },
+            attributeIsSettable: { [self] element, attribute in
+                settableAttributes[key(for: element)]?.contains(attribute) ?? false
             },
             setAttributeValue: { [self] element, attribute, value in
                 if let setAttributeHandler {

--- a/Tests/LogicProMCPTests/ControlsViewParameterEnumeratorTests.swift
+++ b/Tests/LogicProMCPTests/ControlsViewParameterEnumeratorTests.swift
@@ -1,0 +1,608 @@
+@preconcurrency import ApplicationServices
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+@Suite("ADR-018 Controls-view parameter enumerator")
+struct ControlsViewParameterEnumeratorTests {
+    @Test func manifestUsesTheMeasuredRaumRowsRolesAndReadbacks() throws {
+        let fixture = makeControlsFixture()
+        let result = try #require(ControlsViewParameterEnumerator.enumerate(
+            in: fixture.window,
+            buildFingerprint: "Logic-12.x",
+            runtime: fixture.runtime
+        ))
+        let manifest = result.manifest
+
+        #expect(manifest.provider == .controlsViewAX)
+        #expect(manifest.parameters.map(\.name) == [
+            "Sync", "Predelay", "Feedback", "Low Cut", "High Cut", "Mix",
+            "MixLock", "Mode", "Diffusion", "Size", "Decay", "Density",
+            "Modulation", "Damp", "Reverb", "Freeze",
+        ])
+        #expect(manifest.parameters.map(\.index) == [
+            0, 1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+        ])
+        #expect(manifest.parameters.map(\.controlRole) == [
+            .checkBox, .slider, .slider, .slider, .slider, .slider,
+            .checkBox, .slider, .slider, .slider, .slider, .slider,
+            .slider, .slider, .slider, .popUpButton,
+        ])
+        #expect(result.rowObservations.map(\.valueDescription) == measuredRows.map {
+            $0.valueDescription.flatMap(trimmed)
+        })
+        #expect(result.rowObservations.map(\.valueIsSettable) == measuredRows.map(\.valueSettable))
+
+        let allProducedParametersAreReadbackOnly = manifest.parameters.allSatisfy {
+            $0.valueKind == .normalizedReadbackOnly
+        }
+        #expect(allProducedParametersAreReadbackOnly)
+    }
+
+    @Test func placeholderLabelsAreRefusedForTheirLabelsNotTheirSliders() throws {
+        let fixture = makeControlsFixture()
+        let result = try #require(ControlsViewParameterEnumerator.enumerate(
+            in: fixture.window,
+            buildFingerprint: "Logic-12.x",
+            runtime: fixture.runtime
+        ))
+
+        #expect(result.rowObservations[2].controlRoles == ["AXSlider"])
+        #expect(result.rowObservations[3].controlRoles == ["AXSlider"])
+        #expect(result.rowObservations[2].classification == .refusedPlaceholderLabel)
+        #expect(result.rowObservations[3].classification == .refusedPlaceholderLabel)
+        let emittedNames = result.manifest.parameters.map(\.name)
+        let emitsPlaceholder = emittedNames.contains("-")
+        #expect(!emitsPlaceholder)
+        let feedback = try #require(result.manifest.parameters.first { $0.name == "Feedback" })
+        #expect(feedback.index == 4)
+    }
+
+    @Test func checkboxPopupAndRadioRowsAreAddressableParametersWithTheirRoles() throws {
+        var rows = measuredRows
+        rows[0].controlRole = .radioButton
+        let fixture = makeControlsFixture(rows: rows)
+        let result = try #require(ControlsViewParameterEnumerator.enumerate(
+            in: fixture.window,
+            buildFingerprint: "Logic-12.x",
+            runtime: fixture.runtime
+        ))
+
+        let sync = try #require(result.manifest.parameters.first { $0.name == "Sync" })
+        let mixLock = try #require(result.manifest.parameters.first { $0.name == "MixLock" })
+        let freeze = try #require(result.manifest.parameters.first { $0.name == "Freeze" })
+        #expect(sync.controlRole == .radioButton)
+        #expect(mixLock.controlRole == .checkBox)
+        #expect(freeze.controlRole == .popUpButton)
+    }
+
+    @Test func absentControlValueIsRecordedAsUnsupportedNotReadbackCapable() throws {
+        var rows = measuredRows
+        rows[1].value = nil
+        rows[1].valueDescription = nil
+        let fixture = makeControlsFixture(rows: rows)
+        let result = try #require(ControlsViewParameterEnumerator.enumerate(
+            in: fixture.window,
+            buildFingerprint: "Logic-12.x",
+            runtime: fixture.runtime
+        ))
+
+        let predelay = try #require(result.manifest.parameters.first { $0.name == "Predelay" })
+        #expect(predelay.controlRole == .slider)
+        #expect(predelay.valueKind == .unsupported)
+        #expect(result.rowObservations[1].classification == .parameter(
+            controlRole: .slider,
+            valueIsReadable: false
+        ))
+    }
+
+    @Test func failedControlValueReadIsRecordedAsUnsupportedNotReadbackCapable() throws {
+        let fixture = makeControlsFixture(unreadableControlValueIndexes: [1])
+        let result = try #require(ControlsViewParameterEnumerator.enumerate(
+            in: fixture.window,
+            buildFingerprint: "Logic-12.x",
+            runtime: fixture.runtime
+        ))
+
+        let predelay = try #require(result.manifest.parameters.first { $0.name == "Predelay" })
+        let isUnsupported = predelay.valueKind == .unsupported
+        #expect(isUnsupported)
+        let hasUnreadableValue = result.rowObservations[1].classification == .parameter(
+            controlRole: .slider,
+            valueIsReadable: false
+        )
+        #expect(hasUnreadableValue)
+    }
+
+    @Test func producedManifestIsUnapprovedAndPerformsNoAXWrite() throws {
+        let fixture = makeControlsFixture()
+        let manifest = try #require(ControlsViewParameterEnumerator.manifest(
+            from: fixture.window,
+            buildFingerprint: "Logic-12.x",
+            runtime: fixture.runtime
+        ))
+
+        let isApproved = manifest.approved
+        let performedNoWrites = fixture.builder.setCalls.isEmpty && fixture.builder.actionCalls.isEmpty
+        #expect(!isApproved)
+        #expect(performedNoWrites)
+    }
+
+    @Test func everyProducedParameterIsPresentBeforeRejectingExactWriteReadback() throws {
+        let fixture = makeControlsFixture()
+        let manifest = try #require(ControlsViewParameterEnumerator.manifest(
+            from: fixture.window,
+            buildFingerprint: "Logic-12.x",
+            runtime: fixture.runtime
+        ))
+        let hasProducedParameters = !manifest.parameters.isEmpty
+        #expect(hasProducedParameters)
+
+        let claimsExactWriteReadback = manifest.parameters.contains {
+            $0.valueKind == .exactWriteReadback
+        }
+        #expect(!claimsExactWriteReadback)
+    }
+
+    @Test func controlRolesChangeTheUISignatureFingerprintWithoutChangingRefusalState() throws {
+        let originalFixture = makeControlsFixture()
+        var changedRows = measuredRows
+        // A placeholder row remains refused for the same reason while its
+        // observed (but unaddressable) control role changes.
+        changedRows[2].controlRole = .checkBox
+        let changedFixture = makeControlsFixture(rows: changedRows)
+
+        let original = try #require(ControlsViewParameterEnumerator.enumerate(
+            in: originalFixture.window,
+            buildFingerprint: "Logic-12.x",
+            runtime: originalFixture.runtime
+        ))
+        let changed = try #require(ControlsViewParameterEnumerator.enumerate(
+            in: changedFixture.window,
+            buildFingerprint: "Logic-12.x",
+            runtime: changedFixture.runtime
+        ))
+
+        let signatureChanged = original.manifest.uiSignatureFingerprint
+            != changed.manifest.uiSignatureFingerprint
+        #expect(signatureChanged)
+        let refusalStateStayedTheSame = original.rowObservations[2].classification
+            == changed.rowObservations[2].classification
+        #expect(refusalStateStayedTheSame)
+    }
+
+    @Test func refusalStateChangesTheUISignatureFingerprintWithoutChangingControlRoles() throws {
+        let originalFixture = makeControlsFixture()
+        let changedFixture = makeControlsFixture(
+            cellBinding: .separateLabelAndControl(rowIndex: 7)
+        )
+
+        let original = try #require(ControlsViewParameterEnumerator.enumerate(
+            in: originalFixture.window,
+            buildFingerprint: "Logic-12.x",
+            runtime: originalFixture.runtime
+        ))
+        let changed = try #require(ControlsViewParameterEnumerator.enumerate(
+            in: changedFixture.window,
+            buildFingerprint: "Logic-12.x",
+            runtime: changedFixture.runtime
+        ))
+
+        let signatureChanged = original.manifest.uiSignatureFingerprint
+            != changed.manifest.uiSignatureFingerprint
+        #expect(signatureChanged)
+        let controlRolesStayedTheSame = original.rowObservations[7].controlRoles
+            == changed.rowObservations[7].controlRoles
+        #expect(controlRolesStayedTheSame)
+        let refusalStateChanged = original.rowObservations[7].classification
+            != changed.rowObservations[7].classification
+        #expect(refusalStateChanged)
+    }
+
+    @Test func unreadableRowLabelRefusesInsteadOfHashingAnUnstableNilLabel() {
+        let fixture = makeControlsFixture(unreadableLabelIndexes: [7])
+        let result = ControlsViewParameterEnumerator.enumerate(
+            in: fixture.window,
+            buildFingerprint: "Logic-12.x",
+            runtime: fixture.runtime
+        )
+
+        let refusedUnstableLabel = result == nil
+        #expect(refusedUnstableLabel)
+    }
+
+    @Test func unreadableControlRoleRefusesInsteadOfSilentlyDroppingTheControl() {
+        var rows = measuredRows
+        rows[7].additionalControlRole = .checkBox
+        let fixture = makeControlsFixture(
+            rows: rows,
+            unreadableAdditionalControlRoleIndexes: [7]
+        )
+
+        let result = ControlsViewParameterEnumerator.enumerate(
+            in: fixture.window,
+            buildFingerprint: "Logic-12.x",
+            runtime: fixture.runtime
+        )
+
+        let refusedIncompleteControlScan = result == nil
+        #expect(refusedIncompleteControlScan)
+    }
+
+    @Test func unreadableCellDescendantsRefuseInsteadOfClassifyingAPartialCell() {
+        let fixture = makeControlsFixture(unreadableCellChildIndexes: [7])
+        let result = ControlsViewParameterEnumerator.enumerate(
+            in: fixture.window,
+            buildFingerprint: "Logic-12.x",
+            runtime: fixture.runtime
+        )
+
+        let refusedIncompleteCellScan = result == nil
+        #expect(refusedIncompleteCellScan)
+    }
+
+    @Test func tableBindingRequiresWindowRowsCellsAndSharedCellPairing() throws {
+        let nonWindowFixture = makeControlsFixture()
+        nonWindowFixture.builder.setRole(nonWindowFixture.window, kAXGroupRole as String)
+        let nonWindowResult = ControlsViewParameterEnumerator.enumerate(
+            in: nonWindowFixture.window,
+            buildFingerprint: "Logic-12.x",
+            runtime: nonWindowFixture.runtime
+        )
+        let refusedNonWindowRoot = nonWindowResult == nil
+        #expect(refusedNonWindowRoot)
+
+        let fallbackFixture = makeControlsFixture(
+            exposesRowsAttribute: false,
+            includesNonRowTableChild: true
+        )
+        let fallbackResult = ControlsViewParameterEnumerator.enumerate(
+            in: fallbackFixture.window,
+            buildFingerprint: "Logic-12.x",
+            runtime: fallbackFixture.runtime
+        )
+        let refusedNonRowFallback = fallbackResult == nil
+        #expect(refusedNonRowFallback)
+
+        let celllessFixture = makeControlsFixture(cellBinding: .absent)
+        let celllessResult = ControlsViewParameterEnumerator.enumerate(
+            in: celllessFixture.window,
+            buildFingerprint: "Logic-12.x",
+            runtime: celllessFixture.runtime
+        )
+        let refusedCelllessTable = celllessResult == nil
+        #expect(refusedCelllessTable)
+
+        let unpairedFixture = makeControlsFixture(
+            cellBinding: .separateLabelAndControl(rowIndex: 7)
+        )
+        let unpairedResult = try #require(ControlsViewParameterEnumerator.enumerate(
+            in: unpairedFixture.window,
+            buildFingerprint: "Logic-12.x",
+            runtime: unpairedFixture.runtime
+        ))
+        #expect(unpairedResult.rowObservations[7].classification == .refusedUnpairedLabelAndControl)
+        let emittedMix = unpairedResult.manifest.parameters.contains { $0.name == "Mix" }
+        #expect(!emittedMix)
+    }
+
+    @Test func missingOrUnreadableWindowTitleCannotAdmitTheTrackAsPluginName() {
+        let emptyTitleFixture = makeControlsFixture(
+            windowTitle: "",
+            pluginTextPlacement: .nested
+        )
+        let emptyTitleResult = ControlsViewParameterEnumerator.enumerate(
+            in: emptyTitleFixture.window,
+            buildFingerprint: "Logic-12.x",
+            runtime: emptyTitleFixture.runtime
+        )
+        let refusedEmptyTitle = emptyTitleResult == nil
+        #expect(refusedEmptyTitle)
+
+        let unreadableTitleFixture = makeControlsFixture(
+            pluginTextPlacement: .nested,
+            unreadableWindowTitle: true
+        )
+        let unreadableTitleResult = ControlsViewParameterEnumerator.enumerate(
+            in: unreadableTitleFixture.window,
+            buildFingerprint: "Logic-12.x",
+            runtime: unreadableTitleFixture.runtime
+        )
+        let refusedUnreadableTitle = unreadableTitleResult == nil
+        #expect(refusedUnreadableTitle)
+    }
+
+    @Test func pluginNameUsesDirectHeaderTextAndExcludesTheMeasuredTrackTitle() throws {
+        let normalFixture = makeControlsFixture(pluginName: "Raum", trackName: "Compressor")
+        let normal = try #require(ControlsViewParameterEnumerator.enumerate(
+            in: normalFixture.window,
+            buildFingerprint: "Logic-12.x",
+            runtime: normalFixture.runtime
+        ))
+
+        #expect(normal.manifest.pluginName == "Raum")
+        #expect(normal.identityEvidence.windowTitle == "Compressor")
+        #expect(normal.identityEvidence.directStaticTextValues == ["Raum", "Compressor"])
+        #expect(normal.identityEvidence.canonicalPluginIdentifier == nil)
+    }
+
+    @Test func unreadableDirectHeaderRoleRefusesIdentityInsteadOfIgnoringTheCandidate() {
+        let fixture = makeControlsFixture(unreadableDirectHeaderRole: true)
+        let result = ControlsViewParameterEnumerator.enumerate(
+            in: fixture.window,
+            buildFingerprint: "Logic-12.x",
+            runtime: fixture.runtime
+        )
+
+        let refusedIncompleteHeaderScan = result == nil
+        #expect(refusedIncompleteHeaderScan)
+    }
+
+    @Test func exactPluginAndTrackNameCollisionRefusesIdentity() {
+        let fixture = makeControlsFixture(pluginName: "Raum", trackName: "Raum")
+        let result = ControlsViewParameterEnumerator.enumerate(
+            in: fixture.window,
+            buildFingerprint: "Logic-12.x",
+            runtime: fixture.runtime
+        )
+
+        let refusedAmbiguousIdentity = result == nil
+        #expect(refusedAmbiguousIdentity)
+    }
+}
+
+private struct ControlsFixture {
+    let builder: FakeAXRuntimeBuilder
+    let window: AXUIElement
+    let runtime: AXHelpers.Runtime
+}
+
+private struct RowFixture {
+    var label: String
+    var controlRole: GenericParameterControlRole
+    /// The fixture needs a readable AXValue for the enum's readback claim.
+    /// The supplied re-measurement gives the user-facing strings below; it
+    /// does not establish a normalized/raw conversion, so these are only
+    /// non-empty AX-value witnesses and are never asserted as raw units.
+    var value: String?
+    var valueDescription: String?
+    var valueSettable: Bool
+    var additionalControlRole: GenericParameterControlRole?
+}
+
+// The supplied re-measurement names 18 physical rows. Its aggregate says 14
+// AXSlider rows, while the itemized labels include thirteen named sliders and
+// two '-' slider rows (15); the fixture keeps every itemized row rather than
+// silently deleting a measured label to make that aggregate add up.
+private let measuredRows: [RowFixture] = [
+    RowFixture(label: "Sync:", controlRole: .checkBox, value: "0", valueDescription: "", valueSettable: false, additionalControlRole: nil),
+    RowFixture(label: "Predelay:", controlRole: .slider, value: "0.00 ms", valueDescription: "0.00 ms", valueSettable: true, additionalControlRole: nil),
+    RowFixture(label: "-", controlRole: .slider, value: "-", valueDescription: "-", valueSettable: true, additionalControlRole: nil),
+    RowFixture(label: "-", controlRole: .slider, value: "-", valueDescription: "-", valueSettable: true, additionalControlRole: nil),
+    RowFixture(label: "Feedback:", controlRole: .slider, value: "0.0 %", valueDescription: "0.0 %", valueSettable: true, additionalControlRole: nil),
+    RowFixture(label: "Low Cut:", controlRole: .slider, value: "Off", valueDescription: "Off", valueSettable: true, additionalControlRole: nil),
+    RowFixture(label: "High Cut:", controlRole: .slider, value: "Off", valueDescription: "Off", valueSettable: true, additionalControlRole: nil),
+    RowFixture(label: "Mix:", controlRole: .slider, value: "50.0 %", valueDescription: "50.0 %", valueSettable: true, additionalControlRole: nil),
+    RowFixture(label: "MixLock:", controlRole: .checkBox, value: "0", valueDescription: "", valueSettable: false, additionalControlRole: nil),
+    RowFixture(label: "Mode:", controlRole: .slider, value: "Airy", valueDescription: "Airy", valueSettable: true, additionalControlRole: nil),
+    RowFixture(label: "Diffusion:", controlRole: .slider, value: "25.0 %", valueDescription: "25.0 %", valueSettable: true, additionalControlRole: nil),
+    RowFixture(label: "Size:", controlRole: .slider, value: "50.0 %", valueDescription: "50.0 %", valueSettable: true, additionalControlRole: nil),
+    RowFixture(label: "Decay:", controlRole: .slider, value: "4.8 s", valueDescription: "4.8 s", valueSettable: true, additionalControlRole: nil),
+    RowFixture(label: "Density:", controlRole: .slider, value: "Dense", valueDescription: "Dense", valueSettable: true, additionalControlRole: nil),
+    RowFixture(label: "Modulation:", controlRole: .slider, value: "25.0 %", valueDescription: "25.0 %", valueSettable: true, additionalControlRole: nil),
+    RowFixture(label: "Damp:", controlRole: .slider, value: "25.0 %", valueDescription: "25.0 %", valueSettable: true, additionalControlRole: nil),
+    RowFixture(label: "Reverb:", controlRole: .slider, value: "100.0 %", valueDescription: "100.0 %", valueSettable: true, additionalControlRole: nil),
+    RowFixture(label: "Freeze:", controlRole: .popUpButton, value: "0", valueDescription: "", valueSettable: false, additionalControlRole: nil),
+]
+
+private enum CellBinding {
+    case paired
+    case absent
+    case separateLabelAndControl(rowIndex: Int)
+}
+
+private enum PluginTextPlacement {
+    case direct
+    case nested
+}
+
+private func makeControlsFixture(
+    pluginName: String = "Raum",
+    trackName: String = "Audio 1",
+    windowTitle: String? = nil,
+    rows: [RowFixture] = measuredRows,
+    exposesRowsAttribute: Bool = true,
+    includesNonRowTableChild: Bool = false,
+    cellBinding: CellBinding = .paired,
+    pluginTextPlacement: PluginTextPlacement = .direct,
+    unreadableLabelIndexes: Set<Int> = [],
+    unreadableWindowTitle: Bool = false,
+    unreadableControlValueIndexes: Set<Int> = [],
+    unreadableAdditionalControlRoleIndexes: Set<Int> = [],
+    unreadableCellChildIndexes: Set<Int> = [],
+    unreadableDirectHeaderRole: Bool = false
+) -> ControlsFixture {
+    let builder = FakeAXRuntimeBuilder()
+    let window = builder.element(90_000)
+    let table = builder.element(90_001)
+    builder.setRole(window, kAXWindowRole as String)
+    builder.setAttribute(window, kAXTitleAttribute as String, windowTitle ?? trackName)
+    builder.setRole(table, kAXTableRole as String)
+
+    var labelElementIDs: [Int] = []
+    var controlElementIDs: [Int] = []
+    var additionalControlElementIDs: [Int: Int] = [:]
+    var unreadableCellChildElementIDs: [Int] = []
+    let rowElements = rows.enumerated().map { rowIndex, rowFixture -> AXUIElement in
+        let base = 90_100 + rowIndex * 20
+        let row = builder.element(base)
+        let label = builder.element(base + 1)
+        let control = builder.element(base + 2)
+        labelElementIDs.append(builder.elementID(label))
+        controlElementIDs.append(builder.elementID(control))
+        builder.setRole(row, kAXRowRole as String)
+        builder.setRole(label, kAXStaticTextRole as String)
+        builder.setAttribute(label, kAXValueAttribute as String, rowFixture.label)
+        configure(
+            control,
+            fixture: rowFixture,
+            role: rowFixture.controlRole,
+            builder: builder
+        )
+
+        var controls = [control]
+        if let additionalControlRole = rowFixture.additionalControlRole {
+            let additionalControl = builder.element(base + 3)
+            configure(
+                additionalControl,
+                fixture: rowFixture,
+                role: additionalControlRole,
+                builder: builder
+            )
+            controls.append(additionalControl)
+            additionalControlElementIDs[rowIndex] = builder.elementID(additionalControl)
+        }
+
+        switch cellBinding {
+        case .paired:
+            let cell = builder.element(base + 4)
+            builder.setRole(cell, kAXCellRole as String)
+            var cellChildren = [label] + controls
+            if unreadableCellChildIndexes.contains(rowIndex) {
+                let unreadableDescendant = builder.element(base + 6)
+                builder.setRole(unreadableDescendant, kAXGroupRole as String)
+                cellChildren.append(unreadableDescendant)
+                unreadableCellChildElementIDs.append(builder.elementID(unreadableDescendant))
+            }
+            builder.setChildren(cell, cellChildren)
+            builder.setChildren(row, [cell])
+        case .absent:
+            builder.setChildren(row, [label] + controls)
+        case .separateLabelAndControl(let targetIndex) where targetIndex == rowIndex:
+            let labelCell = builder.element(base + 4)
+            let controlCell = builder.element(base + 5)
+            builder.setRole(labelCell, kAXCellRole as String)
+            builder.setRole(controlCell, kAXCellRole as String)
+            builder.setChildren(labelCell, [label])
+            builder.setChildren(controlCell, controls)
+            builder.setChildren(row, [labelCell, controlCell])
+        case .separateLabelAndControl:
+            let cell = builder.element(base + 4)
+            builder.setRole(cell, kAXCellRole as String)
+            builder.setChildren(cell, [label] + controls)
+            builder.setChildren(row, [cell])
+        }
+        return row
+    }
+    var tableChildren = rowElements
+    if includesNonRowTableChild {
+        let unrelatedChild = builder.element(91_000)
+        builder.setRole(unrelatedChild, kAXGroupRole as String)
+        tableChildren.append(unrelatedChild)
+    }
+    builder.setChildren(table, tableChildren)
+    if exposesRowsAttribute {
+        builder.setAttribute(table, kAXRowsAttribute as String, rowElements)
+    }
+
+    let pluginText = builder.element(90_010)
+    let trackText = builder.element(90_011)
+    let headerDecoration = builder.element(90_013)
+    builder.setRole(pluginText, kAXStaticTextRole as String)
+    builder.setAttribute(pluginText, kAXValueAttribute as String, pluginName)
+    builder.setRole(trackText, kAXStaticTextRole as String)
+    builder.setAttribute(trackText, kAXValueAttribute as String, trackName)
+    builder.setRole(headerDecoration, kAXGroupRole as String)
+    switch pluginTextPlacement {
+    case .direct:
+        builder.setChildren(window, [pluginText, trackText, headerDecoration, table])
+    case .nested:
+        let pluginContainer = builder.element(90_012)
+        builder.setRole(pluginContainer, kAXGroupRole as String)
+        builder.setChildren(pluginContainer, [pluginText])
+        builder.setChildren(window, [pluginContainer, trackText, headerDecoration, table])
+    }
+
+    let unreadableLabelElementIDs = Set(unreadableLabelIndexes.compactMap { index in
+        labelElementIDs.indices.contains(index) ? labelElementIDs[index] : nil
+    })
+    let unreadableControlValueElementIDs = Set(unreadableControlValueIndexes.compactMap { index in
+        controlElementIDs.indices.contains(index) ? controlElementIDs[index] : nil
+    })
+    let unreadableAdditionalControlRoleElementIDs = Set(
+        unreadableAdditionalControlRoleIndexes.compactMap { additionalControlElementIDs[$0] }
+    )
+    let unreadableCellElementIDs = Set(unreadableCellChildElementIDs)
+    let windowID = builder.elementID(window)
+    let headerDecorationID = builder.elementID(headerDecoration)
+    let runtime: AXHelpers.Runtime
+    if !unreadableLabelElementIDs.isEmpty
+        || unreadableWindowTitle
+        || !unreadableControlValueElementIDs.isEmpty
+        || !unreadableAdditionalControlRoleElementIDs.isEmpty
+        || !unreadableCellElementIDs.isEmpty
+        || unreadableDirectHeaderRole {
+        runtime = builder.makeAXRuntime(
+            attributeValueResultHandler: { element, attribute in
+                let elementID = builder.elementID(element)
+                let unreadableLabel = attribute == (kAXValueAttribute as String)
+                    && unreadableLabelElementIDs.contains(elementID)
+                let unreadableTitle = unreadableWindowTitle
+                    && attribute == (kAXTitleAttribute as String)
+                    && elementID == windowID
+                let unreadableControlValue = unreadableControlValueElementIDs.contains(elementID)
+                    && (attribute == (kAXValueAttribute as String)
+                        || attribute == (kAXValueDescriptionAttribute as String))
+                let unreadableAdditionalControlRole = attribute == (kAXRoleAttribute as String)
+                    && unreadableAdditionalControlRoleElementIDs.contains(elementID)
+                let unreadableHeaderRole = unreadableDirectHeaderRole
+                    && attribute == (kAXRoleAttribute as String)
+                    && elementID == headerDecorationID
+                guard unreadableLabel
+                    || unreadableTitle
+                    || unreadableControlValue
+                    || unreadableAdditionalControlRole
+                    || unreadableHeaderRole else {
+                    return nil
+                }
+                return .failure(AXHelpers.AXStatusError(raw: AXError.failure.rawValue))
+            },
+            childrenResultHandler: { element in
+                guard unreadableCellElementIDs.contains(builder.elementID(element)) else {
+                    return nil
+                }
+                return .failure(AXHelpers.AXStatusError(raw: AXError.failure.rawValue))
+            },
+            setAttributeHandler: nil,
+            performActionHandler: nil
+        )
+    } else {
+        runtime = builder.makeAXRuntime()
+    }
+    return ControlsFixture(builder: builder, window: window, runtime: runtime)
+}
+
+private func configure(
+    _ control: AXUIElement,
+    fixture: RowFixture,
+    role: GenericParameterControlRole,
+    builder: FakeAXRuntimeBuilder
+) {
+    builder.setRole(control, role.rawValue)
+    if let value = fixture.value {
+        builder.setAttribute(control, kAXValueAttribute as String, value)
+    }
+    if let valueDescription = fixture.valueDescription {
+        builder.setAttribute(control, kAXValueDescriptionAttribute as String, valueDescription)
+    }
+    builder.setAttributeSettable(
+        control,
+        kAXValueAttribute as String,
+        fixture.valueSettable
+    )
+}
+
+private func trimmed(_ value: String) -> String? {
+    let result = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    return result.isEmpty ? nil : result
+}

--- a/Tests/LogicProMCPTests/HostParameterTests.swift
+++ b/Tests/LogicProMCPTests/HostParameterTests.swift
@@ -119,6 +119,31 @@ struct HostParameterTests {
         )
     }
 
+    @Test func approvedReadbackOnlyParameterCannotBecomeAHostWrite() {
+        let readbackOnly = makeParameter("ins_observed", .normalizedReadbackOnly)
+        let subject = makeManifest(
+            provider: .controlsViewAX,
+            approved: true,
+            parameters: [readbackOnly]
+        )
+
+        let exposed = publicParameters(
+            subject,
+            currentBuildFingerprint: "build-1",
+            currentUISignature: "ui-1"
+        )
+        let hidesReadbackOnlyParameter = exposed.isEmpty
+        #expect(hidesReadbackOnlyParameter)
+        #expect(
+            validateHostWrite(
+                manifest: subject,
+                parameterRef: readbackOnly.parameterRef,
+                currentBuildFingerprint: "build-1",
+                currentUISignature: "ui-1"
+            ) == [.readbackOnlyParameter(readbackOnly.parameterRef)]
+        )
+    }
+
     @Test func nonHostedProviderCannotExposeOrValidateWrite() {
         let parameter = makeParameter("ins_gain", .exactWriteReadback)
         let subject = makeManifest(

--- a/Tests/LogicProMCPTests/LogicProServerTransportTests.swift
+++ b/Tests/LogicProMCPTests/LogicProServerTransportTests.swift
@@ -242,13 +242,32 @@ func testProductionKeyCmdTransportDefaultPacketSinkSmoke() async throws {
         portName: "LogicProMCP-KeyCmd-Smoke-\(UUID().uuidString)"
     )
 
+    // The THIRD instance of the same defect, found by the ship gate after the
+    // other two were fixed: a hardcoded -50 excuses exactly one environmental
+    // status, so every other CoreMIDI refusal reads as a product failure. This
+    // host returns -2 while MIDIServer is between launches.
+    //
+    // Same treatment as the other production smoke tests: probe BEFORE the
+    // product path and again after a failure, and excuse only a refusal that
+    // predated the product's own start. A refusal that appears only afterwards
+    // may have been caused by the product and is never excused.
+    let preflightProbe = coreMIDIRefusesAClientRightNow()
     do {
         try await manager.start()
     } catch let error as MIDIPortError {
-        if case .clientCreationFailed(let status) = error, [-50].contains(status) {
-            return
+        guard case .clientCreationFailed(let startStatus) = error else { throw error }
+        let postFailureProbe = coreMIDIRefusesAClientRightNow()
+        guard coreMIDIRefusalPredatedProductStart(before: preflightProbe, after: postFailureProbe),
+              let preflight = preflightProbe, let postFailure = postFailureProbe else {
+            throw error
         }
-        throw error
+        reportCoreMIDIUnavailable(
+            "testProductionKeyCmdTransportDefaultPacketSinkSmoke",
+            startStatus: startStatus,
+            preflightProbeStatus: preflight,
+            postFailureProbeStatus: postFailure
+        )
+        return
     }
     try await transport.send([0x90, 0x3C, 0x64])
 


### PR DESCRIPTION
`Sources/LogicProMCP/HostParameters/` had a gate requiring an approved manifest with matching build and UI fingerprints before any parameter becomes public. **Nothing produced one** — `PluginCapabilityManifest(` was constructed only in tests. A door with no building behind it.

This adds the producer: it reads a plug-in editor's Controls view and emits a manifest for `provider: .controlsViewAX`. Read-only, no write path.

## What made ADR-018's actual subject reachable

Third-party plug-ins were unmeasured. Measured on Native Instruments Raum, Logic 12.x (ko):

```
Raum's own AU view:     zero AXSliders  — the old "AU parameter view is AX-opaque" note
                        is true about THAT view
Logic's Controls view:  one AXTable, 18 rows, one per parameter, each labelled
  AXSlider       15 rows  (13 named + two whose LABEL is «-»)   settable=true
                 Predelay «0.00 ms» · Feedback «0.0 %» · Mix «50.0 %» ·
                 Mode «Airy» · Decay «4.8 s» · Density «Dense» · …
  AXCheckBox      2 rows   Sync: · MixLock:
  AXPopUpButton   1 row    Freeze:
```

Getting there needs two facts: Logic's plug-in popup menus hang off the **application root**, not the control that opened them, and their items answer to **`AXPick`** — an `AXPress` returns status 0 and does nothing.

## The rules, and why each exists

| | |
|---|---|
| `settable == true` is a **claim** | AX settability has lied here before and no round trip is established, so every parameter is `.normalizedReadbackOnly`, never `.exactWriteReadback` |
| that value now **means** read-only | it previously promised read-only in its name while `publicParameters` filtered out only `.unsupported` and `validateHostWrite` rejected only missing/unsupported — so an approved manifest's readback-only rows passed write validation |
| nothing self-approves | a producer that approves its own manifest defeats the gate that exists so a human approves it |
| every unreadable read **refuses** | label, value, title — and now role, because a partial traversal cannot prove a cell holds exactly one control |
| identity is not the display name | the ADR says so; the name excludes the value equal to `AXTitle` (that is the track), and canonical identity is recorded as unavailable |
| the build fingerprint comes from the caller | AX carries no trustworthy one, and fabricating it would make the gate's invalidation a lie |

Binding is `AXWindow` → sole table → `AXRow` → `AXCell`, label and control in the same cell, so an unrelated table cannot mint a manifest. The UI signature covers labels, control roles and each row's classification — a `Mix:` slider row and a `Mix:` checkbox row do not hash alike.

## Three review rounds, and two errors of mine

Adversarial review returned FIX_FIRST twice. The worst finding traced to a measurement of mine: I told the implementation "a row with no slider (`Sync:`) is not a parameter", from a probe counting only `AXSlider`. `Sync:` is a boolean parameter carrying a checkbox — and the repository had already recorded this. `live_306_controls_view_labels_the_row_not_the_slider.py` says the controls "can be AXSlider, AXRadioButton, or AXPopUpButton", and its filename says it too.

I also gave a wrong aggregate — 14 slider rows where the itemized list has 15. The evidence was kept and the discrepancy flagged rather than a row trimmed to fit my number.

## Two unrelated fixes the gates surfaced

**A third hardcoded `-50`.** `testProductionKeyCmdTransportDefaultPacketSinkSmoke` failed with `clientCreationFailed(-2)` — the third instance of a defect fixed twice earlier the same day. I fixed the two named instances and did not grep for a third. It uses the shared probe now: excuse a refusal only when it **predated** the product's own start, verified by making the product return -2 on a healthy host.

**A title Logic rewrites.** `live_726` failed at its hiding precondition, correctly, stopping before recording verdicts on a state it had not built. Logic rewrites that menu item between «…가리기» and «…보기», so a fixed string works in one state and raises -1728 in the other. Same trap the #369 export ticket recorded independently: `Tracks as Audio Files…` becomes `1 Track as Audio File…`.

## Deliberately not done

The producer is **unwired**. Nothing calls it, and the source says what wiring it needs and that choosing the surface is not this change's decision. Named rather than quietly left, because implementation behind an unreachable surface is what this repository retired eleven table rows for on 2026-08-18.

Full suite 4116 passed; guards 15; 29 focused tests, each mutation-tested after a forced rebuild, with each signature component's deletion reddening only its own test.
