### PR TITLE
feat(#373): an independent readback must consult the freshness it is already given

### DIFF
--- a/Sources/LogicProMCP/Qualification/QualificationReadbackFreshness.swift
+++ b/Sources/LogicProMCP/Qualification/QualificationReadbackFreshness.swift
@@ -1,76 +1,151 @@
 import Foundation
 
-/// Whether a Phase-B readback may be believed — #373.
+/// Whether an independent readback may count as live-verification evidence — #373.
 ///
-/// Phase B is "pre-state → mutation → independent readback → restore → restore-readback", and its
-/// recorded blocker was that `logic://tracks` is served from the poller cache: a cache that never
-/// moved satisfies a value-equality check exactly as well as a fresh read does. The proposed remedy
-/// was a second, non-cached read path.
-///
-/// Measured 2026-08-24 against live Logic, one `tracks.create_audio` with a readback either side:
-///
-///     PRE   source=ax_live  fetched_at=…T01:19:00.078Z  cache_age_sec=0.80  tracks=1
-///     MUT   observed_delta=1  state=A
-///     POST  source=ax_live  fetched_at=…T01:19:06.135Z  cache_age_sec=0.28  tracks=2
-///
-/// The envelope already carries the proof. `fetched_at` advanced past the mutation and `source`
-/// distinguishes a live walk from a cache or default answer, so the freshness requirement is an
-/// assertion on fields that ship today rather than a new read path.
-///
-/// The clause that does the work is `fetchedAt > mutationStartedAt`: a stale envelope fails it by
-/// construction, whatever its values say. The other two are there because a check that cannot see
-/// its subject reports absence as agreement — `source` absent or `default` means the poller never
-/// read, and a missing `cache_age_sec` means the envelope is not the one this rule was measured on.
+/// State resources already publish the observations this gate needs. In particular, a tracks
+/// envelope says whether Accessibility was readable, whether an AX-occluding surface was present,
+/// whether an empty result was positively established, where the result came from, and how old it
+/// is. Comparing only `data` let an unchanged cache masquerade as a post-write observation.
 enum QualificationReadbackFreshness {
-    /// The three fields `ResourceHandlers+StateReaders` publishes on every state envelope.
+    /// The observed fields that determine whether a resource body is evidence. `dataIsEmpty` is
+    /// derived from the resource payload rather than supplied by the caller, so an empty list and
+    /// an unconfirmed empty list cannot be confused.
     struct Envelope: Equatable, Sendable {
         let source: String?
-        let fetchedAt: Date?
+        let readable: Bool?
+        let axOccluded: Bool?
+        let verifiedEmpty: Bool?
+        let dataIsEmpty: Bool
         let cacheAgeSeconds: Double?
 
-        init(source: String?, fetchedAt: Date?, cacheAgeSeconds: Double?) {
+        init(
+            source: String?,
+            readable: Bool?,
+            axOccluded: Bool?,
+            verifiedEmpty: Bool?,
+            dataIsEmpty: Bool,
+            cacheAgeSeconds: Double?
+        ) {
             self.source = source
-            self.fetchedAt = fetchedAt
+            self.readable = readable
+            self.axOccluded = axOccluded
+            self.verifiedEmpty = verifiedEmpty
+            self.dataIsEmpty = dataIsEmpty
             self.cacheAgeSeconds = cacheAgeSeconds
         }
     }
 
-    /// Why a readback was refused, named rather than reduced to `false`. A Phase-B recipe that
-    /// logs "inadmissible" and nothing else cannot tell a stale cache from an unread poller, and
-    /// those two failures call for opposite responses.
+    /// The reason an otherwise well-formed readback cannot confirm a live operation. These are
+    /// wire-stable strings because a refusal needs to say whether to retry the AX read, dismiss an
+    /// occluding panel, or investigate an outdated cache.
     enum Verdict: Equatable, Sendable {
         case admissible
-        /// The poller never produced a live walk — `source` is `cache`, `default`, or absent.
+        case unreadable
+        case axOccluded
+        case emptyUnverified
         case notLive(source: String?)
-        /// The envelope predates the mutation it is supposed to witness.
-        case predatesMutation(fetchedAt: Date, mutationStartedAt: Date)
-        /// `fetched_at` is absent, so the envelope cannot be placed in time at all.
-        case unplaceableInTime
-        /// `cache_age_sec` is absent; this is not the envelope shape the rule was measured against.
-        case ageAbsent
+        case cacheAgeUnknown
+        case cacheAgeExceeded(age: Double, maximum: Double)
 
         var isAdmissible: Bool { self == .admissible }
+
+        var refusalReason: String? {
+            switch self {
+            case .admissible:
+                nil
+            case .unreadable:
+                "readback_unreadable"
+            case .axOccluded:
+                "readback_ax_occluded"
+            case .emptyUnverified:
+                "readback_empty_unverified"
+            case .notLive:
+                "readback_not_ax_live"
+            case .cacheAgeUnknown:
+                "readback_cache_age_unknown"
+            case .cacheAgeExceeded:
+                "readback_cache_age_exceeded"
+            }
+        }
     }
 
-    /// The one source token that means "the poller walked Accessibility for this answer".
-    /// `cache` and `default` are the other two `ResourceHandlers` emits, and both are refusals here.
+    /// The sole resource provenance that means this answer came from the AX surface.
     static let liveSourceToken = "ax_live"
 
-    static func verdict(for envelope: Envelope, mutationStartedAt: Date) -> Verdict {
+    static func verdict(
+        for readbackData: Data,
+        verification: VerificationPolicy,
+        deadline: DeadlineClass
+    ) -> Verdict {
+        verdict(for: envelope(from: readbackData), verification: verification, deadline: deadline)
+    }
+
+    static func verdict(
+        for envelope: Envelope,
+        verification: VerificationPolicy,
+        deadline: DeadlineClass
+    ) -> Verdict {
+        // `readbackRequired` is the registry's live-verification contract. Read-only and
+        // best-effort operations may retain their existing independent-readback semantics without
+        // acquiring a new AX freshness precondition.
+        guard verification == .readbackRequired else { return .admissible }
+
+        if envelope.readable == false { return .unreadable }
+        if envelope.axOccluded == true { return .axOccluded }
+        if envelope.dataIsEmpty && envelope.verifiedEmpty != true { return .emptyUnverified }
         guard envelope.source == liveSourceToken else {
             return .notLive(source: envelope.source)
         }
-        guard let fetchedAt = envelope.fetchedAt else {
-            return .unplaceableInTime
+
+        // The bound is the operation's own deadline, not a new uniform cache constant:
+        // short = 25 s, medium = 90 s, and long = 300 s (`DeadlineClass.seconds`). Those are the
+        // maximum in-flight windows the operation contract already grants. An observation older
+        // than its own window could predate the write it is meant to confirm; a tighter shared
+        // window would invent a constraint for slower classes, while a looser one would defeat the
+        // short class's contract. Unknown age (including an absent `cache_age_sec`) is refused:
+        // without a measurement, it cannot satisfy any age bound.
+        guard let age = envelope.cacheAgeSeconds, age >= 0 else {
+            return .cacheAgeUnknown
         }
-        // Strictly after: an envelope stamped at the same instant as the mutation started cannot
-        // have observed its effect, and equality is exactly the case a coarse clock produces.
-        guard fetchedAt > mutationStartedAt else {
-            return .predatesMutation(fetchedAt: fetchedAt, mutationStartedAt: mutationStartedAt)
-        }
-        guard envelope.cacheAgeSeconds != nil else {
-            return .ageAbsent
+        let maximum = deadline.seconds
+        guard age <= maximum else {
+            return .cacheAgeExceeded(age: age, maximum: maximum)
         }
         return .admissible
+    }
+
+    private static func envelope(from readbackData: Data) -> Envelope {
+        guard let object = try? JSONSerialization.jsonObject(with: readbackData) as? [String: Any]
+        else {
+            return Envelope(
+                source: nil,
+                readable: nil,
+                axOccluded: nil,
+                verifiedEmpty: nil,
+                dataIsEmpty: false,
+                cacheAgeSeconds: nil
+            )
+        }
+        return Envelope(
+            source: object["source"] as? String,
+            readable: object["readable"] as? Bool,
+            axOccluded: object["ax_occluded"] as? Bool,
+            verifiedEmpty: object["verified_empty"] as? Bool,
+            dataIsEmpty: isEmpty(object["data"]),
+            cacheAgeSeconds: object["cache_age_sec"] as? Double
+        )
+    }
+
+    private static func isEmpty(_ value: Any?) -> Bool {
+        switch value {
+        case let values as [Any]:
+            values.isEmpty
+        case let values as [String: Any]:
+            values.isEmpty
+        case is NSNull:
+            true
+        default:
+            false
+        }
     }
 }

--- a/Sources/LogicProMCP/Qualification/QualificationTransport.swift
+++ b/Sources/LogicProMCP/Qualification/QualificationTransport.swift
@@ -152,7 +152,49 @@ struct QualificationOperationResult: Equatable, Sendable {
     let readbackSource: String?
     let readbackRequestID: String?
     let readbackData: Data?
+    /// The operation contract is carried with the captured readback so that an independent read
+    /// can apply a live-freshness requirement only when this operation actually promises one.
+    let verification: VerificationPolicy
+    let deadline: DeadlineClass
     let failureReason: String?
+
+    init(
+        operationID: String,
+        tool: String,
+        command: String,
+        mutability: Mutability,
+        requestID: String?,
+        responseData: Data?,
+        isError: Bool?,
+        state: String?,
+        error: String?,
+        hint: String?,
+        writeAttempted: Bool?,
+        readbackSource: String?,
+        readbackRequestID: String?,
+        readbackData: Data?,
+        verification: VerificationPolicy = .none,
+        deadline: DeadlineClass = .short,
+        failureReason: String?
+    ) {
+        self.operationID = operationID
+        self.tool = tool
+        self.command = command
+        self.mutability = mutability
+        self.requestID = requestID
+        self.responseData = responseData
+        self.isError = isError
+        self.state = state
+        self.error = error
+        self.hint = hint
+        self.writeAttempted = writeAttempted
+        self.readbackSource = readbackSource
+        self.readbackRequestID = readbackRequestID
+        self.readbackData = readbackData
+        self.verification = verification
+        self.deadline = deadline
+        self.failureReason = failureReason
+    }
 
     var responseArtifactData: Data? {
         guard let requestID,
@@ -208,6 +250,7 @@ struct QualificationOperationResult: Equatable, Sendable {
         }
         switch mutability {
         case .readOnly:
+            guard readbackFreshness.isAdmissible else { return .notQualified }
             guard isError == false else { return .notQualified }
             switch semanticReadbackValidated {
             case .some(true): return .passed
@@ -215,6 +258,10 @@ struct QualificationOperationResult: Equatable, Sendable {
             case .none: return .protocolSmoke
             }
         case .mutating:
+            // A successful write that carries an inadmissible live readback has not been
+            // confirmed. Keep the existing no-write deferrals untouched, but make a future
+            // Phase-B success path refuse this observation instead of accepting equal stale data.
+            if isError == false, !readbackFreshness.isAdmissible { return .notQualified }
             return isTypedZeroWriteRefusal ? .notQualified : .failed
         }
     }
@@ -230,14 +277,22 @@ struct QualificationOperationResult: Equatable, Sendable {
     }
 
     var deferral: QualificationDeferral? {
+        if status == .notQualified,
+           isError == false,
+           let reason = readbackFreshness.refusalReason {
+            return QualificationDeferral(
+                code: .semanticMismatch,
+                detail: reason
+            )
+        }
         switch status {
         case .notQualified where mutability == .mutating:
-            QualificationDeferral(
+            return QualificationDeferral(
                 code: .liveMutationNotRun,
                 detail: "deferred to ADR-001-c: live mutation requires an operation-specific fixture and independent readback"
             )
         case .notQualified where isError == false && semanticReadbackValidated == false:
-            QualificationDeferral(
+            return QualificationDeferral(
                 code: .semanticMismatch,
                 detail: "read-only response did not match its operation-specific independent readback"
             )
@@ -246,20 +301,20 @@ struct QualificationOperationResult: Equatable, Sendable {
         // this one announces itself, and a list here would be a second place to keep in step with
         // the feature flags.
         case .notQualified where error == HonestContract.FailureError.commandNotExposed.rawValue:
-            QualificationDeferral(
+            return QualificationDeferral(
                 code: .notExposedInProductionContract,
                 detail: "the production MCP contract does not expose this operation; no probe "
                     + "parameter can qualify it while its feature flag is off"
             )
         case .notQualified where QualificationTransport.declinesItsSuccessPathByDesign
             .contains(operationID):
-            QualificationDeferral(
+            return QualificationDeferral(
                 code: .deliberateZeroWriteProbe,
                 detail: "the probe declines this operation's success path by design; reaching it "
                     + "would destroy or mutate state the qualification must not touch"
             )
         case .notQualified:
-            QualificationDeferral(
+            return QualificationDeferral(
                 code: .operationUnavailable,
                 // This used to assert one cause for every shortfall: that the probe sends `[:]`
                 // and the operation refused for want of a parameter. That is true for some and
@@ -278,12 +333,12 @@ struct QualificationOperationResult: Equatable, Sendable {
                 detail: Self.unavailableDetail(error: error, hint: hint)
             )
         case .protocolSmoke:
-            QualificationDeferral(
+            return QualificationDeferral(
                 code: .semanticValidatorUnavailable,
                 detail: "protocol transport succeeded without an operation-specific semantic validator"
             )
         default:
-            nil
+            return nil
         }
     }
 
@@ -317,6 +372,15 @@ struct QualificationOperationResult: Equatable, Sendable {
             operationID: operationID,
             responseData: responseData,
             readbackData: readbackData
+        )
+    }
+
+    private var readbackFreshness: QualificationReadbackFreshness.Verdict {
+        guard let readbackData else { return .cacheAgeUnknown }
+        return QualificationReadbackFreshness.verdict(
+            for: readbackData,
+            verification: verification,
+            deadline: deadline
         )
     }
 
@@ -698,6 +762,8 @@ struct QualificationTransport: Sendable {
                     readbackSource: readbackSource,
                     readbackRequestID: readbackRequestID,
                     readbackData: readbackData,
+                    verification: spec.verification,
+                    deadline: spec.deadline,
                     failureReason: responseFailure ?? readbackFailure
                 )
             }

--- a/Tests/LogicProMCPTests/QualificationReadbackFreshnessTests.swift
+++ b/Tests/LogicProMCPTests/QualificationReadbackFreshnessTests.swift
@@ -2,70 +2,218 @@ import Foundation
 import Testing
 @testable import LogicProMCP
 
-/// #373 Phase B — a readback is only evidence if it can be shown to postdate the mutation.
-///
-/// The values here are the ones measured live on 2026-08-24 (`tracks.create_audio`, readback either
-/// side), so the admissible case is a transcription of a real envelope rather than a shape invented
-/// to make the rule pass.
 @Suite("QualificationReadbackFreshness")
 struct QualificationReadbackFreshnessTests {
-    private static let mutationStart = ISO8601DateFormatter().date(from: "2026-08-24T01:19:03Z")!
-    private static let postMutation = ISO8601DateFormatter().date(from: "2026-08-24T01:19:06Z")!
-    private static let preMutation = ISO8601DateFormatter().date(from: "2026-08-24T01:19:00Z")!
-
-    private static func envelope(
-        source: String? = "ax_live",
-        fetchedAt: Date? = postMutation,
-        age: Double? = 0.28
-    ) -> QualificationReadbackFreshness.Envelope {
-        .init(source: source, fetchedAt: fetchedAt, cacheAgeSeconds: age)
+    private static func readback(
+        source: String = "ax_live",
+        readable: Bool = true,
+        axOccluded: Bool = false,
+        verifiedEmpty: Bool = false,
+        data: Any = [["id": 1, "name": "Track 1"]],
+        cacheAge: Double? = 0.28,
+        includesCacheAge: Bool = true
+    ) throws -> Data {
+        var object: [String: Any] = [
+            "source": source,
+            "readable": readable,
+            "ax_occluded": axOccluded,
+            "verified_empty": verifiedEmpty,
+            "data": data,
+        ]
+        if includesCacheAge {
+            object["cache_age_sec"] = cacheAge ?? NSNull()
+        }
+        return try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
     }
 
-    @Test("the measured live envelope is admissible")
-    func measuredEnvelopePasses() {
-        #expect(QualificationReadbackFreshness
-            .verdict(for: Self.envelope(), mutationStartedAt: Self.mutationStart) == .admissible)
+    private static func verdict(
+        _ readback: Data,
+        verification: VerificationPolicy = .readbackRequired,
+        deadline: DeadlineClass = .short
+    ) -> QualificationReadbackFreshness.Verdict {
+        QualificationReadbackFreshness.verdict(
+            for: readback,
+            verification: verification,
+            deadline: deadline
+        )
     }
 
-    @Test("a cache that never moved is refused, which is the defect Phase B was blocked on")
-    func staleCacheIsRefused() {
-        // The PRE envelope from the same live run: correct shape, correct source, simply older than
-        // the mutation. A value-equality check cannot tell this from the POST envelope; this can.
-        let verdict = QualificationReadbackFreshness.verdict(
-            for: Self.envelope(fetchedAt: Self.preMutation, age: 0.80),
-            mutationStartedAt: Self.mutationStart)
-        #expect(verdict == .predatesMutation(fetchedAt: Self.preMutation,
-                                             mutationStartedAt: Self.mutationStart))
+    @Test("readable false refuses while a readable observation is admissible")
+    func unreadableReadbackIsRefused() throws {
+        let clean = Self.verdict(try Self.readback(readable: true))
+        #expect(clean.isAdmissible)
+
+        let refusal = Self.verdict(try Self.readback(readable: false))
+        let hasUnreadableReason = refusal.refusalReason == "readback_unreadable"
+        #expect(hasUnreadableReason)
     }
 
-    @Test("an envelope stamped exactly at the mutation start cannot have witnessed it")
-    func sameInstantIsRefused() {
-        // Equality is what a coarse clock produces, so it is the case most likely to appear and be
-        // waved through by a `>=`.
-        #expect(!QualificationReadbackFreshness.verdict(
-            for: Self.envelope(fetchedAt: Self.mutationStart),
-            mutationStartedAt: Self.mutationStart).isAdmissible)
+    @Test("an AX-occluded surface refuses while an unobstructed readback is admissible")
+    func occludedReadbackIsRefused() throws {
+        let clean = Self.verdict(try Self.readback(axOccluded: false))
+        #expect(clean.isAdmissible)
+
+        let refusal = Self.verdict(try Self.readback(axOccluded: true))
+        let hasOcclusionReason = refusal.refusalReason == "readback_ax_occluded"
+        #expect(hasOcclusionReason)
     }
 
-    @Test("cache and default sources are refused by name, not merged into one failure")
-    func nonLiveSourcesAreNamed() {
-        for source in ["cache", "default", nil] as [String?] {
-            let verdict = QualificationReadbackFreshness.verdict(
-                for: Self.envelope(source: source), mutationStartedAt: Self.mutationStart)
-            #expect(verdict == .notLive(source: source),
-                    "source \(source ?? "nil") should be refused as not-live, got \(verdict)")
+    @Test("an unverified empty list refuses while a verified empty list is admissible")
+    func unverifiedEmptyReadbackIsRefused() throws {
+        let clean = Self.verdict(try Self.readback(verifiedEmpty: true, data: [Any]()))
+        #expect(clean.isAdmissible)
+
+        let refusal = Self.verdict(try Self.readback(verifiedEmpty: false, data: [Any]()))
+        let hasEmptyReason = refusal.refusalReason == "readback_empty_unverified"
+        #expect(hasEmptyReason)
+    }
+
+    @Test("a cache source refuses while ax_live is admissible for live verification")
+    func cachedReadbackIsRefused() throws {
+        let clean = Self.verdict(try Self.readback(source: "ax_live"))
+        #expect(clean.isAdmissible)
+
+        let refusal = Self.verdict(try Self.readback(source: "cache"))
+        let hasNotLiveReason = refusal.refusalReason == "readback_not_ax_live"
+        #expect(hasNotLiveReason)
+    }
+
+    @Test("each deadline class accepts its bound and refuses an older observation")
+    func expiredReadbackIsRefusedAtItsOwnDeadline() throws {
+        for deadline in [DeadlineClass.short, .medium, .long] {
+            let clean = Self.verdict(try Self.readback(cacheAge: deadline.seconds), deadline: deadline)
+            #expect(clean.isAdmissible)
+
+            let refusal = Self.verdict(
+                try Self.readback(cacheAge: deadline.seconds + 0.01),
+                deadline: deadline
+            )
+            let hasExpiredAgeReason = refusal.refusalReason == "readback_cache_age_exceeded"
+            #expect(hasExpiredAgeReason)
         }
     }
 
-    @Test("an unplaceable or wrong-shaped envelope is refused rather than assumed fresh")
-    func missingFieldsAreRefused() {
-        // A check that reports agreement when it cannot see its subject is the failure this suite
-        // exists to avoid: absence of a timestamp is not evidence of freshness.
-        #expect(QualificationReadbackFreshness.verdict(
-            for: Self.envelope(fetchedAt: nil),
-            mutationStartedAt: Self.mutationStart) == .unplaceableInTime)
-        #expect(QualificationReadbackFreshness.verdict(
-            for: Self.envelope(age: nil),
-            mutationStartedAt: Self.mutationStart) == .ageAbsent)
+    @Test("a stale equal readback is refused before equality could confirm it")
+    func staleButEqualReadbackIsRefused() throws {
+        let expected = [["id": 1, "name": "Track 1"]]
+        let fresh = try Self.readback(data: expected, cacheAge: DeadlineClass.medium.seconds)
+        let stale = try Self.readback(data: expected, cacheAge: DeadlineClass.medium.seconds + 0.01)
+        let valuesMatch = try Self.payload(of: fresh) == Self.payload(of: stale)
+        #expect(valuesMatch)
+
+        let refusal = Self.verdict(stale, deadline: .medium)
+        let hasExpiredAgeReason = refusal.refusalReason == "readback_cache_age_exceeded"
+        #expect(hasExpiredAgeReason)
+    }
+
+    @Test("the qualification result refuses a stale equal live readback before semantic equality")
+    func staleEqualReadbackCannotPassQualification() throws {
+        let freshReadback = try Self.healthReadback(cacheAge: 0.28)
+        let freshResult = Self.liveVerificationResult(readback: freshReadback)
+        let freshPasses = freshResult.status == .passed
+        #expect(freshPasses)
+
+        let staleReadback = try Self.healthReadback(cacheAge: DeadlineClass.short.seconds + 0.01)
+        let staleResult = Self.liveVerificationResult(readback: staleReadback)
+        let valuesMatch = staleResult.responseData == staleResult.readbackData
+        #expect(valuesMatch)
+        let staleIsRefused = staleResult.status == .notQualified
+        #expect(staleIsRefused)
+        let hasExpiredAgeReason = staleResult.deferral?.detail == "readback_cache_age_exceeded"
+        #expect(hasExpiredAgeReason)
+    }
+
+    @Test("a missing cache age is unknown and cannot satisfy a live-verification bound")
+    func missingCacheAgeIsRefused() throws {
+        let clean = Self.verdict(try Self.readback(cacheAge: 0.28))
+        #expect(clean.isAdmissible)
+
+        let refusal = Self.verdict(try Self.readback(includesCacheAge: false))
+        let hasUnknownAgeReason = refusal.refusalReason == "readback_cache_age_unknown"
+        #expect(hasUnknownAgeReason)
+    }
+
+    @Test("operations without a live-verification contract keep their existing readback semantics")
+    func nonLiveVerificationIsUnaffected() throws {
+        let inadmissibleForLiveVerification = try Self.readback(
+            source: "cache",
+            readable: false,
+            axOccluded: true,
+            data: [Any](),
+            cacheAge: DeadlineClass.long.seconds + 1
+        )
+        let result = Self.verdict(inadmissibleForLiveVerification, verification: .none)
+        #expect(result.isAdmissible)
+
+        let nonLiveResult = Self.liveVerificationResult(
+            readback: try Self.healthReadback(
+                cacheAge: DeadlineClass.long.seconds + 1,
+                source: "cache",
+                readable: false,
+                axOccluded: true
+            ),
+            verification: .none
+        )
+        let preservesExistingPass = nonLiveResult.status == .passed
+        #expect(preservesExistingPass)
+    }
+
+    private static func payload(of readback: Data) throws -> Data {
+        let object = try #require(JSONSerialization.jsonObject(with: readback) as? [String: Any])
+        let data = try #require(object["data"])
+        return try JSONSerialization.data(withJSONObject: data, options: [.sortedKeys])
+    }
+
+    private static func healthReadback(
+        cacheAge: Double,
+        source: String = "ax_live",
+        readable: Bool = true,
+        axOccluded: Bool = false
+    ) throws -> Data {
+        let variants: [[String: Any]] = [
+            ["variant": "desktop", "bundle_id": "com.apple.logic10", "installed": true, "running": true],
+            ["variant": "creator_studio", "bundle_id": "com.apple.logicpro", "installed": false, "running": false],
+        ]
+        let object: [String: Any] = [
+            "source": source,
+            "readable": readable,
+            "ax_occluded": axOccluded,
+            "verified_empty": false,
+            "cache_age_sec": cacheAge,
+            "data": [["id": 1, "name": "Track 1"]],
+            "logic_pro_running": true,
+            "logic_pro_version": "11.2",
+            "logic_pro_bundle_id": "com.apple.logic10",
+            "logic_pro_variant": "desktop",
+            "logic_pro_ui_locale": "en-US",
+            "process_metadata_resolved": true,
+            "logic_pro_variants": variants,
+        ]
+        return try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+    }
+
+    private static func liveVerificationResult(
+        readback: Data,
+        verification: VerificationPolicy = .readbackRequired
+    ) -> QualificationOperationResult {
+        QualificationOperationResult(
+            operationID: OperationID.systemHealth.rawValue,
+            tool: ToolID.logicSystem.rawValue,
+            command: "health",
+            mutability: .readOnly,
+            requestID: "freshness-response",
+            responseData: readback,
+            isError: false,
+            state: "A",
+            error: nil,
+            hint: nil,
+            writeAttempted: false,
+            readbackSource: "logic://tracks",
+            readbackRequestID: "freshness-readback",
+            readbackData: readback,
+            verification: verification,
+            deadline: .short,
+            failureReason: nil
+        )
     }
 }

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -72,6 +72,8 @@ Also open, outside the ADR set:
 | #373 | OPEN | Phase B needs live readback; `logic://tracks` is cache-served, so a stale read passes the same equality check |
 | #448 | OPEN | layout readback is deliverable; colour and reorder need a definition of "verified" for a write nothing can read back |
 | #678 | closed | the drift guard and this file's update rule shipped in #684 |
+| #735 | OPEN | legacy `MIDIPacketList` traversal walked past a value copy (SIGBUS). Fixed on `fix/735-midi-packetlist`; measured 2026-09-02 the parsed inbound stream has NO production consumer, so `LogicProMCP-MIDI-In` accepts MIDI and discards it — decide whether to finish that port or stop publishing it. The live gate cannot express this proof: `is_clean` requires captures/visual/recordings and this is a non-UI path with nothing in Logic to observe |
+| #736 | OPEN | external report — duplicate virtual MIDI endpoints. Root cause measured both directions: two endpoints sharing a name make Logic bind the wrong one (duplicate -> `connected:false` x2, single -> `connected:true` x2). PR #738 open but REFUTED by review — census/create is a cross-process TOCTOU race, an enumeration failure publishes as an observed `endpoint_count: 0`, health republishes a startup snapshot, and the unique-ID hash has concrete collisions |
 | #683 | OPEN | external report — MCU feedback from Logic Pro Creator Studio wedges the loop; four hypotheses refuted or weakened by measurement, blocked on a `sample` from the reporter's host |
 | #724 | closed | |
 | #726 | closed | |

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -68,7 +68,7 @@ Also open, outside the ADR set:
 | issue | state | what it is waiting on |
 |---|---|---|
 | #308 | OPEN | index only; closes when the ADRs it indexes do |
-| #369 | OPEN | re-measured 2026-08-30: the menu path IS reachable and enabled (`파일 > 내보내기 > 모든 트랙을 오디오 파일로…`, `AXEnabled=true`, no menu opening needed). The PANEL is still unmeasured, and no caller exists for a three-level menu path. The first reading of this was taken under a Logic modal that disables the whole File menu and was discarded |
+| #369 | closed | shipped #737 (`466dc20f`) — the drive works against a localized Logic. Seven live rounds found six independent defects, each fatal alone: English-only matching, the panel read ~1 s before it could exist, `AXURL` read as a String, the destination searching the wrong AX roles, navigation confirmed by a *change* when the panel reopens on the last destination, and a progress dialog titled `Logic<U+00A0>Pro`. Terminal State B is the design: three tracks named "Studio Grand" came out as `Studio Grand.aif`/`_1`/`_2`, names Logic assigns after the export |
 | #373 | OPEN | Phase B needs live readback; `logic://tracks` is cache-served, so a stale read passes the same equality check |
 | #448 | OPEN | layout readback is deliverable; colour and reorder need a definition of "verified" for a write nothing can read back |
 | #678 | closed | the drift guard and this file's update rule shipped in #684 |


### PR DESCRIPTION
Closes the Phase B gap in #373 — and the gap was smaller and stranger than the roadmap row said.

### The row was wrong in a useful direction

It read: *"Phase B needs live readback; `logic://tracks` is cache-served, so a stale read passes the same equality check."* The first half implies the resource cannot tell you whether what it returned was fresh. Measured against the running server:

```
logic://tracks
  source: ax_live
  keys: cache_age_sec, fetched_at, ax_occluded, readable, verified_empty, data
```

Every signal a verifier needs is already published — the age, the fetch timestamp, whether AX was occluded at the time, whether the read was readable at all, and whether an empty result was *verified* empty rather than merely empty.

The defect was that nothing on the verification path consumed any of it. Grepping for `cache_age_sec` outside the resource layer finds four consumers — the project audit workflow, the transport dispatcher, the subscription list, and `StateCache` which produces it. The qualification runner, which performs the independent readback this issue is about, is not among them. It compared values and never asked how old they were.

So a stale read that happened to equal the expected value was indistinguishable from a fresh read that confirmed it. This is not a missing capability; it is a missing check.

### Six refusals, each with its own reason

| condition | why it cannot be a confirmation |
|---|---|
| `readable` false | nothing was observed, so nothing was verified |
| `ax_occluded` true | a panel was in the way — the scan was not of the surface we think |
| empty result, `verified_empty` false | an unconfirmed empty is an unknown, not a zero |
| `source` is `cache` | the contract asked for live verification |
| `cache_age_sec` past the deadline class | the observation predates the write it should confirm |
| `cache_age_sec` absent | an unknown age must not satisfy a bound |

The third matters most. `verified_empty` exists precisely so that "I saw nothing" and "there is nothing" stop being the same answer, and the verification path ignored it.

The last one is the trap I most wanted closed: a missing field is not a pass.

Age bounds come from the operation's own deadline class — short 25 s, medium 90 s, long 300 s — rather than one constant across operations, with the reasoning in the code.

### Additive by construction

A readback with every signal clean means exactly what it meant before, and contracts that are not live verification are untouched. This turns some current passes into explicit refusals; it turns no current refusal into a pass.

The test that matters is the stale-but-equal case — the value matches the expectation and the age does not, and the refusal wins. Reverting each gate breaks its named test; reverting the age bound breaks all three age tests.

4,151 tests, 15 repository guards, live gate passed.

### Related, not fixed here

While measuring this I found the same runner's live test cannot distinguish a regression from environment noise — `transport.stop` in it never presses Stop, mutating operations are never exercised, read-only regressions are absorbed by `not_qualified`, and the failure reason is not printed. Three runs of one unchanged build failed on three different operations. That is recorded on #284; this PR does not touch it.

Refs #373
