### PR TITLE
fix(#284): a resolve_path miss says why, and the Library-panel refusal is an environmental prerequisite

### DIFF
--- a/Sources/LogicProMCP/Accessibility/LibraryAccessor.swift
+++ b/Sources/LogicProMCP/Accessibility/LibraryAccessor.swift
@@ -306,10 +306,16 @@ enum LibraryAccessor {
     // MARK: - T3 path parsing + cache-backed resolution + click navigation
 
     public struct PathResolution: Sendable, Equatable {
+        public enum Miss: Sendable, Equatable {
+            case malformedPath
+            case segmentNotFound(segment: String, under: String)
+        }
+
         public let exists: Bool
         public let kind: LibraryNodeKind?
         public let matchedPath: String?
         public let children: [String]?
+        public let miss: Miss?
     }
 
     public struct PathRuntime: Sendable {
@@ -349,9 +355,12 @@ enum LibraryAccessor {
 
     /// Cache-backed path resolver. Traverses the already-scanned LibraryRoot;
     /// never touches live AX; returns existence + kind + children.
-    public static func resolvePath(_ path: String, in root: LibraryRoot) -> PathResolution? {
+    public static func resolvePath(_ path: String, in root: LibraryRoot) -> PathResolution {
         guard let segments = parsePath(path) else {
-            return PathResolution(exists: false, kind: nil, matchedPath: nil, children: nil)
+            return PathResolution(
+                exists: false, kind: nil, matchedPath: nil, children: nil,
+                miss: .malformedPath
+            )
         }
         var current = root.root
         var matched: [String] = []
@@ -361,7 +370,10 @@ enum LibraryAccessor {
             guard let next = current.children.first(where: {
                 $0.name == seg || $0.path.split(separator: "/").last.map(String.init) == seg
             }) else {
-                return PathResolution(exists: false, kind: nil, matchedPath: nil, children: nil)
+                return PathResolution(
+                    exists: false, kind: nil, matchedPath: nil, children: nil,
+                    miss: .segmentNotFound(segment: seg, under: matched.joined(separator: "/"))
+                )
             }
             current = next
             matched.append(seg)
@@ -371,7 +383,8 @@ enum LibraryAccessor {
             exists: true,
             kind: current.kind,
             matchedPath: matched.joined(separator: "/"),
-            children: children
+            children: children,
+            miss: nil
         )
     }
 

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Library.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Library.swift
@@ -365,7 +365,10 @@ extension AccessibilityChannel {
         lastPanelScan: LibraryRoot?,
         lastDiskScan: LibraryRoot?,
         lastScan: LibraryRoot?,
-        lastScanSource: String?
+        lastScanSource: String?,
+        resolveCachedPath: (String, LibraryRoot) -> LibraryAccessor.PathResolution = { path, root in
+            LibraryAccessor.resolvePath(path, in: root)
+        }
     ) -> ChannelResult {
         guard let path = params["path"], !path.isEmpty else {
             return .error("Missing 'path' parameter for library.resolve_path")
@@ -383,50 +386,54 @@ extension AccessibilityChannel {
         //     most recently) so callers that only ran one scan still work.
         //  5. Else return exists:false.
         // Panel cache: take the hit only if the path exists there. A
-        // `PathResolution(exists:false)` means the segment wasn't found in
-        // the panel tree — fall through to the disk cache before declaring
-        // the entry unloadable.
-        if let root = lastPanelScan,
-           let res = LibraryAccessor.resolvePath(path, in: root), res.exists {
-            let diskOverride = lastDiskScan
-                .flatMap { LibraryAccessor.resolvePath(path, in: $0) }
-                .flatMap { diskRes in
-                    diskRes.exists && diskRes.kind != .leaf ? diskRes : nil
-                }
-            let effectiveKind = diskOverride?.kind ?? res.kind
-            let effectiveMatchedPath = diskOverride?.matchedPath ?? res.matchedPath
-            let effectiveChildren = diskOverride?.children ?? res.children
-            let loadable = effectiveKind == .leaf
-            return encodeResult(ResolvePathResponse(
-                exists: true, kind: effectiveKind?.rawValue,
-                matchedPath: effectiveMatchedPath, children: effectiveChildren,
-                reason: loadable ? nil : Self.nonLoadableReason(for: effectiveKind),
-                source: "panel",
-                loadable: loadable,
-                warning: loadable ? nil : Self.nonLoadableWarning(path: path, kind: effectiveKind)
-            ))
-        }
-        if let root = lastDiskScan,
-           let res = LibraryAccessor.resolvePath(path, in: root), res.exists {
-            let hasPanelCache = lastPanelScan != nil
-            let isLoadableDiskCandidate = !hasPanelCache && res.kind == .leaf
-            let source = hasPanelCache ? "disk-only" : "disk"
-            let warning: String?
-            if isLoadableDiskCandidate {
-                warning = nil
-            } else if hasPanelCache {
-                warning = "Path exists on disk but isn't exposed via Logic's Library Panel. set_instrument will fail for this entry; run scan_library with mode=ax to see Panel-loadable paths."
-            } else {
-                warning = Self.nonLoadableWarning(path: path, kind: res.kind)
+        // `PathResolution(exists:false)` means the path was malformed or was
+        // not found in the panel tree — fall through to the disk cache before
+        // declaring the entry unloadable.
+        if let root = lastPanelScan {
+            let res = resolveCachedPath(path, root)
+            if res.exists {
+                let diskOverride = lastDiskScan
+                    .map { resolveCachedPath(path, $0) }
+                    .flatMap { diskRes in
+                        diskRes.exists && diskRes.kind != .leaf ? diskRes : nil
+                    }
+                let effectiveKind = diskOverride?.kind ?? res.kind
+                let effectiveMatchedPath = diskOverride?.matchedPath ?? res.matchedPath
+                let effectiveChildren = diskOverride?.children ?? res.children
+                let loadable = effectiveKind == .leaf
+                return encodeResult(ResolvePathResponse(
+                    exists: true, kind: effectiveKind?.rawValue,
+                    matchedPath: effectiveMatchedPath, children: effectiveChildren,
+                    reason: loadable ? nil : Self.nonLoadableReason(for: effectiveKind),
+                    source: "panel",
+                    loadable: loadable,
+                    warning: loadable ? nil : Self.nonLoadableWarning(path: path, kind: effectiveKind)
+                ))
             }
-            return encodeResult(ResolvePathResponse(
-                exists: true, kind: res.kind?.rawValue,
-                matchedPath: res.matchedPath, children: res.children,
-                reason: isLoadableDiskCandidate ? nil : Self.nonLoadableReason(for: res.kind),
-                source: source,
-                loadable: isLoadableDiskCandidate,
-                warning: warning
-            ))
+        }
+        if let root = lastDiskScan {
+            let res = resolveCachedPath(path, root)
+            if res.exists {
+                let hasPanelCache = lastPanelScan != nil
+                let isLoadableDiskCandidate = !hasPanelCache && res.kind == .leaf
+                let source = hasPanelCache ? "disk-only" : "disk"
+                let warning: String?
+                if isLoadableDiskCandidate {
+                    warning = nil
+                } else if hasPanelCache {
+                    warning = "Path exists on disk but isn't exposed via Logic's Library Panel. set_instrument will fail for this entry; run scan_library with mode=ax to see Panel-loadable paths."
+                } else {
+                    warning = Self.nonLoadableWarning(path: path, kind: res.kind)
+                }
+                return encodeResult(ResolvePathResponse(
+                    exists: true, kind: res.kind?.rawValue,
+                    matchedPath: res.matchedPath, children: res.children,
+                    reason: isLoadableDiskCandidate ? nil : Self.nonLoadableReason(for: res.kind),
+                    source: source,
+                    loadable: isLoadableDiskCandidate,
+                    warning: warning
+                ))
+            }
         }
         // Legacy fallback — use whatever cache was last populated.
         guard let root = lastScan else {
@@ -436,11 +443,31 @@ extension AccessibilityChannel {
                 source: nil, loadable: nil, warning: nil
             ))
         }
-        guard let res = LibraryAccessor.resolvePath(path, in: root) else {
-            return encodeResult(ResolvePathResponse(
-                exists: false, kind: nil, matchedPath: nil, children: nil,
-                reason: nil, source: lastScanSource, loadable: nil, warning: nil
-            ))
+        let res = resolveCachedPath(path, root)
+        // The only reachable `exists:false` shapes in this handler are cold
+        // cache, malformed path, and segment not found. Every other encoded
+        // ResolvePathResponse is a hit.
+        guard res.exists else {
+            switch res.miss {
+            case .malformedPath:
+                return encodeResult(ResolvePathResponse(
+                    exists: false, kind: nil, matchedPath: nil, children: nil,
+                    reason: "Malformed library path; after trimming surrounding spaces and tabs and removing one unescaped trailing '/', it must not be empty or contain an empty segment. Use non-empty slash-separated segments such as 'Bass/Sub Bass'; escape literal '/' in a segment as '\\/'.",
+                    source: lastScanSource, loadable: nil, warning: nil
+                ))
+            case let .segmentNotFound(segment, under):
+                let location = under.isEmpty ? "at the library root" : "under '\(under)'"
+                return encodeResult(ResolvePathResponse(
+                    exists: false, kind: nil, matchedPath: nil, children: nil,
+                    reason: "Library path segment '\(segment)' was not found \(location) in the scanned library cache.",
+                    source: lastScanSource, loadable: nil, warning: nil
+                ))
+            case nil:
+                return .error(HonestContract.encodeStateC(
+                    error: .internalInconsistency,
+                    hint: "Library path resolution returned a miss without a miss category. No absence was observed; run scan_library and retry."
+                ))
+            }
         }
         // If lastScanSource is "disk" or "both" and we didn't find the path
         // in lastPanelScan above, treat as disk-only.

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -473,31 +473,33 @@ actor AccessibilityChannel: Channel {
                 isPanelOpen: { rt in LibraryAccessor.isLibraryPanelOpen(runtime: rt) },
                 openPanel: { rt in await AccessibilityChannel.openLibraryPanelViaKeyCommand(runtime: rt) },
                 resolvePathKind: { path in
-                    if let panelRoot = panelScanSnapshot,
-                       let panelResolution = LibraryAccessor.resolvePath(path, in: panelRoot),
-                       panelResolution.exists {
-                        if let diskRoot = diskScanSnapshot,
-                           let diskResolution = LibraryAccessor.resolvePath(path, in: diskRoot),
-                           diskResolution.exists,
-                           diskResolution.kind != .leaf {
+                    if let panelRoot = panelScanSnapshot {
+                        let panelResolution = LibraryAccessor.resolvePath(path, in: panelRoot)
+                        if panelResolution.exists {
+                            if let diskRoot = diskScanSnapshot {
+                                let diskResolution = LibraryAccessor.resolvePath(path, in: diskRoot)
+                                if diskResolution.exists, diskResolution.kind != .leaf {
+                                    return diskResolution.kind
+                                }
+                            }
+                            return panelResolution.kind
+                        }
+                    }
+                    if let diskRoot = diskScanSnapshot {
+                        let diskResolution = LibraryAccessor.resolvePath(path, in: diskRoot)
+                        if diskResolution.exists {
                             return diskResolution.kind
                         }
-                        return panelResolution.kind
-                    }
-                    if let diskRoot = diskScanSnapshot,
-                       let diskResolution = LibraryAccessor.resolvePath(path, in: diskRoot),
-                       diskResolution.exists {
-                        return diskResolution.kind
                     }
                     return nil
                 },
                 resolvePath: { path in
-                    if let root = panelScanSnapshot,
-                       let resolution = LibraryAccessor.resolvePath(path, in: root) {
+                    if let root = panelScanSnapshot {
+                        let resolution = LibraryAccessor.resolvePath(path, in: root)
                         return resolution.exists
                     }
-                    if let root = diskScanSnapshot,
-                       let resolution = LibraryAccessor.resolvePath(path, in: root) {
+                    if let root = diskScanSnapshot {
+                        let resolution = LibraryAccessor.resolvePath(path, in: root)
                         return resolution.exists
                     }
                     return nil   // no cache → undecided, attempt nav

--- a/Sources/LogicProMCP/Qualification/QualificationTransport.swift
+++ b/Sources/LogicProMCP/Qualification/QualificationTransport.swift
@@ -320,14 +320,25 @@ struct QualificationOperationResult: Equatable, Sendable {
     /// above, the exact refusal is part of the classification so a new error
     /// from the same operation stays visible as a failure.
     var liveGateUnmetEnvironmentalPrecondition: String? {
-        guard OperationID(rawValue: operationID) == .tracksScanPluginPresets,
-              isError == true,
-              error == "channels_exhausted",
-              hint == "No plugin window with Setting dropdown found. Open an instrument plugin window first."
-        else {
+        guard isError == true, error == "channels_exhausted" else { return nil }
+        switch OperationID(rawValue: operationID) {
+        case .tracksScanPluginPresets
+            where hint == "No plugin window with Setting dropdown found. Open an instrument plugin window first.":
+            return "requires an open plugin window with a Setting dropdown"
+        // Measured 2026-09-02: `tracks.list_library` answers differently depending
+        // on whether Logic's Library panel is open. With the panel open it returns
+        // categories and presets and its readback is compared; with the panel
+        // closed it refuses with this exact hint. Both observations are true — they
+        // are of different states — so the closed-panel refusal is an environmental
+        // prerequisite, exactly like the plug-in window above, and not a semantic
+        // shortfall. Pinning it as a semantic failure made the gate's exact-match
+        // assertion fire on a panel the operator happened to close.
+        case .tracksListLibrary
+            where hint == "Library panel not found. Open Library (Y) in Logic Pro.":
+            return "requires Logic's Library panel to be open"
+        default:
             return nil
         }
-        return "requires an open plugin window with a Setting dropdown"
     }
 
     /// The outcome used by the live qualification gate. A non-passing

--- a/Sources/LogicProMCP/Utilities/HonestContract.swift
+++ b/Sources/LogicProMCP/Utilities/HonestContract.swift
@@ -220,6 +220,9 @@ enum HonestContract {
         /// Recovery: pick a path present in scan_library. v3.6.x (#135/#141).
         case pathNotInLibrary = "path_not_in_library"
         case folderNotPreset = "folder_not_preset"
+        /// A server-side invariant was violated while processing a request. The
+        /// result must fail closed without claiming an observed absence.
+        case internalInconsistency = "internal_inconsistency"
         /// The requested operation cannot be performed in the front document's
         /// current state — e.g. `project.save` on an UNTITLED document that has
         /// no on-disk path. Firing `save front document` on such a document
@@ -479,6 +482,7 @@ enum HonestContract {
         // the client must read the parent collection for valid indices.
         FailureError.indexOutOfRange.rawValue,
         FailureError.folderNotPreset.rawValue,
+        FailureError.internalInconsistency.rawValue,
         // #219: an unknown help category is terminal — no channel/retry can turn
         // a bad category token into a valid one; the caller must pick a listed
         // category. (help doesn't route through the fallback chain; listed for

--- a/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
+++ b/Tests/LogicProMCPTests/AccessibilityChannelTests.swift
@@ -738,6 +738,27 @@ private func makeSetInstrumentFixture() -> (
     return (builder, app, firstHeader, secondHeader, category, preset)
 }
 
+private func makeInstrumentCacheRoot(preset: String) -> LibraryRoot {
+    let leaf = LibraryNode(name: preset, path: "Bass/\(preset)", kind: .leaf, children: [])
+    let bass = LibraryNode(name: "Bass", path: "Bass", kind: .folder, children: [leaf])
+    let root = LibraryNode(name: "(library-root)", path: "", kind: .folder, children: [bass])
+    return LibraryRoot(
+        generatedAt: "2026-09-02T00:00:00Z",
+        scanDurationMs: 0,
+        measuredSettleDelayMs: 0,
+        selectionRestored: false,
+        truncatedBranches: 0,
+        probeTimeouts: 0,
+        cycleCount: 0,
+        nodeCount: 3,
+        leafCount: 1,
+        folderCount: 2,
+        root: root,
+        categories: ["Bass"],
+        presetsByCategory: ["Bass": [preset]]
+    )
+}
+
 @Test func testAccessibilityChannelStartRequiresTrustAndAllowsMissingLogic() async throws {
     let untrusted = AccessibilityChannel(runtime: makeAccessibilityRuntime(isTrusted: false))
     await #expect(throws: AccessibilityError.notTrusted) {
@@ -3528,6 +3549,59 @@ private func makeGMDeviceTargetFixture() -> (builder: FakeAXRuntimeBuilder, app:
     #expect(obj["error"] as? String == "path_not_in_library")
     #expect(obj["precondition"] as? String == "missing_path")
     #expect(obj["error"] as? String != "ax_write_failed")
+}
+
+@Test func testSetInstrumentPanelMissRefusesEvenWhenDiskCacheHasPath() async throws {
+    let fixture = makeSetInstrumentFixture()
+    let logicRuntime = fixture.builder.makeLogicRuntime(
+        appElement: fixture.app,
+        setAttributeHandler: { _, _, _ in true },
+        performActionHandler: { element, action in
+            guard action == kAXPressAction as String else { return true }
+            if element == fixture.secondHeader {
+                fixture.builder.setAttribute(fixture.firstHeader, kAXSelectedAttribute as String, false)
+                fixture.builder.setAttribute(fixture.secondHeader, kAXSelectedAttribute as String, true)
+            }
+            return true
+        }
+    )
+    let channel = makeAXBackedAccessibilityChannel(
+        builder: fixture.builder,
+        app: fixture.app,
+        logicRuntime: logicRuntime
+    )
+    await channel.seedLastScanForTest(
+        makeInstrumentCacheRoot(preset: "Panel Only"), source: "panel"
+    )
+    await channel.seedLastScanForTest(
+        makeInstrumentCacheRoot(preset: "Disk Only"), source: "disk"
+    )
+
+    let result = await channel.execute(
+        operation: "track.set_instrument",
+        params: ["index": "1", "path": "Bass/Disk Only"]
+    )
+
+    let isFailure = !result.isSuccess
+    #expect(isFailure)
+    let obj = try #require(JSONSerialization.jsonObject(
+        with: Data(result.message.utf8)
+    ) as? [String: Any])
+    let error = try #require(obj["error"] as? String)
+    let isPathNotInLibrary = error == "path_not_in_library"
+    #expect(isPathNotInLibrary)
+    let precondition = try #require(obj["precondition"] as? String)
+    let isMissingPathPrecondition = precondition == "missing_path"
+    #expect(isMissingPathPrecondition)
+    let actionElementIDs = fixture.builder.actionCalls.map(\.elementID)
+    let categoryWasNotNavigated = !actionElementIDs.contains(
+        fixture.builder.elementID(fixture.category)
+    )
+    #expect(categoryWasNotNavigated)
+    let presetWasNotNavigated = !actionElementIDs.contains(
+        fixture.builder.elementID(fixture.preset)
+    )
+    #expect(presetWasNotNavigated)
 }
 
 @Test func testSetInstrumentFolderPathFailsClosedBeforeAXNav() async {

--- a/Tests/LogicProMCPTests/LibraryAccessorHelpersTests.swift
+++ b/Tests/LogicProMCPTests/LibraryAccessorHelpersTests.swift
@@ -37,8 +37,9 @@ struct LibraryAccessorHelpersTests {
         let leaf = LibraryNode(name: "Quick", path: "Quick", kind: .leaf, children: [])
         let root = buildRoot([leaf])
         let r = LibraryAccessor.resolvePath("Quick", in: root)
-        #expect((r?.exists)!)
-        #expect(r?.kind == .leaf)
+        let isHit = r.exists
+        #expect(isHit)
+        #expect(r.kind == .leaf)
     }
 
     @Test func testResolvePath_ChildrenListedForFolder() async throws {
@@ -46,8 +47,8 @@ struct LibraryAccessorHelpersTests {
         let l2 = LibraryNode(name: "B", path: "Cat/B", kind: .leaf, children: [])
         let cat = LibraryNode(name: "Cat", path: "Cat", kind: .folder, children: [l1, l2])
         let r = LibraryAccessor.resolvePath("Cat", in: buildRoot([cat]))
-        #expect(r?.kind == .folder)
-        #expect(Set(r?.children ?? []) == Set(["A", "B"]))
+        #expect(r.kind == .folder)
+        #expect(Set(r.children ?? []) == Set(["A", "B"]))
     }
 
     // ---- Inventory.Codable (legacy type) ----

--- a/Tests/LogicProMCPTests/LibraryAccessorResolvePathTests.swift
+++ b/Tests/LogicProMCPTests/LibraryAccessorResolvePathTests.swift
@@ -73,66 +73,73 @@ struct LibraryAccessorResolvePathTests {
 
     @Test func testResolvePath_Depth1Leaf() async throws {
         let r = LibraryAccessor.resolvePath("Bass/Sub", in: sampleRoot())
-        #expect(r != nil)
-        #expect(r!.exists)
-        #expect(r!.kind == .leaf)
-        #expect(r!.matchedPath == "Bass/Sub")
+        let isHit = r.exists
+        let hasNoMiss = r.miss == nil
+        #expect(isHit)
+        #expect(r.kind == .leaf)
+        #expect(r.matchedPath == "Bass/Sub")
+        #expect(hasNoMiss)
     }
 
     @Test func testResolvePath_Depth3Leaf() async throws {
         let r = LibraryAccessor.resolvePath("Orch/Strings/Warm", in: sampleRoot())
-        #expect(r != nil)
-        #expect(r!.kind == .leaf)
-        #expect(r!.matchedPath == "Orch/Strings/Warm")
+        #expect(r.kind == .leaf)
+        #expect(r.matchedPath == "Orch/Strings/Warm")
     }
 
-    @Test func testResolvePath_MissingLeaf_NotExists() async throws {
+    @Test func testResolvePath_MissingLeaf_CarriesSegmentNotFoundMiss() async throws {
         let r = LibraryAccessor.resolvePath("Bass/Nope", in: sampleRoot())
-        #expect(r != nil)
-        #expect(!(r!.exists))
-        #expect(r!.kind == nil)
+        let isMiss = !r.exists
+        let expectedMiss: LibraryAccessor.PathResolution.Miss = .segmentNotFound(
+            segment: "Nope", under: "Bass"
+        )
+        #expect(isMiss)
+        #expect(r.kind == nil)
+        #expect(r.miss == expectedMiss)
     }
 
     @Test func testResolvePath_EscapedSlash() async throws {
         let r = LibraryAccessor.resolvePath(#"Foo/Sub\/Thing"#, in: sampleRoot())
-        #expect(r != nil)
-        #expect(r!.exists)
-        #expect(r!.kind == .leaf)
+        let isHit = r.exists
+        #expect(isHit)
+        #expect(r.kind == .leaf)
     }
 
     @Test func testResolvePath_DisambiguatedDuplicate() async throws {
         let r = LibraryAccessor.resolvePath("Synth/Pad[1]", in: sampleRoot())
-        #expect(r != nil)
-        #expect(r!.exists)
-        #expect(r!.kind == .leaf)
-        #expect(r!.matchedPath == "Synth/Pad[1]")
+        let isHit = r.exists
+        #expect(isHit)
+        #expect(r.kind == .leaf)
+        #expect(r.matchedPath == "Synth/Pad[1]")
     }
 
     @Test func testResolvePath_FolderPath_KindFolder() async throws {
         let r = LibraryAccessor.resolvePath("Orch", in: sampleRoot())
-        #expect(r != nil)
-        #expect(r!.exists)
-        #expect(r!.kind == .folder)
-        #expect((r!.children ?? []).contains("Strings"))
+        let isHit = r.exists
+        #expect(isHit)
+        #expect(r.kind == .folder)
+        #expect((r.children ?? []).contains("Strings"))
     }
 
-    @Test func testResolvePath_EmptyPath_NotExists() async throws {
+    @Test func testResolvePath_EmptyPath_CarriesMalformedPathMiss() async throws {
         let r = LibraryAccessor.resolvePath("", in: sampleRoot())
-        #expect(r != nil)
-        #expect(!(r!.exists))
+        let isMiss = !r.exists
+        #expect(isMiss)
+        #expect(r.miss == .malformedPath)
     }
 
-    @Test func testResolvePath_EmptySegment_NotExists() async throws {
+    @Test func testResolvePath_EmptySegment_CarriesMalformedPathMiss() async throws {
         let r = LibraryAccessor.resolvePath("A//C", in: sampleRoot())
-        #expect(r != nil)
-        #expect(!(r!.exists))
+        let isMiss = !r.exists
+        #expect(isMiss)
+        #expect(r.miss == .malformedPath)
     }
 
     @Test func testResolvePath_TrailingSlash() async throws {
         let r = LibraryAccessor.resolvePath("Bass/", in: sampleRoot())
-        #expect(r != nil)
-        #expect(r!.exists)
-        #expect(r!.kind == .folder)
+        let isHit = r.exists
+        #expect(isHit)
+        #expect(r.kind == .folder)
     }
 
     // -- selectByPath click sequence tests --

--- a/Tests/LogicProMCPTests/LibraryDiskScannerTests.swift
+++ b/Tests/LogicProMCPTests/LibraryDiskScannerTests.swift
@@ -123,11 +123,9 @@ struct LibraryDiskScannerTests {
         #expect(leaf.path == "Electronic Drums/Kit Pieces/02 Snares/Snare 3 - Pawn Shop 808")
         #expect(root.presetsByCategory["Electronic Drums"] == ["Snare 3 - Pawn Shop 808"])
 
-        let resolved = try #require(
-            LibraryAccessor.resolvePath(
-                "Electronic Drums/Kit Pieces/02 Snares/Snare 3 - Pawn Shop 808",
-                in: root
-            )
+        let resolved = LibraryAccessor.resolvePath(
+            "Electronic Drums/Kit Pieces/02 Snares/Snare 3 - Pawn Shop 808",
+            in: root
         )
         #expect(resolved.exists)
         #expect(resolved.kind == .leaf)
@@ -418,11 +416,11 @@ struct LibraryDiskScannerTests {
         let root = try LibraryDiskScanner.scan(bundleURL: bundle)
         #expect(root.categories.sorted() == ["Bass", "Orchestral", "Studio Horns", "Studio Strings", "World"])
         #expect(root.leafCount == 5)
-        let horns = try #require(LibraryAccessor.resolvePath("Studio Horns/3-Piece Section", in: root))
+        let horns = LibraryAccessor.resolvePath("Studio Horns/3-Piece Section", in: root)
         #expect(horns.kind == .folder)
-        let strings = try #require(LibraryAccessor.resolvePath("Studio Strings/Section Instruments", in: root))
+        let strings = LibraryAccessor.resolvePath("Studio Strings/Section Instruments", in: root)
         #expect(strings.kind == .folder)
-        let world = try #require(LibraryAccessor.resolvePath("World/Stringed", in: root))
+        let world = LibraryAccessor.resolvePath("World/Stringed", in: root)
         #expect(world.kind == .folder)
         let orchestral = try #require(root.root.children.first { $0.name == "Orchestral" })
         #expect(orchestral.children.map(\.name) == ["Brass"])
@@ -451,18 +449,14 @@ struct LibraryDiskScannerTests {
         #expect(root.leafCount == 3)
         #expect(root.candidatePatchCount == 5)
         #expect(root.nonApplicablePatchCount == 2)
-        let emptyPad = try #require(
-            LibraryAccessor.resolvePath(
-                "Electronic Drums/Kit Pieces/Empty Pad",
-                in: root
-            )
+        let emptyPad = LibraryAccessor.resolvePath(
+            "Electronic Drums/Kit Pieces/Empty Pad",
+            in: root
         )
         #expect(emptyPad.kind == LibraryNodeKind.leaf)
-        let templatePad = try #require(
-            LibraryAccessor.resolvePath(
-                "Electronic Drums/Kit Pieces/Template/Empty Pad",
-                in: root
-            )
+        let templatePad = LibraryAccessor.resolvePath(
+            "Electronic Drums/Kit Pieces/Template/Empty Pad",
+            in: root
         )
         #expect(!(templatePad.exists))
         #expect(root.scanWarnings.contains { warning in

--- a/Tests/LogicProMCPTests/QualificationRunnerTests.swift
+++ b/Tests/LogicProMCPTests/QualificationRunnerTests.swift
@@ -21,11 +21,15 @@ struct QualificationRunnerTests {
     }
 
     private static let knownLiveGateFailures: [KnownLiveGateFailure] = [
-        .init(
-            operationID: OperationID.tracksListLibrary.rawValue,
-            failureReason: "semantic readback mismatch: response did not match its independent readback",
-            trackingIssue: "#284"
-        ),
+        // `tracks.list_library` was pinned here until 2026-09-02. It is not a
+        // semantic shortfall: measured, it answers differently depending on whether
+        // Logic's Library panel is open — returning categories and presets when it
+        // is, and refusing with an exact hint when it is not. The closed-panel
+        // refusal is now classified as an environmental prerequisite, like the
+        // plug-in window `scan_plugin_presets` needs, so it left this list by being
+        // correctly bucketed rather than by being fixed. This comment is here
+        // because a name disappearing from a known-failure list should never be
+        // silent.
         .init(
             operationID: OperationID.tracksResolvePath.rawValue,
             failureReason: "semantic readback mismatch: response did not match its independent readback",

--- a/Tests/LogicProMCPTests/QualificationRunnerTests.swift
+++ b/Tests/LogicProMCPTests/QualificationRunnerTests.swift
@@ -6,10 +6,10 @@ import Testing
 
 @Suite("ADR-001 qualification runner", .serialized)
 struct QualificationRunnerTests {
-    /// #284 has two measured product defects. This is intentionally an exact
-    /// list, rather than an allow-list: a new failure, a changed reason, OR a
-    /// known failure beginning to pass must all redden the live gate so the list
-    /// cannot silently absorb regressions or rot after a fix.
+    /// #284 has no measured product defect pinned here at the moment. This is
+    /// intentionally an exact list, rather than an allow-list: a new failure, a
+    /// changed reason, OR a known failure beginning to pass must all redden the
+    /// live gate so the list cannot silently absorb regressions or rot after a fix.
     private struct KnownLiveGateFailure: Equatable {
         let operationID: String
         let failureReason: String
@@ -30,11 +30,12 @@ struct QualificationRunnerTests {
         // correctly bucketed rather than by being fixed. This comment is here
         // because a name disappearing from a known-failure list should never be
         // silent.
-        .init(
-            operationID: OperationID.tracksResolvePath.rawValue,
-            failureReason: "semantic readback mismatch: response did not match its independent readback",
-            trackingIssue: "#284"
-        ),
+        //
+        // `tracks.resolve_path` was pinned here until 2026-09-02 as well, and left
+        // by being fixed: a warm-cache miss answered `exists:false` with no `reason`
+        // and a warning claiming the path had resolved. Its oracle checks the
+        // response alone: a miss needs a non-empty `reason`; a hit needs a
+        // `matchedPath` and a known `kind`.
     ]
 
     @Test func qualificationExecutesEachOperationAndBindsIndependentReadback() async throws {
@@ -1421,39 +1422,117 @@ struct QualificationRunnerTests {
         #expect(everyDispositionIsAccountedFor)
     }
 
+    @Test func liveGateClassifiesExactClosedLibraryPanelHintAsEnvironmental() {
+        let summary = QualificationLiveGateSummary(operationResults: [
+            Self.tracksListLibraryRefusal()
+        ])
+        let classifiesClosedPanelAsEnvironmental = summary.environmentalPreconditions == [
+            .init(
+                operationID: OperationID.tracksListLibrary.rawValue,
+                reason: "requires Logic's Library panel to be open"
+            ),
+        ] && summary.failed == 0
+
+        #expect(classifiesClosedPanelAsEnvironmental)
+    }
+
+    @Test func liveGateRejectsDifferentTracksListLibraryHintAsFailure() {
+        let summary = QualificationLiveGateSummary(operationResults: [
+            Self.tracksListLibraryRefusal(hint: "A different library-panel refusal.")
+        ])
+        let differentHintRemainsFailure = summary.environmentalPreconditions.isEmpty
+            && summary.failed == 1
+
+        #expect(differentHintRemainsFailure)
+    }
+
+    @Test func liveGateRejectsDifferentTracksListLibraryErrorAsFailure() {
+        let summary = QualificationLiveGateSummary(operationResults: [
+            Self.tracksListLibraryRefusal(error: "different_error")
+        ])
+        let differentErrorRemainsFailure = summary.environmentalPreconditions.isEmpty
+            && summary.failed == 1
+
+        #expect(differentErrorRemainsFailure)
+    }
+
     @Test func knownLiveGateFailuresCarryReasonsAndTrackingReferences() {
         let eachFailureIsExplainedAndTracked = Self.knownLiveGateFailures.allSatisfy {
-            !$0.operationID.isEmpty && !$0.failureReason.isEmpty && $0.trackingIssue == "#284"
+            Self.hasValidKnownLiveGateFailureMetadata($0)
         }
 
         #expect(eachFailureIsExplainedAndTracked)
     }
 
+    @Test func knownLiveGateFailureMetadataPredicateRejectsMalformedEntries() {
+        let emptyReason = KnownLiveGateFailure(
+            operationID: "fixture.empty-reason", failureReason: "", trackingIssue: "#284"
+        )
+        let wrongTrackingIssue = KnownLiveGateFailure(
+            operationID: "fixture.wrong-tracking", failureReason: "observed cause", trackingIssue: "#999"
+        )
+        let wellFormed = KnownLiveGateFailure(
+            operationID: "fixture.well-formed", failureReason: "observed cause", trackingIssue: "#284"
+        )
+        let rejectsEmptyReason = !Self.hasValidKnownLiveGateFailureMetadata(emptyReason)
+        let rejectsWrongTrackingIssue = !Self.hasValidKnownLiveGateFailureMetadata(wrongTrackingIssue)
+        let acceptsWellFormedEntry = Self.hasValidKnownLiveGateFailureMetadata(wellFormed)
+
+        #expect(rejectsEmptyReason)
+        #expect(rejectsWrongTrackingIssue)
+        #expect(acceptsWellFormedEntry)
+    }
+
+    /// Exactness is a property of the matcher, not of whatever the production
+    /// list happens to hold -- and that list is legitimately empty when nothing
+    /// is pinned. These properties are therefore proved against a fixture list;
+    /// the live gate test above still holds the real list to the real run.
+    private static let exactnessFixture: [KnownLiveGateFailure] = [
+        .init(operationID: "fixture.first", failureReason: "first observed cause", trackingIssue: "#284"),
+        .init(operationID: "fixture.second", failureReason: "second observed cause", trackingIssue: "#284"),
+    ]
+
+    @Test func knownLiveGateFailureSetAcceptsTheExactKnownSet() {
+        let observed = Self.exactnessFixture.map(\.failure)
+        let acceptsExactSet = Self.matchesKnownLiveGateFailures(observed, against: Self.exactnessFixture)
+
+        #expect(acceptsExactSet)
+    }
+
     @Test func knownLiveGateFailureSetRejectsNewFailure() {
-        let observed = Self.knownLiveGateFailures.map(\.failure) + [
+        let observed = Self.exactnessFixture.map(\.failure) + [
             .init(operationID: "synthetic.new.failure", failureReason: "a newly observed failure"),
         ]
-        let rejectsNewFailure = !Self.matchesKnownLiveGateFailures(observed)
+        let rejectsNewFailure = !Self.matchesKnownLiveGateFailures(observed, against: Self.exactnessFixture)
 
         #expect(rejectsNewFailure)
     }
 
     @Test func knownLiveGateFailureSetRejectsAKnownFailureStartingToPass() {
-        let observed = Array(Self.knownLiveGateFailures.map(\.failure).dropLast())
-        let rejectsMissingKnownFailure = !Self.matchesKnownLiveGateFailures(observed)
+        let observed = Array(Self.exactnessFixture.map(\.failure).dropLast())
+        let rejectsMissingKnownFailure = !Self.matchesKnownLiveGateFailures(observed, against: Self.exactnessFixture)
 
         #expect(rejectsMissingKnownFailure)
     }
 
     @Test func knownLiveGateFailureSetRejectsChangedReason() {
-        var observed = Self.knownLiveGateFailures.map(\.failure)
+        var observed = Self.exactnessFixture.map(\.failure)
         observed[0] = .init(
             operationID: observed[0].operationID,
             failureReason: "semantic readback mismatch: a different observed cause"
         )
-        let rejectsChangedReason = !Self.matchesKnownLiveGateFailures(observed)
+        let rejectsChangedReason = !Self.matchesKnownLiveGateFailures(observed, against: Self.exactnessFixture)
 
         #expect(rejectsChangedReason)
+    }
+
+    @Test func emptyKnownLiveGateFailureSetRejectsAnyFailure() {
+        let observed = [QualificationLiveGateSummary.Failure(
+            operationID: "synthetic.new.failure", failureReason: "a newly observed failure"
+        )]
+        let rejectsAnyFailure = !Self.matchesKnownLiveGateFailures(observed, against: [])
+
+        #expect(rejectsAnyFailure)
     }
 
     @Test func liveGateSummaryStatesMutatingOperationExclusion() throws {
@@ -3209,9 +3288,39 @@ struct QualificationRunnerTests {
     }
 
     private static func matchesKnownLiveGateFailures(
-        _ observed: [QualificationLiveGateSummary.Failure]
+        _ observed: [QualificationLiveGateSummary.Failure],
+        against known: [KnownLiveGateFailure] = knownLiveGateFailures
     ) -> Bool {
-        observed == knownLiveGateFailures.map(\.failure)
+        observed == known.map(\.failure)
+    }
+
+    private static func hasValidKnownLiveGateFailureMetadata(
+        _ failure: KnownLiveGateFailure
+    ) -> Bool {
+        !failure.operationID.isEmpty && !failure.failureReason.isEmpty && failure.trackingIssue == "#284"
+    }
+
+    private static func tracksListLibraryRefusal(
+        error: String = "channels_exhausted",
+        hint: String = "Library panel not found. Open Library (Y) in Logic Pro."
+    ) -> QualificationOperationResult {
+        QualificationOperationResult(
+            operationID: OperationID.tracksListLibrary.rawValue,
+            tool: "logic_tracks",
+            command: "list_library",
+            mutability: .readOnly,
+            requestID: "missing-library-panel-request",
+            responseData: Data(#"{\"state\":\"C\",\"error\":\"\#(error)\",\"write_attempted\":false}"#.utf8),
+            isError: true,
+            state: "C",
+            error: error,
+            hint: hint,
+            writeAttempted: false,
+            readbackSource: "logic://library/inventory",
+            readbackRequestID: "missing-library-panel-readback",
+            readbackData: Data(#"{}"#.utf8),
+            failureReason: nil
+        )
     }
 
     private static func driveResult(

--- a/Tests/LogicProMCPTests/ScanLibraryCacheSplitTests.swift
+++ b/Tests/LogicProMCPTests/ScanLibraryCacheSplitTests.swift
@@ -6,7 +6,7 @@ import Testing
 // / both). resolve_path responses carry `source` and `loadable` fields so the
 // client can distinguish disk-catalog candidates from panel-proven misses.
 
-@Test func testResolvePathMissingCacheReturnsReason() async {
+@Test func testResolvePathMissingCacheReturnsReason() async throws {
     // No scan has been run; resolve_path should hint at scan_library without
     // crashing.
     let channel = AccessibilityChannel(runtime: makeRuntime())
@@ -14,15 +14,148 @@ import Testing
         operation: "library.resolve_path",
         params: ["path": "Bass/Sub"]
     )
-    #expect(result.isSuccess)
-    let obj = try! JSONSerialization.jsonObject(
+    let isSuccess = result.isSuccess
+    #expect(isSuccess)
+    let obj = try #require(JSONSerialization.jsonObject(
         with: Data(result.message.utf8)
-    ) as! [String: Any]
-    #expect(!((obj["exists"] as? Bool)!))
-    #expect(obj["reason"] as? String == "No cached library scan; call scan_library first")
+    ) as? [String: Any])
+    let exists = try #require(obj["exists"] as? Bool)
+    let isMiss = !exists
+    #expect(isMiss)
+    let reason = try #require(obj["reason"] as? String)
+    let hasExistingColdCacheReason = reason == "No cached library scan; call scan_library first"
+    #expect(hasExistingColdCacheReason)
 }
 
-@Test func testResolvePathReturnsPanelSourceAndLoadableTrueForMatch() async {
+@Test func testResolvePathWarmCacheAbsentPathNamesMissingSegmentAndPrefix() async throws {
+    let channel = AccessibilityChannel(runtime: makeRuntime())
+    let root = makeTestRoot(categories: ["Bass"], presets: ["Sub Bass"])
+    await channel.seedLastScanForTest(root, source: "disk")
+
+    let result = await channel.execute(
+        operation: "library.resolve_path",
+        params: ["path": "Bass/Absent"]
+    )
+    let isSuccess = result.isSuccess
+    #expect(isSuccess)
+    let obj = try #require(JSONSerialization.jsonObject(
+        with: Data(result.message.utf8)
+    ) as? [String: Any])
+    let exists = try #require(obj["exists"] as? Bool)
+    let isMiss = !exists
+    #expect(isMiss)
+    let reason = try #require(obj["reason"] as? String)
+    let namesMissingSegmentAndPrefix = reason == "Library path segment 'Absent' was not found under 'Bass' in the scanned library cache."
+    #expect(namesMissingSegmentAndPrefix)
+    let source = try #require(obj["source"] as? String)
+    let consultedDiskCache = source == "disk"
+    #expect(consultedDiskCache)
+    let warningIsOmitted = obj["warning"] == nil
+    #expect(warningIsOmitted)
+}
+
+@Test func testResolvePathWarmCacheRootMissNamesLibraryRoot() async throws {
+    let channel = AccessibilityChannel(runtime: makeRuntime())
+    let root = makeTestRoot(categories: ["Bass"], presets: ["Sub Bass"])
+    await channel.seedLastScanForTest(root, source: "disk")
+
+    let result = await channel.execute(
+        operation: "library.resolve_path",
+        params: ["path": "Absent"]
+    )
+    let isSuccess = result.isSuccess
+    #expect(isSuccess)
+    let obj = try #require(JSONSerialization.jsonObject(
+        with: Data(result.message.utf8)
+    ) as? [String: Any])
+    let exists = try #require(obj["exists"] as? Bool)
+    let isMiss = !exists
+    #expect(isMiss)
+    let reason = try #require(obj["reason"] as? String)
+    let namesLibraryRoot = reason == "Library path segment 'Absent' was not found at the library root in the scanned library cache."
+    #expect(namesLibraryRoot)
+}
+
+@Test func testResolvePathWarmCacheMalformedPathExplainsSyntaxAndOmitsWarning() async throws {
+    let channel = AccessibilityChannel(runtime: makeRuntime())
+    let root = makeTestRoot(categories: ["Bass"], presets: ["Sub Bass"])
+    await channel.seedLastScanForTest(root, source: "disk")
+
+    let result = await channel.execute(
+        operation: "library.resolve_path",
+        params: ["path": "A//C"]
+    )
+    let obj = try #require(JSONSerialization.jsonObject(
+        with: Data(result.message.utf8)
+    ) as? [String: Any])
+    let exists = try #require(obj["exists"] as? Bool)
+    let isMiss = !exists
+    #expect(isMiss)
+    let reason = try #require(obj["reason"] as? String)
+    let explainsMalformedSyntax = reason == "Malformed library path; after trimming surrounding spaces and tabs and removing one unescaped trailing '/', it must not be empty or contain an empty segment. Use non-empty slash-separated segments such as 'Bass/Sub Bass'; escape literal '/' in a segment as '\\/'."
+    #expect(explainsMalformedSyntax)
+    let source = try #require(obj["source"] as? String)
+    let consultedDiskCache = source == "disk"
+    #expect(consultedDiskCache)
+    let warningIsOmitted = obj["warning"] == nil
+    #expect(warningIsOmitted)
+}
+
+@Test func testResolvePathLeadingNewlineIsNotTrimmed() async throws {
+    let channel = AccessibilityChannel(runtime: makeRuntime())
+    let root = makeTestRoot(categories: ["Bass"], presets: ["Sub Bass"])
+    await channel.seedLastScanForTest(root, source: "disk")
+
+    let result = await channel.execute(
+        operation: "library.resolve_path",
+        params: ["path": "\nBass/Sub Bass"]
+    )
+    let isSuccess = result.isSuccess
+    #expect(isSuccess)
+    let obj = try #require(JSONSerialization.jsonObject(
+        with: Data(result.message.utf8)
+    ) as? [String: Any])
+    let exists = try #require(obj["exists"] as? Bool)
+    let isMiss = !exists
+    #expect(isMiss)
+    let reason = try #require(obj["reason"] as? String)
+    let keepsLeadingNewlineAsSegment = reason == "Library path segment '\nBass' was not found at the library root in the scanned library cache."
+    #expect(keepsLeadingNewlineAsSegment)
+}
+
+@Test func testResolvePathInvariantViolationReturnsStateCWithoutExists() async throws {
+    let root = makeTestRoot(categories: ["Bass"], presets: ["Sub Bass"])
+    let invalidMiss = LibraryAccessor.PathResolution(
+        exists: false, kind: nil, matchedPath: nil, children: nil, miss: nil
+    )
+
+    let result = AccessibilityChannel.resolveLibraryPath(
+        params: ["path": "Bass/Sub Bass"],
+        lastPanelScan: nil,
+        lastDiskScan: nil,
+        lastScan: root,
+        lastScanSource: "disk",
+        resolveCachedPath: { _, _ in invalidMiss }
+    )
+
+    let isFailure = !result.isSuccess
+    #expect(isFailure)
+    let obj = try #require(JSONSerialization.jsonObject(
+        with: Data(result.message.utf8)
+    ) as? [String: Any])
+    let state = try #require(obj["state"] as? String)
+    let isStateC = state == "C"
+    #expect(isStateC)
+    let error = try #require(obj["error"] as? String)
+    let isInternalInconsistency = error == "internal_inconsistency"
+    #expect(isInternalInconsistency)
+    let existsIsOmitted = obj["exists"] == nil
+    #expect(existsIsOmitted)
+    let isTerminal = HonestContract.isTerminalStateC(result.message)
+    #expect(isTerminal)
+}
+
+@Test func testResolvePathReturnsPanelSourceAndLoadableTrueForMatch() async throws {
     let channel = AccessibilityChannel(runtime: makeRuntime())
     // Seed panel cache directly via a canned scan run. We can't easily run
     // runLiveScan here without a live AX tree, so we drive setLastScan via
@@ -35,13 +168,18 @@ import Testing
         operation: "library.resolve_path",
         params: ["path": "Bass/Sub Bass"]
     )
-    let obj = try! JSONSerialization.jsonObject(
+    let obj = try #require(JSONSerialization.jsonObject(
         with: Data(result.message.utf8)
-    ) as! [String: Any]
-    #expect((obj["exists"] as? Bool)!)
-    #expect(obj["source"] as? String == "panel")
-    #expect((obj["loadable"] as? Bool)!)
-    #expect(obj["warning"] == nil)
+    ) as? [String: Any])
+    let exists = try #require(obj["exists"] as? Bool)
+    #expect(exists)
+    let source = try #require(obj["source"] as? String)
+    let reportsPanelSource = source == "panel"
+    #expect(reportsPanelSource)
+    let loadable = try #require(obj["loadable"] as? Bool)
+    #expect(loadable)
+    let warningIsOmitted = obj["warning"] == nil
+    #expect(warningIsOmitted)
 }
 
 @Test func testResolvePathReturnsPanelFolderAsNonLoadable() async {
@@ -64,7 +202,7 @@ import Testing
     #expect(((obj["warning"] as? String)?.contains("leaf preset paths"))!)
 }
 
-@Test func testResolvePathReturnsDiskLeafAsLoadableCandidateWithoutPanelCache() async {
+@Test func testResolvePathReturnsDiskLeafAsLoadableCandidateWithoutPanelCache() async throws {
     let channel = AccessibilityChannel(runtime: makeRuntime())
     let disk = makeFolderRoot()
     await channel.seedLastScanForTest(disk, source: "disk")
@@ -73,15 +211,23 @@ import Testing
         operation: "library.resolve_path",
         params: ["path": "Synthesizer/Bass/Acid Etched Bass"]
     )
-    let obj = try! JSONSerialization.jsonObject(
+    let obj = try #require(JSONSerialization.jsonObject(
         with: Data(result.message.utf8)
-    ) as! [String: Any]
-    #expect((obj["exists"] as? Bool)!)
-    #expect(obj["kind"] as? String == "leaf")
-    #expect(obj["source"] as? String == "disk")
-    #expect((obj["loadable"] as? Bool)!)
-    #expect(obj["reason"] == nil)
-    #expect(obj["warning"] == nil)
+    ) as? [String: Any])
+    let exists = try #require(obj["exists"] as? Bool)
+    #expect(exists)
+    let kind = try #require(obj["kind"] as? String)
+    let reportsLeaf = kind == "leaf"
+    #expect(reportsLeaf)
+    let source = try #require(obj["source"] as? String)
+    let reportsDiskSource = source == "disk"
+    #expect(reportsDiskSource)
+    let loadable = try #require(obj["loadable"] as? Bool)
+    #expect(loadable)
+    let reasonIsOmitted = obj["reason"] == nil
+    #expect(reasonIsOmitted)
+    let warningIsOmitted = obj["warning"] == nil
+    #expect(warningIsOmitted)
 }
 
 @Test func testResolvePathUsesDiskTreeToDisambiguateShallowPanelFolderRows() async {
@@ -150,7 +296,7 @@ import Testing
     #expect(obj["warning"] == nil, "No disk-only warning for Panel-known entry")
 }
 
-@Test func testResolvePathReturnsDiskOnlyWithLoadableFalse() async {
+@Test func testResolvePathReturnsDiskOnlyWithLoadableFalse() async throws {
     let channel = AccessibilityChannel(runtime: makeRuntime())
     // Panel cache has category Bass / preset Sub Bass.
     let panel = makeTestRoot(categories: ["Bass"], presets: ["Sub Bass"])
@@ -164,13 +310,19 @@ import Testing
         operation: "library.resolve_path",
         params: ["path": "Drums/Disk Only Kit"]
     )
-    let obj = try! JSONSerialization.jsonObject(
+    let obj = try #require(JSONSerialization.jsonObject(
         with: Data(result.message.utf8)
-    ) as! [String: Any]
-    #expect((obj["exists"] as? Bool)!)
-    #expect(obj["source"] as? String == "disk-only")
-    #expect(!((obj["loadable"] as? Bool)!))
-    #expect(obj["warning"] != nil)
+    ) as? [String: Any])
+    let exists = try #require(obj["exists"] as? Bool)
+    #expect(exists)
+    let source = try #require(obj["source"] as? String)
+    let reportsDiskOnlySource = source == "disk-only"
+    #expect(reportsDiskOnlySource)
+    let loadable = try #require(obj["loadable"] as? Bool)
+    let isNotLoadable = !loadable
+    #expect(isNotLoadable)
+    let warningIsPresent = obj["warning"] != nil
+    #expect(warningIsPresent)
 }
 
 // MARK: - Helpers

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -74,6 +74,7 @@ Also open, outside the ADR set:
 | #678 | closed | the drift guard and this file's update rule shipped in #684 |
 | #735 | OPEN | legacy `MIDIPacketList` traversal walked past a value copy (SIGBUS). Fixed on `fix/735-midi-packetlist`; measured 2026-09-02 the parsed inbound stream has NO production consumer, so `LogicProMCP-MIDI-In` accepts MIDI and discards it — decide whether to finish that port or stop publishing it. The live gate cannot express this proof: `is_clean` requires captures/visual/recordings and this is a non-UI path with nothing in Logic to observe |
 | #736 | OPEN | external report — duplicate virtual MIDI endpoints. Root cause measured both directions: two endpoints sharing a name make Logic bind the wrong one (duplicate -> `connected:false` x2, single -> `connected:true` x2). PR #738 open but REFUTED by review — census/create is a cross-process TOCTOU race, an enumeration failure publishes as an observed `endpoint_count: 0`, health republishes a startup snapshot, and the unique-ID hash has concrete collisions |
+| #742 | OPEN | a handoff for whoever picks up the open issues next: where main is, which branches carry unmerged work, the one confirmed live-gate failure and its trace, and the corrections made publicly so they are not re-inherited. Closes when the work it hands off is picked up |
 | #683 | OPEN | external report — MCU feedback from Logic Pro Creator Studio wedges the loop; four hypotheses refuted or weakened by measurement, blocked on a `sample` from the reporter's host |
 | #724 | closed | |
 | #726 | closed | |


### PR DESCRIPTION
Two fixes to the same-release live qualification gate, each measured against the release binary on a live Logic.

## 1. The Library-panel refusal is an environmental prerequisite, not a defect

`tracks.list_library` answers differently depending on whether Logic's Library panel is open:

```
panel open     returns categories and presets; its readback is compared
panel closed   refuses: channels_exhausted / "Library panel not found. Open Library (Y) in Logic Pro."
```

The closed-panel refusal was pinned as a semantic readback mismatch while the panel happened to be open. When it closed, the exact-match assertion fired — correctly. The refusal now goes to the environmental-prerequisite bucket, matched on the exact hint, so any other `channels_exhausted` from that operation stays a failure.

## 2. A `resolve_path` miss says why, and never claims the path resolved

The gate's last failure, `tracks.resolve_path`, was a real defect. Measured before:

```
COLD  {"exists":false,"reason":"No cached library scan; call scan_library first"}
WARM  {"exists":false,"loadable":false,"source":"disk",
       "warning":"Path resolved from disk cache; may not be loadable via Library Panel."}
```

The warm miss carried no `reason`, and its `warning` asserted the path was resolved on a response whose `exists` is false. A negative resolution now returns before the hit-shaped encoder, every miss explains itself, and the resolver reports *why* it missed so the handler cannot describe a malformed path as a failed traversal. Hit encodings are unchanged; the oracle is untouched.

Measured against the release binary built from this head:

```
COLD  Bass/Absent  {"exists":false,"reason":"No cached library scan; call scan_library first"}
scan_library       source=disk nodeCount=5780
WARM  Bass/Absent  {"exists":false,"source":"disk","reason":"Library path segment 'Absent' was not found under 'Bass' in the scanned library cache."}
WARM  Nope/Sub     {"exists":false,"source":"disk","reason":"Library path segment 'Nope' was not found at the library root in the scanned library cache."}
WARM  A//C         {"exists":false,"source":"disk","reason":"Malformed library path; after trimming surrounding spaces and tabs ..."}
HIT   Bass         {"exists":true,"kind":"folder","source":"disk","reason":"folder_path","warning":"... resolves to folder; ..."}
```

### One caller had to be repaired along the way

Making the resolver non-optional turned `set_instrument`'s "the panel proved this path absent" into a fall-through, and `setTrackInstrument` reads anything but `false` as permission to drive the live Library panel. A panel-proven absence could therefore actuate the panel for an entry `resolve_path` already reports as `loadable:false`. The first cache consulted now gives its verdict, true or false; only "no cache at all" stays undecided, as before. Two adversarial review passes ran on this branch; the first found four defects, the second found this regression plus four smaller ones, and all are fixed.

## Live gate

At this head, on a live Logic:

```
in_scope_passed=21  out_of_scope=89  environmental_preconditions=2  failed=0 of 112
unmet: tracks.list_library (Library panel closed), tracks.scan_plugin_presets (no plug-in window)
```

Both unmet entries are that run's environment, not shortfalls: with the Library panel open the same build counts `list_library` as an in-scope pass. The known-failure list is now empty and asserted exactly, so a new failure reddens the gate and a listed one that starts passing does too.

## Verification

- `swift build --disable-sandbox --build-tests`, `swift test --disable-sandbox --no-parallel`: 4,234 tests pass.
- `python3 Scripts/run-repo-guards.py`: 15 of 15.
- Live qualification gate at this head: above.
- Live evidence bound to this head: `live_369_export_menu_path_is_reachable`, 17 records, 0 failures. That harness proves the release artifact answers a live Logic; it is not about the library path, and no harness on `main` declares coverage for the files this branch changes. The library behaviour above was measured by hand against the same artifact.

Refs #284
