### PR TITLE
fix(#369): make the stem export drive work on a live, localized Logic

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -254,6 +254,21 @@ enum AXLocalePolicy {
         rationale: "Measured from the live stem-export panel on 2026-09-01; the panel window title is the OS Open-panel string and is therefore not a usable signal."
     )
 
+    /// #369: The transient progress window title is rendered with an ordinary
+    /// space in some locales and a NO-BREAK SPACE in Korean. Keep the measured
+    /// product label in locale policy rather than scattering a literal through
+    /// the export driver.
+    static let stemExportProgressWindowTitle = LabelSet(
+        canonical: "Logic Pro",
+        variants: [],
+        rationale: "Measured on the live Korean progress dialog on 2026-09-02 as `Logic\\u{00A0}Pro`; whitespace is normalized only for this product-title rendering."
+    )
+
+    static func progressWindowTitleMatches(_ title: String) -> Bool {
+        let normalized = String(title.map { $0.isWhitespace ? " " : $0 })
+        return stemExportProgressWindowTitle.matches(normalized)
+    }
+
     static let editMenuBar = LabelSet(
         canonical: "Edit",
         variants: ["편집", "編集"],
@@ -1263,6 +1278,7 @@ enum AXLocalePolicy {
         oneFilePerTrackPopupValue,
         stemExportCommitButton,
         stemExportDismissButton,
+        stemExportProgressWindowTitle,
         editMenuBar,
         navigateMenuBar,
         trackMenuBar,

--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -212,6 +212,48 @@ enum AXLocalePolicy {
         rationale: "Reveals the New Project chooser, or creates the project directly where Logic skips it."
     )
 
+    /// #369: File > Export. Both forms were read from Logic's File menu; no other locale has been
+    /// measured for this submenu, so callers must refuse rather than translate or guess one.
+    static let exportMenuItem = LabelSet(
+        canonical: "Export",
+        variants: ["내보내기"],
+        rationale: "File submenu title measured in English and Korean; a locale without one of these labels is refused as an unmeasured stem-export menu label."
+    )
+
+    /// #369: File > Export > All Tracks as Audio Files… — the only measured leaf that reaches the
+    /// one-file-per-track export panel. Exact labels deliberately distinguish all three audio-file
+    /// entries that share the rest of their wording. English identifies the target with `All Tracks`,
+    /// rather than the selection-rewritten singular `1 Track as Audio File…` or a `Selected…` range
+    /// entry. Korean identifies it with `모든 트랙을`, rather than `1개의 트랙을` or `선택 범위를`.
+    /// The discriminator is therefore locale-specific: the English word `selected` is not assumed to
+    /// exist in Korean. Only these English and Korean forms are measured; other locales must refuse
+    /// as an unmeasured all-tracks-audio-file label instead of falling back to keyword matching.
+    static let allTracksAsAudioFilesMenuItem = LabelSet(
+        canonical: "All Tracks as Audio Files…",
+        variants: ["모든 트랙을 오디오 파일로…"],
+        rationale: "Measured all-tracks audio-file export leaf: EN uses `All Tracks` against singular/Selected entries; KO uses `모든 트랙을` against `1개의 트랙을` and `선택 범위를`."
+    )
+
+    /// #369: controls inside the per-track stem-export panel. The panel's own
+    /// window title is the OS Open-panel string, so it is not a usable signal.
+    static let oneFilePerTrackPopupValue = LabelSet(
+        canonical: "One File per Track",
+        variants: ["트랙당 하나의 파일"],
+        rationale: "Measured from the live stem-export panel on 2026-09-01; the panel window title is the OS Open-panel string and is therefore not a usable signal."
+    )
+
+    static let stemExportCommitButton = LabelSet(
+        canonical: "Export",
+        variants: ["내보내기"],
+        rationale: "Measured from the live stem-export panel on 2026-09-01; the panel window title is the OS Open-panel string and is therefore not a usable signal."
+    )
+
+    static let stemExportDismissButton = LabelSet(
+        canonical: "Cancel",
+        variants: ["취소"],
+        rationale: "Measured from the live stem-export panel on 2026-09-01; the panel window title is the OS Open-panel string and is therefore not a usable signal."
+    )
+
     static let editMenuBar = LabelSet(
         canonical: "Edit",
         variants: ["편집", "編集"],
@@ -1216,6 +1258,11 @@ enum AXLocalePolicy {
         eventPositionAsTimeMenuItem,
         fileMenuBar,
         newProjectMenuItem,
+        exportMenuItem,
+        allTracksAsAudioFilesMenuItem,
+        oneFilePerTrackPopupValue,
+        stemExportCommitButton,
+        stemExportDismissButton,
         editMenuBar,
         navigateMenuBar,
         trackMenuBar,

--- a/Sources/LogicProMCP/Projects/ProjectExportExecutorArtifactFlow.swift
+++ b/Sources/LogicProMCP/Projects/ProjectExportExecutorArtifactFlow.swift
@@ -307,14 +307,17 @@ extension ProjectExportExecutor {
                 reason: nil,
                 observations: nil
             )
-        case .uncertain(let reason):
+        case let .uncertain(reason, exportEffectObserved):
             return stemSubjectArtifacts(
                 artifact: artifact,
                 destination: destination,
                 subjects: subjects,
                 state: "B",
-                bounceFired: true,
-                writeAttempted: true,
+                // A status-success AXPress is not evidence that the export
+                // fired. These flags are true only when the driver observed the
+                // panel disappear or the progress dialog appear after the press.
+                bounceFired: exportEffectObserved,
+                writeAttempted: exportEffectObserved,
                 error: nil,
                 reason: reason,
                 observations: nil

--- a/Sources/LogicProMCP/Projects/ProjectExportExecutorArtifactFlow.swift
+++ b/Sources/LogicProMCP/Projects/ProjectExportExecutorArtifactFlow.swift
@@ -314,10 +314,12 @@ extension ProjectExportExecutor {
                 subjects: subjects,
                 state: "B",
                 // A status-success AXPress is not evidence that the export
-                // fired. These flags are true only when the driver observed the
-                // panel disappear or the progress dialog appear after the press.
+                // fired. `bounceFired` is true only when the driver observed
+                // the progress dialog after the press. `writeAttempted` records
+                // the distinct fact that the driver had reached the Export
+                // actuator before this post-press observation phase.
                 bounceFired: exportEffectObserved,
-                writeAttempted: exportEffectObserved,
+                writeAttempted: true,
                 error: nil,
                 reason: reason,
                 observations: nil

--- a/Sources/LogicProMCP/Projects/ProjectStemExportPanelDriver.swift
+++ b/Sources/LogicProMCP/Projects/ProjectStemExportPanelDriver.swift
@@ -63,8 +63,10 @@ enum ProjectStemExportPanelDriver {
         /// `write_attempted:false`.
         case refused(String)
         /// Completion could not be established after the Export route. The
-        /// Boolean is evidence-derived: it is true only when the panel
-        /// disappeared or the progress dialog appeared after the press.
+        /// Boolean is evidence-derived: it is true only when the progress
+        /// dialog appeared after the press. The panel going away can happen for
+        /// unrelated reasons, including a user Escape, so it is not export
+        /// evidence.
         case uncertain(String, exportEffectObserved: Bool)
     }
 
@@ -237,9 +239,11 @@ enum ProjectStemExportPanelDriver {
         for attempt in 0..<max(1, progressPollAttempts) {
             switch surface.exportPanelPresence() {
             case .absent:
-                // The panel's observed disappearance is evidence that the press
-                // landed, but not alone evidence that the export completed.
-                sawExportEffect = true
+                // The panel can disappear because the user dismissed it or a
+                // transient census missed it. The actuator was already reached
+                // by `pressExport()`, but disappearance alone is not evidence
+                // that an export started.
+                break
             case .unavailable:
                 panelReadFailed = true
             case .present, .partiallyMeasured, .unmeasured:
@@ -269,12 +273,6 @@ enum ProjectStemExportPanelDriver {
         if sawProgressWindow {
             return finish(.uncertain(
                 "stem_progress_window_did_not_disappear_within_budget",
-                exportEffectObserved: true
-            ))
-        }
-        if sawExportEffect {
-            return finish(.uncertain(
-                "stem_export_effect_observed_but_progress_window_not_observed",
                 exportEffectObserved: true
             ))
         }
@@ -571,9 +569,7 @@ final class AXSurface: ProjectStemExportPanelDriver.Surface, @unchecked Sendable
             return .absent
         case let .success(.elements(windows)):
             for window in windows {
-                switch AXHelpers.getAttributeResult(
-                    window, kAXTitleAttribute as String, runtime: runtime.ax
-                ) as Result<String?, AXHelpers.AXStatusError> {
+                switch readAttribute(window, kAXTitleAttribute as String) as Result<String?, PanelReadFailure> {
                 case .failure:
                     return .unavailable
                 case let .success(title):
@@ -653,13 +649,10 @@ final class AXSurface: ProjectStemExportPanelDriver.Surface, @unchecked Sendable
     }
 
     private func assessPanel(_ window: AXUIElement) -> Result<PanelAssessment?, PanelReadFailure> {
-        switch AXHelpers.getAttributeResult(
-            window, kAXSubroleAttribute as String, runtime: runtime.ax
-        ) as Result<String?, AXHelpers.AXStatusError> {
-        case let .failure(error):
-            guard Self.absentAttributeStatuses.contains(error.raw) else {
-                return .failure(.unavailable)
-            }
+        switch readAttribute(window, kAXSubroleAttribute as String) as Result<String?, PanelReadFailure> {
+        case .failure:
+            return .failure(.unavailable)
+        case .success(nil):
             // No subrole at all means this is not the dialog we are looking for.
             return .success(nil)
         case let .success(subrole):
@@ -675,20 +668,16 @@ final class AXSurface: ProjectStemExportPanelDriver.Surface, @unchecked Sendable
         }
 
         var buttons: [(element: AXUIElement, label: String)] = []
-        var popupHasPerTrackValue = false
         var popupCount = 0
         var titledPopupCount = 0
         for element in descendants {
-            let role: String?
-            switch AXHelpers.getAttributeResult(
-                element, kAXRoleAttribute as String, runtime: runtime.ax
-            ) as Result<String?, AXHelpers.AXStatusError> {
-            case let .failure(error):
-                guard Self.absentAttributeStatuses.contains(error.raw) else {
-                    return .failure(.unavailable)
-                }
-                role = nil
-            case let .success(value):
+            let role: String
+            switch readAttribute(element, kAXRoleAttribute as String) as Result<String?, PanelReadFailure> {
+            case .failure, .success(nil):
+                // A role is the mandatory census evidence. An element with no
+                // readable role cannot safely be omitted as irrelevant.
+                return .failure(.unavailable)
+            case let .success(.some(value)):
                 role = value
             }
             if role == (kAXButtonRole as String) {
@@ -703,19 +692,16 @@ final class AXSurface: ProjectStemExportPanelDriver.Surface, @unchecked Sendable
                 switch elementTextResult(element) {
                 case .failure:
                     return .failure(.unavailable)
-                case let .success(label):
-                    popupHasPerTrackValue = popupHasPerTrackValue
-                        || AXLocalePolicy.oneFilePerTrackPopupValue.matches(label)
+                case .success:
+                    break
                 }
-                switch AXHelpers.getAttributeResult(
-                    element, kAXTitleAttribute as String, runtime: runtime.ax
-                ) as Result<String?, AXHelpers.AXStatusError> {
-                case let .failure(error):
+                switch readAttribute(element, kAXTitleAttribute as String) as Result<String?, PanelReadFailure> {
+                case .failure:
+                    return .failure(.unavailable)
+                case .success(nil):
                     // An untitled popup is exactly what the five decoys are; the
                     // absence IS the discriminator, not a failure to observe it.
-                    guard Self.absentAttributeStatuses.contains(error.raw) else {
-                        return .failure(.unavailable)
-                    }
+                    break
                 case let .success(title):
                     if !(title ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                         titledPopupCount += 1
@@ -729,18 +715,22 @@ final class AXSurface: ProjectStemExportPanelDriver.Surface, @unchecked Sendable
         guard commits.count <= 1, dismisses.count <= 1 else {
             return .failure(.unavailable)
         }
+        // The live panel's six popup controls have one titled destination
+        // control and five untitled option controls, one of which is the
+        // per-track popup. This structural witness identifies the panel without
+        // conflating the current per-track value (state) with panel identity.
+        let hasStemPerTrackPopup = popupCount == 6 && titledPopupCount == 1
         switch (commits.first, dismisses.first) {
         case let (.some(commit), .some(dismiss)):
-            // The two button labels alone are a generic macOS dialog shape. A
-            // measured per-track value is the stem-specific witness for a fully
-            // recognised panel.
-            guard popupHasPerTrackValue else { return .success(nil) }
+            // The two button labels alone are a generic macOS dialog shape.
+            // Whether the per-track popup currently has the desired active
+            // value is checked later by `oneFilePerTrackIsActive()`.
+            guard hasStemPerTrackPopup else { return .success(nil) }
             return .success(.recognized(window, commit.element, dismiss.element))
         case (.some, nil):
-            // In a partially measured locale the per-track value itself can be
-            // unmeasured. A popup still distinguishes this panel shape from the
-            // bare two-button dialog that must never be cancelled.
-            guard popupCount > 0 else { return .success(nil) }
+            // Partial measurement relaxes only a button label. It retains the
+            // exact same stem-specific structural witness as full recognition.
+            guard hasStemPerTrackPopup else { return .success(nil) }
             return .success(.partiallyMeasured(
                 window,
                 recognized: AXLocalePolicy.stemExportCommitButton.canonical,
@@ -748,7 +738,7 @@ final class AXSurface: ProjectStemExportPanelDriver.Surface, @unchecked Sendable
                 dismiss: nil
             ))
         case let (nil, .some(dismiss)):
-            guard popupCount > 0 else { return .success(nil) }
+            guard hasStemPerTrackPopup else { return .success(nil) }
             return .success(.partiallyMeasured(
                 window,
                 recognized: AXLocalePolicy.stemExportDismissButton.canonical,
@@ -760,7 +750,7 @@ final class AXSurface: ProjectStemExportPanelDriver.Surface, @unchecked Sendable
             // The uniquely titled destination popup is the remaining measured
             // export-panel structure; report the modal as unmeasured so the
             // outcome honestly says it was left open.
-            guard titledPopupCount == 1 else { return .success(nil) }
+            guard hasStemPerTrackPopup else { return .success(nil) }
             return .success(.unmeasured(window))
         }
     }
@@ -786,8 +776,10 @@ final class AXSurface: ProjectStemExportPanelDriver.Surface, @unchecked Sendable
         AXError.attributeUnsupported.rawValue,
     ]
 
-    /// One read for the whole driver, so "the attribute is not there" can never be
-    /// mistaken for "the attribute could not be read" at ANY site.
+    /// The driver's single absent-aware ATTRIBUTE reader, so "the attribute is
+    /// not there" cannot be mistaken for "the attribute could not be read" at a
+    /// call site. Child traversal is separate because an absent children
+    /// attribute has its own structural meaning (a leaf).
     ///
     /// Three separate sites were fixed one at a time before this existed — the
     /// children walk, the button text, then the browser entries — each one
@@ -858,13 +850,10 @@ final class AXSurface: ProjectStemExportPanelDriver.Surface, @unchecked Sendable
             kAXTitleAttribute as String,
             kAXDescriptionAttribute as String,
         ] {
-            switch AXHelpers.getAttributeResult(
-                element, attribute, runtime: runtime.ax
-            ) as Result<String?, AXHelpers.AXStatusError> {
-            case let .failure(error):
-                guard Self.absentAttributeStatuses.contains(error.raw) else {
-                    return .failure(.unavailable)
-                }
+            switch readAttribute(element, attribute) as Result<String?, PanelReadFailure> {
+            case .failure:
+                return .failure(.unavailable)
+            case .success(nil):
                 continue
             case let .success(value):
                 if let value { return .success(value) }

--- a/Sources/LogicProMCP/Projects/ProjectStemExportPanelDriver.swift
+++ b/Sources/LogicProMCP/Projects/ProjectStemExportPanelDriver.swift
@@ -27,10 +27,22 @@ enum ProjectStemExportPanelDriver {
         case present
         case absent
         case unavailable
+        /// A dialog has the stem-specific per-track control and exactly one
+        /// measured button label. The associated values make the missing
+        /// measurement actionable and tell `finish()` whether Cancel is known.
+        case partiallyMeasured(recognized: String, notMeasured: String)
         /// An AXDialog appeared after AXPick, but its buttons use no measured
         /// stem-export labels. Its OS-localized Open-panel title is deliberately
         /// not used as a fallback signal.
         case unmeasured(String)
+    }
+
+    /// A progress observation keeps an unavailable AX read distinct from an
+    /// observed absence. A transient failure must never advance completion.
+    enum ProgressPresence: Sendable, Equatable {
+        case present
+        case absent
+        case unavailable
     }
 
     enum MenuAvailability: Sendable, Equatable {
@@ -50,9 +62,10 @@ enum ProjectStemExportPanelDriver {
         /// No Export click was made. The associated State C must expose
         /// `write_attempted:false`.
         case refused(String)
-        /// Export was pressed, but completion could not be established. The
-        /// caller must report State B rather than claim success.
-        case uncertain(String)
+        /// Completion could not be established after the Export route. The
+        /// Boolean is evidence-derived: it is true only when the panel
+        /// disappeared or the progress dialog appeared after the press.
+        case uncertain(String, exportEffectObserved: Bool)
     }
 
     protocol Surface: AnyObject, Sendable {
@@ -81,11 +94,13 @@ enum ProjectStemExportPanelDriver {
         /// Reads the current per-track popup value; it does not infer enablement
         /// from the control merely existing.
         func oneFilePerTrackIsActive() -> Bool
-        func pressExport() -> Bool
-        func progressWindowPresent() -> Bool
+        /// Attempts Export. Its AX status is intentionally not returned: the
+        /// driver judges the press only by the post-press observations below.
+        func pressExport()
+        func progressWindowPresence() -> ProgressPresence
         /// Attempts Cancel. The subsequent `exportPanelPresence()` readback,
         /// not this action's return, establishes whether the panel closed.
-        @discardableResult func closeExportPanel() -> Bool
+        func closeExportPanel()
     }
 
     static func drive(
@@ -93,12 +108,15 @@ enum ProjectStemExportPanelDriver {
         surface: Surface,
         progressPollAttempts: Int,
         sleep: @escaping @Sendable (UInt64) async -> Void,
-        pollIntervalNanos: UInt64
+        pollIntervalNanos: UInt64,
+        monotonicNowNanos: @escaping @Sendable () -> UInt64 = {
+            DispatchTime.now().uptimeNanoseconds
+        }
     ) async -> Outcome {
         // AC-6: every exit attempts Cancel and then observes the panel's
         // absence. A press action is not a close confirmation.
         func finish(_ outcome: Outcome) -> Outcome {
-            _ = surface.closeExportPanel()
+            surface.closeExportPanel()
             switch surface.exportPanelPresence() {
             case .absent:
                 return outcome
@@ -106,27 +124,39 @@ enum ProjectStemExportPanelDriver {
                 switch outcome {
                 case .refused:
                     return .refused("stem_export_panel_remained_open_after_close_attempt")
-                case .completed, .uncertain:
-                    return .uncertain("stem_export_panel_remained_open_after_close_attempt")
+                case .completed:
+                    return .uncertain("stem_export_panel_remained_open_after_close_attempt", exportEffectObserved: true)
+                case let .uncertain(_, exportEffectObserved):
+                    return .uncertain("stem_export_panel_remained_open_after_close_attempt", exportEffectObserved: exportEffectObserved)
                 }
             case .unavailable:
                 switch outcome {
                 case .refused:
                     return .refused("readback_unavailable: stem_export_panel_close_not_observed")
-                case .completed, .uncertain:
-                    return .uncertain("readback_unavailable: stem_export_panel_close_not_observed")
+                case .completed:
+                    return .uncertain("readback_unavailable: stem_export_panel_close_not_observed", exportEffectObserved: true)
+                case let .uncertain(_, exportEffectObserved):
+                    return .uncertain("readback_unavailable: stem_export_panel_close_not_observed", exportEffectObserved: exportEffectObserved)
                 }
-            case let .unmeasured(reason):
-                // The initial observation already refused with the precise
-                // missing-measurement reason. Do not replace it with a generic
-                // close-readback error merely because an unmeasured panel cannot
-                // be dismissed by a measured Cancel label. If one appears only
-                // after a write, it prevents a success claim instead.
+            case let .partiallyMeasured(recognized, notMeasured):
+                let leftOpen = "stem_export_panel_left_open_after_close_attempt: recognized=\(recognized); not_measured=\(notMeasured)"
                 switch outcome {
                 case .refused:
-                    return outcome
-                case .completed, .uncertain:
-                    return .uncertain(reason)
+                    return .refused(leftOpen)
+                case .completed:
+                    return .uncertain(leftOpen, exportEffectObserved: true)
+                case let .uncertain(_, exportEffectObserved):
+                    return .uncertain(leftOpen, exportEffectObserved: exportEffectObserved)
+                }
+            case let .unmeasured(reason):
+                let leftOpen = "stem_export_panel_left_open_unmeasured: \(reason)"
+                switch outcome {
+                case .refused:
+                    return .refused(leftOpen)
+                case .completed:
+                    return .uncertain(leftOpen, exportEffectObserved: true)
+                case let .uncertain(_, exportEffectObserved):
+                    return .uncertain(leftOpen, exportEffectObserved: exportEffectObserved)
                 }
             }
         }
@@ -149,25 +179,30 @@ enum ProjectStemExportPanelDriver {
             return finish(.refused(reason))
         }
         surface.pickStemLeaf()
-        var panelWaitNanos: UInt64 = 0
+        let panelWaitStarted = monotonicNowNanos()
         while true {
             switch surface.exportPanelPresence() {
             case .present:
                 break
             case .absent:
-                guard panelWaitNanos < exportPanelObservationDeadlineNanos,
+                let now = monotonicNowNanos()
+                let elapsed = now >= panelWaitStarted ? now - panelWaitStarted : UInt64.max
+                guard elapsed < exportPanelObservationDeadlineNanos,
                       pollIntervalNanos > 0 else {
                     return finish(.refused(
                         "stem_export_panel_not_observed_after_bounded_wait_elapsed"
                     ))
                 }
-                let remainingWaitNanos = exportPanelObservationDeadlineNanos - panelWaitNanos
+                let remainingWaitNanos = exportPanelObservationDeadlineNanos - elapsed
                 let nextWaitNanos = min(pollIntervalNanos, remainingWaitNanos)
                 await sleep(nextWaitNanos)
-                panelWaitNanos += nextWaitNanos
                 continue
             case .unavailable:
                 return finish(.refused("readback_unavailable: stem_export_panel_not_observed_after_axpick"))
+            case let .partiallyMeasured(recognized, notMeasured):
+                return finish(.refused(
+                    "stem_export_panel_partially_measured: recognized=\(recognized); not_measured=\(notMeasured)"
+                ))
             case let .unmeasured(reason):
                 return finish(.refused(reason))
             }
@@ -194,24 +229,59 @@ enum ProjectStemExportPanelDriver {
         guard surface.oneFilePerTrackIsActive() else {
             return finish(.refused("stem_one_file_per_track_not_active"))
         }
-        guard surface.pressExport() else {
-            return finish(.refused("stem_export_button_not_pressed"))
-        }
-
+        surface.pressExport()
         var sawProgressWindow = false
+        var sawExportEffect = false
+        var progressReadFailed = false
+        var panelReadFailed = false
         for attempt in 0..<max(1, progressPollAttempts) {
-            let progressVisible = surface.progressWindowPresent()
-            if sawProgressWindow && !progressVisible {
-                return finish(.completed)
+            switch surface.exportPanelPresence() {
+            case .absent:
+                // The panel's observed disappearance is evidence that the press
+                // landed, but not alone evidence that the export completed.
+                sawExportEffect = true
+            case .unavailable:
+                panelReadFailed = true
+            case .present, .partiallyMeasured, .unmeasured:
+                break
             }
-            sawProgressWindow = sawProgressWindow || progressVisible
+            switch surface.progressWindowPresence() {
+            case .present:
+                sawProgressWindow = true
+                sawExportEffect = true
+            case .absent:
+                if sawProgressWindow {
+                    return finish(.completed)
+                }
+            case .unavailable:
+                progressReadFailed = true
+            }
             if attempt + 1 < max(1, progressPollAttempts) {
                 await sleep(pollIntervalNanos)
             }
         }
-        return finish(sawProgressWindow
-            ? .uncertain("stem_progress_window_did_not_disappear_within_budget")
-            : .uncertain("readback_unavailable: stem_progress_window_not_observed"))
+        if progressReadFailed || panelReadFailed {
+            return finish(.uncertain(
+                "readback_unavailable: stem_export_effect_or_progress_not_observed_after_press",
+                exportEffectObserved: sawExportEffect
+            ))
+        }
+        if sawProgressWindow {
+            return finish(.uncertain(
+                "stem_progress_window_did_not_disappear_within_budget",
+                exportEffectObserved: true
+            ))
+        }
+        if sawExportEffect {
+            return finish(.uncertain(
+                "stem_export_effect_observed_but_progress_window_not_observed",
+                exportEffectObserved: true
+            ))
+        }
+        return finish(.uncertain(
+            "stem_export_press_effect_not_observed",
+            exportEffectObserved: false
+        ))
     }
 
     static func live(
@@ -247,6 +317,15 @@ enum ProjectStemExportPanelDriver {
 
 final class AXSurface: ProjectStemExportPanelDriver.Surface, @unchecked Sendable {
     private let runtime: AXLogicProElements.Runtime
+    private let directoryListing: @Sendable (String) -> DirectoryListing
+    private let navigationNowNanos: @Sendable () -> UInt64
+    private let navigationSleep: @Sendable (UInt64) -> Void
+
+    enum DirectoryListing: Sendable, Equatable {
+        case empty
+        case hasEntries
+        case unavailable
+    }
 
     // Live navigation took 60 ms (volume root), 206 ms and 402 ms to materialize
     // the next column. Poll for 5 s at 50 ms intervals — ~12x the slowest of those.
@@ -256,11 +335,31 @@ final class AXSurface: ProjectStemExportPanelDriver.Surface, @unchecked Sendable
     // run. Idle-machine samples set the floor for these budgets, never the ceiling,
     // and a column that is merely slow must not be reported as a column that never
     // came. The bound stays finite so a genuinely stuck panel still refuses.
-    private static let destinationNavigationDeadline: TimeInterval = 5.0
-    private static let destinationNavigationPollInterval: TimeInterval = 0.05
+    private static let destinationNavigationDeadlineNanos: UInt64 = 5_000_000_000
+    private static let destinationNavigationPollIntervalNanos: UInt64 = 50_000_000
 
-    init(runtime: AXLogicProElements.Runtime = .production) {
+    init(
+        runtime: AXLogicProElements.Runtime = .production,
+        directoryListing: @escaping @Sendable (String) -> DirectoryListing = { path in
+            do {
+                return try FileManager.default.contentsOfDirectory(atPath: path).isEmpty
+                    ? .empty
+                    : .hasEntries
+            } catch {
+                return .unavailable
+            }
+        },
+        navigationNowNanos: @escaping @Sendable () -> UInt64 = {
+            DispatchTime.now().uptimeNanoseconds
+        },
+        navigationSleep: @escaping @Sendable (UInt64) -> Void = { duration in
+            Thread.sleep(forTimeInterval: Double(duration) / 1_000_000_000)
+        }
+    ) {
         self.runtime = runtime
+        self.directoryListing = directoryListing
+        self.navigationNowNanos = navigationNowNanos
+        self.navigationSleep = navigationSleep
     }
 
     func openFileMenu() -> Bool {
@@ -275,7 +374,10 @@ final class AXSurface: ProjectStemExportPanelDriver.Surface, @unchecked Sendable
               ) else {
             return false
         }
-        return AXHelpers.performAction(item, kAXPressAction as String, runtime: runtime.ax)
+        // Status is not evidence that the menu materialised. `resolveStemLeaf`
+        // observes the enabled leaf only after both menu-opening attempts.
+        _ = AXHelpers.performAction(item, kAXPressAction as String, runtime: runtime.ax)
+        return true
     }
 
     func openExportMenu() -> ProjectStemExportPanelDriver.MenuAvailability {
@@ -288,9 +390,10 @@ final class AXSurface: ProjectStemExportPanelDriver.Surface, @unchecked Sendable
                 ? ProjectStemExportPanelDriver.exportMenuLabelNotMeasuredReason
                 : "stem_export_export_menu_unavailable")
         }
-        return AXHelpers.performAction(export, kAXPressAction as String, runtime: runtime.ax)
-            ? .available
-            : .unavailable("stem_export_export_menu_unavailable")
+        // The leaf observation below, rather than this status, proves that the
+        // submenu became readable.
+        _ = AXHelpers.performAction(export, kAXPressAction as String, runtime: runtime.ax)
+        return .available
     }
 
     func resolveStemLeaf() -> ProjectStemExportPanelDriver.MenuAvailability {
@@ -329,31 +432,46 @@ final class AXSurface: ProjectStemExportPanelDriver.Surface, @unchecked Sendable
     }
 
     func exportPanelPresence() -> ProjectStemExportPanelDriver.PanelPresence {
-        guard let app = AXLogicProElements.appRoot(runtime: runtime) else {
+        switch panelAssessments() {
+        case .failure:
             return .unavailable
-        }
-        guard let windows: [AXUIElement] = AXHelpers.getAttribute(
-            app, kAXWindowsAttribute as String, runtime: runtime.ax
-        ) else {
-            return .unavailable
-        }
-        let panels = exportPanels(in: windows)
-        let count = panels.count
-        switch count {
-        case 0:
-            return hasUnmeasuredStemExportPanel(in: windows)
-                ? .unmeasured(ProjectStemExportPanelDriver.panelLabelNotMeasuredReason)
-                : .absent
-        case 1: return .present
-        default: return .unavailable
+        case let .success(assessments):
+            guard assessments.count == 1, let assessment = assessments.first else {
+                return assessments.isEmpty ? .absent : .unavailable
+            }
+            switch assessment {
+            case .recognized:
+                return .present
+            case let .partiallyMeasured(_, recognized, notMeasured, _):
+                return .partiallyMeasured(recognized: recognized, notMeasured: notMeasured)
+            case .unmeasured:
+                return .unmeasured(ProjectStemExportPanelDriver.panelLabelNotMeasuredReason)
+            }
         }
     }
 
+    /// Identifies the destination popup structurally, never by ordinal.
+    ///
+    /// The live panel carries SIX popup buttons — destination, dither, file
+    /// format, bit depth, normalization, and end-silence trimming. Taking
+    /// `.first` was reading whichever one AX traversal happened to yield, and
+    /// measurement showed that order is not stable between reads. It is also the
+    /// ordinal-selection pattern this project forbids outright.
+    ///
+    /// Measured 2026-09-02: exactly one of the six exposes an AXTitle (`위치:`);
+    /// the other five report nil. That is a structural property of the panel, not
+    /// a linguistic one, so it identifies the control without needing the label
+    /// measured in every locale. More or fewer than one titled popup refuses
+    /// rather than picking.
     func destinationPopupValue() -> String? {
-        guard let panel = exportPanel(), let popup = popupButtons(in: panel).first else {
-            return nil
+        guard let panel = exportPanel() else { return nil }
+        let titled = popupButtons(in: panel).filter { popup in
+            let title: String? = AXHelpers.getTitle(popup, runtime: runtime.ax)
+            return !(title ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         }
-        return elementText(popup)
+        guard titled.count == 1, let popup = titled.first else { return nil }
+        // The VALUE is the folder; the TITLE was only the identity.
+        return AXHelpers.getValue(popup, runtime: runtime.ax) as? String
     }
 
     func selectDestinationBrowserElement(
@@ -369,9 +487,12 @@ final class AXSurface: ProjectStemExportPanelDriver.Surface, @unchecked Sendable
         let target = URL(fileURLWithPath: wanted)
 
         let startingDirectory: String
-        if let listedDirectory = deepestListedAncestor(of: wanted, in: panel) {
+        switch deepestListedAncestor(of: wanted, in: panel) {
+        case .failure:
+            return .refused("readback_unavailable: stem_destination_browser_entries_unreadable")
+        case let .success(.some(listedDirectory)):
             startingDirectory = listedDirectory
-        } else {
+        case .success(nil):
             guard let volume = volume(containing: target) else {
                 return .refused("stem_destination_volume_unresolvable")
             }
@@ -416,14 +537,15 @@ final class AXSurface: ProjectStemExportPanelDriver.Surface, @unchecked Sendable
         }
     }
 
-    func pressExport() -> Bool {
-        guard let panel = exportPanel(),
-              let export = buttons(in: panel).first(where: {
-                  AXLocalePolicy.stemExportCommitButton.matches(elementText($0))
-              }) else {
-            return false
+    func pressExport() {
+        guard case let .success(assessments) = panelAssessments(),
+              assessments.count == 1,
+              case let .recognized(_, export, _) = assessments[0] else {
+            return
         }
-        return AXHelpers.performAction(export, kAXPressAction as String, runtime: runtime.ax)
+        // A status-zero AXPress can be a no-op and a failed status can still
+        // coincide with a real press. `drive` observes panel/progress effects.
+        _ = AXHelpers.performAction(export, kAXPressAction as String, runtime: runtime.ax)
     }
 
     /// The export progress dialog's title only LOOKS like `"Logic Pro"`. Measured
@@ -436,68 +558,319 @@ final class AXSurface: ProjectStemExportPanelDriver.Surface, @unchecked Sendable
     /// `readback_unavailable: stem_progress_window_not_observed`, downgrading a
     /// real completion to State B.
     ///
-    /// `LogicProTarget.normalizedProcessName` already exists for exactly this —
-    /// it collapses every whitespace character to `U+0020`, so U+00A0 here and
-    /// U+202F elsewhere both match while `LogicPro` with the separator removed
-    /// still does not.
-    func progressWindowPresent() -> Bool {
-        guard let app = AXLogicProElements.appRoot(runtime: runtime) else { return false }
-        let windows: [AXUIElement] = AXHelpers.getAttribute(
+    /// The comparison is owned by `AXLocalePolicy`, so this localized AX title
+    /// follows the same policy route as every other measured UI label.
+    func progressWindowPresence() -> ProjectStemExportPanelDriver.ProgressPresence {
+        guard let app = AXLogicProElements.appRoot(runtime: runtime) else { return .unavailable }
+        switch AXHelpers.getAXUIElementArrayRead(
             app, kAXWindowsAttribute as String, runtime: runtime.ax
-        ) ?? []
-        let wanted = LogicProTarget.normalizedProcessName("Logic Pro")
-        return windows.contains {
-            let title = (AXHelpers.getTitle($0, runtime: runtime.ax) ?? "")
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            return LogicProTarget.normalizedProcessName(title) == wanted
+        ) {
+        case .failure, .success(.malformed):
+            return .unavailable
+        case .success(.absent):
+            return .absent
+        case let .success(.elements(windows)):
+            for window in windows {
+                switch AXHelpers.getAttributeResult(
+                    window, kAXTitleAttribute as String, runtime: runtime.ax
+                ) as Result<String?, AXHelpers.AXStatusError> {
+                case .failure:
+                    return .unavailable
+                case let .success(title):
+                    if let title, AXLocalePolicy.progressWindowTitleMatches(title) {
+                        return .present
+                    }
+                }
+            }
+            return .absent
         }
     }
 
-    func closeExportPanel() -> Bool {
-        guard let panel = exportPanel(),
-              let cancel = buttons(in: panel).first(where: {
-                  AXLocalePolicy.stemExportDismissButton.matches(elementText($0))
-              }) else {
-            return false
+    func closeExportPanel() {
+        guard case let .success(assessments) = panelAssessments(), assessments.count == 1 else {
+            return
         }
-        return AXHelpers.performAction(cancel, kAXPressAction as String, runtime: runtime.ax)
+        let cancel: AXUIElement?
+        switch assessments[0] {
+        case let .recognized(_, _, dismiss):
+            cancel = dismiss
+        case let .partiallyMeasured(_, recognized, _, dismiss):
+            cancel = recognized == AXLocalePolicy.stemExportDismissButton.canonical ? dismiss : nil
+        case .unmeasured:
+            cancel = nil
+        }
+        guard let cancel else { return }
+        // The following panel observation, not this action status, confirms close.
+        _ = AXHelpers.performAction(cancel, kAXPressAction as String, runtime: runtime.ax)
     }
 
     private func exportPanel() -> AXUIElement? {
-        guard let app = AXLogicProElements.appRoot(runtime: runtime) else { return nil }
-        let windows: [AXUIElement] = AXHelpers.getAttribute(
-            app, kAXWindowsAttribute as String, runtime: runtime.ax
-        ) ?? []
-        let panels = exportPanels(in: windows)
-        return panels.count == 1 ? panels[0] : nil
+        guard case let .success(assessments) = panelAssessments(),
+              assessments.count == 1,
+              case let .recognized(panel, _, _) = assessments[0] else {
+            return nil
+        }
+        return panel
     }
 
-    private func exportPanels(in windows: [AXUIElement]) -> [AXUIElement] {
-        windows.filter { window in
-            let buttonTexts = buttons(in: window).compactMap(elementText)
-            return buttonTexts.contains { AXLocalePolicy.stemExportCommitButton.matches($0) }
-                && buttonTexts.contains { AXLocalePolicy.stemExportDismissButton.matches($0) }
+    private enum PanelAssessment {
+        case recognized(AXUIElement, AXUIElement, AXUIElement)
+        case partiallyMeasured(AXUIElement, recognized: String, notMeasured: String, dismiss: AXUIElement?)
+        case unmeasured(AXUIElement)
+    }
+
+    private enum PanelReadFailure: Error {
+        case unavailable
+    }
+
+    /// Surveys dialogs without flattening a failed child or label read into an
+    /// empty descendant list. The panel signature requires all three facts:
+    /// AXDialog, the per-track popup, and the measured buttons. This avoids
+    /// cancelling a user's unrelated two-button export dialog.
+    private func panelAssessments() -> Result<[PanelAssessment], PanelReadFailure> {
+        guard let app = AXLogicProElements.appRoot(runtime: runtime) else {
+            return .failure(.unavailable)
+        }
+        switch AXHelpers.getAXUIElementArrayRead(
+            app, kAXWindowsAttribute as String, runtime: runtime.ax
+        ) {
+        case .failure, .success(.malformed):
+            return .failure(.unavailable)
+        case .success(.absent):
+            return .success([])
+        case let .success(.elements(windows)):
+            var assessments: [PanelAssessment] = []
+            for window in windows {
+                switch assessPanel(window) {
+                case .failure:
+                    return .failure(.unavailable)
+                case let .success(assessment):
+                    if let assessment { assessments.append(assessment) }
+                }
+            }
+            return .success(assessments)
         }
     }
 
-    /// A post-AXPick AXDialog with buttons that match neither measured panel
-    /// label set may be the export panel in an unmeasured locale. Its title is
-    /// macOS's localized Open string, so it cannot safely refine this result.
-    /// A dialog that matches only one known button remains merely a decoy, not
-    /// a panel and not a locale measurement claim.
-    private func hasUnmeasuredStemExportPanel(in windows: [AXUIElement]) -> Bool {
-        windows.contains { window in
-            let subrole: String? = AXHelpers.getAttribute(
-                window, kAXSubroleAttribute as String, runtime: runtime.ax
-            )
-            guard subrole == (kAXDialogSubrole as String) else { return false }
-            let buttonTexts = buttons(in: window).compactMap(elementText)
-            guard !buttonTexts.isEmpty else { return false }
-            return buttonTexts.allSatisfy {
-                !AXLocalePolicy.stemExportCommitButton.matches($0)
-                    && !AXLocalePolicy.stemExportDismissButton.matches($0)
+    private func assessPanel(_ window: AXUIElement) -> Result<PanelAssessment?, PanelReadFailure> {
+        switch AXHelpers.getAttributeResult(
+            window, kAXSubroleAttribute as String, runtime: runtime.ax
+        ) as Result<String?, AXHelpers.AXStatusError> {
+        case let .failure(error):
+            guard Self.absentAttributeStatuses.contains(error.raw) else {
+                return .failure(.unavailable)
+            }
+            // No subrole at all means this is not the dialog we are looking for.
+            return .success(nil)
+        case let .success(subrole):
+            guard subrole == (kAXDialogSubrole as String) else { return .success(nil) }
+        }
+
+        let descendants: [AXUIElement]
+        switch descendantsResult(of: window, maxDepth: 12) {
+        case .failure:
+            return .failure(.unavailable)
+        case let .success(elements):
+            descendants = elements
+        }
+
+        var buttons: [(element: AXUIElement, label: String)] = []
+        var popupHasPerTrackValue = false
+        var popupCount = 0
+        var titledPopupCount = 0
+        for element in descendants {
+            let role: String?
+            switch AXHelpers.getAttributeResult(
+                element, kAXRoleAttribute as String, runtime: runtime.ax
+            ) as Result<String?, AXHelpers.AXStatusError> {
+            case let .failure(error):
+                guard Self.absentAttributeStatuses.contains(error.raw) else {
+                    return .failure(.unavailable)
+                }
+                role = nil
+            case let .success(value):
+                role = value
+            }
+            if role == (kAXButtonRole as String) {
+                switch elementTextResult(element) {
+                case .failure:
+                    return .failure(.unavailable)
+                case let .success(label):
+                    if let label { buttons.append((element, label)) }
+                }
+            } else if role == (kAXPopUpButtonRole as String) {
+                popupCount += 1
+                switch elementTextResult(element) {
+                case .failure:
+                    return .failure(.unavailable)
+                case let .success(label):
+                    popupHasPerTrackValue = popupHasPerTrackValue
+                        || AXLocalePolicy.oneFilePerTrackPopupValue.matches(label)
+                }
+                switch AXHelpers.getAttributeResult(
+                    element, kAXTitleAttribute as String, runtime: runtime.ax
+                ) as Result<String?, AXHelpers.AXStatusError> {
+                case let .failure(error):
+                    // An untitled popup is exactly what the five decoys are; the
+                    // absence IS the discriminator, not a failure to observe it.
+                    guard Self.absentAttributeStatuses.contains(error.raw) else {
+                        return .failure(.unavailable)
+                    }
+                case let .success(title):
+                    if !(title ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        titledPopupCount += 1
+                    }
+                }
             }
         }
+
+        let commits = buttons.filter { AXLocalePolicy.stemExportCommitButton.matches($0.label) }
+        let dismisses = buttons.filter { AXLocalePolicy.stemExportDismissButton.matches($0.label) }
+        guard commits.count <= 1, dismisses.count <= 1 else {
+            return .failure(.unavailable)
+        }
+        switch (commits.first, dismisses.first) {
+        case let (.some(commit), .some(dismiss)):
+            // The two button labels alone are a generic macOS dialog shape. A
+            // measured per-track value is the stem-specific witness for a fully
+            // recognised panel.
+            guard popupHasPerTrackValue else { return .success(nil) }
+            return .success(.recognized(window, commit.element, dismiss.element))
+        case (.some, nil):
+            // In a partially measured locale the per-track value itself can be
+            // unmeasured. A popup still distinguishes this panel shape from the
+            // bare two-button dialog that must never be cancelled.
+            guard popupCount > 0 else { return .success(nil) }
+            return .success(.partiallyMeasured(
+                window,
+                recognized: AXLocalePolicy.stemExportCommitButton.canonical,
+                notMeasured: AXLocalePolicy.stemExportDismissButton.canonical,
+                dismiss: nil
+            ))
+        case let (nil, .some(dismiss)):
+            guard popupCount > 0 else { return .success(nil) }
+            return .success(.partiallyMeasured(
+                window,
+                recognized: AXLocalePolicy.stemExportDismissButton.canonical,
+                notMeasured: AXLocalePolicy.stemExportCommitButton.canonical,
+                dismiss: dismiss.element
+            ))
+        case (nil, nil):
+            // With no measured label there is no safe commit or cancel action.
+            // The uniquely titled destination popup is the remaining measured
+            // export-panel structure; report the modal as unmeasured so the
+            // outcome honestly says it was left open.
+            guard titledPopupCount == 1 else { return .success(nil) }
+            return .success(.unmeasured(window))
+        }
+    }
+
+    /// AX statuses that mean "this element does not expose that attribute", as
+    /// distinct from "the attribute could not be read".
+    ///
+    /// The production runtime's status-preserving seam turns EVERY non-success
+    /// status into an error, so a button that simply has no `AXValue` — which is
+    /// most of them — arrives here looking exactly like a failed read. Measured on
+    /// the live export panel: 348 elements walked, 0 genuine failures, 60 leaves
+    /// answering kAXErrorNoValue for `AXChildren`, and the very first titled
+    /// button answering it for `AXValue`. Treating those as failures made the
+    /// panel permanently unassessable: every exit reported
+    /// `stem_export_panel_close_not_observed` while the modal stayed open on
+    /// screen.
+    ///
+    /// Narrowed here rather than in AXHelpers on purpose: other callers depend on
+    /// the shared projection's current meaning, and widening a shared definition
+    /// to clear one blocker is how the next one gets made.
+    private static let absentAttributeStatuses: Set<Int32> = [
+        AXError.noValue.rawValue,
+        AXError.attributeUnsupported.rawValue,
+    ]
+
+    /// One read for the whole driver, so "the attribute is not there" can never be
+    /// mistaken for "the attribute could not be read" at ANY site.
+    ///
+    /// Three separate sites were fixed one at a time before this existed — the
+    /// children walk, the button text, then the browser entries — each one
+    /// surfacing only after the previous fix let the live run get one stage
+    /// further. The property, not the instance, is that the production runtime's
+    /// status-preserving seam reports an absent attribute as an error.
+    private func readAttribute<T>(
+        _ element: AXUIElement,
+        _ attribute: String
+    ) -> Result<T?, PanelReadFailure> {
+        switch AXHelpers.getAttributeResult(
+            element, attribute, runtime: runtime.ax
+        ) as Result<T?, AXHelpers.AXStatusError> {
+        case let .failure(error):
+            guard Self.absentAttributeStatuses.contains(error.raw) else {
+                return .failure(.unavailable)
+            }
+            return .success(nil)
+        case let .success(value):
+            return .success(value)
+        }
+    }
+
+    private func descendantsResult(
+        of root: AXUIElement,
+        maxDepth: Int
+    ) -> Result<[AXUIElement], PanelReadFailure> {
+        guard maxDepth > 0 else { return .success([]) }
+        switch AXHelpers.childrenResult(root, runtime: runtime.ax) {
+        case let .failure(error):
+            // "This element has no children" is an ANSWER, not a failed read.
+            // A leaf — AXStaticText, AXImage — reports kAXErrorNoValue (-25212)
+            // or kAXErrorAttributeUnsupported (-25205) for kAXChildren, and
+            // AXHelpers.projectChildrenStatus turns every non-success status into
+            // an error. Treating those two as read failures made the very first
+            // leaf poison the whole subtree: measured on the live export panel,
+            // 348 elements visited, 0 genuine failures, and 60 of these — so the
+            // panel could never be assessed and every exit reported
+            // `stem_export_panel_close_not_observed` while the modal stayed open.
+            //
+            // Narrowed here rather than in AXHelpers on purpose: other callers
+            // depend on the shared projection's current meaning, and widening a
+            // shared definition to clear one blocker is how the next one gets made.
+            guard Self.absentAttributeStatuses.contains(error.raw) else {
+                return .failure(.unavailable)
+            }
+            return .success([])
+        case let .success(children):
+            var descendants: [AXUIElement] = []
+            for child in children {
+                descendants.append(child)
+                switch descendantsResult(of: child, maxDepth: maxDepth - 1) {
+                case .failure:
+                    return .failure(.unavailable)
+                case let .success(nested):
+                    descendants.append(contentsOf: nested)
+                }
+            }
+            return .success(descendants)
+        }
+    }
+
+    private func elementTextResult(
+        _ element: AXUIElement
+    ) -> Result<String?, PanelReadFailure> {
+        for attribute in [
+            kAXValueAttribute as String,
+            kAXTitleAttribute as String,
+            kAXDescriptionAttribute as String,
+        ] {
+            switch AXHelpers.getAttributeResult(
+                element, attribute, runtime: runtime.ax
+            ) as Result<String?, AXHelpers.AXStatusError> {
+            case let .failure(error):
+                guard Self.absentAttributeStatuses.contains(error.raw) else {
+                    return .failure(.unavailable)
+                }
+                continue
+            case let .success(value):
+                if let value { return .success(value) }
+            }
+        }
+        return .success(nil)
     }
 
     private func menuItem(
@@ -589,9 +962,9 @@ final class AXSurface: ProjectStemExportPanelDriver.Surface, @unchecked Sendable
             )
         }
 
-        // The sidebar is an AXOutline, not an AXList, so there is no
-        // AXSelectedChildren to read back here; the volume hop is confirmed by the
-        // browser listing "/" contents.
+        // The sidebar's display name only chooses a candidate. It is confirmed
+        // only when the browser exposes entries whose parent is the requested
+        // volume root path.
         // A zero AX status only says the write was accepted. It does not say
         // Finder's browser changed, so its Boolean return is intentionally not
         // used as a success signal.
@@ -601,10 +974,26 @@ final class AXSurface: ProjectStemExportPanelDriver.Surface, @unchecked Sendable
             [row] as CFArray,
             runtime: runtime.ax
         )
-        guard waitsForSidebarSelection(of: row, in: outline) else {
-            return .refused("stem_destination_volume_root_not_confirmed:\(volumeName)")
+        switch waitsForSidebarSelection(of: row, in: outline) {
+        case .confirmed:
+            break
+        case .unavailable:
+            return .refused(
+                "readback_unavailable: stem_destination_volume_root_not_confirmed:\(volumeName):\(root)"
+            )
+        case .notConfirmed:
+            return .refused("stem_destination_volume_root_not_confirmed:\(volumeName):\(root)")
         }
-        return .selected
+        switch waitsForDirectoryListing(of: root, in: panel) {
+        case .confirmed:
+            return .selected
+        case .unavailable:
+            return .refused(
+                "readback_unavailable: stem_destination_volume_path_not_confirmed:\(volumeName):\(root)"
+            )
+        case .notConfirmed:
+            return .refused("stem_destination_volume_path_not_confirmed:\(volumeName):\(root)")
+        }
     }
 
     private func selectListedComponent(
@@ -612,8 +1001,12 @@ final class AXSurface: ProjectStemExportPanelDriver.Surface, @unchecked Sendable
         named component: String,
         in panel: AXUIElement
     ) -> ProjectStemExportPanelDriver.DestinationSelection {
-        let entries = browserPathFields(in: panel).filter {
-            urlPath(of: $0) == path
+        let entries: [AXUIElement]
+        switch browserPathFields(in: panel) {
+        case .failure:
+            return .refused("readback_unavailable: stem_destination_browser_entries_unreadable")
+        case let .success(fields):
+            entries = fields.filter { $0.path == path }.map(\.element)
         }
         guard entries.count == 1, let entry = entries.first else {
             let failure = entries.isEmpty ? "not_listed" : "ambiguous"
@@ -634,7 +1027,21 @@ final class AXSurface: ProjectStemExportPanelDriver.Surface, @unchecked Sendable
             [group] as CFArray,
             runtime: runtime.ax
         )
-        guard waitsForSelection(of: path, in: list, panel: panel) else {
+        let listingExpectation = directoryListing(path)
+        guard listingExpectation != .unavailable else {
+            return .refused("readback_unavailable: stem_destination_component_directory_unreadable:\(component)")
+        }
+        switch waitsForSelection(
+            of: path,
+            in: list,
+            panel: panel,
+            requireObservedNavigation: listingExpectation == .hasEntries
+        ) {
+        case .confirmed:
+            break
+        case .unavailable:
+            return .refused("readback_unavailable: stem_destination_component_not_confirmed:\(component)")
+        case .notConfirmed:
             return .refused("stem_destination_component_not_confirmed:\(component)")
         }
         return .selected
@@ -660,72 +1067,165 @@ final class AXSurface: ProjectStemExportPanelDriver.Surface, @unchecked Sendable
     /// signal 2 was also silent because the target folder was empty. Signal 1
     /// answers both cases: measured the same day, the list read back
     /// `AXSelectedChildren = [/Users/isaac/Music/logic-pro-mcp-stem-test]`.
+    ///
+    /// For a non-empty directory, both signals are required. A genuinely empty
+    /// destination has no listable child entry to witness navigation; its
+    /// selection readback remains the only confirmation. A panel that echoes a
+    /// selection without navigating cannot be distinguished for an empty
+    /// destination. Safety then rests downstream: if the export lands elsewhere,
+    /// this destination contains no new audio and the executor refuses with
+    /// `stem_audio_files_not_observed_after_progress_completion`, so this is an
+    /// unintended write, never a false success.
+    private enum NavigationConfirmation {
+        case confirmed
+        case notConfirmed
+        case unavailable
+    }
+
     private func waitsForSelection(
         of path: String,
         in list: AXUIElement?,
-        panel: AXUIElement
-    ) -> Bool {
-        guard let list else { return false }
-        let deadline = Date().addingTimeInterval(Self.destinationNavigationDeadline)
-        repeat {
-            if selectionReadsBack(path, in: list) {
-                return true
+        panel: AXUIElement,
+        requireObservedNavigation: Bool
+    ) -> NavigationConfirmation {
+        guard let list else { return .notConfirmed }
+        let started = navigationNowNanos()
+        var sawReadFailure = false
+        while true {
+            switch selectionReadsBack(path, in: list) {
+            case .failure:
+                sawReadFailure = true
+            case let .success(selectionMatches):
+                if selectionMatches {
+                    guard requireObservedNavigation else { return .confirmed }
+                    switch listsChildren(of: path, in: panel) {
+                    case .failure:
+                        sawReadFailure = true
+                    case .success(true):
+                        return .confirmed
+                    case .success(false):
+                        break
+                    }
+                }
             }
-            Thread.sleep(forTimeInterval: Self.destinationNavigationPollInterval)
-        } while Date() < deadline
-        return false
+            let now = navigationNowNanos()
+            let elapsed = now >= started ? now - started : UInt64.max
+            guard elapsed < Self.destinationNavigationDeadlineNanos else {
+                return sawReadFailure ? .unavailable : .notConfirmed
+            }
+            let remaining = Self.destinationNavigationDeadlineNanos - elapsed
+            navigationSleep(min(Self.destinationNavigationPollIntervalNanos, remaining))
+        }
     }
 
     /// The sidebar hop's equivalent: read the outline's selection back and check
     /// the row we wrote is the row it now reports. Measured 2026-09-02 —
     /// `AXSelectedRows` reads back one row labelled `Macintosh HD` after the write.
-    private func waitsForSidebarSelection(of row: AXUIElement, in outline: AXUIElement) -> Bool {
-        let deadline = Date().addingTimeInterval(Self.destinationNavigationDeadline)
-        repeat {
-            let selected: [AXUIElement] = AXHelpers.getAttribute(
+    private func waitsForSidebarSelection(
+        of row: AXUIElement,
+        in outline: AXUIElement
+    ) -> NavigationConfirmation {
+        let started = navigationNowNanos()
+        var sawReadFailure = false
+        while true {
+            switch AXHelpers.getAXUIElementArrayRead(
                 outline, kAXSelectedRowsAttribute as String, runtime: runtime.ax
-            ) ?? []
-            if selected.contains(where: { CFEqual($0, row) }) {
-                return true
+            ) {
+            case .failure, .success(.malformed):
+                sawReadFailure = true
+            case .success(.absent):
+                break
+            case let .success(.elements(selected)):
+                if selected.contains(where: { CFEqual($0, row) }) {
+                    return .confirmed
+                }
             }
-            Thread.sleep(forTimeInterval: Self.destinationNavigationPollInterval)
-        } while Date() < deadline
-        return false
+            let now = navigationNowNanos()
+            let elapsed = now >= started ? now - started : UInt64.max
+            guard elapsed < Self.destinationNavigationDeadlineNanos else {
+                return sawReadFailure ? .unavailable : .notConfirmed
+            }
+            let remaining = Self.destinationNavigationDeadlineNanos - elapsed
+            navigationSleep(min(Self.destinationNavigationPollIntervalNanos, remaining))
+        }
+    }
+
+    private func waitsForDirectoryListing(
+        of directory: String,
+        in panel: AXUIElement
+    ) -> NavigationConfirmation {
+        let started = navigationNowNanos()
+        var sawReadFailure = false
+        while true {
+            switch listsChildren(of: directory, in: panel) {
+            case .failure:
+                sawReadFailure = true
+            case .success(true):
+                return .confirmed
+            case .success(false):
+                break
+            }
+            let now = navigationNowNanos()
+            let elapsed = now >= started ? now - started : UInt64.max
+            guard elapsed < Self.destinationNavigationDeadlineNanos else {
+                return sawReadFailure ? .unavailable : .notConfirmed
+            }
+            let remaining = Self.destinationNavigationDeadlineNanos - elapsed
+            navigationSleep(min(Self.destinationNavigationPollIntervalNanos, remaining))
+        }
     }
 
     /// Reads the list's selection back and compares AXURLs. A zero status from
     /// the write says only that the write was accepted.
-    private func selectionReadsBack(_ path: String, in list: AXUIElement) -> Bool {
-        let selected: [AXUIElement] = AXHelpers.getAttribute(
+    private func selectionReadsBack(
+        _ path: String,
+        in list: AXUIElement
+    ) -> Result<Bool, PanelReadFailure> {
+        let selected: [AXUIElement]
+        switch AXHelpers.getAXUIElementArrayRead(
             list, kAXSelectedChildrenAttribute as String, runtime: runtime.ax
-        ) ?? []
-        return selected.contains { group in
-            AXHelpers.censusDescendant(
-                of: group, role: kAXTextFieldRole as String, maxDepth: 4, runtime: runtime.ax
-            ).matches.contains { urlPath(of: $0) == path }
+        ) {
+        case .failure, .success(.malformed):
+            return .failure(.unavailable)
+        case .success(.absent):
+            return .success(false)
+        case let .success(.elements(elements)):
+            selected = elements
+        }
+        for group in selected {
+            switch browserPathFields(in: group, maxDepth: 4) {
+            case .failure:
+                return .failure(.unavailable)
+            case let .success(fields):
+                if fields.contains(where: { $0.path == path }) { return .success(true) }
+            }
+        }
+        return .success(false)
+    }
+
+    private func listsChildren(
+        of directory: String,
+        in panel: AXUIElement
+    ) -> Result<Bool, PanelReadFailure> {
+        browserPathFields(in: panel).map { fields in
+            fields.contains {
+                URL(fileURLWithPath: $0.path).deletingLastPathComponent().path == directory
+            }
         }
     }
 
-    private func listsChildren(of directory: String, in panel: AXUIElement) -> Bool {
-        browserPathFields(in: panel).contains { field in
-            guard let path = urlPath(of: field) else { return false }
-            return URL(fileURLWithPath: path).deletingLastPathComponent().path == directory
+    private func deepestListedAncestor(
+        of path: String,
+        in panel: AXUIElement
+    ) -> Result<String?, PanelReadFailure> {
+        browserPathFields(in: panel).map { fields in
+            let directories = Set(fields.map {
+                URL(fileURLWithPath: $0.path).deletingLastPathComponent().path
+            })
+            return directories
+                .filter { isDirectory($0, anAncestorOf: path) }
+                .max { $0.count < $1.count }
         }
-    }
-
-    private func deepestListedAncestor(of path: String, in panel: AXUIElement) -> String? {
-        let directories = Set(browserPathFields(in: panel).compactMap { field in
-            urlPath(of: field).map { URL(fileURLWithPath: $0).deletingLastPathComponent().path }
-        })
-        return directories
-            .filter { isDirectory($0, anAncestorOf: path) }
-            .max { $0.count < $1.count }
-    }
-
-    private func browserPathFields(in panel: AXUIElement) -> [AXUIElement] {
-        AXHelpers.censusDescendant(
-            of: panel, role: kAXTextFieldRole as String, maxDepth: 16, runtime: runtime.ax
-        ).matches.filter { urlPath(of: $0) != nil }
     }
 
     /// AXURL is a CFURL, never a CFString. Measured on the live export panel on
@@ -734,11 +1234,44 @@ final class AXSurface: ProjectStemExportPanelDriver.Surface, @unchecked Sendable
     /// the whole browser census silently — the destination stage then believed no
     /// ancestor was listed and refused on every machine. A String read here is not
     /// a stricter check; it is a guaranteed-empty one.
-    private func urlPath(of field: AXUIElement) -> String? {
-        let url: NSURL? = AXHelpers.getAttribute(
-            field, kAXURLAttribute as String, runtime: runtime.ax
-        )
-        return url?.path.flatMap(normalizedFilePath)
+    private func browserPathFields(
+        in root: AXUIElement,
+        maxDepth: Int = 16
+    ) -> Result<[(element: AXUIElement, path: String)], PanelReadFailure> {
+        switch descendantsResult(of: root, maxDepth: maxDepth) {
+        case .failure:
+            return .failure(.unavailable)
+        case let .success(descendants):
+            var fields: [(element: AXUIElement, path: String)] = []
+            for element in descendants {
+                switch readAttribute(element, kAXRoleAttribute as String) as Result<String?, PanelReadFailure> {
+        case .failure:
+            return .failure(.unavailable)
+                case let .success(role):
+                    guard role == (kAXTextFieldRole as String) else { continue }
+                }
+                switch urlPath(of: element) {
+                case .failure:
+                    return .failure(.unavailable)
+                case let .success(.some(path)):
+                    fields.append((element, path))
+                case .success(nil):
+                    break
+                }
+            }
+            return .success(fields)
+        }
+    }
+
+    private func urlPath(
+        of field: AXUIElement
+    ) -> Result<String?, PanelReadFailure> {
+        switch readAttribute(field, kAXURLAttribute as String) as Result<NSURL?, PanelReadFailure> {
+        case .failure:
+            return .failure(.unavailable)
+        case let .success(url):
+            return .success(url?.path.flatMap(normalizedFilePath))
+        }
     }
 
     private func ancestor(

--- a/Sources/LogicProMCP/Projects/ProjectStemExportPanelDriver.swift
+++ b/Sources/LogicProMCP/Projects/ProjectStemExportPanelDriver.swift
@@ -7,10 +7,40 @@ import Foundation
 /// that make each transition safe instead of testing a collection of calls.
 enum ProjectStemExportPanelDriver {
     static let stemLeafPickAction = kAXPickAction as String
+    static let exportMenuLabelNotMeasuredReason =
+        "stem_export_export_menu_label_not_measured_for_current_locale"
+    static let stemLeafLabelNotMeasuredReason =
+        "stem_export_all_tracks_audio_file_label_not_measured_for_current_locale"
+    static let panelLabelNotMeasuredReason =
+        "stem_export_panel_label_not_measured_for_current_locale"
+    // Live Logic observation on 2026-09-01, 8 samples: the panel appeared
+    // 1005-1108 ms after AXPick on an idle machine. The deadline is 10,000 ms —
+    // ~9x the observed maximum — because the samples describe the cheap case and
+    // this wait exists for the expensive one: a machine under export load, where
+    // a panel that is merely slow would otherwise be reported as a panel that
+    // never appeared. Waiting longer costs nothing when the panel arrives in ~1 s;
+    // a thin budget converts load into a false refusal. The bound stays finite so
+    // a genuinely absent panel still refuses rather than hanging.
+    static let exportPanelObservationDeadlineNanos: UInt64 = 10_000_000_000
+
     enum PanelPresence: Sendable, Equatable {
         case present
         case absent
         case unavailable
+        /// An AXDialog appeared after AXPick, but its buttons use no measured
+        /// stem-export labels. Its OS-localized Open-panel title is deliberately
+        /// not used as a fallback signal.
+        case unmeasured(String)
+    }
+
+    enum MenuAvailability: Sendable, Equatable {
+        case available
+        case unavailable(String)
+    }
+
+    enum DestinationSelection: Sendable, Equatable {
+        case selected
+        case refused(String)
     }
 
     enum Outcome: Sendable, Equatable {
@@ -29,9 +59,13 @@ enum ProjectStemExportPanelDriver {
         /// Must materialize the File menu before `resolveStemLeaf` reads
         /// enabled state. Logic reports false enablement on closed menus.
         func openFileMenu() -> Bool
-        func openExportMenu() -> Bool
+        /// Carries an exact failure reason because a locale without a measured
+        /// Export label must refuse rather than fall back to a guessed title.
+        func openExportMenu() -> MenuAvailability
         /// Resolve the enabled leaf only after both parent menus are open.
-        func resolveStemLeaf() -> Bool
+        /// Carries an exact failure reason because only measured all-tracks
+        /// leaf labels are safe to pick.
+        func resolveStemLeaf() -> MenuAvailability
         /// Popup menu leaves require AXPick; AXPress is a measured silent no-op.
         func pickStemLeaf()
         /// Distinguishes an observed absence from a failed AX readback. A
@@ -40,7 +74,10 @@ enum ProjectStemExportPanelDriver {
         func destinationPopupValue() -> String?
         /// Selects a folder element in the export panel's browser. It must
         /// never type a path, because typing dismisses this panel in Logic.
-        func selectDestinationBrowserElement(at path: String) -> Bool
+        /// Selects a destination entirely through the measured AX browser
+        /// primitive. A refusal names the failed component so `finish()` can
+        /// still cancel a partially navigated panel.
+        func selectDestinationBrowserElement(at path: String) -> DestinationSelection
         /// Reads the current per-track popup value; it does not infer enablement
         /// from the control merely existing.
         func oneFilePerTrackIsActive() -> Bool
@@ -79,6 +116,18 @@ enum ProjectStemExportPanelDriver {
                 case .completed, .uncertain:
                     return .uncertain("readback_unavailable: stem_export_panel_close_not_observed")
                 }
+            case let .unmeasured(reason):
+                // The initial observation already refused with the precise
+                // missing-measurement reason. Do not replace it with a generic
+                // close-readback error merely because an unmeasured panel cannot
+                // be dismissed by a measured Cancel label. If one appears only
+                // after a write, it prevents a success claim instead.
+                switch outcome {
+                case .refused:
+                    return outcome
+                case .completed, .uncertain:
+                    return .uncertain(reason)
+                }
             }
         }
 
@@ -87,28 +136,58 @@ enum ProjectStemExportPanelDriver {
         guard surface.openFileMenu() else {
             return finish(.refused("stem_export_file_menu_unavailable"))
         }
-        guard surface.openExportMenu() else {
-            return finish(.refused("stem_export_export_menu_unavailable"))
+        switch surface.openExportMenu() {
+        case .available:
+            break
+        case let .unavailable(reason):
+            return finish(.refused(reason))
         }
-        guard surface.resolveStemLeaf() else {
-            return finish(.refused("stem_export_menu_leaf_unavailable_after_open"))
+        switch surface.resolveStemLeaf() {
+        case .available:
+            break
+        case let .unavailable(reason):
+            return finish(.refused(reason))
         }
         surface.pickStemLeaf()
-        switch surface.exportPanelPresence() {
-        case .present:
+        var panelWaitNanos: UInt64 = 0
+        while true {
+            switch surface.exportPanelPresence() {
+            case .present:
+                break
+            case .absent:
+                guard panelWaitNanos < exportPanelObservationDeadlineNanos,
+                      pollIntervalNanos > 0 else {
+                    return finish(.refused(
+                        "stem_export_panel_not_observed_after_bounded_wait_elapsed"
+                    ))
+                }
+                let remainingWaitNanos = exportPanelObservationDeadlineNanos - panelWaitNanos
+                let nextWaitNanos = min(pollIntervalNanos, remainingWaitNanos)
+                await sleep(nextWaitNanos)
+                panelWaitNanos += nextWaitNanos
+                continue
+            case .unavailable:
+                return finish(.refused("readback_unavailable: stem_export_panel_not_observed_after_axpick"))
+            case let .unmeasured(reason):
+                return finish(.refused(reason))
+            }
             break
-        case .absent:
-            return finish(.refused("stem_export_panel_not_observed_after_axpick"))
-        case .unavailable:
-            return finish(.refused("readback_unavailable: stem_export_panel_not_observed_after_axpick"))
         }
 
-        let beforeDestination = surface.destinationPopupValue()
-        guard surface.selectDestinationBrowserElement(at: destination) else {
-            return finish(.refused("stem_destination_browser_selection_failed"))
+        switch surface.selectDestinationBrowserElement(at: destination) {
+        case .selected:
+            break
+        case let .refused(reason):
+            return finish(.refused(reason))
         }
+        // Confirm by identity, not by change. Logic's export panel reopens at the
+        // last committed destination, so asking for that same folder produces no
+        // change at all — requiring one made an already-correct panel permanently
+        // unconfirmable (measured live 2026-09-02). The selection readback inside
+        // `selectDestinationBrowserElement` is what proves the path; this popup
+        // check is a second, weaker witness kept only to catch a panel that moved
+        // somewhere else entirely.
         guard let afterDestination = surface.destinationPopupValue(),
-              destinationChanged(from: beforeDestination, to: afterDestination),
               destinationDisplay(afterDestination, confirms: destination) else {
             return finish(.refused("stem_destination_not_confirmed_after_browser_selection"))
         }
@@ -166,8 +245,19 @@ enum ProjectStemExportPanelDriver {
     }
 }
 
-private final class AXSurface: ProjectStemExportPanelDriver.Surface, @unchecked Sendable {
+final class AXSurface: ProjectStemExportPanelDriver.Surface, @unchecked Sendable {
     private let runtime: AXLogicProElements.Runtime
+
+    // Live navigation took 60 ms (volume root), 206 ms and 402 ms to materialize
+    // the next column. Poll for 5 s at 50 ms intervals — ~12x the slowest of those.
+    // The multiplier is deliberately large because a sibling measurement on this
+    // same panel already exceeded its own observed maximum: the panel appeared
+    // within 1005-1108 ms across eight samples and then took 1601 ms on a later
+    // run. Idle-machine samples set the floor for these budgets, never the ceiling,
+    // and a column that is merely slow must not be reported as a column that never
+    // came. The bound stays finite so a genuinely stuck panel still refuses.
+    private static let destinationNavigationDeadline: TimeInterval = 5.0
+    private static let destinationNavigationPollInterval: TimeInterval = 0.05
 
     init(runtime: AXLogicProElements.Runtime = .production) {
         self.runtime = runtime
@@ -188,18 +278,30 @@ private final class AXSurface: ProjectStemExportPanelDriver.Surface, @unchecked 
         return AXHelpers.performAction(item, kAXPressAction as String, runtime: runtime.ax)
     }
 
-    func openExportMenu() -> Bool {
-        guard let app = AXLogicProElements.appRoot(runtime: runtime),
-              let export = menuItem(in: app, matching: isExportMenuTitle) else {
-            return false
+    func openExportMenu() -> ProjectStemExportPanelDriver.MenuAvailability {
+        guard let app = AXLogicProElements.appRoot(runtime: runtime) else {
+            return .unavailable("stem_export_export_menu_unavailable")
+        }
+        let exports = menuItems(in: app, matching: ProjectStemExportPanelDriver.exportMenuTitleMatches)
+        guard exports.count == 1, let export = exports.first else {
+            return .unavailable(exports.isEmpty
+                ? ProjectStemExportPanelDriver.exportMenuLabelNotMeasuredReason
+                : "stem_export_export_menu_unavailable")
         }
         return AXHelpers.performAction(export, kAXPressAction as String, runtime: runtime.ax)
+            ? .available
+            : .unavailable("stem_export_export_menu_unavailable")
     }
 
-    func resolveStemLeaf() -> Bool {
-        guard let app = AXLogicProElements.appRoot(runtime: runtime),
-              let leaf = menuItem(in: app, matching: ProjectStemExportPanelDriver.stemLeafTitleMatches) else {
-            return false
+    func resolveStemLeaf() -> ProjectStemExportPanelDriver.MenuAvailability {
+        guard let app = AXLogicProElements.appRoot(runtime: runtime) else {
+            return .unavailable("stem_export_menu_leaf_unavailable_after_open")
+        }
+        let leaves = menuItems(in: app, matching: ProjectStemExportPanelDriver.stemLeafTitleMatches)
+        guard leaves.count == 1, let leaf = leaves.first else {
+            return .unavailable(leaves.isEmpty
+                ? ProjectStemExportPanelDriver.stemLeafLabelNotMeasuredReason
+                : "stem_export_menu_leaf_unavailable_after_open")
         }
         // This read intentionally happens here, after `openFileMenu` and
         // `openExportMenu`; closed-menu enablement is not a valid observation.
@@ -207,6 +309,8 @@ private final class AXSurface: ProjectStemExportPanelDriver.Surface, @unchecked 
             leaf, kAXEnabledAttribute as String, runtime: runtime.ax
         )
         return enabled?.boolValue == true
+            ? .available
+            : .unavailable("stem_export_menu_leaf_unavailable_after_open")
     }
 
     func pickStemLeaf() {
@@ -233,9 +337,13 @@ private final class AXSurface: ProjectStemExportPanelDriver.Surface, @unchecked 
         ) else {
             return .unavailable
         }
-        let count = exportPanels(in: windows).count
+        let panels = exportPanels(in: windows)
+        let count = panels.count
         switch count {
-        case 0: return .absent
+        case 0:
+            return hasUnmeasuredStemExportPanel(in: windows)
+                ? .unmeasured(ProjectStemExportPanelDriver.panelLabelNotMeasuredReason)
+                : .absent
         case 1: return .present
         default: return .unavailable
         }
@@ -248,67 +356,107 @@ private final class AXSurface: ProjectStemExportPanelDriver.Surface, @unchecked 
         return elementText(popup)
     }
 
-    func selectDestinationBrowserElement(at path: String) -> Bool {
-        guard let panel = exportPanel() else { return false }
+    func selectDestinationBrowserElement(
+        at path: String
+    ) -> ProjectStemExportPanelDriver.DestinationSelection {
+        guard let panel = exportPanel() else {
+            return .refused("stem_destination_browser_panel_unavailable")
+        }
+        guard path.hasPrefix("/") else {
+            return .refused("stem_destination_path_not_absolute")
+        }
         let wanted = URL(fileURLWithPath: path).standardizedFileURL.path
-        // The browser exposes folder rows and cells. Count BOTH role sets and
-        // then require one path-bearing match, rather than inheriting AX tree
-        // order when the same folder is presented twice.
-        let rows = AXHelpers.censusDescendant(
-            of: panel, role: kAXRowRole as String, maxDepth: 16, runtime: runtime.ax
-        )
-        let cells = AXHelpers.censusDescendant(
-            of: panel, role: kAXCellRole as String, maxDepth: 16, runtime: runtime.ax
-        )
-        let folders = (rows.matches + cells.matches).filter { element in
-            let texts = [
-                elementText(element),
-                AXHelpers.getAttribute(element, kAXURLAttribute as String, runtime: runtime.ax) as String?,
-            ].compactMap { $0 }
-            return texts.contains { text in
-                normalizedFilePath(text) == wanted
+        let target = URL(fileURLWithPath: wanted)
+
+        let startingDirectory: String
+        if let listedDirectory = deepestListedAncestor(of: wanted, in: panel) {
+            startingDirectory = listedDirectory
+        } else {
+            guard let volume = volume(containing: target) else {
+                return .refused("stem_destination_volume_unresolvable")
+            }
+            switch selectVolumeRoot(named: volume.name, at: volume.root, in: panel) {
+            case .selected:
+                startingDirectory = volume.root
+            case let .refused(reason):
+                return .refused(reason)
             }
         }
-        guard folders.count == 1, let folder = folders.first else {
-            return false
+
+        guard isDirectory(startingDirectory, anAncestorOf: wanted) else {
+            return .refused("stem_destination_component_unresolved:\(wanted)")
         }
-        // Browser rows/cells are not popup menu leaves, so use their ordinary
-        // press action. There is deliberately no keyboard path fallback.
-        return AXHelpers.performAction(folder, kAXPressAction as String, runtime: runtime.ax)
+
+        var selectedPath = startingDirectory
+        let remainingComponents = wanted.dropFirst(startingDirectory.count)
+            .split(separator: "/")
+            .map(String.init)
+        for component in remainingComponents {
+            selectedPath = URL(fileURLWithPath: selectedPath)
+                .appendingPathComponent(component)
+                .standardizedFileURL.path
+            switch selectListedComponent(
+                at: selectedPath,
+                named: component,
+                in: panel
+            ) {
+            case .selected:
+                break
+            case let .refused(reason):
+                return .refused(reason)
+            }
+        }
+        return .selected
     }
 
     func oneFilePerTrackIsActive() -> Bool {
         guard let panel = exportPanel() else { return false }
         return popupButtons(in: panel).contains { popup in
-            (elementText(popup) ?? "").caseInsensitiveCompare("One File per Track") == .orderedSame
+            AXLocalePolicy.oneFilePerTrackPopupValue.matches(elementText(popup))
         }
     }
 
     func pressExport() -> Bool {
         guard let panel = exportPanel(),
               let export = buttons(in: panel).first(where: {
-                  (elementText($0) ?? "").caseInsensitiveCompare("Export") == .orderedSame
+                  AXLocalePolicy.stemExportCommitButton.matches(elementText($0))
               }) else {
             return false
         }
         return AXHelpers.performAction(export, kAXPressAction as String, runtime: runtime.ax)
     }
 
+    /// The export progress dialog's title only LOOKS like `"Logic Pro"`. Measured
+    /// on the live Korean UI, 2026-09-02, its scalars are
+    /// `U+004C U+006F U+0067 U+0069 U+0063 U+00A0 U+0050 U+0072 U+006F` — the
+    /// separator is a NO-BREAK SPACE. An `==` against `"Logic Pro"` is therefore
+    /// false, and trimming cannot help because the character is interior, not at
+    /// an edge. The consequence was silent and expensive: the export ran, the
+    /// files landed, and the operation still reported
+    /// `readback_unavailable: stem_progress_window_not_observed`, downgrading a
+    /// real completion to State B.
+    ///
+    /// `LogicProTarget.normalizedProcessName` already exists for exactly this —
+    /// it collapses every whitespace character to `U+0020`, so U+00A0 here and
+    /// U+202F elsewhere both match while `LogicPro` with the separator removed
+    /// still does not.
     func progressWindowPresent() -> Bool {
         guard let app = AXLogicProElements.appRoot(runtime: runtime) else { return false }
         let windows: [AXUIElement] = AXHelpers.getAttribute(
             app, kAXWindowsAttribute as String, runtime: runtime.ax
         ) ?? []
+        let wanted = LogicProTarget.normalizedProcessName("Logic Pro")
         return windows.contains {
-            (AXHelpers.getTitle($0, runtime: runtime.ax) ?? "")
-                .trimmingCharacters(in: .whitespacesAndNewlines) == "Logic Pro"
+            let title = (AXHelpers.getTitle($0, runtime: runtime.ax) ?? "")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return LogicProTarget.normalizedProcessName(title) == wanted
         }
     }
 
     func closeExportPanel() -> Bool {
         guard let panel = exportPanel(),
               let cancel = buttons(in: panel).first(where: {
-                  (elementText($0) ?? "").caseInsensitiveCompare("Cancel") == .orderedSame
+                  AXLocalePolicy.stemExportDismissButton.matches(elementText($0))
               }) else {
             return false
         }
@@ -326,8 +474,29 @@ private final class AXSurface: ProjectStemExportPanelDriver.Surface, @unchecked 
 
     private func exportPanels(in windows: [AXUIElement]) -> [AXUIElement] {
         windows.filter { window in
-            let titles = Set(buttons(in: window).compactMap(elementText))
-            return titles.contains("Export") && titles.contains("Cancel")
+            let buttonTexts = buttons(in: window).compactMap(elementText)
+            return buttonTexts.contains { AXLocalePolicy.stemExportCommitButton.matches($0) }
+                && buttonTexts.contains { AXLocalePolicy.stemExportDismissButton.matches($0) }
+        }
+    }
+
+    /// A post-AXPick AXDialog with buttons that match neither measured panel
+    /// label set may be the export panel in an unmeasured locale. Its title is
+    /// macOS's localized Open string, so it cannot safely refine this result.
+    /// A dialog that matches only one known button remains merely a decoy, not
+    /// a panel and not a locale measurement claim.
+    private func hasUnmeasuredStemExportPanel(in windows: [AXUIElement]) -> Bool {
+        windows.contains { window in
+            let subrole: String? = AXHelpers.getAttribute(
+                window, kAXSubroleAttribute as String, runtime: runtime.ax
+            )
+            guard subrole == (kAXDialogSubrole as String) else { return false }
+            let buttonTexts = buttons(in: window).compactMap(elementText)
+            guard !buttonTexts.isEmpty else { return false }
+            return buttonTexts.allSatisfy {
+                !AXLocalePolicy.stemExportCommitButton.matches($0)
+                    && !AXLocalePolicy.stemExportDismissButton.matches($0)
+            }
         }
     }
 
@@ -335,13 +504,20 @@ private final class AXSurface: ProjectStemExportPanelDriver.Surface, @unchecked 
         in app: AXUIElement,
         matching predicate: (String) -> Bool
     ) -> AXUIElement? {
+        let matches = menuItems(in: app, matching: predicate)
+        return matches.count == 1 ? matches[0] : nil
+    }
+
+    private func menuItems(
+        in app: AXUIElement,
+        matching predicate: (String) -> Bool
+    ) -> [AXUIElement] {
         let census = AXHelpers.censusDescendant(
             of: app, role: kAXMenuItemRole as String, maxDepth: 12, runtime: runtime.ax
         )
-        let matches = census.matches.filter {
+        return census.matches.filter {
             predicate(AXHelpers.getTitle($0, runtime: runtime.ax) ?? "")
         }
-        return matches.count == 1 ? matches[0] : nil
     }
 
     private func buttons(in root: AXUIElement) -> [AXUIElement] {
@@ -366,22 +542,237 @@ private final class AXSurface: ProjectStemExportPanelDriver.Surface, @unchecked 
         return URL(fileURLWithPath: value).standardizedFileURL.path
     }
 
-    private func isExportMenuTitle(_ title: String) -> Bool {
-        title.trimmingCharacters(in: .whitespacesAndNewlines)
-            .caseInsensitiveCompare("Export") == .orderedSame
+    private struct Volume {
+        let root: String
+        let name: String
     }
 
-    /// Selection rewrites this title (for example `1 Track as Audio File…`),
-    /// so an exact canonical-title matcher would be a false route guarantee.
+    private func volume(containing target: URL) -> Volume? {
+        guard let values = try? target.resourceValues(forKeys: [.volumeURLKey, .volumeNameKey]),
+              let volumeURL = values.volume,
+              let volumeName = values.volumeName else {
+            return nil
+        }
+        return Volume(root: volumeURL.standardizedFileURL.path, name: volumeName)
+    }
+
+    /// The sidebar's volume label is user-settable and localized. There is no
+    /// stable AX identifier or path attribute for it, so a missing or duplicate
+    /// display-name match must refuse rather than guess at a sidebar row.
+    private func selectVolumeRoot(
+        named volumeName: String,
+        at root: String,
+        in panel: AXUIElement
+    ) -> ProjectStemExportPanelDriver.DestinationSelection {
+        let outlines = AXHelpers.censusDescendant(
+            of: panel, role: kAXOutlineRole as String, maxDepth: 16, runtime: runtime.ax
+        )
+        guard outlines.matches.count == 1, let outline = outlines.matches.first else {
+            return .refused("stem_destination_volume_outline_not_uniquely_resolvable")
+        }
+        let rows = AXHelpers.censusDescendant(
+            of: outline, role: kAXRowRole as String, maxDepth: 16, runtime: runtime.ax
+        ).matches
+        let volumeRows = rows.filter { row in
+            AXHelpers.censusDescendant(
+                of: row, role: kAXStaticTextRole as String, maxDepth: 8, runtime: runtime.ax
+            ).matches.contains { text in
+                let value: String? = AXHelpers.getAttribute(
+                    text, kAXValueAttribute as String, runtime: runtime.ax
+                )
+                return value?.trimmingCharacters(in: .whitespacesAndNewlines) == volumeName
+            }
+        }
+        guard volumeRows.count == 1, let row = volumeRows.first else {
+            return .refused(
+                "stem_destination_volume_row_not_uniquely_resolvable:\(volumeName)"
+            )
+        }
+
+        // The sidebar is an AXOutline, not an AXList, so there is no
+        // AXSelectedChildren to read back here; the volume hop is confirmed by the
+        // browser listing "/" contents.
+        // A zero AX status only says the write was accepted. It does not say
+        // Finder's browser changed, so its Boolean return is intentionally not
+        // used as a success signal.
+        _ = AXHelpers.setAttribute(
+            outline,
+            kAXSelectedRowsAttribute as String,
+            [row] as CFArray,
+            runtime: runtime.ax
+        )
+        guard waitsForSidebarSelection(of: row, in: outline) else {
+            return .refused("stem_destination_volume_root_not_confirmed:\(volumeName)")
+        }
+        return .selected
+    }
+
+    private func selectListedComponent(
+        at path: String,
+        named component: String,
+        in panel: AXUIElement
+    ) -> ProjectStemExportPanelDriver.DestinationSelection {
+        let entries = browserPathFields(in: panel).filter {
+            urlPath(of: $0) == path
+        }
+        guard entries.count == 1, let entry = entries.first else {
+            let failure = entries.isEmpty ? "not_listed" : "ambiguous"
+            return .refused("stem_destination_component_\(failure):\(component)")
+        }
+        guard let group = ancestor(of: entry, role: kAXGroupRole as String, maxDepth: 8) else {
+            return .refused("stem_destination_component_group_unresolved:\(component)")
+        }
+        guard let list = ancestor(of: group, role: kAXListRole as String, maxDepth: 8) else {
+            return .refused("stem_destination_component_list_unresolved:\(component)")
+        }
+
+        // A successful AXSelectedChildren write is not navigation evidence; only
+        // the selection readback or the child column below establishes it.
+        _ = AXHelpers.setAttribute(
+            list,
+            kAXSelectedChildrenAttribute as String,
+            [group] as CFArray,
+            runtime: runtime.ax
+        )
+        guard waitsForSelection(of: path, in: list, panel: panel) else {
+            return .refused("stem_destination_component_not_confirmed:\(component)")
+        }
+        return .selected
+    }
+
+    /// Confirms a navigation hop by PATH IDENTITY, never by a display name and
+    /// never by the fact that something changed.
+    ///
+    /// Two signals qualify, both keyed on full POSIX paths:
+    ///   1. the owning list reads back an `AXSelectedChildren` entry whose AXURL
+    ///      is exactly this path;
+    ///   2. the browser lists entries whose parent directory is exactly this path.
+    ///
+    /// The destination popup is deliberately NOT accepted here. It shows the
+    /// folder's leaf name (`Logic`, `logic-pro-mcp-stem-test`), so it cannot tell
+    /// this folder from a same-named folder elsewhere on the volume.
+    ///
+    /// Requiring the popup to have *changed* was worse than merely weak: Logic's
+    /// export panel reopens at the last committed destination, so asking for that
+    /// same folder produces no change at all, and an already-correct panel became
+    /// permanently unconfirmable. Measured 2026-09-02 — this was the live failure
+    /// `stem_destination_component_not_confirmed:logic-pro-mcp-stem-test`, where
+    /// signal 2 was also silent because the target folder was empty. Signal 1
+    /// answers both cases: measured the same day, the list read back
+    /// `AXSelectedChildren = [/Users/isaac/Music/logic-pro-mcp-stem-test]`.
+    private func waitsForSelection(
+        of path: String,
+        in list: AXUIElement?,
+        panel: AXUIElement
+    ) -> Bool {
+        guard let list else { return false }
+        let deadline = Date().addingTimeInterval(Self.destinationNavigationDeadline)
+        repeat {
+            if selectionReadsBack(path, in: list) {
+                return true
+            }
+            Thread.sleep(forTimeInterval: Self.destinationNavigationPollInterval)
+        } while Date() < deadline
+        return false
+    }
+
+    /// The sidebar hop's equivalent: read the outline's selection back and check
+    /// the row we wrote is the row it now reports. Measured 2026-09-02 —
+    /// `AXSelectedRows` reads back one row labelled `Macintosh HD` after the write.
+    private func waitsForSidebarSelection(of row: AXUIElement, in outline: AXUIElement) -> Bool {
+        let deadline = Date().addingTimeInterval(Self.destinationNavigationDeadline)
+        repeat {
+            let selected: [AXUIElement] = AXHelpers.getAttribute(
+                outline, kAXSelectedRowsAttribute as String, runtime: runtime.ax
+            ) ?? []
+            if selected.contains(where: { CFEqual($0, row) }) {
+                return true
+            }
+            Thread.sleep(forTimeInterval: Self.destinationNavigationPollInterval)
+        } while Date() < deadline
+        return false
+    }
+
+    /// Reads the list's selection back and compares AXURLs. A zero status from
+    /// the write says only that the write was accepted.
+    private func selectionReadsBack(_ path: String, in list: AXUIElement) -> Bool {
+        let selected: [AXUIElement] = AXHelpers.getAttribute(
+            list, kAXSelectedChildrenAttribute as String, runtime: runtime.ax
+        ) ?? []
+        return selected.contains { group in
+            AXHelpers.censusDescendant(
+                of: group, role: kAXTextFieldRole as String, maxDepth: 4, runtime: runtime.ax
+            ).matches.contains { urlPath(of: $0) == path }
+        }
+    }
+
+    private func listsChildren(of directory: String, in panel: AXUIElement) -> Bool {
+        browserPathFields(in: panel).contains { field in
+            guard let path = urlPath(of: field) else { return false }
+            return URL(fileURLWithPath: path).deletingLastPathComponent().path == directory
+        }
+    }
+
+    private func deepestListedAncestor(of path: String, in panel: AXUIElement) -> String? {
+        let directories = Set(browserPathFields(in: panel).compactMap { field in
+            urlPath(of: field).map { URL(fileURLWithPath: $0).deletingLastPathComponent().path }
+        })
+        return directories
+            .filter { isDirectory($0, anAncestorOf: path) }
+            .max { $0.count < $1.count }
+    }
+
+    private func browserPathFields(in panel: AXUIElement) -> [AXUIElement] {
+        AXHelpers.censusDescendant(
+            of: panel, role: kAXTextFieldRole as String, maxDepth: 16, runtime: runtime.ax
+        ).matches.filter { urlPath(of: $0) != nil }
+    }
+
+    /// AXURL is a CFURL, never a CFString. Measured on the live export panel on
+    /// 2026-09-02: of the entries carrying AXURL, 4 of 4 read as NSURL and 0 as
+    /// String. Reading it as a String returned nil for every entry, which emptied
+    /// the whole browser census silently — the destination stage then believed no
+    /// ancestor was listed and refused on every machine. A String read here is not
+    /// a stricter check; it is a guaranteed-empty one.
+    private func urlPath(of field: AXUIElement) -> String? {
+        let url: NSURL? = AXHelpers.getAttribute(
+            field, kAXURLAttribute as String, runtime: runtime.ax
+        )
+        return url?.path.flatMap(normalizedFilePath)
+    }
+
+    private func ancestor(
+        of element: AXUIElement,
+        role: String,
+        maxDepth: Int
+    ) -> AXUIElement? {
+        var current = element
+        for _ in 0..<maxDepth {
+            guard let parent: AXUIElement = AXHelpers.getAttribute(
+                current, kAXParentAttribute as String, runtime: runtime.ax
+            ) else {
+                return nil
+            }
+            if AXHelpers.getRole(parent, runtime: runtime.ax) == role {
+                return parent
+            }
+            current = parent
+        }
+        return nil
+    }
+
+    private func isDirectory(_ directory: String, anAncestorOf path: String) -> Bool {
+        directory == "/" || path == directory || path.hasPrefix(directory + "/")
+    }
+
 }
 
 extension ProjectStemExportPanelDriver {
-    /// Selection rewrites this title (for example `1 Track as Audio File…`),
-    /// so an exact canonical-title matcher would be a false route guarantee.
+    static func exportMenuTitleMatches(_ title: String) -> Bool {
+        AXLocalePolicy.exportMenuItem.matches(title)
+    }
+
     static func stemLeafTitleMatches(_ title: String) -> Bool {
-        let normalized = title.lowercased()
-        return normalized.contains("track")
-            && normalized.contains("audio file")
-            && !normalized.contains("selected")
+        AXLocalePolicy.allTracksAsAudioFilesMenuItem.matches(title)
     }
 }

--- a/Tests/LogicProMCPTests/Issue369StemExportTests.swift
+++ b/Tests/LogicProMCPTests/Issue369StemExportTests.swift
@@ -1,20 +1,25 @@
+@preconcurrency import ApplicationServices
 import Foundation
 import MCP
 import Testing
 @testable import LogicProMCP
 
-// These tests prove the driver state machine against a semantic fake only.
-// They do NOT exercise AXSurface.openFileMenu, AX browser traversal, AX
-// progress discovery, or AX Cancel in a live Logic process; those production
-// Accessibility interactions remain for the user's live acceptance. The fake
-// is intentionally stateful so mutations to the driver's observations and
-// transitions still turn these tests red.
+// These tests prove the driver state machine against a semantic fake and the
+// panel-label and destination-browser paths against synthetic AX trees. They
+// do NOT exercise AXSurface.openFileMenu or progress discovery in a live Logic
+// process; those production Accessibility interactions remain for the user's
+// live acceptance. The fake is intentionally stateful so mutations to the
+// driver's observations and transitions still turn these tests red.
 private final class StemPanelSurfaceFake: ProjectStemExportPanelDriver.Surface, @unchecked Sendable {
     var events: [String] = []
     var fileMenuOpens = true
-    var exportMenuOpens = true
-    var leafResolves = true
+    var exportMenuAvailability: ProjectStemExportPanelDriver.MenuAvailability = .available
+    var stemLeafAvailability: ProjectStemExportPanelDriver.MenuAvailability = .available
     var panelAppears = true
+    /// `exportPanelPresence()` reports absence for this many initial reads,
+    /// then reports the configured presence. This models a panel materializing
+    /// after AXPick instead of encoding an instantaneous fake-only contract.
+    var absentPanelReadsBeforePresent = 0
     var browserSelectionSucceeds = true
     var destinationBefore: String? = "Old Exports"
     var destinationAfter: String? = "Stem Exports"
@@ -29,16 +34,20 @@ private final class StemPanelSurfaceFake: ProjectStemExportPanelDriver.Surface, 
         return fileMenuOpens
     }
 
-    func openExportMenu() -> Bool {
+    func openExportMenu() -> ProjectStemExportPanelDriver.MenuAvailability {
         events.append("export_open")
-        return exportMenuOpens && events.contains("file_open")
+        return events.contains("file_open")
+            ? exportMenuAvailability
+            : .unavailable("stem_export_export_menu_unavailable")
     }
 
-    func resolveStemLeaf() -> Bool {
+    func resolveStemLeaf() -> ProjectStemExportPanelDriver.MenuAvailability {
         events.append("leaf_enabled_read")
         // Closed-menu enablement is deliberately false in this fake. The only
         // passing route is the one that opened both parent menus first.
-        return leafResolves && events.starts(with: ["file_open", "export_open"])
+        return events.starts(with: ["file_open", "export_open"])
+            ? stemLeafAvailability
+            : .unavailable("stem_export_menu_leaf_unavailable_after_open")
     }
 
     func pickStemLeaf() {
@@ -48,6 +57,10 @@ private final class StemPanelSurfaceFake: ProjectStemExportPanelDriver.Surface, 
     func exportPanelPresence() -> ProjectStemExportPanelDriver.PanelPresence {
         events.append("panel_read")
         if !panelAppears { return .absent }
+        if panelPresence == .present, absentPanelReadsBeforePresent > 0 {
+            absentPanelReadsBeforePresent -= 1
+            return .absent
+        }
         return panelPresence
     }
 
@@ -57,9 +70,13 @@ private final class StemPanelSurfaceFake: ProjectStemExportPanelDriver.Surface, 
         return afterSelection ? destinationAfter : destinationBefore
     }
 
-    func selectDestinationBrowserElement(at path: String) -> Bool {
+    func selectDestinationBrowserElement(
+        at path: String
+    ) -> ProjectStemExportPanelDriver.DestinationSelection {
         events.append("destination_browser_select")
         return browserSelectionSucceeds && path.hasSuffix("Stem Exports")
+            ? .selected
+            : .refused("stem_destination_component_not_listed:Stem Exports")
     }
 
     func oneFilePerTrackIsActive() -> Bool {
@@ -89,15 +106,233 @@ private final class StemPanelSurfaceFake: ProjectStemExportPanelDriver.Surface, 
 
 private func driveStemPanel(
     _ surface: StemPanelSurfaceFake,
-    attempts: Int = 3
+    attempts: Int = 3,
+    pollIntervalNanos: UInt64 = 250_000_000
 ) async -> ProjectStemExportPanelDriver.Outcome {
     await ProjectStemExportPanelDriver.drive(
         destination: "/private/tmp/Stem Exports",
         surface: surface,
         progressPollAttempts: attempts,
-        sleep: { _ in },
-        pollIntervalNanos: 1
+        sleep: { _ in surface.events.append("poll_sleep") },
+        pollIntervalNanos: pollIntervalNanos
     )
+}
+
+private struct StemExportPanelAXFixture {
+    let runtime: AXLogicProElements.Runtime
+
+    init(
+        popupValue: String,
+        exportButtonTitle: String?,
+        cancelButtonTitle: String?,
+        isDialog: Bool = true
+    ) {
+        let builder = FakeAXRuntimeBuilder()
+        let app = builder.element(1)
+        let panel = builder.element(2)
+        let popup = builder.element(3)
+
+        builder.setRole(panel, kAXWindowRole as String)
+        if isDialog {
+            builder.setAttribute(panel, kAXSubroleAttribute as String, kAXDialogSubrole as String)
+        }
+
+        builder.setRole(popup, kAXPopUpButtonRole as String)
+        builder.setAttribute(popup, kAXValueAttribute as String, popupValue)
+        var panelChildren = [popup]
+
+        if let exportButtonTitle {
+            let export = builder.element(4)
+            builder.setButton(
+                export,
+                title: exportButtonTitle,
+                x: 100,
+                y: 100,
+                width: 70,
+                height: 24
+            )
+            panelChildren.append(export)
+        }
+        if let cancelButtonTitle {
+            let cancel = builder.element(5)
+            builder.setButton(
+                cancel,
+                title: cancelButtonTitle,
+                x: 180,
+                y: 100,
+                width: 70,
+                height: 24
+            )
+            panelChildren.append(cancel)
+        }
+
+        builder.setChildren(panel, panelChildren)
+        builder.setAttribute(app, kAXWindowsAttribute as String, [panel])
+
+        runtime = builder.makeLogicRuntime(appElement: app)
+    }
+}
+
+/// A Logic app whose only window is the export progress dialog, titled exactly as
+/// the live Korean UI titles it. Measured 2026-09-02, its scalars are
+/// `U+004C U+006F U+0067 U+0069 U+0063 U+00A0 U+0050 U+0072 U+006F` — the
+/// separator is a NO-BREAK SPACE, so the title prints as "Logic Pro" but is not
+/// equal to it.
+private struct ProgressWindowAXFixture {
+    let runtime: AXLogicProElements.Runtime
+
+    init(windowTitle: String?) {
+        let builder = FakeAXRuntimeBuilder()
+        let app = builder.element(1)
+        var windows: [AXUIElement] = []
+        if let windowTitle {
+            let window = builder.element(2)
+            builder.setRole(window, kAXWindowRole as String)
+            builder.setAttribute(window, kAXTitleAttribute as String, windowTitle)
+            windows.append(window)
+        }
+        builder.setAttribute(app, kAXWindowsAttribute as String, windows)
+        runtime = builder.makeLogicRuntime(appElement: app)
+    }
+}
+
+/// Finder-column AX fixture for the measured destination route. Each URL entry
+/// is `AXList -> AXGroup -> AXTextField(AXURL)`; selecting its group can
+/// materialize the next column, exactly the readback the production code needs.
+private final class DestinationBrowserFixtureState: @unchecked Sendable {
+    let builder: FakeAXRuntimeBuilder
+    let panel: AXUIElement
+    private var nextElementID = 100
+    private var panelChildren: [AXUIElement]
+    private var pathByGroupID: [Int: String] = [:]
+    private var listIDs: Set<Int> = []
+    private let childrenByPath: [String: [String]]
+    private let observesSelection: Bool
+    private(set) var selectedChildrenWrites: [(listID: Int, selectedGroupID: Int)] = []
+    private(set) var actions: [(elementID: Int, action: String)] = []
+
+    init(
+        builder: FakeAXRuntimeBuilder,
+        panel: AXUIElement,
+        initialEntries: [String],
+        childrenByPath: [String: [String]],
+        observesSelection: Bool
+    ) {
+        self.builder = builder
+        self.panel = panel
+        self.panelChildren = AXHelpers.getChildren(panel, runtime: builder.makeAXRuntime())
+        self.childrenByPath = childrenByPath
+        self.observesSelection = observesSelection
+        appendColumn(entries: initialEntries)
+    }
+
+    func handleWrite(_ element: AXUIElement, _ attribute: String, _ value: CFTypeRef) -> Bool {
+        guard attribute == (kAXSelectedChildrenAttribute as String),
+              listIDs.contains(builder.elementID(element)),
+              let selected = value as? [AXUIElement],
+              let group = selected.first,
+              let path = pathByGroupID[builder.elementID(group)] else {
+            builder.setAttribute(element, attribute, value)
+            return true
+        }
+        selectedChildrenWrites.append((builder.elementID(element), builder.elementID(group)))
+        // Deliberately return success in both states. The no-readback fixture
+        // models an AX status 0 that had no observed effect at all: the write is
+        // accepted and then leaves no trace, so neither the selection nor a child
+        // column can be read back.
+        //
+        // It deliberately does NOT model "the selection is recorded but the panel
+        // does not navigate". That intermediate state has never been observed on
+        // the live panel — measured 2026-09-02, the selection readback and the
+        // destination agreed on every hop — and a fixture asserting it would be
+        // asserting behaviour we cannot show exists.
+        if observesSelection {
+            builder.setAttribute(element, attribute, value)
+            if let children = childrenByPath[path] {
+                appendColumn(entries: children)
+            }
+        }
+        return true
+    }
+
+    func recordAction(_ element: AXUIElement, _ action: String) -> Bool {
+        actions.append((builder.elementID(element), action))
+        return false
+    }
+
+    private func appendColumn(entries: [String]) {
+        let list = builder.element(nextElementID)
+        nextElementID += 1
+        builder.setRole(list, kAXListRole as String)
+        listIDs.insert(builder.elementID(list))
+        var groups: [AXUIElement] = []
+        for path in entries {
+            let group = builder.element(nextElementID)
+            nextElementID += 1
+            let field = builder.element(nextElementID)
+            nextElementID += 1
+            builder.setRole(group, kAXGroupRole as String)
+            builder.setRole(field, kAXTextFieldRole as String)
+            // AXURL is a CFURL, never a CFString. Measured on the live export
+            // panel 2026-09-02: 4 of 4 URL-bearing entries read back as NSURL and
+            // 0 as String. Supplying a String here is what let a production read
+            // typed `String?` — which returns nil for every real entry — pass a
+            // green suite while the destination stage could not work on any
+            // machine. The fixture must hand back the type the API hands back.
+            builder.setAttribute(field, kAXURLAttribute as String, URL(fileURLWithPath: path) as NSURL)
+            builder.setAttribute(field, kAXFilenameAttribute as String, URL(fileURLWithPath: path).lastPathComponent)
+            builder.setChildren(group, [field])
+            groups.append(group)
+            pathByGroupID[builder.elementID(group)] = path
+        }
+        builder.setChildren(list, groups)
+        panelChildren.append(list)
+        builder.setChildren(panel, panelChildren)
+    }
+}
+
+private struct DestinationBrowserAXFixture {
+    let runtime: AXLogicProElements.Runtime
+    let state: DestinationBrowserFixtureState
+
+    init(
+        initialEntries: [String],
+        childrenByPath: [String: [String]],
+        observesSelection: Bool = true
+    ) {
+        let builder = FakeAXRuntimeBuilder()
+        let app = builder.element(1)
+        let panel = builder.element(2)
+        let popup = builder.element(3)
+        let export = builder.element(4)
+        let cancel = builder.element(5)
+        builder.setRole(panel, kAXWindowRole as String)
+        builder.setAttribute(panel, kAXSubroleAttribute as String, kAXDialogSubrole as String)
+        builder.setRole(popup, kAXPopUpButtonRole as String)
+        builder.setAttribute(popup, kAXValueAttribute as String, "Other Destination")
+        builder.setButton(export, title: "Export", x: 100, y: 100, width: 70, height: 24)
+        builder.setButton(cancel, title: "Cancel", x: 180, y: 100, width: 70, height: 24)
+        builder.setChildren(panel, [popup, export, cancel])
+        builder.setAttribute(app, kAXWindowsAttribute as String, [panel])
+
+        let state = DestinationBrowserFixtureState(
+            builder: builder,
+            panel: panel,
+            initialEntries: initialEntries,
+            childrenByPath: childrenByPath,
+            observesSelection: observesSelection
+        )
+        self.state = state
+        runtime = builder.makeLogicRuntime(
+            appElement: app,
+            setAttributeHandler: { element, attribute, value in
+                state.handleWrite(element, attribute, value)
+            },
+            performActionHandler: { element, action in
+                state.recordAction(element, action)
+            }
+        )
+    }
 }
 
 private func scannedStemSubjects(for project: URL) -> ProjectExportStemSubjectInventory {
@@ -155,16 +390,332 @@ struct Issue369StemExportTests {
         #expect(openingPrecedesRead)
     }
 
-    // Logic REWRITES the leaf title with the selection — `Tracks as Audio Files…`
-    // became `1 Track as Audio File…` live. Resolution must survive a title the app
-    // edits, not only one it localizes, so it cannot key on the whole string. The structural
-    // route predicate; exact canonical title matching would make this red.
-    @Test("resolves Logic's selection-rewritten per-track export title")
-    func rewrittenStemLeafTitleResolves() {
-        let rewritten = ProjectStemExportPanelDriver.stemLeafTitleMatches("1 Track as Audio File…")
-        #expect(rewritten)
-        let unrelated = ProjectStemExportPanelDriver.stemLeafTitleMatches("Project as Audio File…")
-        #expect(!unrelated)
+    @Test("a late export panel is polled through to destination selection")
+    func lateExportPanelReachesDestinationStage() async throws {
+        let surface = StemPanelSurfaceFake()
+        surface.absentPanelReadsBeforePresent = 2
+
+        let outcome = await driveStemPanel(surface)
+
+        let destinationIndex = try #require(
+            surface.events.firstIndex(of: "destination_browser_select")
+        )
+        let eventsBeforeDestination = surface.events[..<destinationIndex]
+        let panelReadsBeforeDestination = eventsBeforeDestination.filter { $0 == "panel_read" }
+        let panelWasPolled = panelReadsBeforeDestination.count == 3
+        #expect(panelWasPolled)
+        let sleepsBeforeDestination = eventsBeforeDestination.filter { $0 == "poll_sleep" }
+        let pollIntervalsWereUsed = sleepsBeforeDestination.count == 2
+        #expect(pollIntervalsWereUsed)
+        let completed = outcome == .completed
+        #expect(completed)
+        let didNotRefuseOnTheInitialRead = outcome != .refused(
+            "stem_export_panel_not_observed_after_axpick"
+        )
+        #expect(didNotRefuseOnTheInitialRead)
+    }
+
+    @Test("a panel that never appears refuses after the bounded wait")
+    func missingExportPanelRefusesWithinBoundedWait() async {
+        let surface = StemPanelSurfaceFake()
+        surface.panelAppears = false
+
+        let outcome = await driveStemPanel(surface)
+
+        let refusedAfterBoundedWait = outcome == .refused(
+            "stem_export_panel_not_observed_after_bounded_wait_elapsed"
+        )
+        #expect(refusedAfterBoundedWait)
+        let panelReadCount = surface.events.filter { $0 == "panel_read" }.count
+        let expectedPanelReads = Int(
+            ProjectStemExportPanelDriver.exportPanelObservationDeadlineNanos / 250_000_000
+        ) + 2 // initial read, one read after every poll, then close readback
+        let observationStayedBounded = panelReadCount == expectedPanelReads
+        #expect(observationStayedBounded)
+    }
+
+    @Test("an unavailable panel readback refuses without becoming absence")
+    func unavailableExportPanelReadbackRefusesDistinctly() async {
+        let surface = StemPanelSurfaceFake()
+        surface.panelPresence = .unavailable
+
+        let outcome = await driveStemPanel(surface)
+
+        let readbackUnavailable = outcome == .refused(
+            "readback_unavailable: stem_export_panel_close_not_observed"
+        )
+        #expect(readbackUnavailable)
+        let neverBecameBoundedAbsence = outcome != .refused(
+            "stem_export_panel_not_observed_after_bounded_wait_elapsed"
+        )
+        #expect(neverBecameBoundedAbsence)
+        let panelReadCount = surface.events.filter { $0 == "panel_read" }.count
+        let unavailableWasNotRetried = panelReadCount == 2 // initial read plus close readback
+        #expect(unavailableWasNotRetried)
+    }
+
+    @Test("stem Export submenu resolves its measured Korean title")
+    func koreanExportMenuTitleResolves() {
+        let resolves = ProjectStemExportPanelDriver.exportMenuTitleMatches("내보내기")
+        #expect(resolves)
+    }
+
+    @Test("stem Export submenu still resolves its measured English title")
+    func englishExportMenuTitleResolves() {
+        let resolves = ProjectStemExportPanelDriver.exportMenuTitleMatches("Export")
+        #expect(resolves)
+    }
+
+    @Test("English stem-export panel is recognised and its measured controls operate")
+    func englishStemExportPanelIsRecognised() {
+        let fixture = StemExportPanelAXFixture(
+            popupValue: "One File per Track",
+            exportButtonTitle: "Export",
+            cancelButtonTitle: "Cancel"
+        )
+        let surface = AXSurface(runtime: fixture.runtime)
+
+        let recognised = surface.exportPanelPresence() == .present
+        #expect(recognised)
+        let oneFilePerTrackIsActive = surface.oneFilePerTrackIsActive()
+        #expect(oneFilePerTrackIsActive)
+        let exportPressed = surface.pressExport()
+        #expect(exportPressed)
+        let cancelPressed = surface.closeExportPanel()
+        #expect(cancelPressed)
+    }
+
+    @Test("Korean stem-export panel is recognised and its measured controls operate")
+    func koreanStemExportPanelIsRecognised() {
+        let fixture = StemExportPanelAXFixture(
+            popupValue: "트랙당 하나의 파일",
+            exportButtonTitle: "내보내기",
+            cancelButtonTitle: "취소"
+        )
+        let surface = AXSurface(runtime: fixture.runtime)
+
+        let recognised = surface.exportPanelPresence() == .present
+        #expect(recognised)
+        let oneFilePerTrackIsActive = surface.oneFilePerTrackIsActive()
+        #expect(oneFilePerTrackIsActive)
+        let exportPressed = surface.pressExport()
+        #expect(exportPressed)
+        let cancelPressed = surface.closeExportPanel()
+        #expect(cancelPressed)
+    }
+
+    @Test("destination browser writes AXSelectedChildren for a URL-backed one-level entry")
+    func destinationBrowserSelectsURLTextFieldThroughOwningList() {
+        let destination = "/Users/fixture/Exports"
+        let fixture = DestinationBrowserAXFixture(
+            initialEntries: [destination],
+            childrenByPath: [destination: ["\(destination)/Rendered"]]
+        )
+        let result = AXSurface(runtime: fixture.runtime)
+            .selectDestinationBrowserElement(at: destination)
+
+        let selected = result == .selected
+        #expect(selected)
+        let wroteOwningList = fixture.state.selectedChildrenWrites.count == 1
+        #expect(wroteOwningList)
+        let selectedEntryGroup = fixture.state.selectedChildrenWrites.first?.selectedGroupID != nil
+        #expect(selectedEntryGroup)
+        let neverPressedEntry = fixture.state.actions.isEmpty
+        #expect(neverPressedEntry)
+    }
+
+    @Test("destination browser descends URL-backed components one at a time")
+    func destinationBrowserDescendsMultipleComponents() {
+        let first = "/Users/fixture/Exports"
+        let destination = "\(first)/Mixes"
+        let fixture = DestinationBrowserAXFixture(
+            initialEntries: [first],
+            childrenByPath: [
+                first: [destination],
+                destination: ["\(destination)/Rendered"],
+            ]
+        )
+        let result = AXSurface(runtime: fixture.runtime)
+            .selectDestinationBrowserElement(at: destination)
+
+        let selected = result == .selected
+        #expect(selected)
+        let wroteEachComponent = fixture.state.selectedChildrenWrites.count == 2
+        #expect(wroteEachComponent)
+    }
+
+    @Test("destination browser refuses with the component that is never listed")
+    func destinationBrowserNamesUnresolvedComponent() {
+        let fixture = DestinationBrowserAXFixture(
+            initialEntries: ["/Users/fixture/Exports"],
+            childrenByPath: [:]
+        )
+        let result = AXSurface(runtime: fixture.runtime)
+            .selectDestinationBrowserElement(at: "/Users/fixture/Missing")
+
+        guard case let .refused(reason) = result else {
+            Issue.record("an unlisted destination component was accepted")
+            return
+        }
+        let namesMissingComponent = reason.contains("Missing")
+        #expect(namesMissingComponent)
+    }
+
+    @Test("destination browser refuses a status-zero write without navigation readback")
+    func destinationBrowserRequiresObservedWriteEffect() {
+        let destination = "/Users/fixture/Exports"
+        let fixture = DestinationBrowserAXFixture(
+            initialEntries: [destination],
+            childrenByPath: [destination: ["\(destination)/Rendered"]],
+            observesSelection: false
+        )
+        let result = AXSurface(runtime: fixture.runtime)
+            .selectDestinationBrowserElement(at: destination)
+
+        guard case let .refused(reason) = result else {
+            Issue.record("a status-zero write with no readback was accepted")
+            return
+        }
+        let writeWasAttempted = fixture.state.selectedChildrenWrites.count == 1
+        #expect(writeWasAttempted)
+        let refusalRequiresReadback = reason.contains("not_confirmed:Exports")
+        #expect(refusalRequiresReadback)
+    }
+
+    @Test("the export progress dialog is recognised through its NO-BREAK SPACE title")
+    func progressWindowTitleUsesNoBreakSpace() {
+        // The exact live title, written as scalars so the NBSP cannot be lost to
+        // an editor or a copy-paste that silently normalises it.
+        let liveTitle = "Logic\u{00A0}Pro"
+        let looksIdenticalButIsNotEqual = liveTitle != "Logic Pro"
+        #expect(looksIdenticalButIsNotEqual)
+
+        let observed = AXSurface(runtime: ProgressWindowAXFixture(windowTitle: liveTitle).runtime)
+            .progressWindowPresent()
+        #expect(observed)
+
+        let ordinarySpace = AXSurface(runtime: ProgressWindowAXFixture(windowTitle: "Logic Pro").runtime)
+            .progressWindowPresent()
+        #expect(ordinarySpace)
+    }
+
+    @Test("a window that is not the progress dialog is not mistaken for it")
+    func progressWindowRejectsOtherTitles() {
+        // The separator may localise, but it must still BE a separator: a title
+        // with the space removed is a different product string, not this dialog.
+        let noSeparator = AXSurface(runtime: ProgressWindowAXFixture(windowTitle: "LogicPro").runtime)
+            .progressWindowPresent()
+        let rejectsRemovedSeparator = !noSeparator
+        #expect(rejectsRemovedSeparator)
+
+        let project = AXSurface(runtime: ProgressWindowAXFixture(windowTitle: "lpm-606-warm - 트랙").runtime)
+            .progressWindowPresent()
+        let rejectsProjectWindow = !project
+        #expect(rejectsProjectWindow)
+
+        let none = AXSurface(runtime: ProgressWindowAXFixture(windowTitle: nil).runtime)
+            .progressWindowPresent()
+        let rejectsNoWindows = !none
+        #expect(rejectsNoWindows)
+    }
+
+    @Test("destination browser refuses duplicate URL entries rather than using traversal order")
+    func destinationBrowserRefusesDuplicateURL() {
+        let destination = "/Users/fixture/Exports"
+        let fixture = DestinationBrowserAXFixture(
+            initialEntries: [destination, destination],
+            childrenByPath: [destination: ["\(destination)/Rendered"]]
+        )
+        let result = AXSurface(runtime: fixture.runtime)
+            .selectDestinationBrowserElement(at: destination)
+
+        guard case let .refused(reason) = result else {
+            Issue.record("a duplicate URL entry was accepted using traversal order")
+            return
+        }
+        let duplicateWasNamed = reason.contains("ambiguous:Exports")
+        #expect(duplicateWasNamed)
+        let wroteNothing = fixture.state.selectedChildrenWrites.isEmpty
+        #expect(wroteNothing)
+    }
+
+    @Test("a Cancel-only decoy is not recognised as a stem-export panel")
+    func cancelOnlyDecoyIsNotRecognised() {
+        let fixture = StemExportPanelAXFixture(
+            popupValue: "One File per Track",
+            exportButtonTitle: nil,
+            cancelButtonTitle: "Cancel"
+        )
+        let surface = AXSurface(runtime: fixture.runtime)
+
+        let decoyIsAbsent = surface.exportPanelPresence() == .absent
+        #expect(decoyIsAbsent)
+        let exportWasNotPressed = !surface.pressExport()
+        #expect(exportWasNotPressed)
+    }
+
+    @Test("an unmeasured stem-export panel refuses with the missing-measurement reason")
+    func unmeasuredStemExportPanelRefuses() async {
+        // Deliberately synthetic AX labels: neither is claimed as a Logic
+        // translation, so the fixture models a locale awaiting measurement.
+        let fixture = StemExportPanelAXFixture(
+            popupValue: "未測定のトラック別ファイル",
+            exportButtonTitle: "未測定の書き出し",
+            cancelButtonTitle: "未測定の取り消し"
+        )
+        let panelPresence = AXSurface(runtime: fixture.runtime).exportPanelPresence()
+        let namesMissingMeasurement = panelPresence == .unmeasured(
+            ProjectStemExportPanelDriver.panelLabelNotMeasuredReason
+        )
+        #expect(namesMissingMeasurement)
+
+        let surface = StemPanelSurfaceFake()
+        surface.panelPresence = panelPresence
+        let outcome = await driveStemPanel(surface)
+        let refusedForMissingMeasurement = outcome == .refused(
+            ProjectStemExportPanelDriver.panelLabelNotMeasuredReason
+        )
+        #expect(refusedForMissingMeasurement)
+    }
+
+    @Test("Korean all-tracks audio-file leaf resolves")
+    func koreanAllTracksStemLeafResolves() {
+        let resolves = ProjectStemExportPanelDriver.stemLeafTitleMatches("모든 트랙을 오디오 파일로…")
+        #expect(resolves)
+    }
+
+    @Test("Korean selection-rewritten single-track audio-file leaf is rejected")
+    func koreanSingleTrackStemLeafIsRejected() {
+        let resolves = ProjectStemExportPanelDriver.stemLeafTitleMatches("1개의 트랙을 오디오 파일로…")
+        #expect(!resolves)
+    }
+
+    @Test("Korean selection-range audio-file leaf is rejected")
+    func koreanSelectionRangeStemLeafIsRejected() {
+        let resolves = ProjectStemExportPanelDriver.stemLeafTitleMatches("선택 범위를 오디오 파일로…")
+        #expect(!resolves)
+    }
+
+    @Test("unmeasured stem-export labels refuse instead of falling back to a guess")
+    func unmeasuredLocaleStemMenuRefuses() async {
+        // A synthetic Japanese-script AX title, deliberately NOT offered as a
+        // Logic translation or a policy variant: this leaf has no Japanese
+        // measurement, so it must remain an unrecognized title.
+        let unmatchedTitle = "未測定ロケールのオーディオ書き出し"
+        let titleMatches = ProjectStemExportPanelDriver.stemLeafTitleMatches(unmatchedTitle)
+        #expect(!titleMatches)
+
+        let surface = StemPanelSurfaceFake()
+        surface.stemLeafAvailability = .unavailable(
+            ProjectStemExportPanelDriver.stemLeafLabelNotMeasuredReason
+        )
+        let outcome = await driveStemPanel(surface)
+        let refusalNamesMeasurement = outcome == .refused(
+            ProjectStemExportPanelDriver.stemLeafLabelNotMeasuredReason
+        )
+        #expect(refusalNamesMeasurement)
+        let leafWasNotPicked = !surface.events.contains("leaf_axpick")
+        #expect(leafWasNotPicked)
     }
 
     // Typing a destination path DISMISSES the panel — reproduced twice live with

--- a/Tests/LogicProMCPTests/Issue369StemExportTests.swift
+++ b/Tests/LogicProMCPTests/Issue369StemExportTests.swift
@@ -28,11 +28,19 @@ private final class StemPanelSurfaceFake: ProjectStemExportPanelDriver.Surface, 
     /// driver must never use the first as evidence for the second.
     var exportActionStatus = true
     var exportEffectOccurs = true
+    /// Models the user pressing Escape (or an unrelated transient census) after
+    /// the driver reaches Export but before progress was ever observed.
+    var panelDisappearsAfterExportPress = false
     var progressObservations: [ProjectStemExportPanelDriver.ProgressPresence] = [.present, .absent]
     var panelPresence: ProjectStemExportPanelDriver.PanelPresence = .present
     var closeChangesPanelPresence = true
     var dismissLabelMeasured = true
     var onPanelRead: (() -> Void)?
+    /// Lets a state-machine test use AXSurface's real panel classifier for its
+    /// pre-close observations while the semantic fake still supplies the other
+    /// protocol actions.
+    var panelPresenceReader: (() -> ProjectStemExportPanelDriver.PanelPresence)?
+    var panelCloseAction: (() -> Void)?
 
     func openFileMenu() -> Bool {
         events.append("file_open")
@@ -62,6 +70,9 @@ private final class StemPanelSurfaceFake: ProjectStemExportPanelDriver.Surface, 
     func exportPanelPresence() -> ProjectStemExportPanelDriver.PanelPresence {
         events.append("panel_read")
         onPanelRead?()
+        if !events.contains("panel_close"), let panelPresenceReader {
+            return panelPresenceReader()
+        }
         if !panelAppears { return .absent }
         if panelPresence == .present, absentPanelReadsBeforePresent > 0 {
             absentPanelReadsBeforePresent -= 1
@@ -92,6 +103,9 @@ private final class StemPanelSurfaceFake: ProjectStemExportPanelDriver.Surface, 
 
     func pressExport() {
         events.append("export_press_status_\(exportActionStatus)")
+        if panelDisappearsAfterExportPress {
+            panelPresence = .absent
+        }
         if !exportEffectOccurs {
             progressObservations = Array(repeating: .absent, count: max(1, progressObservations.count))
         }
@@ -105,6 +119,7 @@ private final class StemPanelSurfaceFake: ProjectStemExportPanelDriver.Surface, 
 
     func closeExportPanel() {
         events.append("panel_close")
+        panelCloseAction?()
         if closeChangesPanelPresence,
            dismissLabelMeasured,
            panelPresence != .unavailable {
@@ -196,12 +211,15 @@ private struct StemExportPanelAXFixture {
         popupTitle: String? = nil,
         actionStatus: Bool = true,
         actionEffectsOccur: Bool = true,
-        failPanelChildrenRead: Bool = false
+        failPanelChildrenRead: Bool = false,
+        usesStemPopupStructure: Bool = true,
+        unreadablePerTrackPopupRole: Bool = false
     ) {
         let builder = FakeAXRuntimeBuilder()
         let app = builder.element(1)
         let panel = builder.element(2)
         let popup = builder.element(3)
+        let perTrackPopup = builder.element(4)
 
         builder.setRole(panel, kAXWindowRole as String)
         if isDialog {
@@ -210,17 +228,39 @@ private struct StemExportPanelAXFixture {
 
         var panelChildren: [AXUIElement] = []
         if includesPopup {
-            builder.setRole(popup, kAXPopUpButtonRole as String)
-            builder.setAttribute(popup, kAXValueAttribute as String, popupValue)
-            if let popupTitle {
-                builder.setAttribute(popup, kAXTitleAttribute as String, popupTitle)
+            if usesStemPopupStructure {
+                // Logic's panel has one titled destination popup plus five
+                // untitled option popups. The fixture mirrors that complete
+                // structural witness instead of letting a lone generic popup
+                // stand in for the per-track control.
+                builder.setRole(popup, kAXPopUpButtonRole as String)
+                builder.setAttribute(popup, kAXValueAttribute as String, "Stem Exports")
+                builder.setAttribute(popup, kAXTitleAttribute as String, popupTitle ?? "Location:")
+                panelChildren.append(popup)
+
+                builder.setRole(perTrackPopup, kAXPopUpButtonRole as String)
+                builder.setAttribute(perTrackPopup, kAXValueAttribute as String, popupValue)
+                panelChildren.append(perTrackPopup)
+
+                for (offset, value) in ["AIFF", "16-bit", "Normalize", "Include Audio Tail"].enumerated() {
+                    let option = builder.element(10 + offset)
+                    builder.setRole(option, kAXPopUpButtonRole as String)
+                    builder.setAttribute(option, kAXValueAttribute as String, value)
+                    panelChildren.append(option)
+                }
+            } else {
+                builder.setRole(popup, kAXPopUpButtonRole as String)
+                builder.setAttribute(popup, kAXValueAttribute as String, popupValue)
+                if let popupTitle {
+                    builder.setAttribute(popup, kAXTitleAttribute as String, popupTitle)
+                }
+                panelChildren.append(popup)
             }
-            panelChildren.append(popup)
         }
 
         var export: AXUIElement?
         if let exportButtonTitle {
-            let button = builder.element(4)
+            let button = builder.element(20)
             builder.setButton(
                 button,
                 title: exportButtonTitle,
@@ -234,7 +274,7 @@ private struct StemExportPanelAXFixture {
         }
         var cancel: AXUIElement?
         if let cancelButtonTitle {
-            let button = builder.element(5)
+            let button = builder.element(21)
             builder.setButton(
                 button,
                 title: cancelButtonTitle,
@@ -261,6 +301,14 @@ private struct StemExportPanelAXFixture {
         self.state = state
         runtime = builder.makeLogicRuntime(
             appElement: app,
+            attributeValueResultHandler: { element, attribute in
+                if unreadablePerTrackPopupRole,
+                   CFEqual(element, perTrackPopup),
+                   attribute == (kAXRoleAttribute as String) {
+                    return .failure(AXHelpers.AXStatusError(raw: AXError.noValue.rawValue))
+                }
+                return nil
+            },
             childrenResultHandler: { element in
                 if failPanelChildrenRead, CFEqual(element, panel) {
                     return .failure(AXHelpers.AXStatusError(raw: AXError.failure.rawValue))
@@ -326,12 +374,27 @@ private struct DestinationPopupAXFixture {
 private struct ProgressWindowAXFixture {
     let runtime: AXLogicProElements.Runtime
 
-    init(windowTitle: String?, failWindowsRead: Bool = false) {
+    init(
+        windowTitle: String?,
+        failWindowsRead: Bool = false,
+        untitledWindowBeforeProgress: Bool = false
+    ) {
         let builder = FakeAXRuntimeBuilder()
         let app = builder.element(1)
         var windows: [AXUIElement] = []
+        var nextElementID = 2
+        let untitledWindow: AXUIElement?
+        if untitledWindowBeforeProgress {
+            let window = builder.element(nextElementID)
+            nextElementID += 1
+            builder.setRole(window, kAXWindowRole as String)
+            windows.append(window)
+            untitledWindow = window
+        } else {
+            untitledWindow = nil
+        }
         if let windowTitle {
-            let window = builder.element(2)
+            let window = builder.element(nextElementID)
             builder.setRole(window, kAXWindowRole as String)
             builder.setAttribute(window, kAXTitleAttribute as String, windowTitle)
             windows.append(window)
@@ -340,6 +403,11 @@ private struct ProgressWindowAXFixture {
         runtime = builder.makeLogicRuntime(
             appElement: app,
             attributeValueResultHandler: { element, attribute in
+                if let untitledWindow,
+                   CFEqual(element, untitledWindow),
+                   attribute == (kAXTitleAttribute as String) {
+                    return .failure(AXHelpers.AXStatusError(raw: AXError.noValue.rawValue))
+                }
                 if failWindowsRead,
                    CFEqual(element, app),
                    attribute == (kAXWindowsAttribute as String) {
@@ -494,12 +562,20 @@ private struct DestinationBrowserAXFixture {
         builder.setRole(panel, kAXWindowRole as String)
         builder.setAttribute(panel, kAXSubroleAttribute as String, kAXDialogSubrole as String)
         builder.setRole(popup, kAXPopUpButtonRole as String)
+        builder.setAttribute(popup, kAXTitleAttribute as String, "Location:")
         builder.setAttribute(popup, kAXValueAttribute as String, "Other Destination")
         builder.setRole(perTrack, kAXPopUpButtonRole as String)
         builder.setAttribute(perTrack, kAXValueAttribute as String, "One File per Track")
         builder.setButton(export, title: "Export", x: 100, y: 100, width: 70, height: 24)
         builder.setButton(cancel, title: "Cancel", x: 180, y: 100, width: 70, height: 24)
-        var panelChildren = [popup, perTrack, export, cancel]
+        var panelChildren = [popup, perTrack]
+        for (offset, value) in ["AIFF", "16-bit", "Normalize", "Include Audio Tail"].enumerated() {
+            let option = builder.element(20 + offset)
+            builder.setRole(option, kAXPopUpButtonRole as String)
+            builder.setAttribute(option, kAXValueAttribute as String, value)
+            panelChildren.append(option)
+        }
+        panelChildren += [export, cancel]
         let outline: AXUIElement?
         if let volumeName {
             let outlineElement = builder.element(6)
@@ -1005,6 +1081,17 @@ struct Issue369StemExportTests {
         #expect(didNotClaimCompletion)
     }
 
+    @Test("an untitled auxiliary window does not hide the later progress window")
+    func untitledWindowBeforeProgressWindowIsSkipped() {
+        let presence = AXSurface(runtime: ProgressWindowAXFixture(
+            windowTitle: "Logic Pro",
+            untitledWindowBeforeProgress: true
+        ).runtime).progressWindowPresence()
+
+        let laterProgressWindowWasObserved = presence == .present
+        #expect(laterProgressWindowWasObserved)
+    }
+
     @Test("destination browser refuses duplicate URL entries rather than using traversal order")
     func destinationBrowserRefusesDuplicateURL() {
         let destination = "/Users/fixture/Exports"
@@ -1050,6 +1137,69 @@ struct Issue369StemExportTests {
             "stem_export_panel_partially_measured: recognized=Cancel; not_measured=Export"
         )
         #expect(refusalNamesRecognizedAndMissingLabels)
+    }
+
+    @Test("a popup-bearing Cancel decoy is neither recognised nor cancelled")
+    func popupBearingCancelDecoyIsNotTouched() async {
+        let fixture = StemExportPanelAXFixture(
+            popupValue: "General Settings",
+            exportButtonTitle: "Apply",
+            cancelButtonTitle: "Cancel",
+            usesStemPopupStructure: false
+        )
+        let axSurface = AXSurface(runtime: fixture.runtime)
+        let driverSurface = StemPanelSurfaceFake()
+        driverSurface.panelPresenceReader = { axSurface.exportPanelPresence() }
+        driverSurface.panelCloseAction = { axSurface.closeExportPanel() }
+
+        let outcome = await driveStemPanel(driverSurface)
+        let decoyWasNotRecognised = outcome == .refused(
+            "stem_export_panel_not_observed_after_bounded_wait_elapsed"
+        )
+        #expect(decoyWasNotRecognised)
+        let decoyCancelWasNotPressed = fixture.state.cancelActionAttempts == 0
+        #expect(decoyCancelWasNotPressed)
+    }
+
+    @Test("a non-active per-track popup is recognised then refused at its state guard")
+    func inactivePerTrackPopupUsesDedicatedStateRefusal() async {
+        let fixture = StemExportPanelAXFixture(
+            popupValue: "One File",
+            exportButtonTitle: "Export",
+            cancelButtonTitle: "Cancel"
+        )
+        let axSurface = AXSurface(runtime: fixture.runtime)
+        let productionPresence = axSurface.exportPanelPresence()
+
+        let panelWasRecognised = productionPresence == .present
+        #expect(panelWasRecognised)
+        let perTrackStateWasInactive = !axSurface.oneFilePerTrackIsActive()
+        #expect(perTrackStateWasInactive)
+
+        let driverSurface = StemPanelSurfaceFake()
+        driverSurface.panelPresenceReader = { axSurface.exportPanelPresence() }
+        driverSurface.perTrackActive = false
+        let outcome = await driveStemPanel(driverSurface)
+
+        let refusedAtPerTrackGuard = outcome == .refused("stem_one_file_per_track_not_active")
+        #expect(refusedAtPerTrackGuard)
+    }
+
+    @Test("a descendant with no readable role makes the stem-panel census unavailable")
+    func unreadableDescendantRoleDoesNotDisappearFromCensus() {
+        let fixture = StemExportPanelAXFixture(
+            popupValue: "One File per Track",
+            exportButtonTitle: "Export",
+            cancelButtonTitle: "Cancel",
+            unreadablePerTrackPopupRole: true
+        )
+        let surface = AXSurface(runtime: fixture.runtime)
+
+        let censusWasUnavailable = surface.exportPanelPresence() == .unavailable
+        #expect(censusWasUnavailable)
+        surface.closeExportPanel()
+        let unreadableRoleDidNotAuthorizeCancel = fixture.state.cancelActionAttempts == 0
+        #expect(unreadableRoleDidNotAuthorizeCancel)
     }
 
     @Test("an unmeasured stem-export panel states that it was left open")
@@ -1309,14 +1459,33 @@ struct Issue369StemExportTests {
         #expect(noEffectWasObserved)
     }
 
-    @Test("an effect-unobserved panel drive does not publish bounce_fired")
-    func unobservedEffectMapsWithoutBounceFired() async throws {
+    @Test("a disappearing panel without progress is not an observed export effect")
+    func escapeShapedPanelDisappearanceDoesNotFireBounce() async {
+        let surface = StemPanelSurfaceFake()
+        surface.exportEffectOccurs = false
+        surface.panelDisappearsAfterExportPress = true
+        surface.progressObservations = [.absent, .absent]
+
+        let outcome = await driveStemPanel(surface, attempts: 2)
+
+        let didNotTreatPanelDisappearanceAsEffect = outcome == .uncertain(
+            "stem_export_press_effect_not_observed",
+            exportEffectObserved: false
+        )
+        #expect(didNotTreatPanelDisappearanceAsEffect)
+    }
+
+    @Test("a post-press unobserved effect preserves write_attempted without bounce_fired")
+    func unobservedEffectMapsToActuatorReceiptWithoutBounce() async throws {
         let projectRoot = try makeExecTempDir()
         let outputRoot = try makeExecTempDir()
         let project = try makeLogicxProject(in: projectRoot, named: "Unobserved Stem Press")
         var options = fastOptions(identity: { project.path })
         options.driveStemExport = { _ in
-            .uncertain("stem_export_press_effect_not_observed", exportEffectObserved: false)
+            .uncertain(
+                "readback_unavailable: stem_export_effect_or_progress_not_observed_after_press",
+                exportEffectObserved: false
+            )
         }
 
         let run = await ProjectExportExecutor.run(
@@ -1335,8 +1504,8 @@ struct Issue369StemExportTests {
         let artifact = try #require(run.projects.first?.artifacts.first)
         let didNotClaimBounce = !artifact.bounceFired
         #expect(didNotClaimBounce)
-        let didNotClaimWrite = !artifact.writeAttempted
-        #expect(didNotClaimWrite)
+        let actuatorWasReached = artifact.writeAttempted
+        #expect(actuatorWasReached)
     }
 
     @Test("panel refusal becomes State C with write_attempted false")

--- a/Tests/LogicProMCPTests/Issue369StemExportTests.swift
+++ b/Tests/LogicProMCPTests/Issue369StemExportTests.swift
@@ -24,10 +24,15 @@ private final class StemPanelSurfaceFake: ProjectStemExportPanelDriver.Surface, 
     var destinationBefore: String? = "Old Exports"
     var destinationAfter: String? = "Stem Exports"
     var perTrackActive = true
-    var exportPressSucceeds = true
-    var progressStates: [Bool] = [true, false]
+    /// The action status and observable UI effect vary independently. The
+    /// driver must never use the first as evidence for the second.
+    var exportActionStatus = true
+    var exportEffectOccurs = true
+    var progressObservations: [ProjectStemExportPanelDriver.ProgressPresence] = [.present, .absent]
     var panelPresence: ProjectStemExportPanelDriver.PanelPresence = .present
     var closeChangesPanelPresence = true
+    var dismissLabelMeasured = true
+    var onPanelRead: (() -> Void)?
 
     func openFileMenu() -> Bool {
         events.append("file_open")
@@ -56,6 +61,7 @@ private final class StemPanelSurfaceFake: ProjectStemExportPanelDriver.Surface, 
 
     func exportPanelPresence() -> ProjectStemExportPanelDriver.PanelPresence {
         events.append("panel_read")
+        onPanelRead?()
         if !panelAppears { return .absent }
         if panelPresence == .present, absentPanelReadsBeforePresent > 0 {
             absentPanelReadsBeforePresent -= 1
@@ -84,24 +90,31 @@ private final class StemPanelSurfaceFake: ProjectStemExportPanelDriver.Surface, 
         return perTrackActive
     }
 
-    func pressExport() -> Bool {
-        events.append("export_press")
-        return exportPressSucceeds
+    func pressExport() {
+        events.append("export_press_status_\(exportActionStatus)")
+        if !exportEffectOccurs {
+            progressObservations = Array(repeating: .absent, count: max(1, progressObservations.count))
+        }
     }
 
-    func progressWindowPresent() -> Bool {
+    func progressWindowPresence() -> ProjectStemExportPanelDriver.ProgressPresence {
         events.append("progress_read")
-        guard !progressStates.isEmpty else { return false }
-        return progressStates.removeFirst()
+        guard !progressObservations.isEmpty else { return .absent }
+        return progressObservations.removeFirst()
     }
 
-    func closeExportPanel() -> Bool {
+    func closeExportPanel() {
         events.append("panel_close")
-        if closeChangesPanelPresence, panelPresence == .present {
+        if closeChangesPanelPresence,
+           dismissLabelMeasured,
+           panelPresence != .unavailable {
             panelPresence = .absent
         }
-        return true
     }
+}
+
+private final class StemPanelTestClock: @unchecked Sendable {
+    var now: UInt64 = 0
 }
 
 private func driveStemPanel(
@@ -109,23 +122,81 @@ private func driveStemPanel(
     attempts: Int = 3,
     pollIntervalNanos: UInt64 = 250_000_000
 ) async -> ProjectStemExportPanelDriver.Outcome {
-    await ProjectStemExportPanelDriver.drive(
+    let clock = StemPanelTestClock()
+    return await ProjectStemExportPanelDriver.drive(
         destination: "/private/tmp/Stem Exports",
         surface: surface,
         progressPollAttempts: attempts,
-        sleep: { _ in surface.events.append("poll_sleep") },
-        pollIntervalNanos: pollIntervalNanos
+        sleep: { duration in
+            surface.events.append("poll_sleep")
+            clock.now += duration
+        },
+        pollIntervalNanos: pollIntervalNanos,
+        monotonicNowNanos: { clock.now }
     )
+}
+
+private final class StemExportPanelAXFixtureState: @unchecked Sendable {
+    let builder: FakeAXRuntimeBuilder
+    let app: AXUIElement
+    let panel: AXUIElement
+    let export: AXUIElement?
+    let cancel: AXUIElement?
+    let actionEffectsOccur: Bool
+    private(set) var exportActionAttempts = 0
+    private(set) var cancelActionAttempts = 0
+
+    init(
+        builder: FakeAXRuntimeBuilder,
+        app: AXUIElement,
+        panel: AXUIElement,
+        export: AXUIElement?,
+        cancel: AXUIElement?,
+        actionEffectsOccur: Bool
+    ) {
+        self.builder = builder
+        self.app = app
+        self.panel = panel
+        self.export = export
+        self.cancel = cancel
+        self.actionEffectsOccur = actionEffectsOccur
+    }
+
+    func performAction(_ element: AXUIElement, _ action: String, status: Bool) -> Bool {
+        guard action == (kAXPressAction as String) else { return status }
+        if let export, CFEqual(element, export) {
+            exportActionAttempts += 1
+            if actionEffectsOccur {
+                let progress = builder.element(99)
+                builder.setRole(progress, kAXWindowRole as String)
+                builder.setAttribute(progress, kAXTitleAttribute as String, "Logic\u{00A0}Pro")
+                builder.setAttribute(app, kAXWindowsAttribute as String, [progress])
+            }
+        }
+        if let cancel, CFEqual(element, cancel) {
+            cancelActionAttempts += 1
+            if actionEffectsOccur {
+                builder.setAttribute(app, kAXWindowsAttribute as String, [])
+            }
+        }
+        return status
+    }
 }
 
 private struct StemExportPanelAXFixture {
     let runtime: AXLogicProElements.Runtime
+    let state: StemExportPanelAXFixtureState
 
     init(
         popupValue: String,
         exportButtonTitle: String?,
         cancelButtonTitle: String?,
-        isDialog: Bool = true
+        isDialog: Bool = true,
+        includesPopup: Bool = true,
+        popupTitle: String? = nil,
+        actionStatus: Bool = true,
+        actionEffectsOccur: Bool = true,
+        failPanelChildrenRead: Bool = false
     ) {
         let builder = FakeAXRuntimeBuilder()
         let app = builder.element(1)
@@ -137,38 +208,112 @@ private struct StemExportPanelAXFixture {
             builder.setAttribute(panel, kAXSubroleAttribute as String, kAXDialogSubrole as String)
         }
 
-        builder.setRole(popup, kAXPopUpButtonRole as String)
-        builder.setAttribute(popup, kAXValueAttribute as String, popupValue)
-        var panelChildren = [popup]
+        var panelChildren: [AXUIElement] = []
+        if includesPopup {
+            builder.setRole(popup, kAXPopUpButtonRole as String)
+            builder.setAttribute(popup, kAXValueAttribute as String, popupValue)
+            if let popupTitle {
+                builder.setAttribute(popup, kAXTitleAttribute as String, popupTitle)
+            }
+            panelChildren.append(popup)
+        }
 
+        var export: AXUIElement?
         if let exportButtonTitle {
-            let export = builder.element(4)
+            let button = builder.element(4)
             builder.setButton(
-                export,
+                button,
                 title: exportButtonTitle,
                 x: 100,
                 y: 100,
                 width: 70,
                 height: 24
             )
-            panelChildren.append(export)
+            panelChildren.append(button)
+            export = button
         }
+        var cancel: AXUIElement?
         if let cancelButtonTitle {
-            let cancel = builder.element(5)
+            let button = builder.element(5)
             builder.setButton(
-                cancel,
+                button,
                 title: cancelButtonTitle,
                 x: 180,
                 y: 100,
                 width: 70,
                 height: 24
             )
-            panelChildren.append(cancel)
+            panelChildren.append(button)
+            cancel = button
         }
 
         builder.setChildren(panel, panelChildren)
         builder.setAttribute(app, kAXWindowsAttribute as String, [panel])
 
+        let state = StemExportPanelAXFixtureState(
+            builder: builder,
+            app: app,
+            panel: panel,
+            export: export,
+            cancel: cancel,
+            actionEffectsOccur: actionEffectsOccur
+        )
+        self.state = state
+        runtime = builder.makeLogicRuntime(
+            appElement: app,
+            childrenResultHandler: { element in
+                if failPanelChildrenRead, CFEqual(element, panel) {
+                    return .failure(AXHelpers.AXStatusError(raw: AXError.failure.rawValue))
+                }
+                return nil
+            },
+            setAttributeHandler: nil,
+            performActionHandler: { element, action in
+                state.performAction(element, action, status: actionStatus)
+            }
+        )
+    }
+}
+
+/// The live export panel carries SIX popup buttons and only the destination one
+/// exposes an AXTitle. This fixture reproduces that shape so the production code
+/// cannot fall back to taking the first popup in traversal order — the untitled
+/// decoys are deliberately emitted BEFORE the titled one.
+private struct DestinationPopupAXFixture {
+    let runtime: AXLogicProElements.Runtime
+
+    init(titledPopups: [(title: String, value: String)], untitledValues: [String]) {
+        let builder = FakeAXRuntimeBuilder()
+        let app = builder.element(1)
+        let panel = builder.element(2)
+        builder.setRole(panel, kAXWindowRole as String)
+        builder.setAttribute(panel, kAXSubroleAttribute as String, kAXDialogSubrole as String)
+
+        var next = 3
+        var children: [AXUIElement] = []
+        for value in untitledValues {
+            let popup = builder.element(next); next += 1
+            builder.setRole(popup, kAXPopUpButtonRole as String)
+            builder.setAttribute(popup, kAXValueAttribute as String, value)
+            children.append(popup)
+        }
+        for entry in titledPopups {
+            let popup = builder.element(next); next += 1
+            builder.setRole(popup, kAXPopUpButtonRole as String)
+            builder.setAttribute(popup, kAXTitleAttribute as String, entry.title)
+            builder.setAttribute(popup, kAXValueAttribute as String, entry.value)
+            children.append(popup)
+        }
+        // The panel must still be recognisable, so give it its measured buttons.
+        let export = builder.element(next); next += 1
+        builder.setButton(export, title: "내보내기", x: 100, y: 100, width: 70, height: 24)
+        children.append(export)
+        let cancel = builder.element(next); next += 1
+        builder.setButton(cancel, title: "취소", x: 180, y: 100, width: 70, height: 24)
+        children.append(cancel)
+
+        builder.setChildren(panel, children)
+        builder.setAttribute(app, kAXWindowsAttribute as String, [panel])
         runtime = builder.makeLogicRuntime(appElement: app)
     }
 }
@@ -181,7 +326,7 @@ private struct StemExportPanelAXFixture {
 private struct ProgressWindowAXFixture {
     let runtime: AXLogicProElements.Runtime
 
-    init(windowTitle: String?) {
+    init(windowTitle: String?, failWindowsRead: Bool = false) {
         let builder = FakeAXRuntimeBuilder()
         let app = builder.element(1)
         var windows: [AXUIElement] = []
@@ -192,7 +337,19 @@ private struct ProgressWindowAXFixture {
             windows.append(window)
         }
         builder.setAttribute(app, kAXWindowsAttribute as String, windows)
-        runtime = builder.makeLogicRuntime(appElement: app)
+        runtime = builder.makeLogicRuntime(
+            appElement: app,
+            attributeValueResultHandler: { element, attribute in
+                if failWindowsRead,
+                   CFEqual(element, app),
+                   attribute == (kAXWindowsAttribute as String) {
+                    return .failure(AXHelpers.AXStatusError(raw: AXError.failure.rawValue))
+                }
+                return nil
+            },
+            setAttributeHandler: nil,
+            performActionHandler: nil
+        )
     }
 }
 
@@ -207,8 +364,13 @@ private final class DestinationBrowserFixtureState: @unchecked Sendable {
     private var pathByGroupID: [Int: String] = [:]
     private var listIDs: Set<Int> = []
     private let childrenByPath: [String: [String]]
-    private let observesSelection: Bool
+    private let acceptsWrite: Bool
+    private let navigationOccurs: Bool
+    private let outlineID: Int?
+    private let volumeRootEntriesAfterSelection: [String]?
+    private var navigationNowNanos: UInt64 = 0
     private(set) var selectedChildrenWrites: [(listID: Int, selectedGroupID: Int)] = []
+    private(set) var selectionEchoCount = 0
     private(set) var actions: [(elementID: Int, action: String)] = []
 
     init(
@@ -216,17 +378,31 @@ private final class DestinationBrowserFixtureState: @unchecked Sendable {
         panel: AXUIElement,
         initialEntries: [String],
         childrenByPath: [String: [String]],
-        observesSelection: Bool
+        acceptsWrite: Bool,
+        navigationOccurs: Bool,
+        outline: AXUIElement?,
+        volumeRootEntriesAfterSelection: [String]?
     ) {
         self.builder = builder
         self.panel = panel
         self.panelChildren = AXHelpers.getChildren(panel, runtime: builder.makeAXRuntime())
         self.childrenByPath = childrenByPath
-        self.observesSelection = observesSelection
+        self.acceptsWrite = acceptsWrite
+        self.navigationOccurs = navigationOccurs
+        self.outlineID = outline.map(builder.elementID)
+        self.volumeRootEntriesAfterSelection = volumeRootEntriesAfterSelection
         appendColumn(entries: initialEntries)
     }
 
     func handleWrite(_ element: AXUIElement, _ attribute: String, _ value: CFTypeRef) -> Bool {
+        if attribute == (kAXSelectedRowsAttribute as String),
+           outlineID == builder.elementID(element) {
+            builder.setAttribute(element, attribute, value)
+            if let volumeRootEntriesAfterSelection {
+                appendColumn(entries: volumeRootEntriesAfterSelection)
+            }
+            return true
+        }
         guard attribute == (kAXSelectedChildrenAttribute as String),
               listIDs.contains(builder.elementID(element)),
               let selected = value as? [AXUIElement],
@@ -236,23 +412,28 @@ private final class DestinationBrowserFixtureState: @unchecked Sendable {
             return true
         }
         selectedChildrenWrites.append((builder.elementID(element), builder.elementID(group)))
-        // Deliberately return success in both states. The no-readback fixture
-        // models an AX status 0 that had no observed effect at all: the write is
-        // accepted and then leaves no trace, so neither the selection nor a child
-        // column can be read back.
-        //
-        // It deliberately does NOT model "the selection is recorded but the panel
-        // does not navigate". That intermediate state has never been observed on
-        // the live panel — measured 2026-09-02, the selection readback and the
-        // destination agreed on every hop — and a fixture asserting it would be
-        // asserting behaviour we cannot show exists.
-        if observesSelection {
-            builder.setAttribute(element, attribute, value)
-            if let children = childrenByPath[path] {
-                appendColumn(entries: children)
-            }
+        guard acceptsWrite else { return false }
+        // A successful settable AX attribute write always echoes in a real AX
+        // server. Navigation is a distinct physical effect and is deliberately
+        // controlled separately, so all three states are expressible: rejected,
+        // echoed-without-navigation, and echoed-with-navigation.
+        builder.setAttribute(element, attribute, value)
+        selectionEchoCount += 1
+        if navigationOccurs, let children = childrenByPath[path] {
+            appendColumn(entries: children)
         }
         return true
+    }
+
+    func directoryListing(at path: String) -> AXSurface.DirectoryListing {
+        guard let entries = childrenByPath[path] else { return .empty }
+        return entries.isEmpty ? .empty : .hasEntries
+    }
+
+    func navigationNow() -> UInt64 { navigationNowNanos }
+
+    func advanceNavigationClock(by duration: UInt64) {
+        navigationNowNanos += duration
     }
 
     func recordAction(_ element: AXUIElement, _ action: String) -> Bool {
@@ -298,7 +479,10 @@ private struct DestinationBrowserAXFixture {
     init(
         initialEntries: [String],
         childrenByPath: [String: [String]],
-        observesSelection: Bool = true
+        acceptsWrite: Bool = true,
+        navigationOccurs: Bool = true,
+        volumeName: String? = nil,
+        volumeRootEntriesAfterSelection: [String]? = nil
     ) {
         let builder = FakeAXRuntimeBuilder()
         let app = builder.element(1)
@@ -306,13 +490,33 @@ private struct DestinationBrowserAXFixture {
         let popup = builder.element(3)
         let export = builder.element(4)
         let cancel = builder.element(5)
+        let perTrack = builder.element(9)
         builder.setRole(panel, kAXWindowRole as String)
         builder.setAttribute(panel, kAXSubroleAttribute as String, kAXDialogSubrole as String)
         builder.setRole(popup, kAXPopUpButtonRole as String)
         builder.setAttribute(popup, kAXValueAttribute as String, "Other Destination")
+        builder.setRole(perTrack, kAXPopUpButtonRole as String)
+        builder.setAttribute(perTrack, kAXValueAttribute as String, "One File per Track")
         builder.setButton(export, title: "Export", x: 100, y: 100, width: 70, height: 24)
         builder.setButton(cancel, title: "Cancel", x: 180, y: 100, width: 70, height: 24)
-        builder.setChildren(panel, [popup, export, cancel])
+        var panelChildren = [popup, perTrack, export, cancel]
+        let outline: AXUIElement?
+        if let volumeName {
+            let outlineElement = builder.element(6)
+            let row = builder.element(7)
+            let text = builder.element(8)
+            builder.setRole(outlineElement, kAXOutlineRole as String)
+            builder.setRole(row, kAXRowRole as String)
+            builder.setRole(text, kAXStaticTextRole as String)
+            builder.setAttribute(text, kAXValueAttribute as String, volumeName)
+            builder.setChildren(row, [text])
+            builder.setChildren(outlineElement, [row])
+            panelChildren.append(outlineElement)
+            outline = outlineElement
+        } else {
+            outline = nil
+        }
+        builder.setChildren(panel, panelChildren)
         builder.setAttribute(app, kAXWindowsAttribute as String, [panel])
 
         let state = DestinationBrowserFixtureState(
@@ -320,7 +524,10 @@ private struct DestinationBrowserAXFixture {
             panel: panel,
             initialEntries: initialEntries,
             childrenByPath: childrenByPath,
-            observesSelection: observesSelection
+            acceptsWrite: acceptsWrite,
+            navigationOccurs: navigationOccurs,
+            outline: outline,
+            volumeRootEntriesAfterSelection: volumeRootEntriesAfterSelection
         )
         self.state = state
         runtime = builder.makeLogicRuntime(
@@ -331,6 +538,15 @@ private struct DestinationBrowserAXFixture {
             performActionHandler: { element, action in
                 state.recordAction(element, action)
             }
+        )
+    }
+
+    func makeSurface() -> AXSurface {
+        AXSurface(
+            runtime: runtime,
+            directoryListing: { [state] path in state.directoryListing(at: path) },
+            navigationNowNanos: { [state] in state.navigationNow() },
+            navigationSleep: { [state] duration in state.advanceNavigationClock(by: duration) }
         )
     }
 }
@@ -434,6 +650,36 @@ struct Issue369StemExportTests {
         #expect(observationStayedBounded)
     }
 
+    @Test("panel observation budget includes synchronous AX census time")
+    func panelDeadlineCountsReadTime() async {
+        let surface = StemPanelSurfaceFake()
+        surface.panelAppears = false
+        let clock = StemPanelTestClock()
+        surface.onPanelRead = {
+            // One slow AX census already exceeds the advertised ten-second
+            // bound. Sleep-only accounting would still perform forty polls.
+            clock.now += ProjectStemExportPanelDriver.exportPanelObservationDeadlineNanos + 1
+        }
+        let outcome = await ProjectStemExportPanelDriver.drive(
+            destination: "/private/tmp/Stem Exports",
+            surface: surface,
+            progressPollAttempts: 1,
+            sleep: { duration in
+                surface.events.append("poll_sleep")
+                clock.now += duration
+            },
+            pollIntervalNanos: 250_000_000,
+            monotonicNowNanos: { clock.now }
+        )
+
+        let refusedAtElapsedBound = outcome == .refused(
+            "stem_export_panel_not_observed_after_bounded_wait_elapsed"
+        )
+        #expect(refusedAtElapsedBound)
+        let noSleepOccurred = !surface.events.contains("poll_sleep")
+        #expect(noSleepOccurred)
+    }
+
     @Test("an unavailable panel readback refuses without becoming absence")
     func unavailableExportPanelReadbackRefusesDistinctly() async {
         let surface = StemPanelSurfaceFake()
@@ -466,7 +712,33 @@ struct Issue369StemExportTests {
         #expect(resolves)
     }
 
-    @Test("English stem-export panel is recognised and its measured controls operate")
+    @Test("parent-menu action status is not treated as evidence that the menu opened")
+    func menuActionStatusDoesNotDecideAvailability() {
+        let builder = FakeAXRuntimeBuilder()
+        let app = builder.element(1)
+        let menuBar = builder.element(2)
+        let file = builder.element(3)
+        let export = builder.element(4)
+        builder.setAttribute(app, "AXMenuBar", menuBar)
+        builder.setAttribute(file, kAXTitleAttribute as String, "File")
+        builder.setChildren(menuBar, [file])
+        builder.setRole(export, kAXMenuItemRole as String)
+        builder.setAttribute(export, kAXTitleAttribute as String, "Export")
+        builder.setChildren(app, [export])
+        let runtime = builder.makeLogicRuntime(
+            appElement: app,
+            setAttributeHandler: nil,
+            performActionHandler: { _, _ in false }
+        )
+        let surface = AXSurface(runtime: runtime)
+
+        let fileCandidateWasFound = surface.openFileMenu()
+        #expect(fileCandidateWasFound)
+        let exportCandidateWasFound = surface.openExportMenu() == .available
+        #expect(exportCandidateWasFound)
+    }
+
+    @Test("English stem-export controls are identified and their effects are observed")
     func englishStemExportPanelIsRecognised() {
         let fixture = StemExportPanelAXFixture(
             popupValue: "One File per Track",
@@ -479,13 +751,24 @@ struct Issue369StemExportTests {
         #expect(recognised)
         let oneFilePerTrackIsActive = surface.oneFilePerTrackIsActive()
         #expect(oneFilePerTrackIsActive)
-        let exportPressed = surface.pressExport()
-        #expect(exportPressed)
-        let cancelPressed = surface.closeExportPanel()
-        #expect(cancelPressed)
+        surface.pressExport()
+        let exportEffectWasObserved = surface.progressWindowPresence() == .present
+        #expect(exportEffectWasObserved)
+        #expect(fixture.state.exportActionAttempts == 1)
+
+        let cancelFixture = StemExportPanelAXFixture(
+            popupValue: "One File per Track",
+            exportButtonTitle: "Export",
+            cancelButtonTitle: "Cancel"
+        )
+        let cancelSurface = AXSurface(runtime: cancelFixture.runtime)
+        cancelSurface.closeExportPanel()
+        let cancelEffectWasObserved = cancelSurface.exportPanelPresence() == .absent
+        #expect(cancelEffectWasObserved)
+        #expect(cancelFixture.state.cancelActionAttempts == 1)
     }
 
-    @Test("Korean stem-export panel is recognised and its measured controls operate")
+    @Test("Korean stem-export controls are identified and their effects are observed")
     func koreanStemExportPanelIsRecognised() {
         let fixture = StemExportPanelAXFixture(
             popupValue: "트랙당 하나의 파일",
@@ -498,10 +781,19 @@ struct Issue369StemExportTests {
         #expect(recognised)
         let oneFilePerTrackIsActive = surface.oneFilePerTrackIsActive()
         #expect(oneFilePerTrackIsActive)
-        let exportPressed = surface.pressExport()
-        #expect(exportPressed)
-        let cancelPressed = surface.closeExportPanel()
-        #expect(cancelPressed)
+        surface.pressExport()
+        let exportEffectWasObserved = surface.progressWindowPresence() == .present
+        #expect(exportEffectWasObserved)
+
+        let cancelFixture = StemExportPanelAXFixture(
+            popupValue: "트랙당 하나의 파일",
+            exportButtonTitle: "내보내기",
+            cancelButtonTitle: "취소"
+        )
+        let cancelSurface = AXSurface(runtime: cancelFixture.runtime)
+        cancelSurface.closeExportPanel()
+        let cancelEffectWasObserved = cancelSurface.exportPanelPresence() == .absent
+        #expect(cancelEffectWasObserved)
     }
 
     @Test("destination browser writes AXSelectedChildren for a URL-backed one-level entry")
@@ -511,8 +803,7 @@ struct Issue369StemExportTests {
             initialEntries: [destination],
             childrenByPath: [destination: ["\(destination)/Rendered"]]
         )
-        let result = AXSurface(runtime: fixture.runtime)
-            .selectDestinationBrowserElement(at: destination)
+        let result = fixture.makeSurface().selectDestinationBrowserElement(at: destination)
 
         let selected = result == .selected
         #expect(selected)
@@ -535,8 +826,7 @@ struct Issue369StemExportTests {
                 destination: ["\(destination)/Rendered"],
             ]
         )
-        let result = AXSurface(runtime: fixture.runtime)
-            .selectDestinationBrowserElement(at: destination)
+        let result = fixture.makeSurface().selectDestinationBrowserElement(at: destination)
 
         let selected = result == .selected
         #expect(selected)
@@ -550,8 +840,7 @@ struct Issue369StemExportTests {
             initialEntries: ["/Users/fixture/Exports"],
             childrenByPath: [:]
         )
-        let result = AXSurface(runtime: fixture.runtime)
-            .selectDestinationBrowserElement(at: "/Users/fixture/Missing")
+        let result = fixture.makeSurface().selectDestinationBrowserElement(at: "/Users/fixture/Missing")
 
         guard case let .refused(reason) = result else {
             Issue.record("an unlisted destination component was accepted")
@@ -561,25 +850,100 @@ struct Issue369StemExportTests {
         #expect(namesMissingComponent)
     }
 
-    @Test("destination browser refuses a status-zero write without navigation readback")
-    func destinationBrowserRequiresObservedWriteEffect() {
+    @Test("destination browser refuses an echoed selection without navigation for a non-empty destination")
+    func destinationBrowserRequiresObservedNavigationEffect() {
         let destination = "/Users/fixture/Exports"
         let fixture = DestinationBrowserAXFixture(
             initialEntries: [destination],
             childrenByPath: [destination: ["\(destination)/Rendered"]],
-            observesSelection: false
+            navigationOccurs: false
         )
-        let result = AXSurface(runtime: fixture.runtime)
-            .selectDestinationBrowserElement(at: destination)
+        let result = fixture.makeSurface().selectDestinationBrowserElement(at: destination)
 
         guard case let .refused(reason) = result else {
-            Issue.record("a status-zero write with no readback was accepted")
+            Issue.record("an echoed selection without navigation was accepted")
             return
         }
         let writeWasAttempted = fixture.state.selectedChildrenWrites.count == 1
         #expect(writeWasAttempted)
-        let refusalRequiresReadback = reason.contains("not_confirmed:Exports")
-        #expect(refusalRequiresReadback)
+        let refusalRequiresNavigation = reason.contains("not_confirmed:Exports")
+        #expect(refusalRequiresNavigation)
+    }
+
+    @Test("destination browser keeps a rejected write distinct from an echoed selection")
+    func destinationBrowserCanModelRejectedWrite() {
+        let destination = "/Users/fixture/Exports"
+        let fixture = DestinationBrowserAXFixture(
+            initialEntries: [destination],
+            childrenByPath: [destination: ["\(destination)/Rendered"]],
+            acceptsWrite: false,
+            navigationOccurs: true
+        )
+        let result = fixture.makeSurface().selectDestinationBrowserElement(at: destination)
+
+        guard case let .refused(reason) = result else {
+            Issue.record("a rejected AX selection write was accepted")
+            return
+        }
+        let attemptedOneWrite = fixture.state.selectedChildrenWrites.count == 1
+        #expect(attemptedOneWrite)
+        let didNotEchoRejectedWrite = fixture.state.selectionEchoCount == 0
+        #expect(didNotEchoRejectedWrite)
+        let refusedWithoutReadback = reason.contains("not_confirmed:Exports")
+        #expect(refusedWithoutReadback)
+    }
+
+    @Test("a sidebar volume-name match is refused unless the browser lists that exact volume root")
+    func volumeSidebarRequiresRootPathListing() throws {
+        let root = URL(fileURLWithPath: "/")
+        let values = try root.resourceValues(forKeys: [.volumeNameKey])
+        let volumeName = try #require(values.volumeName)
+        let fixture = DestinationBrowserAXFixture(
+            initialEntries: [],
+            childrenByPath: [:],
+            volumeName: volumeName,
+            // This materializes a browser entry, but its parent is not the
+            // requested root. A Favorites row with this display name must not
+            // be accepted as a volume hop.
+            volumeRootEntriesAfterSelection: ["/Volumes/not-the-requested-root/entry"]
+        )
+        let result = fixture.makeSurface().selectDestinationBrowserElement(at: "/")
+
+        let expected = ProjectStemExportPanelDriver.DestinationSelection.refused(
+            "stem_destination_volume_path_not_confirmed:\(volumeName):/"
+        )
+        let refusedWrongRootListing = result == expected
+        #expect(refusedWrongRootListing)
+    }
+
+    @Test("the destination popup is identified by carrying a title, not by traversal order")
+    func destinationPopupIsIdentifiedStructurally() {
+        // Five untitled decoys come first; taking the first popup would read
+        // "AIFF" as the destination.
+        let fixture = DestinationPopupAXFixture(
+            titledPopups: [(title: "위치:", value: "logic-pro-mcp-stem-test")],
+            untitledValues: ["AIFF", "16비트", "트랙당 하나의 파일", "과부하 보호만", "파일 끝점의 무음 구간 다듬기"]
+        )
+        let value = AXSurface(runtime: fixture.runtime).destinationPopupValue()
+        let readsTheTitledPopup = value == "logic-pro-mcp-stem-test"
+        #expect(readsTheTitledPopup)
+    }
+
+    @Test("an ambiguous or missing destination popup refuses instead of picking one")
+    func destinationPopupRefusesWhenNotUnique() {
+        let none = AXSurface(runtime: DestinationPopupAXFixture(
+            titledPopups: [],
+            untitledValues: ["AIFF", "16비트"]
+        ).runtime).destinationPopupValue()
+        let refusesWhenAbsent = none == nil
+        #expect(refusesWhenAbsent)
+
+        let two = AXSurface(runtime: DestinationPopupAXFixture(
+            titledPopups: [(title: "위치:", value: "A"), (title: "Where:", value: "B")],
+            untitledValues: []
+        ).runtime).destinationPopupValue()
+        let refusesWhenAmbiguous = two == nil
+        #expect(refusesWhenAmbiguous)
     }
 
     @Test("the export progress dialog is recognised through its NO-BREAK SPACE title")
@@ -591,11 +955,11 @@ struct Issue369StemExportTests {
         #expect(looksIdenticalButIsNotEqual)
 
         let observed = AXSurface(runtime: ProgressWindowAXFixture(windowTitle: liveTitle).runtime)
-            .progressWindowPresent()
+            .progressWindowPresence() == .present
         #expect(observed)
 
         let ordinarySpace = AXSurface(runtime: ProgressWindowAXFixture(windowTitle: "Logic Pro").runtime)
-            .progressWindowPresent()
+            .progressWindowPresence() == .present
         #expect(ordinarySpace)
     }
 
@@ -604,19 +968,41 @@ struct Issue369StemExportTests {
         // The separator may localise, but it must still BE a separator: a title
         // with the space removed is a different product string, not this dialog.
         let noSeparator = AXSurface(runtime: ProgressWindowAXFixture(windowTitle: "LogicPro").runtime)
-            .progressWindowPresent()
-        let rejectsRemovedSeparator = !noSeparator
+            .progressWindowPresence()
+        let rejectsRemovedSeparator = noSeparator == .absent
         #expect(rejectsRemovedSeparator)
 
         let project = AXSurface(runtime: ProgressWindowAXFixture(windowTitle: "lpm-606-warm - 트랙").runtime)
-            .progressWindowPresent()
-        let rejectsProjectWindow = !project
+            .progressWindowPresence()
+        let rejectsProjectWindow = project == .absent
         #expect(rejectsProjectWindow)
 
         let none = AXSurface(runtime: ProgressWindowAXFixture(windowTitle: nil).runtime)
-            .progressWindowPresent()
-        let rejectsNoWindows = !none
+            .progressWindowPresence()
+        let rejectsNoWindows = none == .absent
         #expect(rejectsNoWindows)
+    }
+
+    @Test("a failed progress-window read cannot be promoted to progress disappearance")
+    func failedProgressWindowReadNeverCompletesExport() async {
+        let unreadableProgress = AXSurface(runtime: ProgressWindowAXFixture(
+            windowTitle: "Logic Pro",
+            failWindowsRead: true
+        ).runtime).progressWindowPresence()
+        let fixturePreservesFailure = unreadableProgress == .unavailable
+        #expect(fixturePreservesFailure)
+
+        let surface = StemPanelSurfaceFake()
+        surface.progressObservations = [.present, .unavailable]
+        let outcome = await driveStemPanel(surface, attempts: 2)
+
+        let readbackUnavailable = outcome == .uncertain(
+            "readback_unavailable: stem_export_effect_or_progress_not_observed_after_press",
+            exportEffectObserved: true
+        )
+        #expect(readbackUnavailable)
+        let didNotClaimCompletion = outcome != .completed
+        #expect(didNotClaimCompletion)
     }
 
     @Test("destination browser refuses duplicate URL entries rather than using traversal order")
@@ -626,8 +1012,7 @@ struct Issue369StemExportTests {
             initialEntries: [destination, destination],
             childrenByPath: [destination: ["\(destination)/Rendered"]]
         )
-        let result = AXSurface(runtime: fixture.runtime)
-            .selectDestinationBrowserElement(at: destination)
+        let result = fixture.makeSurface().selectDestinationBrowserElement(at: destination)
 
         guard case let .refused(reason) = result else {
             Issue.record("a duplicate URL entry was accepted using traversal order")
@@ -639,8 +1024,8 @@ struct Issue369StemExportTests {
         #expect(wroteNothing)
     }
 
-    @Test("a Cancel-only decoy is not recognised as a stem-export panel")
-    func cancelOnlyDecoyIsNotRecognised() {
+    @Test("a Cancel-known and Export-unknown stem panel is partially measured and can close")
+    func cancelKnownPartialPanelCanClose() async {
         let fixture = StemExportPanelAXFixture(
             popupValue: "One File per Track",
             exportButtonTitle: nil,
@@ -648,20 +1033,34 @@ struct Issue369StemExportTests {
         )
         let surface = AXSurface(runtime: fixture.runtime)
 
-        let decoyIsAbsent = surface.exportPanelPresence() == .absent
-        #expect(decoyIsAbsent)
-        let exportWasNotPressed = !surface.pressExport()
-        #expect(exportWasNotPressed)
+        let presence = surface.exportPanelPresence()
+        let partiallyMeasured = presence == .partiallyMeasured(
+            recognized: "Cancel",
+            notMeasured: "Export"
+        )
+        #expect(partiallyMeasured)
+        surface.closeExportPanel()
+        let closeWasObserved = surface.exportPanelPresence() == .absent
+        #expect(closeWasObserved)
+
+        let driverSurface = StemPanelSurfaceFake()
+        driverSurface.panelPresence = presence
+        let outcome = await driveStemPanel(driverSurface)
+        let refusalNamesRecognizedAndMissingLabels = outcome == .refused(
+            "stem_export_panel_partially_measured: recognized=Cancel; not_measured=Export"
+        )
+        #expect(refusalNamesRecognizedAndMissingLabels)
     }
 
-    @Test("an unmeasured stem-export panel refuses with the missing-measurement reason")
+    @Test("an unmeasured stem-export panel states that it was left open")
     func unmeasuredStemExportPanelRefuses() async {
-        // Deliberately synthetic AX labels: neither is claimed as a Logic
-        // translation, so the fixture models a locale awaiting measurement.
+        // Deliberately synthetic button labels: neither is claimed as a Logic
+        // translation, while the per-track popup remains the structural signal.
         let fixture = StemExportPanelAXFixture(
-            popupValue: "未測定のトラック別ファイル",
+            popupValue: "Unmeasured per-track value",
             exportButtonTitle: "未測定の書き出し",
-            cancelButtonTitle: "未測定の取り消し"
+            cancelButtonTitle: "未測定の取り消し",
+            popupTitle: "Location:"
         )
         let panelPresence = AXSurface(runtime: fixture.runtime).exportPanelPresence()
         let namesMissingMeasurement = panelPresence == .unmeasured(
@@ -671,11 +1070,71 @@ struct Issue369StemExportTests {
 
         let surface = StemPanelSurfaceFake()
         surface.panelPresence = panelPresence
+        surface.dismissLabelMeasured = false
         let outcome = await driveStemPanel(surface)
-        let refusedForMissingMeasurement = outcome == .refused(
-            ProjectStemExportPanelDriver.panelLabelNotMeasuredReason
+        let refusedWithOpenPanelDisclosure = outcome == .refused(
+            "stem_export_panel_left_open_unmeasured: "
+                + ProjectStemExportPanelDriver.panelLabelNotMeasuredReason
         )
-        #expect(refusedForMissingMeasurement)
+        #expect(refusedWithOpenPanelDisclosure)
+    }
+
+    @Test("an Export-known and Cancel-unknown stem panel states that it was left open")
+    func exportKnownPartialPanelStatesOpenModal() async {
+        let fixture = StemExportPanelAXFixture(
+            popupValue: "One File per Track",
+            exportButtonTitle: "Export",
+            cancelButtonTitle: "Unmeasured Cancel"
+        )
+        let presence = AXSurface(runtime: fixture.runtime).exportPanelPresence()
+        let partiallyMeasured = presence == .partiallyMeasured(
+            recognized: "Export",
+            notMeasured: "Cancel"
+        )
+        #expect(partiallyMeasured)
+
+        let surface = StemPanelSurfaceFake()
+        surface.panelPresence = presence
+        surface.dismissLabelMeasured = false
+        let outcome = await driveStemPanel(surface)
+        let namesTheLeftOpenPanel = outcome == .refused(
+            "stem_export_panel_left_open_after_close_attempt: recognized=Export; not_measured=Cancel"
+        )
+        #expect(namesTheLeftOpenPanel)
+    }
+
+    @Test("an unreadable open panel's descendants cannot be accepted as absent after close")
+    func unreadablePanelChildrenRefuseCloseAcceptance() {
+        let fixture = StemExportPanelAXFixture(
+            popupValue: "One File per Track",
+            exportButtonTitle: "Export",
+            cancelButtonTitle: "Cancel",
+            failPanelChildrenRead: true
+        )
+        let surface = AXSurface(runtime: fixture.runtime)
+
+        surface.closeExportPanel()
+        let presenceIsUnavailable = surface.exportPanelPresence() == .unavailable
+        #expect(presenceIsUnavailable)
+        let noCancelWasGuessed = fixture.state.cancelActionAttempts == 0
+        #expect(noCancelWasGuessed)
+    }
+
+    @Test("an unrelated two-button dialog without the per-track popup is not a stem panel")
+    func twoButtonDialogWithoutStemPopupIsIgnored() {
+        let fixture = StemExportPanelAXFixture(
+            popupValue: "One File per Track",
+            exportButtonTitle: "Export",
+            cancelButtonTitle: "Cancel",
+            includesPopup: false
+        )
+        let surface = AXSurface(runtime: fixture.runtime)
+
+        let panelIsNotAccepted = surface.exportPanelPresence() == .absent
+        #expect(panelIsNotAccepted)
+        surface.closeExportPanel()
+        let unrelatedCancelWasNotPressed = fixture.state.cancelActionAttempts == 0
+        #expect(unrelatedCancelWasNotPressed)
     }
 
     @Test("Korean all-tracks audio-file leaf resolves")
@@ -730,7 +1189,7 @@ struct Issue369StemExportTests {
 
         let refused = outcome == .refused("stem_destination_not_confirmed_after_browser_selection")
         #expect(refused)
-        let exportWasNotPressed = !surface.events.contains("export_press")
+        let exportWasNotPressed = !surface.events.contains { $0.hasPrefix("export_press") }
         #expect(exportWasNotPressed)
         let panelClosed = surface.panelPresence == .absent
         #expect(panelClosed)
@@ -753,7 +1212,7 @@ struct Issue369StemExportTests {
         _ = await driveStemPanel(surface)
 
         let selected = try #require(surface.events.firstIndex(of: "destination_browser_select"))
-        let export = try #require(surface.events.firstIndex(of: "export_press"))
+        let export = try #require(surface.events.firstIndex(where: { $0.hasPrefix("export_press") }))
         let selectionPrecedesExport = selected < export
         #expect(selectionPrecedesExport)
     }
@@ -766,28 +1225,118 @@ struct Issue369StemExportTests {
 
         let refused = outcome == .refused("stem_one_file_per_track_not_active")
         #expect(refused)
-        let noExport = !surface.events.contains("export_press")
+        let noExport = !surface.events.contains { $0.hasPrefix("export_press") }
         #expect(noExport)
     }
 
     @Test("stuck progress window is State B, never successful completion")
     func stuckProgressIsUncertain() async {
         let surface = StemPanelSurfaceFake()
-        surface.progressStates = [true, true, true]
+        surface.progressObservations = [.present, .present, .present]
         let outcome = await driveStemPanel(surface, attempts: 3)
 
-        let uncertain = outcome == .uncertain("stem_progress_window_did_not_disappear_within_budget")
+        let uncertain = outcome == .uncertain(
+            "stem_progress_window_did_not_disappear_within_budget",
+            exportEffectObserved: true
+        )
         #expect(uncertain)
     }
 
     @Test("unseen progress window is State B, not click-return success")
     func unseenProgressIsUncertain() async {
         let surface = StemPanelSurfaceFake()
-        surface.progressStates = [false, false, false]
+        surface.progressObservations = [.absent, .absent, .absent]
         let outcome = await driveStemPanel(surface, attempts: 3)
 
-        let uncertain = outcome == .uncertain("readback_unavailable: stem_progress_window_not_observed")
+        let uncertain = outcome == .uncertain(
+            "stem_export_press_effect_not_observed",
+            exportEffectObserved: false
+        )
         #expect(uncertain)
+    }
+
+    @Test("a failed Export action status with observed progress is treated as an observed export effect")
+    func failedExportActionStatusWithObservedEffectCompletes() async {
+        let surface = StemPanelSurfaceFake()
+        surface.exportActionStatus = false
+        surface.exportEffectOccurs = true
+        let outcome = await driveStemPanel(surface)
+
+        let completedFromObservation = outcome == .completed
+        #expect(completedFromObservation)
+        let fakeReportedFailure = surface.events.contains("export_press_status_false")
+        #expect(fakeReportedFailure)
+    }
+
+    @Test("a successful Export action status with observed progress completes")
+    func successfulExportActionStatusWithObservedEffectCompletes() async {
+        let surface = StemPanelSurfaceFake()
+        surface.exportActionStatus = true
+        surface.exportEffectOccurs = true
+        let outcome = await driveStemPanel(surface)
+
+        let completedFromObservation = outcome == .completed
+        #expect(completedFromObservation)
+        let fakeReportedSuccess = surface.events.contains("export_press_status_true")
+        #expect(fakeReportedSuccess)
+    }
+
+    @Test("a successful Export action status without an observed effect does not claim a bounce")
+    func successfulExportActionStatusWithoutEffectIsNotFired() async {
+        let surface = StemPanelSurfaceFake()
+        surface.exportActionStatus = true
+        surface.exportEffectOccurs = false
+        let outcome = await driveStemPanel(surface)
+
+        let noEffectWasObserved = outcome == .uncertain(
+            "stem_export_press_effect_not_observed",
+            exportEffectObserved: false
+        )
+        #expect(noEffectWasObserved)
+    }
+
+    @Test("a failed Export action status without an observed effect does not claim a bounce")
+    func failedExportActionStatusWithoutEffectIsNotFired() async {
+        let surface = StemPanelSurfaceFake()
+        surface.exportActionStatus = false
+        surface.exportEffectOccurs = false
+        let outcome = await driveStemPanel(surface)
+
+        let noEffectWasObserved = outcome == .uncertain(
+            "stem_export_press_effect_not_observed",
+            exportEffectObserved: false
+        )
+        #expect(noEffectWasObserved)
+    }
+
+    @Test("an effect-unobserved panel drive does not publish bounce_fired")
+    func unobservedEffectMapsWithoutBounceFired() async throws {
+        let projectRoot = try makeExecTempDir()
+        let outputRoot = try makeExecTempDir()
+        let project = try makeLogicxProject(in: projectRoot, named: "Unobserved Stem Press")
+        var options = fastOptions(identity: { project.path })
+        options.driveStemExport = { _ in
+            .uncertain("stem_export_press_effect_not_observed", exportEffectObserved: false)
+        }
+
+        let run = await ProjectExportExecutor.run(
+            params: [
+                "project": .string(project.path),
+                "output_root": .string(outputRoot.path),
+                "artifact": .string("stem"),
+                "confirmed": .bool(true),
+            ],
+            router: await makeExportRouter(),
+            resume: false,
+            options: options,
+            stemSubjects: scannedStemSubjects(for: project)
+        )
+
+        let artifact = try #require(run.projects.first?.artifacts.first)
+        let didNotClaimBounce = !artifact.bounceFired
+        #expect(didNotClaimBounce)
+        let didNotClaimWrite = !artifact.writeAttempted
+        #expect(didNotClaimWrite)
     }
 
     @Test("panel refusal becomes State C with write_attempted false")

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -72,6 +72,8 @@ Also open, outside the ADR set:
 | #373 | OPEN | Phase B needs live readback; `logic://tracks` is cache-served, so a stale read passes the same equality check |
 | #448 | OPEN | layout readback is deliverable; colour and reorder need a definition of "verified" for a write nothing can read back |
 | #678 | closed | the drift guard and this file's update rule shipped in #684 |
+| #735 | OPEN | legacy `MIDIPacketList` traversal walked past a value copy (SIGBUS). Fixed on `fix/735-midi-packetlist`; measured 2026-09-02 the parsed inbound stream has NO production consumer, so `LogicProMCP-MIDI-In` accepts MIDI and discards it — decide whether to finish that port or stop publishing it. The live gate cannot express this proof: `is_clean` requires captures/visual/recordings and this is a non-UI path with nothing in Logic to observe |
+| #736 | OPEN | external report — duplicate virtual MIDI endpoints. Root cause measured both directions: two endpoints sharing a name make Logic bind the wrong one (duplicate -> `connected:false` x2, single -> `connected:true` x2). PR #738 open but REFUTED by review — census/create is a cross-process TOCTOU race, an enumeration failure publishes as an observed `endpoint_count: 0`, health republishes a startup snapshot, and the unique-ID hash has concrete collisions |
 | #683 | OPEN | external report — MCU feedback from Logic Pro Creator Studio wedges the loop; four hypotheses refuted or weakened by measurement, blocked on a `sample` from the reporter's host |
 | #724 | closed | |
 | #726 | closed | |


### PR DESCRIPTION
Makes the per-track stem export work against a real, localized Logic.

The path passed 4,159 unit tests, three rounds of adversarial review and every repository guard — and failed at the first step against a running Logic. Seven live rounds found six independent defects, each of which made the drive impossible on its own.

| defect | what it was |
|---|---|
| English-only matching | the menu, panel signature, both buttons and the per-track popup were compared against bare English literals. Logic ships ten locales; the code worked in one |
| the panel was read before it existed | AXPick returns in 0 ms; the panel appears ~1 s later (measured 1005–1963 ms). There was no poll at all, so the refusal was unconditional |
| `AXURL` read as `String` | it is a CFURL. Measured live: 4 of 4 entries read back as NSURL, 0 as String — the browser census was always empty |
| the destination searched the wrong roles | paths live on `AXTextField`, not `AXRow`/`AXCell`, and the panel does not offer `AXPress` at all. The measured route is writing `AXSelectedChildren` on the owning `AXList` |
| navigation confirmed by a *change* | Logic's panel reopens on the last committed destination, so asking for that same folder changes nothing and an already-correct panel was permanently unconfirmable |
| the progress dialog title | it is `Logic<U+00A0>Pro`. Prints identically, compares unequal, and trimming cannot reach an interior character |

Two review rounds then found sixteen more, and the second round refuted two claims in the first round's own commit message — partial panel recognition was looser than full recognition, and one site still bypassed the absent-aware read. Both are fixed, and this branch carries a count rather than a claim: two raw `getAttributeResult`/`childrenResult` sites remain, both inside the absent-aware reader itself.

The deepest cause was one property with three faces. The production AX read seam turns *every* non-success status into an error, so "this element has no such attribute" is indistinguishable from "this attribute could not be read". Measured on the live panel: 348 elements walked, zero genuine failures, 60 leaves answering `kAXErrorNoValue`. The panel was unassessable on every attempt while sitting open on screen. I fixed it three times before fixing it once; there is now a single absent-aware read, narrowed inside this driver rather than in `AXHelpers`, because other callers depend on the shared projection's meaning.

Two test doubles were asserting a world that does not exist, which is why the suite stayed green through all of it: the panel fake returned `.present` synchronously, and the AX fixture supplied `AXURL` as a String. Both now model what the real API does.

### Live acceptance on this head

```
export_plan     destination + 3 subjects, filenames_late_bound, rule stated
skip_existing   refused in the plan, with the reason
export_resume   3/3 refused, next_safe_action given
export_run      bounce_fired true, write_attempted true, panel closed cleanly
                3 real .aif files on disk, every observed output verified
```

Terminal State B (`stem_subject_file_binding_unestablished`) is the design, and the run proves the design right: three tracks all named "Studio Grand" came out as `Studio Grand.aif`, `Studio Grand_1.aif`, `Studio Grand_2.aif` — names Logic assigns *after* the export, which no pre-export rule could have predicted.

4,186 tests, 15 repository guards, live gate passed.

Refs #369
