### PR TITLE
feat(#299,#292,#306): verified control of Controls-view boolean parameters

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXHelpers.swift
+++ b/Sources/LogicProMCP/Accessibility/AXHelpers.swift
@@ -604,6 +604,44 @@ enum AXHelpers {
         return Census(element: hits.count == 1 ? hits[0] : nil, candidates: hits.count, matches: hits)
     }
 
+    /// Status-preserving counterpart to `censusDescendant`.
+    ///
+    /// The historical census intentionally keeps its best-effort contract for
+    /// its many existing callers: a failed AX read contributes no match. A
+    /// caller using a census as write authority cannot make that tradeoff,
+    /// because an unreadable competing candidate is not evidence that it is
+    /// absent. This additive form reports the first non-absence AX failure
+    /// instead. `attributeUnsupported` and `noValue` remain an ordinary
+    /// missing role/title/identifier or child list.
+    static func censusDescendantResult(
+        of element: AXUIElement,
+        role: String? = nil,
+        title: String? = nil,
+        identifier: String? = nil,
+        maxDepth: Int = 10,
+        runtime: Runtime = .production
+    ) -> Result<Census, AXStatusError> {
+        var hits: [AXUIElement] = []
+        switch collectMatchingResult(
+            of: element,
+            role: role,
+            title: title,
+            identifier: identifier,
+            maxDepth: maxDepth,
+            runtime: runtime,
+            into: &hits
+        ) {
+        case .success:
+            return .success(Census(
+                element: hits.count == 1 ? hits[0] : nil,
+                candidates: hits.count,
+                matches: hits
+            ))
+        case let .failure(error):
+            return .failure(error)
+        }
+    }
+
     private static func collectMatching(
         of element: AXUIElement,
         role: String?,
@@ -623,6 +661,103 @@ enum AXHelpers {
             }
             collectMatching(of: child, role: role, title: title, identifier: identifier,
                             maxDepth: maxDepth - 1, runtime: runtime, into: &results)
+        }
+    }
+
+    private static func collectMatchingResult(
+        of element: AXUIElement,
+        role: String?,
+        title: String?,
+        identifier: String?,
+        maxDepth: Int,
+        runtime: Runtime,
+        into results: inout [AXUIElement]
+    ) -> Result<Void, AXStatusError> {
+        guard maxDepth > 0 else { return .success(()) }
+        let children: [AXUIElement]
+        switch childrenResult(element, runtime: runtime) {
+        case let .success(observed):
+            children = observed
+        case let .failure(error) where error.isDefinitiveAbsence:
+            children = []
+        case let .failure(error):
+            return .failure(error)
+        }
+        for child in children {
+            switch descendantMatchesResult(
+                child,
+                role: role,
+                title: title,
+                identifier: identifier,
+                runtime: runtime
+            ) {
+            case .success(true):
+                results.append(child)
+            case .success(false):
+                break
+            case let .failure(error):
+                return .failure(error)
+            }
+            switch collectMatchingResult(
+                of: child,
+                role: role,
+                title: title,
+                identifier: identifier,
+                maxDepth: maxDepth - 1,
+                runtime: runtime,
+                into: &results
+            ) {
+            case .success:
+                continue
+            case let .failure(error):
+                return .failure(error)
+            }
+        }
+        return .success(())
+    }
+
+    private static func descendantMatchesResult(
+        _ element: AXUIElement,
+        role: String?,
+        title: String?,
+        identifier: String?,
+        runtime: Runtime
+    ) -> Result<Bool, AXStatusError> {
+        for (attribute, expected) in [
+            (kAXRoleAttribute as String, role),
+            (kAXTitleAttribute as String, title),
+            (kAXIdentifierAttribute as String, identifier),
+        ] {
+            guard let expected else { continue }
+            let value: String?
+            switch stringAttributeResult(element, attribute, runtime: runtime) {
+            case let .success(observed):
+                value = observed
+            case let .failure(error):
+                return .failure(error)
+            }
+            guard value == expected else { return .success(false) }
+        }
+        return .success(true)
+    }
+
+    private static func stringAttributeResult(
+        _ element: AXUIElement,
+        _ attribute: String,
+        runtime: Runtime
+    ) -> Result<String?, AXStatusError> {
+        let read: Result<String?, AXStatusError> = getAttributeResult(
+            element,
+            attribute,
+            runtime: runtime
+        )
+        switch read {
+        case let .success(value):
+            return .success(value)
+        case let .failure(error) where error.isDefinitiveAbsence:
+            return .success(nil)
+        case let .failure(error):
+            return .failure(error)
         }
     }
 

--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -1275,6 +1275,97 @@ enum AXLocalePolicy {
         return Census(element: hits.count == 1 ? hits[0] : nil, candidates: hits.count, matches: hits)
     }
 
+    /// Status-preserving counterpart to `censusDescendant` for a localized
+    /// label lookup. It is deliberately additive: ordinary read-only callers
+    /// keep the historical best-effort census, while a caller using a menu item
+    /// as write authority can refuse an unreadable title or description rather
+    /// than reporting that item as missing.
+    static func censusDescendantResult(
+        of element: AXUIElement,
+        role: String,
+        matching labels: LabelSet,
+        mode: MatchMode = .exact,
+        maxDepth: Int = 5,
+        runtime: AXHelpers.Runtime
+    ) -> Result<Census, AXHelpers.AXStatusError> {
+        let roleCensus: AXHelpers.Census
+        switch AXHelpers.censusDescendantResult(
+            of: element,
+            role: role,
+            maxDepth: maxDepth,
+            runtime: runtime
+        ) {
+        case let .success(observed):
+            roleCensus = observed
+        case let .failure(error):
+            return .failure(error)
+        }
+
+        var hits: [AXUIElement] = []
+        for candidate in roleCensus.matches {
+            switch elementMatchesResult(candidate, labels, mode: mode, runtime: runtime) {
+            case .success(true):
+                hits.append(candidate)
+            case .success(false):
+                continue
+            case let .failure(error):
+                return .failure(error)
+            }
+        }
+        return .success(Census(
+            element: hits.count == 1 ? hits[0] : nil,
+            candidates: hits.count,
+            matches: hits
+        ))
+    }
+
+    private static func elementMatchesResult(
+        _ element: AXUIElement,
+        _ labels: LabelSet,
+        mode: MatchMode,
+        runtime: AXHelpers.Runtime
+    ) -> Result<Bool, AXHelpers.AXStatusError> {
+        let title: String?
+        switch stringAttributeResult(element, kAXTitleAttribute as String, runtime: runtime) {
+        case let .success(observed):
+            title = observed
+        case let .failure(error):
+            return .failure(error)
+        }
+        if labels.matches(title, mode: mode) {
+            return .success(true)
+        }
+
+        let description: String?
+        switch stringAttributeResult(element, kAXDescriptionAttribute as String, runtime: runtime) {
+        case let .success(observed):
+            description = observed
+        case let .failure(error):
+            return .failure(error)
+        }
+        return .success(labels.matches(description, mode: mode))
+    }
+
+    private static func stringAttributeResult(
+        _ element: AXUIElement,
+        _ attribute: String,
+        runtime: AXHelpers.Runtime
+    ) -> Result<String?, AXHelpers.AXStatusError> {
+        let read: Result<String?, AXHelpers.AXStatusError> = AXHelpers.getAttributeResult(
+            element,
+            attribute,
+            runtime: runtime
+        )
+        switch read {
+        case let .success(value):
+            return .success(value)
+        case let .failure(error) where error.isDefinitiveAbsence:
+            return .success(nil)
+        case let .failure(error):
+            return .failure(error)
+        }
+    }
+
     /// Every `LabelSet` declared above, for callers that need to ask "does the product recognise
     /// this string at all" rather than "does it match this particular set".
     ///

--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -1302,6 +1302,7 @@ enum AXLocalePolicy {
         }
 
         var hits: [AXUIElement] = []
+        var firstLabelReadFailure: AXHelpers.AXStatusError?
         for candidate in roleCensus.matches {
             switch elementMatchesResult(candidate, labels, mode: mode, runtime: runtime) {
             case .success(true):
@@ -1309,8 +1310,11 @@ enum AXLocalePolicy {
             case .success(false):
                 continue
             case let .failure(error):
-                return .failure(error)
+                firstLabelReadFailure = firstLabelReadFailure ?? error
             }
+        }
+        if hits.isEmpty, let firstLabelReadFailure {
+            return .failure(firstLabelReadFailure)
         }
         return .success(Census(
             element: hits.count == 1 ? hits[0] : nil,
@@ -1325,12 +1329,14 @@ enum AXLocalePolicy {
         mode: MatchMode,
         runtime: AXHelpers.Runtime
     ) -> Result<Bool, AXHelpers.AXStatusError> {
+        var firstReadFailure: AXHelpers.AXStatusError?
         let title: String?
         switch stringAttributeResult(element, kAXTitleAttribute as String, runtime: runtime) {
         case let .success(observed):
             title = observed
         case let .failure(error):
-            return .failure(error)
+            firstReadFailure = error
+            title = nil
         }
         if labels.matches(title, mode: mode) {
             return .success(true)
@@ -1341,9 +1347,16 @@ enum AXLocalePolicy {
         case let .success(observed):
             description = observed
         case let .failure(error):
-            return .failure(error)
+            firstReadFailure = firstReadFailure ?? error
+            description = nil
         }
-        return .success(labels.matches(description, mode: mode))
+        if labels.matches(description, mode: mode) {
+            return .success(true)
+        }
+        if let firstReadFailure {
+            return .failure(firstReadFailure)
+        }
+        return .success(false)
     }
 
     private static func stringAttributeResult(

--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -929,6 +929,38 @@ enum AXLocalePolicy {
         rationale: "Locates a plugin-slot open/list control by label; read-only locator (structural fallback exists)."
     )
 
+    /// Controls/editor switching is deliberately keyed from AXDescription:
+    /// live Compressor evidence on 2026-09-02 showed the `AXMenuButton`
+    /// description is the localized View label, while AXTitle is the most
+    /// recently selected view *or zoom* menu item and is not a view readback.
+    /// English `View` and Korean `보기` are the only measured descriptions;
+    /// another locale must refuse rather than treating an arbitrary menu
+    /// button as the view switcher.
+    static let pluginWindowViewSwitcher = LabelSet(
+        canonical: "View",
+        variants: ["보기"],
+        rationale: "Measured live on 2026-09-02 in Compressor: the Controls/editor AXMenuButton identifies itself by AXDescription (View/보기); AXTitle is not a view readback."
+    )
+
+    /// The measured Controls item in the scoped plugin-window View menu.
+    /// `Controls` and `컨트롤` were measured live on 2026-09-02; this is not a
+    /// translation table for unmeasured locales and is never used as a title
+    /// readback.
+    static let pluginWindowControlsViewMenuItem = LabelSet(
+        canonical: "Controls",
+        variants: ["컨트롤"],
+        rationale: "Measured live on 2026-09-02 in Compressor's scoped View menu; use to select Controls only."
+    )
+
+    /// The measured native-editor item in the scoped plugin-window View menu.
+    /// `Editor` and `편집기` are not inferred translations and are never used
+    /// as a title readback.
+    static let pluginWindowEditorViewMenuItem = LabelSet(
+        canonical: "Editor",
+        variants: ["편집기"],
+        rationale: "Measured live on 2026-09-02 in Compressor's scoped View menu; paired evidence for Controls/컨트롤."
+    )
+
     /// #405: the "Smart Controls" toggle in a Drummer track's docked Smart Controls
     /// pane. Combined with an AXDialog subrole and an empty window title it forms
     /// the `isSmartControlsWindow` signature that classifies that pane as
@@ -1254,6 +1286,9 @@ enum AXLocalePolicy {
     /// is tolerable at all; the unsafe direction is not reachable from a missing entry.
     static let allLabelSets: [LabelSet] = [
         viewMenuBar,
+        pluginWindowViewSwitcher,
+        pluginWindowControlsViewMenuItem,
+        pluginWindowEditorViewMenuItem,
         showMixerMenuItem,
         windowMenuBar,
         hideAllPluginWindowsMenuItem,

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+PluginSlots.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+PluginSlots.swift
@@ -347,6 +347,10 @@ extension AXLogicProElements {
         case none
         case unique(AXUIElement)
         case ambiguous
+        /// A required candidate-window observation failed. This is not an
+        /// empty census: another editor may exist behind the unreadable AX
+        /// boundary, so choosing a visible candidate would be unsound.
+        case unreadable(AXHelpers.AXStatusError)
         /// A candidate has the requested track and parameter control, but its
         /// direct static-text header does not prove the requested plug-in.
         /// `observedNames` is empty when those children exposed no readable
@@ -406,29 +410,38 @@ extension AXLogicProElements {
         requiringMatchingSlider: Bool = true,
         runtime: Runtime = .production
     ) -> PluginWindowMatch {
-        guard let app = appRoot(runtime: runtime) else { return .none }
-        let windows: [AXUIElement] = AXHelpers.getAttribute(
-            app, kAXWindowsAttribute, runtime: runtime.ax
-        ) ?? []
         let target = trackName.trimmingCharacters(in: .whitespacesAndNewlines)
         var match: AXUIElement?
         var mismatchedObservedNames: [String] = []
         var foundMismatchedCandidate = false
-        for window in windows {
-            guard isPluginEditorWindow(window, runtime: runtime.ax) else { continue }
-            guard AXHelpers.getRole(window, runtime: runtime.ax) == (kAXWindowRole as String) else { continue }
-            let title = (AXHelpers.getTitle(window, runtime: runtime.ax) ?? "")
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            guard title == target else { continue }
-            let observedNames = pluginWindowHeaderStaticTextValues(in: window, runtime: runtime.ax)
+        let candidates: [PluginEditorWindowCandidate]
+        switch pluginEditorWindowCandidates(runtime: runtime) {
+        case let .success(observed):
+            candidates = observed
+        case let .failure(error):
+            return .unreadable(error)
+        }
+        for candidate in candidates {
+            guard candidate.title == target else { continue }
+            let observedNames: [String]
+            switch pluginWindowHeaderStaticTextValues(in: candidate, runtime: runtime.ax) {
+            case let .success(observed):
+                observedNames = observed
+            case let .failure(error):
+                return .unreadable(error)
+            }
             let headerMatchesPlugin = pluginWindowHeaderNames(
                 observedNames,
                 containPluginID: pluginID,
-                excludingTrackName: title,
+                excludingTrackName: candidate.title,
                 callerTrackName: target
             )
-            let sliderWitness = axDescription.map {
-                pluginWindowSliderMatch(in: window, axDescription: $0, runtime: runtime.ax)
+            let sliderWitness: Result<PluginSliderMatch, AXHelpers.AXStatusError>? = axDescription.map {
+                pluginWindowSliderMatchResult(
+                    in: candidate.element,
+                    axDescription: $0,
+                    runtime: runtime.ax
+                )
             }
             guard headerMatchesPlugin else {
                 // A header-only binding has no parameter precondition: the
@@ -441,14 +454,16 @@ extension AXLogicProElements {
                     continue
                 }
                 switch sliderWitness {
-                case .some(.ambiguous):
+                case .some(.success(.ambiguous)):
                     return .ambiguous
-                case .some(.unique):
+                case .some(.success(.unique)):
                     foundMismatchedCandidate = true
                     mismatchedObservedNames.append(contentsOf: observedNames)
                     continue
-                case .some(.none), nil:
+                case .some(.success(.none)), nil:
                     continue
+                case let .some(.failure(error)):
+                    return .unreadable(error)
                 }
             }
             // Header identity always selects the candidate. A slider witness
@@ -456,16 +471,18 @@ extension AXLogicProElements {
             // view deliberately removes descriptions from its sliders.
             if requiringMatchingSlider {
                 switch sliderWitness {
-                case .some(.none), nil:
+                case .some(.success(.none)), nil:
                     continue
-                case .some(.ambiguous):
+                case .some(.success(.ambiguous)):
                     return .ambiguous
-                case .some(.unique):
+                case .some(.success(.unique)):
                     break
+                case let .some(.failure(error)):
+                    return .unreadable(error)
                 }
             }
             guard match == nil else { return .ambiguous }
-            match = window
+            match = candidate.element
         }
         if let match {
             return .unique(match)
@@ -490,41 +507,43 @@ extension AXLogicProElements {
         forTrackName trackName: String,
         matchingPluginID pluginID: String,
         runtime: Runtime = .production
-    ) -> [AXUIElement] {
-        guard let app = appRoot(runtime: runtime) else { return [] }
-        let windows: [AXUIElement] = AXHelpers.getAttribute(
-            app, kAXWindowsAttribute, runtime: runtime.ax
-        ) ?? []
+    ) -> Result<[AXUIElement], AXHelpers.AXStatusError> {
         let target = trackName.trimmingCharacters(in: .whitespacesAndNewlines)
-        return windows.filter { window in
-            guard isPluginEditorWindow(window, runtime: runtime.ax),
-                  AXHelpers.getRole(window, runtime: runtime.ax) == (kAXWindowRole as String) else {
-                return false
-            }
-            let title = (AXHelpers.getTitle(window, runtime: runtime.ax) ?? "")
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            guard title == target else { return false }
-            return pluginWindowHeaderNames(
-                pluginWindowHeaderStaticTextValues(in: window, runtime: runtime.ax),
-                containPluginID: pluginID,
-                excludingTrackName: title,
-                callerTrackName: target
-            )
+        let candidates: [PluginEditorWindowCandidate]
+        switch pluginEditorWindowCandidates(runtime: runtime) {
+        case let .success(observed):
+            candidates = observed
+        case let .failure(error):
+            return .failure(error)
         }
+        var matches: [AXUIElement] = []
+        for candidate in candidates where candidate.title == target {
+            let observedNames: [String]
+            switch pluginWindowHeaderStaticTextValues(in: candidate, runtime: runtime.ax) {
+            case let .success(observed):
+                observedNames = observed
+            case let .failure(error):
+                return .failure(error)
+            }
+            if pluginWindowHeaderNames(
+                observedNames,
+                containPluginID: pluginID,
+                excludingTrackName: candidate.title,
+                callerTrackName: target
+            ) {
+                matches.append(candidate.element)
+            }
+        }
+        return .success(matches)
     }
 
     /// Every currently open plug-in editor window. Duplicate-instance
     /// acquisition snapshots this before it presses an insert control, then
     /// requires its accepted candidate to be a newly observed AX element.
-    static func pluginEditorWindows(runtime: Runtime = .production) -> [AXUIElement] {
-        guard let app = appRoot(runtime: runtime) else { return [] }
-        let windows: [AXUIElement] = AXHelpers.getAttribute(
-            app, kAXWindowsAttribute, runtime: runtime.ax
-        ) ?? []
-        return windows.filter {
-            isPluginEditorWindow($0, runtime: runtime.ax)
-                && AXHelpers.getRole($0, runtime: runtime.ax) == (kAXWindowRole as String)
-        }
+    static func pluginEditorWindows(
+        runtime: Runtime = .production
+    ) -> Result<[AXUIElement], AXHelpers.AXStatusError> {
+        pluginEditorWindowCandidates(runtime: runtime).map { $0.map(\.element) }
     }
 
     /// Whether the exact AX window element remains in the application's
@@ -560,21 +579,202 @@ extension AXLogicProElements {
         }
     }
 
-    /// Return only readable values of direct static-text children. Do not fall
-    /// back to a title, a descendant, or a fixed child index: neither identifies
-    /// the plug-in editor reliably.
-    private static func pluginWindowHeaderStaticTextValues(
-        in window: AXUIElement,
-        runtime: AXHelpers.Runtime
-    ) -> [String] {
-        AXHelpers.getChildren(window, runtime: runtime).compactMap { child in
-            guard AXHelpers.getRole(child, runtime: runtime) == (kAXStaticTextRole as String),
-                  let value = AXHelpers.getValue(child, runtime: runtime) as? String else {
-                return nil
-            }
-            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-            return trimmed.isEmpty ? nil : trimmed
+    private struct PluginEditorWindowCandidate {
+        let element: AXUIElement
+        let title: String
+        let directChildren: [(element: AXUIElement, role: String?)]
+    }
+
+    /// Enumerate only windows whose plugin-editor classification was fully
+    /// observed. Any failed status is returned to the caller: a choice cannot
+    /// safely discard an editor whose classification could not be completed.
+    private static func pluginEditorWindowCandidates(
+        runtime: Runtime
+    ) -> Result<[PluginEditorWindowCandidate], AXHelpers.AXStatusError> {
+        guard let app = appRoot(runtime: runtime) else { return .success([]) }
+        let windows: [AXUIElement]
+        switch AXHelpers.getAXUIElementArrayRead(
+            app,
+            kAXWindowsAttribute as String,
+            runtime: runtime.ax
+        ) {
+        case let .success(.elements(observed)):
+            windows = observed
+        case .success(.absent):
+            // The AX attribute answered absent, which is an observed empty
+            // census rather than a failed enumeration.
+            windows = []
+        case .success(.malformed):
+            return .failure(.malformedAttribute)
+        case let .failure(error):
+            return .failure(error)
         }
+
+        var candidates: [PluginEditorWindowCandidate] = []
+        for window in windows {
+            let subrole: String?
+            switch AXHelpers.getAttributeResult(
+                window,
+                kAXSubroleAttribute as String,
+                runtime: runtime.ax
+            ) as Result<String?, AXHelpers.AXStatusError> {
+            case let .success(observed):
+                subrole = observed
+            case let .failure(error):
+                return .failure(error)
+            }
+            guard subrole == (kAXDialogSubrole as String) else { continue }
+
+            let closeButton: AXUIElement?
+            switch AXHelpers.getAttributeResult(
+                window,
+                kAXCloseButtonAttribute as String,
+                runtime: runtime.ax
+            ) as Result<AXUIElement?, AXHelpers.AXStatusError> {
+            case let .success(observed):
+                closeButton = observed
+            case let .failure(error):
+                return .failure(error)
+            }
+            guard closeButton != nil else { continue }
+
+            let children: [AXUIElement]
+            switch AXHelpers.childrenResult(window, runtime: runtime.ax) {
+            case let .success(observed):
+                children = observed
+            case let .failure(error):
+                return .failure(error)
+            }
+            var directChildren: [(element: AXUIElement, role: String?)] = []
+            for child in children {
+                let role: String?
+                switch AXHelpers.getAttributeResult(
+                    child,
+                    kAXRoleAttribute as String,
+                    runtime: runtime.ax
+                ) as Result<String?, AXHelpers.AXStatusError> {
+                case let .success(observed):
+                    role = observed
+                case let .failure(error):
+                    return .failure(error)
+                }
+                directChildren.append((child, role))
+            }
+            let hasBypass: Bool
+            do {
+                var found = false
+                for child in directChildren where child.role == (kAXCheckBoxRole as String)
+                    || child.role == (kAXButtonRole as String) {
+                    switch hasExactLabelResult(
+                        child.element,
+                        matching: AXLocalePolicy.pluginBypassControl,
+                        runtime: runtime.ax
+                    ) {
+                    case let .success(matches):
+                        found = found || matches
+                    case let .failure(error):
+                        throw error
+                    }
+                }
+                hasBypass = found
+            } catch let error as AXHelpers.AXStatusError {
+                return .failure(error)
+            } catch {
+                return .failure(.malformedAttribute)
+            }
+            guard hasBypass else { continue }
+
+            let role: String?
+            switch AXHelpers.getAttributeResult(
+                window,
+                kAXRoleAttribute as String,
+                runtime: runtime.ax
+            ) as Result<String?, AXHelpers.AXStatusError> {
+            case let .success(observed):
+                role = observed
+            case let .failure(error):
+                return .failure(error)
+            }
+            guard role == (kAXWindowRole as String) else { continue }
+
+            let title: String?
+            switch AXHelpers.getAttributeResult(
+                window,
+                kAXTitleAttribute as String,
+                runtime: runtime.ax
+            ) as Result<String?, AXHelpers.AXStatusError> {
+            case let .success(observed):
+                title = observed
+            case let .failure(error):
+                return .failure(error)
+            }
+            candidates.append(PluginEditorWindowCandidate(
+                element: window,
+                title: (title ?? "").trimmingCharacters(in: .whitespacesAndNewlines),
+                directChildren: directChildren
+            ))
+        }
+        return .success(candidates)
+    }
+
+    /// Status-preserving exact-label matcher used only while a window is being
+    /// classified for an imminent selection. An absent label field is a normal
+    /// non-match; a failed read is never silently converted to one.
+    private static func hasExactLabelResult(
+        _ element: AXUIElement,
+        matching labelSet: AXLocalePolicy.LabelSet,
+        runtime: AXHelpers.Runtime
+    ) -> Result<Bool, AXHelpers.AXStatusError> {
+        for attribute in [
+            kAXIdentifierAttribute as String,
+            kAXDescriptionAttribute as String,
+            kAXTitleAttribute as String,
+            kAXHelpAttribute as String,
+        ] {
+            let value: String?
+            switch AXHelpers.getAttributeResult(
+                element,
+                attribute,
+                runtime: runtime
+            ) as Result<String?, AXHelpers.AXStatusError> {
+            case let .success(observed):
+                value = observed
+            case let .failure(error):
+                return .failure(error)
+            }
+            if labelSet.matches(value, mode: .exactStrict) {
+                return .success(true)
+            }
+        }
+        return .success(false)
+    }
+
+    /// Return direct static-text values without falling back to a title,
+    /// descendant, or fixed child index. A failed header read is not an absent
+    /// name and therefore refuses the caller's window choice.
+    private static func pluginWindowHeaderStaticTextValues(
+        in candidate: PluginEditorWindowCandidate,
+        runtime: AXHelpers.Runtime
+    ) -> Result<[String], AXHelpers.AXStatusError> {
+        var values: [String] = []
+        for child in candidate.directChildren where child.role == (kAXStaticTextRole as String) {
+            let value: String?
+            switch AXHelpers.getAttributeResult(
+                child.element,
+                kAXValueAttribute as String,
+                runtime: runtime
+            ) as Result<String?, AXHelpers.AXStatusError> {
+            case let .success(observed):
+                value = observed
+            case let .failure(error):
+                return .failure(error)
+            }
+            if let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !trimmed.isEmpty {
+                values.append(trimmed)
+            }
+        }
+        return .success(values)
     }
 
     /// Find the parameter `AXSlider` inside a plugin window by its
@@ -593,16 +793,16 @@ extension AXLogicProElements {
         axDescription: String,
         runtime: AXHelpers.Runtime = .production
     ) -> PluginWindowSliderResolution {
-        switch pluginWindowSliderMatch(
+        switch pluginWindowSliderMatchResult(
             in: window,
             axDescription: axDescription,
             runtime: runtime
         ) {
-        case .none:
+        case .success(.none), .failure:
             return .none
-        case let .unique(slider):
+        case let .success(.unique(slider)):
             return .unique(slider)
-        case .ambiguous:
+        case .success(.ambiguous):
             return .ambiguous
         }
     }
@@ -628,23 +828,45 @@ extension AXLogicProElements {
         case ambiguous
     }
 
-    private static func pluginWindowSliderMatch(
+    private static func pluginWindowSliderMatchResult(
         in window: AXUIElement,
         axDescription: String,
         runtime: AXHelpers.Runtime
-    ) -> PluginSliderMatch {
+    ) -> Result<PluginSliderMatch, AXHelpers.AXStatusError> {
         let target = axDescription.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !target.isEmpty else { return .none }
-        let sliders = AXHelpers.findAllDescendants(
-            of: window, role: kAXSliderRole, maxDepth: 4, runtime: runtime
-        )
-        let matches = sliders.filter { slider in
-            let desc = (AXHelpers.getDescription(slider, runtime: runtime) ?? "")
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            return desc.caseInsensitiveCompare(target) == .orderedSame
+        guard !target.isEmpty else { return .success(.none) }
+        let sliders: [AXUIElement]
+        switch AXHelpers.censusDescendantResult(
+            of: window,
+            role: kAXSliderRole,
+            maxDepth: 4,
+            runtime: runtime
+        ) {
+        case let .success(census):
+            sliders = census.matches
+        case let .failure(error):
+            return .failure(error)
         }
-        guard let first = matches.first else { return .none }
-        return matches.count == 1 ? .unique(first) : .ambiguous
+        var matches: [AXUIElement] = []
+        for slider in sliders {
+            let description: String?
+            switch AXHelpers.getAttributeResult(
+                slider,
+                kAXDescriptionAttribute as String,
+                runtime: runtime
+            ) as Result<String?, AXHelpers.AXStatusError> {
+            case let .success(observed):
+                description = observed
+            case let .failure(error):
+                return .failure(error)
+            }
+            let trimmed = (description ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.caseInsensitiveCompare(target) == .orderedSame {
+                matches.append(slider)
+            }
+        }
+        guard let first = matches.first else { return .success(.none) }
+        return .success(matches.count == 1 ? .unique(first) : .ambiguous)
     }
 
 }

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+PluginSlots.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+PluginSlots.swift
@@ -423,19 +423,23 @@ extension AXLogicProElements {
         }
         for candidate in candidates {
             guard candidate.title == target else { continue }
-            let observedNames: [String]
+            let headerEvidence: PluginWindowHeaderStaticTextEvidence
             switch pluginWindowHeaderStaticTextValues(in: candidate, runtime: runtime.ax) {
             case let .success(observed):
-                observedNames = observed
+                headerEvidence = observed
             case let .failure(error):
                 return .unreadable(error)
             }
+            let observedNames = headerEvidence.values
             let headerMatchesPlugin = pluginWindowHeaderNames(
                 observedNames,
                 containPluginID: pluginID,
                 excludingTrackName: candidate.title,
                 callerTrackName: target
             )
+            if !headerMatchesPlugin, let error = headerEvidence.firstReadFailure {
+                return .unreadable(error)
+            }
             let sliderWitness: Result<PluginSliderMatch, AXHelpers.AXStatusError>? = axDescription.map {
                 pluginWindowSliderMatchResult(
                     in: candidate.element,
@@ -518,13 +522,14 @@ extension AXLogicProElements {
         }
         var matches: [AXUIElement] = []
         for candidate in candidates where candidate.title == target {
-            let observedNames: [String]
+            let headerEvidence: PluginWindowHeaderStaticTextEvidence
             switch pluginWindowHeaderStaticTextValues(in: candidate, runtime: runtime.ax) {
             case let .success(observed):
-                observedNames = observed
+                headerEvidence = observed
             case let .failure(error):
                 return .failure(error)
             }
+            let observedNames = headerEvidence.values
             if pluginWindowHeaderNames(
                 observedNames,
                 containPluginID: pluginID,
@@ -532,6 +537,8 @@ extension AXLogicProElements {
                 callerTrackName: target
             ) {
                 matches.append(candidate.element)
+            } else if let error = headerEvidence.firstReadFailure {
+                return .failure(error)
             }
         }
         return .success(matches)
@@ -675,27 +682,23 @@ extension AXLogicProElements {
                 }
                 directChildren.append((child, role))
             }
-            let hasBypass: Bool
-            do {
-                var found = false
-                for child in directChildren where child.role == (kAXCheckBoxRole as String)
-                    || child.role == (kAXButtonRole as String) {
-                    switch hasExactLabelResult(
-                        child.element,
-                        matching: AXLocalePolicy.pluginBypassControl,
-                        runtime: runtime.ax
-                    ) {
-                    case let .success(matches):
-                        found = found || matches
-                    case let .failure(error):
-                        throw error
-                    }
+            var hasBypass = false
+            var firstBypassLabelReadFailure: AXHelpers.AXStatusError?
+            for child in directChildren where child.role == (kAXCheckBoxRole as String)
+                || child.role == (kAXButtonRole as String) {
+                switch hasExactLabelResult(
+                    child.element,
+                    matching: AXLocalePolicy.pluginBypassControl,
+                    runtime: runtime.ax
+                ) {
+                case let .success(matches):
+                    hasBypass = hasBypass || matches
+                case let .failure(error):
+                    firstBypassLabelReadFailure = firstBypassLabelReadFailure ?? error
                 }
-                hasBypass = found
-            } catch let error as AXHelpers.AXStatusError {
-                return .failure(error)
-            } catch {
-                return .failure(.malformedAttribute)
+            }
+            if !hasBypass, let firstBypassLabelReadFailure {
+                return .failure(firstBypassLabelReadFailure)
             }
             guard hasBypass else { continue }
 
@@ -744,6 +747,7 @@ extension AXLogicProElements {
         matching labelSet: AXLocalePolicy.LabelSet,
         runtime: AXHelpers.Runtime
     ) -> Result<Bool, AXHelpers.AXStatusError> {
+        var firstReadFailure: AXHelpers.AXStatusError?
         for attribute in [
             kAXIdentifierAttribute as String,
             kAXDescriptionAttribute as String,
@@ -761,23 +765,35 @@ extension AXLogicProElements {
             case let .failure(error) where error.isDefinitiveAbsence:
                 value = nil
             case let .failure(error):
-                return .failure(error)
+                firstReadFailure = firstReadFailure ?? error
+                continue
             }
             if labelSet.matches(value, mode: .exactStrict) {
                 return .success(true)
             }
         }
+        if let firstReadFailure {
+            return .failure(firstReadFailure)
+        }
         return .success(false)
     }
 
+    private struct PluginWindowHeaderStaticTextEvidence {
+        let values: [String]
+        let firstReadFailure: AXHelpers.AXStatusError?
+    }
+
     /// Return direct static-text values without falling back to a title,
-    /// descendant, or fixed child index. An absent AXValue is no header name;
-    /// every other failed header read refuses the caller's window choice.
+    /// descendant, or fixed child index. An absent AXValue is no header name.
+    /// A readable matching name is positive evidence even when another direct
+    /// static text cannot be read; without a matching name, that failure leaves
+    /// the header identity unknown.
     private static func pluginWindowHeaderStaticTextValues(
         in candidate: PluginEditorWindowCandidate,
         runtime: AXHelpers.Runtime
-    ) -> Result<[String], AXHelpers.AXStatusError> {
+    ) -> Result<PluginWindowHeaderStaticTextEvidence, AXHelpers.AXStatusError> {
         var values: [String] = []
+        var firstReadFailure: AXHelpers.AXStatusError?
         for child in candidate.directChildren where child.role == (kAXStaticTextRole as String) {
             let value: String?
             switch AXHelpers.getAttributeResult(
@@ -790,14 +806,18 @@ extension AXLogicProElements {
             case let .failure(error) where error.isDefinitiveAbsence:
                 value = nil
             case let .failure(error):
-                return .failure(error)
+                firstReadFailure = firstReadFailure ?? error
+                continue
             }
             if let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
                !trimmed.isEmpty {
                 values.append(trimmed)
             }
         }
-        return .success(values)
+        return .success(PluginWindowHeaderStaticTextEvidence(
+            values: values,
+            firstReadFailure: firstReadFailure
+        ))
     }
 
     /// Find the parameter `AXSlider` inside a plugin window by its
@@ -809,6 +829,9 @@ extension AXLogicProElements {
         case none
         case unique(AXUIElement)
         case ambiguous
+        /// No slider description matched, and at least one other slider's
+        /// description could not be read. This is unknown, not absence.
+        case unreadable(AXHelpers.AXStatusError)
     }
 
     static func pluginWindowSliderResolution(
@@ -821,12 +844,14 @@ extension AXLogicProElements {
             axDescription: axDescription,
             runtime: runtime
         ) {
-        case .success(.none), .failure:
+        case .success(.none):
             return .none
         case let .success(.unique(slider)):
             return .unique(slider)
         case .success(.ambiguous):
             return .ambiguous
+        case let .failure(error):
+            return .unreadable(error)
         }
     }
 
@@ -871,6 +896,7 @@ extension AXLogicProElements {
             return .failure(error)
         }
         var matches: [AXUIElement] = []
+        var firstDescriptionReadFailure: AXHelpers.AXStatusError?
         for slider in sliders {
             let description: String?
             switch AXHelpers.getAttributeResult(
@@ -883,15 +909,21 @@ extension AXLogicProElements {
             case let .failure(error) where error.isDefinitiveAbsence:
                 description = nil
             case let .failure(error):
-                return .failure(error)
+                firstDescriptionReadFailure = firstDescriptionReadFailure ?? error
+                continue
             }
             let trimmed = (description ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
             if trimmed.caseInsensitiveCompare(target) == .orderedSame {
                 matches.append(slider)
             }
         }
-        guard let first = matches.first else { return .success(.none) }
-        return .success(matches.count == 1 ? .unique(first) : .ambiguous)
+        if let first = matches.first {
+            return .success(matches.count == 1 ? .unique(first) : .ambiguous)
+        }
+        if let firstDescriptionReadFailure {
+            return .failure(firstDescriptionReadFailure)
+        }
+        return .success(.none)
     }
 
 }

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+PluginSlots.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+PluginSlots.swift
@@ -385,10 +385,11 @@ extension AXLogicProElements {
         return names
     }
 
-    /// Find an OPEN plug-in editor whose title equals `trackName`, whose direct
-    /// `AXStaticText` children contain a plug-in name for `pluginID` through the
-    /// verified catalog's observed-name aliases, and which exposes exactly one
-    /// matching slider.
+    /// Find an OPEN plug-in editor whose title equals `trackName` and whose
+    /// direct `AXStaticText` children contain a plug-in name for `pluginID`
+    /// through the verified catalog's observed-name aliases. A slider
+    /// description can corroborate that binding or, when explicitly required,
+    /// additionally constrain it.
     ///
     /// Measured for stock Logic editors only: their direct static-text children
     /// contain the English plug-in display name in both editor and Controls
@@ -401,7 +402,8 @@ extension AXLogicProElements {
     static func pluginWindowMatch(
         forTrackName trackName: String,
         matchingPluginID pluginID: String,
-        matchingSliderDescription axDescription: String,
+        matchingSliderDescription axDescription: String?,
+        requiringMatchingSlider: Bool = true,
         runtime: Runtime = .production
     ) -> PluginWindowMatch {
         guard let app = appRoot(runtime: runtime) else { return .none }
@@ -418,26 +420,52 @@ extension AXLogicProElements {
             let title = (AXHelpers.getTitle(window, runtime: runtime.ax) ?? "")
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             guard title == target else { continue }
-            switch pluginWindowSliderMatch(in: window, axDescription: axDescription, runtime: runtime.ax) {
-            case .none:
-                continue
-            case .ambiguous:
-                return .ambiguous
-            case .unique:
-                let observedNames = pluginWindowHeaderStaticTextValues(in: window, runtime: runtime.ax)
-                guard pluginWindowHeaderNames(
-                    observedNames,
-                    containPluginID: pluginID,
-                    excludingTrackName: title,
-                    callerTrackName: target
-                ) else {
+            let observedNames = pluginWindowHeaderStaticTextValues(in: window, runtime: runtime.ax)
+            let headerMatchesPlugin = pluginWindowHeaderNames(
+                observedNames,
+                containPluginID: pluginID,
+                excludingTrackName: title,
+                callerTrackName: target
+            )
+            let sliderWitness = axDescription.map {
+                pluginWindowSliderMatch(in: window, axDescription: $0, runtime: runtime.ax)
+            }
+            guard headerMatchesPlugin else {
+                // A header-only binding has no parameter precondition: the
+                // requested track title plus catalog-resolved header identity
+                // are sufficient to refuse a same-track wrong editor. For the
+                // legacy slider path, retain the narrower diagnostic rule.
+                if !requiringMatchingSlider {
                     foundMismatchedCandidate = true
                     mismatchedObservedNames.append(contentsOf: observedNames)
                     continue
                 }
-                guard match == nil else { return .ambiguous }
-                match = window
+                switch sliderWitness {
+                case .some(.ambiguous):
+                    return .ambiguous
+                case .some(.unique):
+                    foundMismatchedCandidate = true
+                    mismatchedObservedNames.append(contentsOf: observedNames)
+                    continue
+                case .some(.none), nil:
+                    continue
+                }
             }
+            // Header identity always selects the candidate. A slider witness
+            // is mandatory only for the native-editor parameter path; Controls
+            // view deliberately removes descriptions from its sliders.
+            if requiringMatchingSlider {
+                switch sliderWitness {
+                case .some(.none), nil:
+                    continue
+                case .some(.ambiguous):
+                    return .ambiguous
+                case .some(.unique):
+                    break
+                }
+            }
+            guard match == nil else { return .ambiguous }
+            match = window
         }
         if let match {
             return .unique(match)
@@ -554,12 +582,37 @@ extension AXLogicProElements {
     /// is an unstable NSView id, and unnamed params share the locale word for
     /// "slider"). Matches against the window's slider descendants; the match is
     /// case-insensitive on the trimmed description.
+    enum PluginWindowSliderResolution {
+        case none
+        case unique(AXUIElement)
+        case ambiguous
+    }
+
+    static func pluginWindowSliderResolution(
+        in window: AXUIElement,
+        axDescription: String,
+        runtime: AXHelpers.Runtime = .production
+    ) -> PluginWindowSliderResolution {
+        switch pluginWindowSliderMatch(
+            in: window,
+            axDescription: axDescription,
+            runtime: runtime
+        ) {
+        case .none:
+            return .none
+        case let .unique(slider):
+            return .unique(slider)
+        case .ambiguous:
+            return .ambiguous
+        }
+    }
+
     static func pluginWindowSlider(
         in window: AXUIElement,
         axDescription: String,
         runtime: AXHelpers.Runtime = .production
     ) -> AXUIElement? {
-        if case let .unique(slider) = pluginWindowSliderMatch(
+        if case let .unique(slider) = pluginWindowSliderResolution(
             in: window,
             axDescription: axDescription,
             runtime: runtime

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+PluginSlots.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+PluginSlots.swift
@@ -586,8 +586,11 @@ extension AXLogicProElements {
     }
 
     /// Enumerate only windows whose plugin-editor classification was fully
-    /// observed. Any failed status is returned to the caller: a choice cannot
-    /// safely discard an editor whose classification could not be completed.
+    /// observed. `noValue` and `attributeUnsupported` are observations that an
+    /// optional AX field is absent, so they classify as no windows / no
+    /// children / no matching field. Any other failed status is returned to
+    /// the caller: a choice cannot safely discard an editor whose
+    /// classification could not be completed.
     private static func pluginEditorWindowCandidates(
         runtime: Runtime
     ) -> Result<[PluginEditorWindowCandidate], AXHelpers.AXStatusError> {
@@ -606,6 +609,10 @@ extension AXLogicProElements {
             windows = []
         case .success(.malformed):
             return .failure(.malformedAttribute)
+        case let .failure(error) where error.isDefinitiveAbsence:
+            // `AXWindows` is absent when there are no windows to enumerate;
+            // that is an observed empty census, not an unreadable one.
+            windows = []
         case let .failure(error):
             return .failure(error)
         }
@@ -620,6 +627,8 @@ extension AXLogicProElements {
             ) as Result<String?, AXHelpers.AXStatusError> {
             case let .success(observed):
                 subrole = observed
+            case let .failure(error) where error.isDefinitiveAbsence:
+                subrole = nil
             case let .failure(error):
                 return .failure(error)
             }
@@ -633,6 +642,8 @@ extension AXLogicProElements {
             ) as Result<AXUIElement?, AXHelpers.AXStatusError> {
             case let .success(observed):
                 closeButton = observed
+            case let .failure(error) where error.isDefinitiveAbsence:
+                closeButton = nil
             case let .failure(error):
                 return .failure(error)
             }
@@ -642,6 +653,8 @@ extension AXLogicProElements {
             switch AXHelpers.childrenResult(window, runtime: runtime.ax) {
             case let .success(observed):
                 children = observed
+            case let .failure(error) where error.isDefinitiveAbsence:
+                children = []
             case let .failure(error):
                 return .failure(error)
             }
@@ -655,6 +668,8 @@ extension AXLogicProElements {
                 ) as Result<String?, AXHelpers.AXStatusError> {
                 case let .success(observed):
                     role = observed
+                case let .failure(error) where error.isDefinitiveAbsence:
+                    role = nil
                 case let .failure(error):
                     return .failure(error)
                 }
@@ -692,6 +707,8 @@ extension AXLogicProElements {
             ) as Result<String?, AXHelpers.AXStatusError> {
             case let .success(observed):
                 role = observed
+            case let .failure(error) where error.isDefinitiveAbsence:
+                role = nil
             case let .failure(error):
                 return .failure(error)
             }
@@ -705,6 +722,8 @@ extension AXLogicProElements {
             ) as Result<String?, AXHelpers.AXStatusError> {
             case let .success(observed):
                 title = observed
+            case let .failure(error) where error.isDefinitiveAbsence:
+                title = nil
             case let .failure(error):
                 return .failure(error)
             }
@@ -739,6 +758,8 @@ extension AXLogicProElements {
             ) as Result<String?, AXHelpers.AXStatusError> {
             case let .success(observed):
                 value = observed
+            case let .failure(error) where error.isDefinitiveAbsence:
+                value = nil
             case let .failure(error):
                 return .failure(error)
             }
@@ -750,8 +771,8 @@ extension AXLogicProElements {
     }
 
     /// Return direct static-text values without falling back to a title,
-    /// descendant, or fixed child index. A failed header read is not an absent
-    /// name and therefore refuses the caller's window choice.
+    /// descendant, or fixed child index. An absent AXValue is no header name;
+    /// every other failed header read refuses the caller's window choice.
     private static func pluginWindowHeaderStaticTextValues(
         in candidate: PluginEditorWindowCandidate,
         runtime: AXHelpers.Runtime
@@ -766,6 +787,8 @@ extension AXLogicProElements {
             ) as Result<String?, AXHelpers.AXStatusError> {
             case let .success(observed):
                 value = observed
+            case let .failure(error) where error.isDefinitiveAbsence:
+                value = nil
             case let .failure(error):
                 return .failure(error)
             }
@@ -857,6 +880,8 @@ extension AXLogicProElements {
             ) as Result<String?, AXHelpers.AXStatusError> {
             case let .success(observed):
                 description = observed
+            case let .failure(error) where error.isDefinitiveAbsence:
+                description = nil
             case let .failure(error):
                 return .failure(error)
             }

--- a/Sources/LogicProMCP/Accessibility/AXValueExtractors.swift
+++ b/Sources/LogicProMCP/Accessibility/AXValueExtractors.swift
@@ -80,6 +80,11 @@ enum AXValueExtractors {
         ) as Result<AnyObject?, AXHelpers.AXStatusError> {
         case let .success(observed):
             value = observed
+        case let .failure(error) where error.isDefinitiveAbsence:
+            // A checkbox with no AXValue cannot establish a Boolean state,
+            // but `noValue` / `attributeUnsupported` are still an observed
+            // absent attribute rather than a transport/read failure.
+            value = nil
         case let .failure(error):
             return .failure(error)
         }

--- a/Sources/LogicProMCP/Accessibility/AXValueExtractors.swift
+++ b/Sources/LogicProMCP/Accessibility/AXValueExtractors.swift
@@ -56,35 +56,62 @@ enum AXValueExtractors {
     /// For toggle buttons (mute, solo, arm, cycle, metronome), the value
     /// indicates pressed/active state.
     static func extractButtonState(_ element: AXUIElement, runtime: AXHelpers.Runtime = .production) -> Bool? {
-        guard let value = AXHelpers.getValue(element, runtime: runtime) else { return nil }
+        switch extractButtonStateResult(element, runtime: runtime) {
+        case let .success(observed):
+            return observed
+        case .failure:
+            return nil
+        }
+    }
+
+    /// Status-preserving checkbox/button state reader. A failed AXValue read is
+    /// distinct from a readable absent, mixed, or malformed value; writers that
+    /// decide whether to compensate must surface that distinction rather than
+    /// treating it as an observed state.
+    static func extractButtonStateResult(
+        _ element: AXUIElement,
+        runtime: AXHelpers.Runtime = .production
+    ) -> Result<Bool?, AXHelpers.AXStatusError> {
+        let value: AnyObject?
+        switch AXHelpers.getAttributeResult(
+            element,
+            kAXValueAttribute as String,
+            runtime: runtime
+        ) as Result<AnyObject?, AXHelpers.AXStatusError> {
+        case let .success(observed):
+            value = observed
+        case let .failure(error):
+            return .failure(error)
+        }
+        guard let value else { return .success(nil) }
         // Toggle buttons typically report 0/1 as NSNumber. Do not use
         // `boolValue`: an AX checkbox may report 2 for its mixed state, which
         // is neither a confirmed on nor a confirmed off reading.
         if let number = value as? NSNumber {
             switch number.doubleValue {
             case 0:
-                return false
+                return .success(false)
             case 1:
-                return true
+                return .success(true)
             default:
-                return nil
+                return .success(nil)
             }
         }
         if let bool = value as? Bool {
-            return bool
+            return .success(bool)
         }
         // Some buttons use string "1"/"0". Unknown strings are not false.
         if let str = value as? String {
             switch str.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
             case "1", "true":
-                return true
+                return .success(true)
             case "0", "false":
-                return false
+                return .success(false)
             default:
-                return nil
+                return .success(nil)
             }
         }
-        return nil
+        return .success(nil)
     }
 
     /// Extract the selected state of an element.

--- a/Sources/LogicProMCP/Accessibility/AXValueExtractors.swift
+++ b/Sources/LogicProMCP/Accessibility/AXValueExtractors.swift
@@ -57,16 +57,32 @@ enum AXValueExtractors {
     /// indicates pressed/active state.
     static func extractButtonState(_ element: AXUIElement, runtime: AXHelpers.Runtime = .production) -> Bool? {
         guard let value = AXHelpers.getValue(element, runtime: runtime) else { return nil }
-        // Toggle buttons typically report 0/1 as NSNumber
+        // Toggle buttons typically report 0/1 as NSNumber. Do not use
+        // `boolValue`: an AX checkbox may report 2 for its mixed state, which
+        // is neither a confirmed on nor a confirmed off reading.
         if let number = value as? NSNumber {
-            return number.boolValue
+            switch number.doubleValue {
+            case 0:
+                return false
+            case 1:
+                return true
+            default:
+                return nil
+            }
         }
         if let bool = value as? Bool {
             return bool
         }
-        // Some buttons use string "1"/"0"
+        // Some buttons use string "1"/"0". Unknown strings are not false.
         if let str = value as? String {
-            return str == "1" || str.lowercased() == "true"
+            switch str.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+            case "1", "true":
+                return true
+            case "0", "false":
+                return false
+            default:
+                return nil
+            }
         }
         return nil
     }

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -1782,6 +1782,7 @@ extension AccessibilityChannel {
                     slider,
                     to: before,
                     writeMethod: writeMethod,
+                    tolerance: tolerance,
                     runtime: runtime.ax
                 )
                 return .error(HonestContract.encodeV2StateC(
@@ -1811,6 +1812,7 @@ extension AccessibilityChannel {
                     slider,
                     to: before,
                     writeMethod: writeMethod,
+                    tolerance: tolerance,
                     runtime: runtime.ax
                 )
                 return .error(HonestContract.encodeV2StateC(
@@ -1856,6 +1858,7 @@ extension AccessibilityChannel {
                 slider,
                 to: before,
                 writeMethod: writeMethod,
+                tolerance: tolerance,
                 runtime: runtime.ax
             )
             return .error(HonestContract.encodeV2StateC(
@@ -1944,6 +1947,7 @@ extension AccessibilityChannel {
                     slider,
                     to: before,
                     writeMethod: writeMethod,
+                    tolerance: tolerance,
                     runtime: runtime.ax,
                     incrementWalkBudget: incrementWalkBudget
                 )
@@ -2105,6 +2109,7 @@ extension AccessibilityChannel {
         _ slider: AXUIElement,
         to before: Double?,
         writeMethod: String,
+        tolerance: Double,
         runtime: AXHelpers.Runtime,
         incrementWalkBudget: Int = ChannelEQBandCatalog.incrementWalkBudget
     ) -> SliderRollback {
@@ -2114,7 +2119,7 @@ extension AccessibilityChannel {
         switch writeMethod {
         case "ax_slider_increment_walk":
             let outcome = SliderIncrementWalk.walk(
-                to: .rawValue(before, tolerance: 0),
+                to: .rawValue(before, tolerance: tolerance),
                 read: {
                     AXValueExtractors.extractSliderValue(slider, runtime: runtime).map {
                         SliderIncrementWalk.Reading(value: $0, display: "")
@@ -2148,7 +2153,7 @@ extension AccessibilityChannel {
             }
             return SliderRollback(
                 attempted: true,
-                succeeded: abs(restored - before) <= 0.5,
+                succeeded: abs(restored - before) <= tolerance,
                 observed: restored,
                 walkOutcome: nil
             )

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -1239,10 +1239,17 @@ extension AccessibilityChannel {
             guard let restoration else { return }
             extras["plugin_view_restore_attempted"] = restoration.attempted
             extras["plugin_view_restore_observed"] = restoration.confirmed
-            if !restoration.confirmed {
+            if restoration.leftViewChanged {
                 extras["plugin_view_left_changed"] = true
                 extras["plugin_view_restore_observed_structure"] = restoration.observedStructure ?? NSNull()
                 extras["plugin_view_restore_recovery_hint"] = "The plug-in view could not be restored to the view observed before this write. Select the prior view manually before continuing."
+            } else if !restoration.confirmed {
+                // A failed restore confirmation does not establish that the
+                // view changed. When AX cannot classify the current view, say
+                // exactly that rather than reporting an unobserved change.
+                extras["plugin_view_restore_unobserved"] = true
+                extras["plugin_view_restore_observed_structure"] = restoration.observedStructure ?? NSNull()
+                extras["plugin_view_restore_recovery_hint"] = "The plug-in view restoration could not be observed. Verify the prior view before continuing."
             }
         }
 

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -1681,10 +1681,27 @@ extension AccessibilityChannel {
         let requiredView: ControlsViewBooleanParameterWriter.PluginWindowView = controlsViewCheckbox
             ? .controls
             : .editor
+        // Logic can replace the editor's AX window/switcher during a View
+        // re-render. Rebind only when the already identity-verified editor is
+        // uniquely recoverable; a same-track duplicate remains ambiguous rather
+        // than letting a stale handle select a sibling's view.
+        let refreshPluginWindowForViewSelection: () -> AXUIElement? = {
+            switch AXLogicProElements.matchingPluginEditorWindows(
+                forTrackName: trackName,
+                matchingPluginID: pluginID,
+                runtime: runtime
+            ) {
+            case let .success(editors) where editors.count == 1:
+                return editors[0]
+            case .success, .failure:
+                return nil
+            }
+        }
         let viewSession: ControlsViewBooleanParameterWriter.ViewSession
         switch ControlsViewBooleanParameterWriter.prepareView(
             requiredView,
             in: window,
+            windowRefresher: refreshPluginWindowForViewSelection,
             runtime: runtime.ax
         ) {
         case let .refused(failure, restoration):
@@ -1697,6 +1714,7 @@ extension AccessibilityChannel {
                 "safe_to_retry": false,
                 "write_attempted": false,
             ]
+            extras.merge(failure.responseDiagnostics) { _, new in new }
             // `prepareView` can have picked the target item before its structural
             // confirmation times out. Its compensating re-selection has no
             // ViewSession yet, so carry that observed attempt explicitly.

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -1770,6 +1770,20 @@ extension AccessibilityChannel {
                 identity,
                 "more than one slider exposed the requested AXDescription in the confirmed native plugin view"
             ))
+        case let .unreadable(error):
+            return .error(stateCWithPluginViewRestoration(
+                error: .windowIdentityUnresolved,
+                extras: [
+                    "operation": operation,
+                    "target_identity": identity,
+                    "param": paramAlias,
+                    "slider_description_read_failure": error.diagnosticLabel,
+                    "what_was_attempted": "locate the '\(axDescription)' AXSlider in the plugin window",
+                    "what_was_observed": "no slider with that AX description was observed, and another slider's AXDescription read failed (AX status \(error.diagnosticLabel)); the control was not treated as absent",
+                    "safe_to_retry": false,
+                    "write_attempted": false,
+                ]
+            ))
         case .none:
             return .error(stateCWithPluginViewRestoration(
                 error: .paramControlNotFound,

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -1325,11 +1325,22 @@ extension AccessibilityChannel {
             // make one press restore two editors. These header-proven counts are
             // therefore the provenance proof; neither geometry nor name-only
             // reuse chooses the editor in this branch.
-            let matchingEditorsBeforePress = AXLogicProElements.matchingPluginEditorWindows(
+            let matchingEditorsBeforePress: [AXUIElement]
+            switch AXLogicProElements.matchingPluginEditorWindows(
                 forTrackName: trackName,
                 matchingPluginID: pluginID,
                 runtime: runtime
-            )
+            ) {
+            case let .success(observed):
+                matchingEditorsBeforePress = observed
+            case let .failure(error):
+                return .error(pluginWindowReadFailureStateC(
+                    operation,
+                    identity,
+                    error,
+                    phase: "the duplicate-editor pre-count before target-slot AXPress"
+                ))
+            }
             guard matchingEditorsBeforePress.isEmpty else {
                 return .error(duplicatePluginEditorAlreadyOpenStateC(
                     operation: operation,
@@ -1359,6 +1370,20 @@ extension AccessibilityChannel {
                     observedNames: observedNames
                 ))
             }
+            if case let .unreadable(error) = AXLogicProElements.pluginWindowMatch(
+                forTrackName: trackName,
+                matchingPluginID: pluginID,
+                matchingSliderDescription: axDescription,
+                requiringMatchingSlider: requiringWindowSlider,
+                runtime: runtime
+            ) {
+                return .error(pluginWindowReadFailureStateC(
+                    operation,
+                    identity,
+                    error,
+                    phase: "the duplicate-editor identity census before target-slot AXPress"
+                ))
+            }
 
             guard let targetOpenControl = rankedPluginSlotOpenControls(
                 in: slots[insert].element,
@@ -1385,14 +1410,36 @@ extension AccessibilityChannel {
             // human or other automation opening the same-track sibling between
             // the snapshot and poll remains unprovable; the one-new-window rule
             // makes that uncertainty refuse rather than reuse an old editor.
-            let pluginEditorWindowsBeforePress = AXLogicProElements.pluginEditorWindows(runtime: runtime)
+            let pluginEditorWindowsBeforePress: [AXUIElement]
+            switch AXLogicProElements.pluginEditorWindows(runtime: runtime) {
+            case let .success(observed):
+                pluginEditorWindowsBeforePress = observed
+            case let .failure(error):
+                return .error(pluginWindowReadFailureStateC(
+                    operation,
+                    identity,
+                    error,
+                    phase: "the complete editor census before target-slot AXPress"
+                ))
+            }
             _ = pressElement(targetOpenControl, runtime: runtime.ax)
-            let matchingEditorsAfterPress = await pollMatchingPluginEditorWindows(
+            let matchingEditorsAfterPress: [AXUIElement]
+            switch await pollMatchingPluginEditorWindows(
                 trackName: trackName,
                 pluginID: pluginID,
                 runtime: runtime,
                 timeoutMs: 1_250
-            )
+            ) {
+            case let .success(observed):
+                matchingEditorsAfterPress = observed
+            case let .failure(error):
+                return .error(pluginWindowReadFailureStateC(
+                    operation,
+                    identity,
+                    error,
+                    phase: "the duplicate-editor post-press census"
+                ))
+            }
             let newlyObservedMatchingEditors = matchingEditorsAfterPress.filter { candidate in
                 !pluginEditorWindowsBeforePress.contains { CFEqual($0, candidate) }
             }
@@ -1445,6 +1492,13 @@ extension AccessibilityChannel {
             runtime: runtime
         )
         switch preAcquisitionWindowMatch {
+        case let .unreadable(error):
+            return .error(pluginWindowReadFailureStateC(
+                operation,
+                identity,
+                error,
+                phase: "the plugin-window acquisition census"
+            ))
         case .ambiguous:
             var diagnostics = pluginWindowAcquisitionDiagnostics(
                 trackName: trackName,
@@ -1537,6 +1591,13 @@ extension AccessibilityChannel {
                 requiringMatchingSlider: requiringWindowSlider,
                 runtime: runtime
             ) {
+            case let .unreadable(error):
+                return .error(pluginWindowReadFailureStateC(
+                    operation,
+                    identity,
+                    error,
+                    phase: "the plugin-window acquisition retry census"
+                ))
             case .ambiguous:
                 var diagnostics = pluginWindowAcquisitionDiagnostics(
                     trackName: trackName,
@@ -2065,6 +2126,7 @@ extension AccessibilityChannel {
                 "observed_boolean": observed,
                 "write_source": "ax_controls_view_checkbox",
                 "verify_source": "ax_controls_view_checkbox",
+                "write_attempted": toggle.pressAttempted,
             ]))
         }
 
@@ -2094,6 +2156,8 @@ extension AccessibilityChannel {
                 "observed_boolean": toggle.observedAfterPress ?? NSNull(),
                 "restore_attempted": toggle.restoreAttempted,
                 "restore_observed": toggle.restoreObserved ?? NSNull(),
+                "restore_observed_boolean": toggle.restoreObservedValue ?? NSNull(),
+                "parameter_left_changed": toggle.restoreAttempted && toggle.restoreObserved == false,
                 "what_was_attempted": "AXPress the labelled Controls-view AXCheckBox then require changed AXValue readback",
                 "what_was_observed": failureObservation,
                 "safe_to_retry": false,
@@ -2313,6 +2377,23 @@ extension AccessibilityChannel {
         )
     }
 
+    /// A failed AX window census/classification is not evidence that no
+    /// competing editor exists. Keep the raw diagnostic in the State-C receipt
+    /// and refuse before any window-dependent choice or slot press.
+    private static func pluginWindowReadFailureStateC(
+        _ operation: String,
+        _ identity: [String: Any],
+        _ error: AXHelpers.AXStatusError,
+        phase: String
+    ) -> String {
+        windowIdentityUnresolvedStateC(
+            operation,
+            identity,
+            "plugin-window acquisition could not complete \(phase) (AX status \(error.diagnosticLabel)); unreadable candidates were not treated as absent",
+            diagnostics: ["plugin_window_read_failure": error.diagnosticLabel]
+        )
+    }
+
     private static func pluginWindowPluginMismatchStateC(
         _ operation: String,
         _ identity: [String: Any],
@@ -2420,6 +2501,13 @@ extension AccessibilityChannel {
         ) {
         case let .unique(currentWindow) where CFEqual(currentWindow, acquiredWindow):
             return nil
+        case let .unreadable(error):
+            return pluginWindowReadFailureStateC(
+                operation,
+                identity,
+                error,
+                phase: "the acquired plugin-window identity recheck"
+            )
         case let .pluginIdentityMismatch(observedNames):
             return pluginWindowPluginMismatchStateC(
                 operation,
@@ -2454,11 +2542,22 @@ extension AccessibilityChannel {
         trackName: String,
         runtime: AXLogicProElements.Runtime
     ) -> String? {
-        let headerBoundWindows = AXLogicProElements.matchingPluginEditorWindows(
+        let headerBoundWindows: [AXUIElement]
+        switch AXLogicProElements.matchingPluginEditorWindows(
             forTrackName: trackName,
             matchingPluginID: pluginID,
             runtime: runtime
-        )
+        ) {
+        case let .success(observed):
+            headerBoundWindows = observed
+        case let .failure(error):
+            return pluginWindowReadFailureStateC(
+                operation,
+                identity,
+                error,
+                phase: "the Controls-view acquired-editor header recheck"
+            )
+        }
         guard headerBoundWindows.contains(where: { CFEqual($0, acquiredWindow) }) else {
             return windowIdentityUnresolvedStateC(
                 operation,
@@ -2489,6 +2588,8 @@ extension AccessibilityChannel {
             requiringMatchingSlider: requiringMatchingSlider,
             runtime: runtime
         ) {
+        case .unreadable:
+            return nil
         case .ambiguous:
             return nil
         case .pluginIdentityMismatch:
@@ -2529,6 +2630,8 @@ extension AccessibilityChannel {
                 runtime: runtime,
                 timeoutMs: 1_250
             ) {
+            case .unreadable:
+                return nil
             case let .unique(window):
                 guard pluginWindowIsFront(window, runtime: runtime.ax) else {
                     return nil
@@ -2775,6 +2878,8 @@ extension AccessibilityChannel {
                 return .ambiguous
             case let .pluginIdentityMismatch(observedNames):
                 return .pluginIdentityMismatch(observedNames: observedNames)
+            case let .unreadable(error):
+                return .unreadable(error)
             case .none:
                 lastUniqueWindow = nil
             }
@@ -2795,22 +2900,27 @@ extension AccessibilityChannel {
         pluginID: String,
         runtime: AXLogicProElements.Runtime,
         timeoutMs: Int
-    ) async -> [AXUIElement] {
+    ) async -> Result<[AXUIElement], AXHelpers.AXStatusError> {
         let deadline = Date().addingTimeInterval(Double(timeoutMs) / 1_000.0)
         var matchingEditors: [AXUIElement] = []
         repeat {
-            matchingEditors = AXLogicProElements.matchingPluginEditorWindows(
+            switch AXLogicProElements.matchingPluginEditorWindows(
                 forTrackName: trackName,
                 matchingPluginID: pluginID,
                 runtime: runtime
-            )
+            ) {
+            case let .success(observed):
+                matchingEditors = observed
+            case let .failure(error):
+                return .failure(error)
+            }
             if !matchingEditors.isEmpty {
-                return matchingEditors
+                return .success(matchingEditors)
             }
             guard Date() < deadline else { break }
             try? await Task.sleep(for: .milliseconds(100))
         } while Date() < deadline
-        return matchingEditors
+        return .success(matchingEditors)
     }
 
     /// ADR-001 coordinate ban: open the plugin window from its slot control via

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -1523,6 +1523,27 @@ extension AccessibilityChannel {
         case .none, .unique:
             break
         }
+        // A reused editor belongs to the caller, so the cleanup defer may only
+        // own an editor that was absent from this complete pre-open census.
+        // Take the snapshot before the normal opener can press its target slot;
+        // this covers every later refusal, including a View-session refusal
+        // immediately after a successful acquisition.
+        let pluginEditorWindowsBeforeNormalAcquisition: [AXUIElement]?
+        if constructedWindow == nil, case .none = preAcquisitionWindowMatch {
+            switch AXLogicProElements.pluginEditorWindows(runtime: runtime) {
+            case let .success(observed):
+                pluginEditorWindowsBeforeNormalAcquisition = observed
+            case let .failure(error):
+                return .error(pluginWindowReadFailureStateC(
+                    operation,
+                    identity,
+                    error,
+                    phase: "the complete editor census before normal target-slot acquisition"
+                ))
+            }
+        } else {
+            pluginEditorWindowsBeforeNormalAcquisition = nil
+        }
         let openedCandidate: AXUIElementSendable?
         if let constructedWindow {
             openedCandidate = constructedWindow
@@ -1648,6 +1669,14 @@ extension AccessibilityChannel {
             ))
         }
         let window = opened.element
+        if let beforeNormalAcquisition = pluginEditorWindowsBeforeNormalAcquisition,
+           !beforeNormalAcquisition.contains(where: { CFEqual($0, window) }) {
+            // The opener returned an exact editor element that was not present
+            // before its target-slot acquisition. Register it before popup or
+            // view setup can refuse, so `defer` closes only the editor this
+            // operation created and never a reused caller-owned editor.
+            constructedWindowsNeedingCleanup = [window]
+        }
 
         let requiredView: ControlsViewBooleanParameterWriter.PluginWindowView = controlsViewCheckbox
             ? .controls

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -1232,6 +1232,24 @@ extension AccessibilityChannel {
             }
         }
 
+        func append(
+            pluginViewRestoration restoration: ControlsViewBooleanParameterWriter.ViewRestoration?,
+            to extras: inout [String: Any]
+        ) {
+            guard let restoration else { return }
+            extras["plugin_view_restore_attempted"] = restoration.attempted
+            extras["plugin_view_restore_observed"] = restoration.confirmed
+            if !restoration.confirmed {
+                extras["plugin_view_left_changed"] = true
+                extras["plugin_view_restore_observed_structure"] = restoration.observedStructure ?? NSNull()
+                extras["plugin_view_restore_recovery_hint"] = "The plug-in view could not be restored to the view observed before this write. Select the prior view manually before continuing."
+            }
+        }
+
+        func appendPluginViewRestoration(to extras: inout [String: Any]) {
+            append(pluginViewRestoration: restorePluginViewOnExit?(), to: &extras)
+        }
+
         /// A write may be fully verified before this operation's editor closes.
         /// Keep State A for the established write verdict, while making a
         /// failed observed close actionable rather than deferring that surprise
@@ -1259,27 +1277,38 @@ extension AccessibilityChannel {
             return HonestContract.encodeV2StateA(extras: completedExtras)
         }
 
-        /// A State C built after a confirmed temporary view switch must expose
-        /// a failed restore. Without these fields a locator refusal can look
-        /// like a no-op even though the plug-in remains in Controls view.
+        /// One terminal funnel owns temporary-view cleanup for every State C
+        /// below. Returning an already encoded State C from the body is safe:
+        /// the funnel decodes it once, performs restoration before it is exposed,
+        /// and adds the observed outcome. New early exits cannot bypass it.
+        func finishPluginViewSessionResult(_ result: ChannelResult) -> ChannelResult {
+            guard case let .error(raw) = result,
+                  let data = raw.data(using: .utf8),
+                  var envelope = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  envelope["state"] as? String == "C" else {
+                return result
+            }
+            var extras: [String: Any] = [:]
+            appendPluginViewRestoration(to: &extras)
+            for (key, value) in extras {
+                envelope[key] = value
+            }
+            guard let encoded = try? JSONSerialization.data(
+                withJSONObject: envelope,
+                options: [.sortedKeys]
+            ), let message = String(data: encoded, encoding: .utf8) else {
+                return result
+            }
+            return .error(message)
+        }
+
         func stateCWithPluginViewRestoration(
             error: HonestContract.FailureError,
             extras: [String: Any]
         ) -> String {
-            var completedExtras = extras
-            appendPluginViewRestoration(to: &completedExtras)
-            return HonestContract.encodeV2StateC(error: error, extras: completedExtras)
-        }
-
-        func appendPluginViewRestoration(to extras: inout [String: Any]) {
-            guard let restoration = restorePluginViewOnExit?() else { return }
-            extras["plugin_view_restore_attempted"] = restoration.attempted
-            extras["plugin_view_restore_observed"] = restoration.confirmed
-            if !restoration.confirmed {
-                extras["plugin_view_left_changed"] = true
-                extras["plugin_view_restore_observed_structure"] = restoration.observedStructure ?? NSNull()
-                extras["plugin_view_restore_recovery_hint"] = "The plug-in view could not be restored to the view observed before this write. Select the prior view manually before continuing."
-            }
+            // The name remains at the Controls helper boundary; restoration is
+            // applied by `finishPluginViewSessionResult`, not at each exit site.
+            HonestContract.encodeV2StateC(error: error, extras: extras)
         }
 
         if duplicatedPluginInstance {
@@ -1561,39 +1590,32 @@ extension AccessibilityChannel {
             in: window,
             runtime: runtime.ax
         ) {
-        case let .refused(failure):
+        case let .refused(failure, restoration):
+            var extras: [String: Any] = [
+                "operation": operation,
+                "target_identity": identity,
+                "param": paramAlias,
+                "what_was_attempted": "select the plugin-window View menu item and confirm the required \(requiredView.rawValue) structure before locating its control",
+                "what_was_observed": failure.observation,
+                "safe_to_retry": false,
+                "write_attempted": false,
+            ]
+            // `prepareView` can have picked the target item before its structural
+            // confirmation times out. Its compensating re-selection has no
+            // ViewSession yet, so carry that observed attempt explicitly.
+            append(pluginViewRestoration: restoration, to: &extras)
             return .error(HonestContract.encodeV2StateC(
                 // The slider locator has not run. Keep a failed structural
                 // confirmation distinct from a genuine missing AXSlider so the
                 // live response shows whether view selection was reached.
                 error: .pluginViewNotConfirmed,
-                extras: [
-                    "operation": operation,
-                    "target_identity": identity,
-                    "param": paramAlias,
-                    "what_was_attempted": "select the plugin-window View menu item and confirm the required \(requiredView.rawValue) structure before locating its control",
-                    "what_was_observed": failure.observation,
-                    "safe_to_retry": false,
-                    "write_attempted": false,
-                ]
+                extras: extras
             ))
         case let .ready(session):
             viewSession = session
         }
         restorePluginViewOnExit = { viewSession.restore() }
-        defer {
-            if let restoration = restorePluginViewOnExit?(), !restoration.confirmed {
-                // The write result may already be State A or an unavoidable State C
-                // when this best-effort restoration fails. Keep that result honest,
-                // but never silently strand the user's editor: State A includes the
-                // restore fields above and refusal paths emit this actionable log.
-                Log.warn(
-                    "Plugin view restoration was not confirmed after \(operation); observed structure: \(restoration.observedStructure ?? "unconfirmed")",
-                    subsystem: .ax
-                )
-            }
-        }
-
+        let resultAfterViewPreparation: ChannelResult = {
         if controlsViewCheckbox, let controlsViewRowLabel {
             // This must run before the legacy slider locator: Controls view
             // deliberately removes the parameter's identity from the control
@@ -1679,8 +1701,24 @@ extension AccessibilityChannel {
             return .error(failure)
         }
 
-        // Step 10 — read the before value (for rollback + provenance).
-        let before = AXValueExtractors.extractSliderValue(slider, runtime: runtime.ax)
+        // Step 10 — read the before value (for rollback + provenance). A
+        // direct AXValue write is never safe to issue without a recoverable
+        // state: an accepted write followed by lost readback needs this exact
+        // value for compensation.
+        guard let before = AXValueExtractors.extractSliderValue(slider, runtime: runtime.ax) else {
+            return .error(HonestContract.encodeV2StateC(
+                error: .readbackUnavailable,
+                extras: [
+                    "operation": operation,
+                    "target_identity": identity,
+                    "param": paramAlias,
+                    "what_was_attempted": "read the '\(axDescription)' slider value before any AXValue write",
+                    "what_was_observed": "the slider value could not be read before the write, so no write was attempted without a rollback state",
+                    "safe_to_retry": true,
+                    "write_attempted": false,
+                ]
+            ))
+        }
 
         if let failure = acquiredPluginWindowFailureStateC(
             acquiredWindow: window,
@@ -1740,6 +1778,12 @@ extension AccessibilityChannel {
         switch writeMethod {
         case "ax_slider_axvalue":
             guard AXValueExtractors.setSliderValue(slider, requested, runtime: runtime.ax) else {
+                let rollback = rollbackSliderValue(
+                    slider,
+                    to: before,
+                    writeMethod: writeMethod,
+                    runtime: runtime.ax
+                )
                 return .error(HonestContract.encodeV2StateC(
                     error: .axWriteFailed,
                     extras: [
@@ -1748,8 +1792,13 @@ extension AccessibilityChannel {
                         "param": paramAlias,
                         "requested_normalized": requested,
                         "what_was_attempted": "set AXValue \(requested) on the '\(axDescription)' slider",
-                        "what_was_observed": "the AX value write was rejected",
-                        "safe_to_retry": true,
+                        "rollback_attempted": rollback.attempted,
+                        "rollback_succeeded": rollback.succeeded,
+                        "rollback_observed": rollback.observed ?? NSNull(),
+                        "rolled_back": rollback.succeeded,
+                        "parameter_left_changed": !rollback.succeeded,
+                        "what_was_observed": "the AX value write was rejected; rollback to the readable pre-write value was attempted",
+                        "safe_to_retry": rollback.succeeded,
                         "write_attempted": true,
                     ]
                 ))
@@ -1758,6 +1807,12 @@ extension AccessibilityChannel {
             // Step 12 — read the after value (+ value description). A write
             // that cannot be read back is uncertain, not confirmed — fail closed.
             guard let after = AXValueExtractors.extractSliderValue(slider, runtime: runtime.ax) else {
+                let rollback = rollbackSliderValue(
+                    slider,
+                    to: before,
+                    writeMethod: writeMethod,
+                    runtime: runtime.ax
+                )
                 return .error(HonestContract.encodeV2StateC(
                     error: .readbackLostAfterWrite,
                     extras: [
@@ -1766,8 +1821,13 @@ extension AccessibilityChannel {
                         "param": paramAlias,
                         "requested_normalized": requested,
                         "what_was_attempted": "read back the '\(axDescription)' slider value after writing",
-                        "what_was_observed": "the slider value could not be read after the write",
-                        "safe_to_retry": true,
+                        "rollback_attempted": rollback.attempted,
+                        "rollback_succeeded": rollback.succeeded,
+                        "rollback_observed": rollback.observed ?? NSNull(),
+                        "rolled_back": rollback.succeeded,
+                        "parameter_left_changed": !rollback.succeeded,
+                        "what_was_observed": "the slider value could not be read after the write; rollback to the readable pre-write value was attempted",
+                        "safe_to_retry": rollback.succeeded,
                         "write_attempted": true,
                     ]
                 ))
@@ -1811,8 +1871,11 @@ extension AccessibilityChannel {
                     "tolerance": tolerance,
                     "rollback_attempted": rollback.attempted,
                     "rollback_succeeded": rollback.succeeded,
+                    "rollback_observed": rollback.observed ?? NSNull(),
+                    "rolled_back": rollback.succeeded,
+                    "parameter_left_changed": !rollback.succeeded,
                     "rollback_outcome": rollback.walkOutcome ?? NSNull(),
-                    "rollback_to": before ?? NSNull(),
+                    "rollback_to": before,
                     "what_was_attempted": "verify the '\(axDescription)' write within tolerance \(tolerance)",
                     "what_was_observed": "observed \(after) differs from requested \(requested) beyond tolerance",
                     "safe_to_retry": false,
@@ -1910,6 +1973,8 @@ extension AccessibilityChannel {
                 ]
             ))
         }
+        }()
+        return finishPluginViewSessionResult(resultAfterViewPreparation)
     }
 
     /// The additive ADR-011 / ADR-018 Controls-view checkbox branch. It is
@@ -2029,6 +2094,7 @@ extension AccessibilityChannel {
     private struct SliderRollback {
         let attempted: Bool
         let succeeded: Bool
+        let observed: Double?
         let walkOutcome: String?
     }
 
@@ -2042,7 +2108,9 @@ extension AccessibilityChannel {
         runtime: AXHelpers.Runtime,
         incrementWalkBudget: Int = ChannelEQBandCatalog.incrementWalkBudget
     ) -> SliderRollback {
-        guard let before else { return SliderRollback(attempted: false, succeeded: false, walkOutcome: nil) }
+        guard let before else {
+            return SliderRollback(attempted: false, succeeded: false, observed: nil, walkOutcome: nil)
+        }
         switch writeMethod {
         case "ax_slider_increment_walk":
             let outcome = SliderIncrementWalk.walk(
@@ -2057,24 +2125,31 @@ extension AccessibilityChannel {
                 },
                 budget: incrementWalkBudget
             )
-            if case .arrived(_, _) = outcome {
-                return SliderRollback(attempted: true, succeeded: true, walkOutcome: "arrived")
+            if case let .arrived(_, final) = outcome {
+                return SliderRollback(
+                    attempted: true,
+                    succeeded: true,
+                    observed: final.value,
+                    walkOutcome: "arrived"
+                )
             }
             return SliderRollback(
                 attempted: true,
                 succeeded: false,
+                observed: nil,
                 walkOutcome: incrementWalkOutcomeName(outcome)
             )
         default:
             guard AXValueExtractors.setSliderValue(slider, before, runtime: runtime) else {
-                return SliderRollback(attempted: true, succeeded: false, walkOutcome: nil)
+                return SliderRollback(attempted: true, succeeded: false, observed: nil, walkOutcome: nil)
             }
             guard let restored = AXValueExtractors.extractSliderValue(slider, runtime: runtime) else {
-                return SliderRollback(attempted: true, succeeded: false, walkOutcome: nil)
+                return SliderRollback(attempted: true, succeeded: false, observed: nil, walkOutcome: nil)
             }
             return SliderRollback(
                 attempted: true,
                 succeeded: abs(restored - before) <= 0.5,
+                observed: restored,
                 walkOutcome: nil
             )
         }

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -440,6 +440,10 @@ extension AccessibilityChannel {
             pluginID: pluginID,
             trackName: trackName,
             axDescription: axDescription,
+            // The plug-in remembers its last view. If that is Controls, its
+            // native sliders have no descriptions until the caller selects and
+            // confirms the editor view after this header-bound acquisition.
+            requiringMatchingSlider: false,
             runtime: runtime
         )
     }
@@ -821,6 +825,50 @@ extension AccessibilityChannel {
             ))
         }
 
+        // ADR-011 / ADR-018 negative evidence is a first-class preflight
+        // refusal. The catalog gives this state explicitly to Controls-view
+        // shapes whose AX role is known but whose write path is either measured
+        // inert or unmeasured. Neither branch reaches AX window acquisition or
+        // a speculative actuation.
+        switch metadata.controlsViewActuationState {
+        case .measuredNotActuable:
+            return .failure(HonestContract.encodeV2StateC(
+                error: .unsupportedParamReadback,
+                extras: [
+                    "operation": operation,
+                    "target_identity": identity,
+                    "param": paramAlias,
+                    "what_was_attempted": "preflight the measured Controls-view slider actuation path for \(pluginID).\(paramAlias)",
+                    "what_was_observed": ControlsViewBooleanParameterWriter.LocatorFailure.sliderNotActuable.observation,
+                    "safe_to_retry": false,
+                    "write_attempted": false,
+                ]
+            ))
+        case .unmeasured:
+            return .failure(HonestContract.encodeV2StateC(
+                error: .unsupportedParamReadback,
+                extras: [
+                    "operation": operation,
+                    "target_identity": identity,
+                    "param": paramAlias,
+                    "what_was_attempted": "preflight the measured Controls-view popup actuation path for \(pluginID).\(paramAlias)",
+                    "what_was_observed": ControlsViewBooleanParameterWriter.LocatorFailure.popupUnmeasured.observation,
+                    "safe_to_retry": false,
+                    "write_attempted": false,
+                ]
+            ))
+        case nil:
+            break
+        }
+
+        if metadata.writeMethod == "ax_controls_view_checkbox_press",
+           requested != 0, requested != 1 {
+            return .failure(invalidParamsStateC(
+                operation,
+                "Controls-view boolean parameter \(pluginID).\(paramAlias) requires value 0 or 1"
+            ))
+        }
+
         let declaredUnits = metadata.acceptedUnits ?? metadata.unit.map { [$0] } ?? []
         let normalizedUnit = unit?.trimmingCharacters(in: .whitespacesAndNewlines)
         if case .channelEQ = selector, normalizedUnit?.isEmpty ?? true {
@@ -1005,21 +1053,62 @@ extension AccessibilityChannel {
         incrementWalkBudget: Int
     ) async -> ChannelResult {
         let identity = resolvedIdentity(track: track, insert: insert, pluginID: pluginID)
-        guard let axDescription = VerifiedPluginCatalog.paramAXDescription(
-            pluginID: pluginID,
-            paramKey: paramKey,
-            entryLookup: entryLookup
-        ) else {
-            // A `.writeReadback` parameter must declare its AX matcher; absence is
-            // a catalog defect, surfaced honestly rather than guessed around.
+        let controlsViewCheckbox = writeMethod == "ax_controls_view_checkbox_press"
+        let controlsViewRowLabel = controlsViewCheckbox
+            ? VerifiedPluginCatalog.controlsViewRowLabel(
+                pluginID: pluginID,
+                paramKey: paramKey,
+                entryLookup: entryLookup
+            )
+            : nil
+        let controlsViewEditorAnchor: String?
+        let axDescription: String
+        if controlsViewCheckbox {
+            // An editor-view description can corroborate the header-bound
+            // window when it happens to be present. It is not an acquisition
+            // precondition: an editor may already be in Controls view, where
+            // sliders intentionally have no AXDescription.
+            controlsViewEditorAnchor = VerifiedPluginCatalog.editorWindowAnchorAXDescription(
+                pluginID: pluginID,
+                paramKey: paramKey,
+                entryLookup: entryLookup
+            )
+            axDescription = controlsViewEditorAnchor ?? ""
+        } else {
+            controlsViewEditorAnchor = nil
+            guard let description = VerifiedPluginCatalog.paramAXDescription(
+                pluginID: pluginID,
+                paramKey: paramKey,
+                entryLookup: entryLookup
+            ) else {
+                return .error(HonestContract.encodeV2StateC(
+                    error: .unsupportedParamReadback,
+                    extras: [
+                        "operation": operation,
+                        "target_identity": identity,
+                        "param": paramAlias,
+                        "what_was_attempted": "resolve the AX control matcher for \(pluginID).\(paramAlias)",
+                        "what_was_observed": "parameter declares no AX description matcher",
+                        "safe_to_retry": false,
+                        "write_attempted": false,
+                    ]
+                ))
+            }
+            axDescription = description
+        }
+        // A remembered Controls view has no described sliders. Bind the editor
+        // by its measured track/plugin header first, then select and confirm
+        // the view required by the write plane before any slider lookup.
+        let requiringWindowSlider = false
+        if controlsViewCheckbox, controlsViewRowLabel == nil {
             return .error(HonestContract.encodeV2StateC(
                 error: .unsupportedParamReadback,
                 extras: [
                     "operation": operation,
                     "target_identity": identity,
                     "param": paramAlias,
-                    "what_was_attempted": "resolve the AX control matcher for \(pluginID).\(paramAlias)",
-                    "what_was_observed": "parameter declares no AX description matcher",
+                    "what_was_attempted": "resolve the Controls-view AXRow label for \(pluginID).\(paramAlias)",
+                    "what_was_observed": "parameter declares no measured Controls-view row label",
                     "safe_to_retry": false,
                     "write_attempted": false,
                 ]
@@ -1131,6 +1220,7 @@ extension AccessibilityChannel {
         // make acquisition fail with two editors, and every newly observed
         // editor from that failed attempt still needs best-effort cleanup.
         var constructedWindowsNeedingCleanup: [AXUIElement] = []
+        var restorePluginViewOnExit: (() -> ControlsViewBooleanParameterWriter.ViewRestoration)?
         defer {
             if !constructedWindowsNeedingCleanup.isEmpty {
                 _ = closePluginEditorsOpenedByThisOperation(
@@ -1148,6 +1238,14 @@ extension AccessibilityChannel {
         /// to the next duplicate-instance call.
         func verifiedWriteEnvelope(extras: [String: Any]) -> String {
             var completedExtras = extras
+            if let restoration = restorePluginViewOnExit?() {
+                completedExtras["plugin_view_restore_attempted"] = restoration.attempted
+                completedExtras["plugin_view_restore_observed"] = restoration.confirmed
+                if !restoration.confirmed {
+                    completedExtras["plugin_view_restore_observed_structure"] = restoration.observedStructure ?? NSNull()
+                    completedExtras["plugin_view_restore_recovery_hint"] = "The plug-in view could not be restored to the view observed before this write. Select the prior view manually before continuing."
+                }
+            }
             guard !constructedWindowsNeedingCleanup.isEmpty else {
                 return HonestContract.encodeV2StateA(extras: completedExtras)
             }
@@ -1199,6 +1297,7 @@ extension AccessibilityChannel {
                 forTrackName: trackName,
                 matchingPluginID: pluginID,
                 matchingSliderDescription: axDescription,
+                requiringMatchingSlider: requiringWindowSlider,
                 runtime: runtime
             ) {
                 return .error(pluginWindowPluginMismatchStateC(
@@ -1256,6 +1355,7 @@ extension AccessibilityChannel {
                     forTrackName: trackName,
                     matchingPluginID: pluginID,
                     matchingSliderDescription: axDescription,
+                    requiringMatchingSlider: requiringWindowSlider,
                     runtime: runtime
                 ) {
                     return .error(pluginWindowPluginMismatchStateC(
@@ -1285,12 +1385,14 @@ extension AccessibilityChannel {
         // name/parameter resolution and opener behaviour. For a duplicated
         // instance, `constructedWindow` above is already proven by the one
         // target-slot press and the two editor counts.
-        switch AXLogicProElements.pluginWindowMatch(
+        let preAcquisitionWindowMatch = AXLogicProElements.pluginWindowMatch(
             forTrackName: trackName,
             matchingPluginID: pluginID,
             matchingSliderDescription: axDescription,
+            requiringMatchingSlider: requiringWindowSlider,
             runtime: runtime
-        ) {
+        )
+        switch preAcquisitionWindowMatch {
         case .ambiguous:
             var diagnostics = pluginWindowAcquisitionDiagnostics(
                 trackName: trackName,
@@ -1318,6 +1420,20 @@ extension AccessibilityChannel {
         let openedCandidate: AXUIElementSendable?
         if let constructedWindow {
             openedCandidate = constructedWindow
+        } else if case let .unique(boundWindow) = preAcquisitionWindowMatch {
+            // The header-aware matcher is the binding for a reused editor.
+            // It cannot require the native slider because the remembered view
+            // may be Controls; the requested view is selected below.
+            openedCandidate = AXUIElementSendable(boundWindow)
+        } else if controlsViewCheckbox {
+            openedCandidate = await openPluginWindowFromTargetSlot(
+                slots[insert].element,
+                pluginID: pluginID,
+                trackName: trackName,
+                axDescription: controlsViewEditorAnchor ?? "",
+                requiringMatchingSlider: false,
+                runtime: runtime
+            )
         } else {
             openedCandidate = await pluginWindowOpener(
                 AXUIElementSendable(slots[insert].element),
@@ -1336,6 +1452,7 @@ extension AccessibilityChannel {
                 forTrackName: trackName,
                 matchingPluginID: pluginID,
                 matchingSliderDescription: axDescription,
+                requiringMatchingSlider: requiringWindowSlider,
                 runtime: runtime
             ) {
                 return .error(pluginWindowPluginMismatchStateC(
@@ -1365,6 +1482,7 @@ extension AccessibilityChannel {
                 forTrackName: trackName,
                 matchingPluginID: pluginID,
                 matchingSliderDescription: axDescription,
+                requiringMatchingSlider: requiringWindowSlider,
                 runtime: runtime
             ) {
             case .ambiguous:
@@ -1418,10 +1536,105 @@ extension AccessibilityChannel {
         }
         let window = opened.element
 
+        let requiredView: ControlsViewBooleanParameterWriter.PluginWindowView = controlsViewCheckbox
+            ? .controls
+            : .editor
+        let viewSession: ControlsViewBooleanParameterWriter.ViewSession
+        switch ControlsViewBooleanParameterWriter.prepareView(
+            requiredView,
+            in: window,
+            runtime: runtime.ax
+        ) {
+        case let .refused(failure):
+            return .error(HonestContract.encodeV2StateC(
+                // The slider locator has not run. Keep a failed structural
+                // confirmation distinct from a genuine missing AXSlider so the
+                // live response shows whether view selection was reached.
+                error: .pluginViewNotConfirmed,
+                extras: [
+                    "operation": operation,
+                    "target_identity": identity,
+                    "param": paramAlias,
+                    "what_was_attempted": "select the plugin-window View menu item and confirm the required \(requiredView.rawValue) structure before locating its control",
+                    "what_was_observed": failure.observation,
+                    "safe_to_retry": false,
+                    "write_attempted": false,
+                ]
+            ))
+        case let .ready(session):
+            viewSession = session
+        }
+        restorePluginViewOnExit = { viewSession.restore() }
+        defer {
+            if let restoration = restorePluginViewOnExit?(), !restoration.confirmed {
+                // The write result may already be State A or an unavoidable State C
+                // when this best-effort restoration fails. Keep that result honest,
+                // but never silently strand the user's editor: State A includes the
+                // restore fields above and refusal paths emit this actionable log.
+                Log.warn(
+                    "Plugin view restoration was not confirmed after \(operation); observed structure: \(restoration.observedStructure ?? "unconfirmed")",
+                    subsystem: .ax
+                )
+            }
+        }
+
+        if controlsViewCheckbox, let controlsViewRowLabel {
+            // This must run before the legacy slider locator: Controls view
+            // deliberately removes the parameter's identity from the control
+            // and places it on an AXRow label instead. The existing Threshold
+            // slider path selects the paired native editor view below.
+            guard targetPluginIdentityIsStable(
+                track: track,
+                insert: insert,
+                pluginID: pluginID,
+                originalSlot: slots[insert].element,
+                runtime: runtime
+            ) else {
+                return .error(windowIdentityUnresolvedStateC(
+                    operation,
+                    identity,
+                    "the target plugin slot identity was not stable immediately before Controls-view checkbox actuation"
+                ))
+            }
+            if let failure = controlsViewAcquiredPluginWindowFailureStateC(
+                acquiredWindow: window,
+                operation: operation,
+                identity: identity,
+                pluginID: pluginID,
+                trackName: trackName,
+                runtime: runtime
+            ) {
+                return .error(failure)
+            }
+            return performControlsViewCheckboxWrite(
+                operation: operation,
+                identity: identity,
+                paramAlias: paramAlias,
+                requested: requested,
+                rowLabel: controlsViewRowLabel,
+                window: window,
+                runtime: runtime.ax,
+                verifiedWriteEnvelope: verifiedWriteEnvelope
+            )
+        }
+
         // Step 9 — slider match by AXDescription (the only stable identifier).
-        guard let slider = AXLogicProElements.pluginWindowSlider(
+        // The view is confirmed native above, so this is the first parameter
+        // lookup. An ambiguous description is a window-identity refusal, never
+        // a positional choice between two sliders.
+        let slider: AXUIElement
+        switch AXLogicProElements.pluginWindowSliderResolution(
             in: window, axDescription: axDescription, runtime: runtime.ax
-        ) else {
+        ) {
+        case let .unique(found):
+            slider = found
+        case .ambiguous:
+            return .error(windowIdentityUnresolvedStateC(
+                operation,
+                identity,
+                "more than one slider exposed the requested AXDescription in the confirmed native plugin view"
+            ))
+        case .none:
             return .error(HonestContract.encodeV2StateC(
                 error: .paramControlNotFound,
                 extras: [
@@ -1680,6 +1893,119 @@ extension AccessibilityChannel {
                 ]
             ))
         }
+    }
+
+    /// The additive ADR-011 / ADR-018 Controls-view checkbox branch. It is
+    /// intentionally separate from the slider writer above: the label belongs
+    /// to an AXRow, AXPress is the measured action, and success requires the
+    /// checkbox's own AXValue to change to the requested Boolean state.
+    private static func performControlsViewCheckboxWrite(
+        operation: String,
+        identity: [String: Any],
+        paramAlias: String,
+        requested: Double,
+        rowLabel: String,
+        window: AXUIElement,
+        runtime: AXHelpers.Runtime,
+        verifiedWriteEnvelope: ([String: Any]) -> String
+    ) -> ChannelResult {
+        // The caller already selected and structurally confirmed Controls view.
+        // Do not repeat the selection here: reopening its menu would make this
+        // locator depend on a write status rather than the confirmed bound
+        // window state it was handed.
+        let checkbox: AXUIElement
+        switch ControlsViewBooleanParameterWriter.locate(
+            label: rowLabel,
+            in: window,
+            runtime: runtime
+        ) {
+        case let .refused(failure):
+            return .error(HonestContract.encodeV2StateC(
+                error: .paramControlNotFound,
+                extras: [
+                    "operation": operation,
+                    "target_identity": identity,
+                    "param": paramAlias,
+                    "controls_view_row_label": rowLabel,
+                    "what_was_attempted": "bind the Controls-view AXRow label to one control",
+                    "what_was_observed": failure.observation,
+                    "safe_to_retry": false,
+                    "write_attempted": false,
+                ]
+            ))
+        case let .found(control):
+            guard case let .checkBox(found) = control else {
+                let failure = control.failure ?? .checkboxNotFound
+                return .error(HonestContract.encodeV2StateC(
+                    error: .unsupportedParamReadback,
+                    extras: [
+                        "operation": operation,
+                        "target_identity": identity,
+                        "param": paramAlias,
+                        "controls_view_row_label": rowLabel,
+                        "what_was_attempted": "confirm the labelled Controls-view control is a measured AXCheckBox",
+                        "what_was_observed": failure.observation,
+                        "safe_to_retry": false,
+                        "write_attempted": false,
+                    ]
+                ))
+            }
+            checkbox = found
+        }
+
+        let requestedState = requested == 1
+        let toggle = ControlsViewBooleanParameterWriter.pressAndVerify(
+            checkbox,
+            requested: requestedState,
+            runtime: runtime
+        )
+        if toggle.verified, let observed = toggle.observedAfterPress {
+            return .success(verifiedWriteEnvelope([
+                "operation": operation,
+                "target_identity": identity,
+                "param": paramAlias,
+                "controls_view_row_label": rowLabel,
+                "requested_normalized": requested,
+                "requested_boolean": requestedState,
+                "observed_normalized": observed ? 1.0 : 0.0,
+                "observed_boolean": observed,
+                "write_source": "ax_controls_view_checkbox",
+                "verify_source": "ax_controls_view_checkbox",
+            ]))
+        }
+
+        let restorationObservation: String
+        switch toggle.restoreObserved {
+        case .some(true):
+            restorationObservation = "restore observed: AXValue returned to the pre-press state"
+        case .some(false):
+            restorationObservation = "restore not observed: AXValue did not return to the pre-press state"
+        case nil:
+            restorationObservation = "restore not observed: AXValue was unreadable after the compensating press"
+        }
+        let failureObservation = [
+            toggle.refusal ?? "Controls-view checkbox verification did not establish the requested state",
+            restorationObservation,
+        ].joined(separator: "; ")
+        return .error(HonestContract.encodeV2StateC(
+            error: toggle.observedAfterPress == nil ? .readbackLostAfterWrite : .readbackMismatch,
+            extras: [
+                "operation": operation,
+                "target_identity": identity,
+                "param": paramAlias,
+                "controls_view_row_label": rowLabel,
+                "requested_normalized": requested,
+                "requested_boolean": requestedState,
+                "before_boolean": toggle.before ?? NSNull(),
+                "observed_boolean": toggle.observedAfterPress ?? NSNull(),
+                "restore_attempted": toggle.restoreAttempted,
+                "restore_observed": toggle.restoreObserved ?? NSNull(),
+                "what_was_attempted": "AXPress the labelled Controls-view AXCheckBox then require changed AXValue readback",
+                "what_was_observed": failureObservation,
+                "safe_to_retry": false,
+                "write_attempted": toggle.pressAttempted,
+            ]
+        ))
     }
 
     private struct SliderRollback {
@@ -2010,17 +2336,52 @@ extension AccessibilityChannel {
         }
     }
 
+    /// Controls-view writes have already bound an editor through the caller's
+    /// target slot and the header-aware `pluginWindowMatch` acquisition above.
+    /// An editor-view slider description remains only an optional witness during
+    /// that match: Controls view is expected to expose no described sliders, so
+    /// its absence must never invalidate the already-bound editor.
+    private static func controlsViewAcquiredPluginWindowFailureStateC(
+        acquiredWindow: AXUIElement,
+        operation: String,
+        identity: [String: Any],
+        pluginID: String,
+        trackName: String,
+        runtime: AXLogicProElements.Runtime
+    ) -> String? {
+        let headerBoundWindows = AXLogicProElements.matchingPluginEditorWindows(
+            forTrackName: trackName,
+            matchingPluginID: pluginID,
+            runtime: runtime
+        )
+        guard headerBoundWindows.contains(where: { CFEqual($0, acquiredWindow) }) else {
+            return windowIdentityUnresolvedStateC(
+                operation,
+                identity,
+                "the target-slot editor no longer proved the requested track and plugin header identity before Controls view selection",
+                diagnostics: pluginWindowAcquisitionDiagnostics(
+                    trackName: trackName,
+                    axDescription: "not required for Controls-view header binding",
+                    runtime: runtime
+                )
+            )
+        }
+        return nil
+    }
+
     private static func openPluginWindowFromTargetSlot(
         _ targetSlot: AXUIElement,
         pluginID: String,
         trackName: String,
         axDescription: String,
+        requiringMatchingSlider: Bool = true,
         runtime: AXLogicProElements.Runtime
     ) async -> AXUIElementSendable? {
         switch AXLogicProElements.pluginWindowMatch(
             forTrackName: trackName,
             matchingPluginID: pluginID,
             matchingSliderDescription: axDescription,
+            requiringMatchingSlider: requiringMatchingSlider,
             runtime: runtime
         ) {
         case .ambiguous:
@@ -2059,6 +2420,7 @@ extension AccessibilityChannel {
                 pluginID: pluginID,
                 trackName: trackName,
                 axDescription: axDescription,
+                requiringMatchingSlider: requiringMatchingSlider,
                 runtime: runtime,
                 timeoutMs: 1_250
             ) {
@@ -2288,6 +2650,7 @@ extension AccessibilityChannel {
         pluginID: String,
         trackName: String,
         axDescription: String,
+        requiringMatchingSlider: Bool = true,
         runtime: AXLogicProElements.Runtime,
         timeoutMs: Int
     ) async -> AXLogicProElements.PluginWindowMatch {
@@ -2298,6 +2661,7 @@ extension AccessibilityChannel {
                 forTrackName: trackName,
                 matchingPluginID: pluginID,
                 matchingSliderDescription: axDescription,
+                requiringMatchingSlider: requiringMatchingSlider,
                 runtime: runtime
             ) {
             case let .unique(window):

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+VerifiedPlugins.swift
@@ -1238,14 +1238,7 @@ extension AccessibilityChannel {
         /// to the next duplicate-instance call.
         func verifiedWriteEnvelope(extras: [String: Any]) -> String {
             var completedExtras = extras
-            if let restoration = restorePluginViewOnExit?() {
-                completedExtras["plugin_view_restore_attempted"] = restoration.attempted
-                completedExtras["plugin_view_restore_observed"] = restoration.confirmed
-                if !restoration.confirmed {
-                    completedExtras["plugin_view_restore_observed_structure"] = restoration.observedStructure ?? NSNull()
-                    completedExtras["plugin_view_restore_recovery_hint"] = "The plug-in view could not be restored to the view observed before this write. Select the prior view manually before continuing."
-                }
-            }
+            appendPluginViewRestoration(to: &completedExtras)
             guard !constructedWindowsNeedingCleanup.isEmpty else {
                 return HonestContract.encodeV2StateA(extras: completedExtras)
             }
@@ -1264,6 +1257,29 @@ extension AccessibilityChannel {
                 completedExtras["recovery_hint"] = "The \(pluginID) editor opened for this write is still visible on track \(track). Close it before another duplicate-instance write."
             }
             return HonestContract.encodeV2StateA(extras: completedExtras)
+        }
+
+        /// A State C built after a confirmed temporary view switch must expose
+        /// a failed restore. Without these fields a locator refusal can look
+        /// like a no-op even though the plug-in remains in Controls view.
+        func stateCWithPluginViewRestoration(
+            error: HonestContract.FailureError,
+            extras: [String: Any]
+        ) -> String {
+            var completedExtras = extras
+            appendPluginViewRestoration(to: &completedExtras)
+            return HonestContract.encodeV2StateC(error: error, extras: completedExtras)
+        }
+
+        func appendPluginViewRestoration(to extras: inout [String: Any]) {
+            guard let restoration = restorePluginViewOnExit?() else { return }
+            extras["plugin_view_restore_attempted"] = restoration.attempted
+            extras["plugin_view_restore_observed"] = restoration.confirmed
+            if !restoration.confirmed {
+                extras["plugin_view_left_changed"] = true
+                extras["plugin_view_restore_observed_structure"] = restoration.observedStructure ?? NSNull()
+                extras["plugin_view_restore_recovery_hint"] = "The plug-in view could not be restored to the view observed before this write. Select the prior view manually before continuing."
+            }
         }
 
         if duplicatedPluginInstance {
@@ -1614,7 +1630,8 @@ extension AccessibilityChannel {
                 rowLabel: controlsViewRowLabel,
                 window: window,
                 runtime: runtime.ax,
-                verifiedWriteEnvelope: verifiedWriteEnvelope
+                verifiedWriteEnvelope: verifiedWriteEnvelope,
+                stateCWithPluginViewRestoration: stateCWithPluginViewRestoration
             )
         }
 
@@ -1635,7 +1652,7 @@ extension AccessibilityChannel {
                 "more than one slider exposed the requested AXDescription in the confirmed native plugin view"
             ))
         case .none:
-            return .error(HonestContract.encodeV2StateC(
+            return .error(stateCWithPluginViewRestoration(
                 error: .paramControlNotFound,
                 extras: [
                     "operation": operation,
@@ -1907,7 +1924,8 @@ extension AccessibilityChannel {
         rowLabel: String,
         window: AXUIElement,
         runtime: AXHelpers.Runtime,
-        verifiedWriteEnvelope: ([String: Any]) -> String
+        verifiedWriteEnvelope: ([String: Any]) -> String,
+        stateCWithPluginViewRestoration: (HonestContract.FailureError, [String: Any]) -> String
     ) -> ChannelResult {
         // The caller already selected and structurally confirmed Controls view.
         // Do not repeat the selection here: reopening its menu would make this
@@ -1920,9 +1938,9 @@ extension AccessibilityChannel {
             runtime: runtime
         ) {
         case let .refused(failure):
-            return .error(HonestContract.encodeV2StateC(
-                error: .paramControlNotFound,
-                extras: [
+            return .error(stateCWithPluginViewRestoration(
+                .paramControlNotFound,
+                [
                     "operation": operation,
                     "target_identity": identity,
                     "param": paramAlias,
@@ -1936,9 +1954,9 @@ extension AccessibilityChannel {
         case let .found(control):
             guard case let .checkBox(found) = control else {
                 let failure = control.failure ?? .checkboxNotFound
-                return .error(HonestContract.encodeV2StateC(
-                    error: .unsupportedParamReadback,
-                    extras: [
+                return .error(stateCWithPluginViewRestoration(
+                    .unsupportedParamReadback,
+                    [
                         "operation": operation,
                         "target_identity": identity,
                         "param": paramAlias,
@@ -1987,9 +2005,9 @@ extension AccessibilityChannel {
             toggle.refusal ?? "Controls-view checkbox verification did not establish the requested state",
             restorationObservation,
         ].joined(separator: "; ")
-        return .error(HonestContract.encodeV2StateC(
-            error: toggle.observedAfterPress == nil ? .readbackLostAfterWrite : .readbackMismatch,
-            extras: [
+        return .error(stateCWithPluginViewRestoration(
+            toggle.observedAfterPress == nil ? .readbackLostAfterWrite : .readbackMismatch,
+            [
                 "operation": operation,
                 "target_identity": identity,
                 "param": paramAlias,

--- a/Sources/LogicProMCP/HostParameters/ControlsViewBooleanParameterWriter.swift
+++ b/Sources/LogicProMCP/HostParameters/ControlsViewBooleanParameterWriter.swift
@@ -21,6 +21,7 @@ enum ControlsViewBooleanParameterWriter {
         case controlMissing
         case controlAmbiguous
         case accessibilityReadFailed
+        case accessibilityReadMalformed
         case checkboxNotFound
         case sliderNotActuable
         case popupUnmeasured
@@ -46,6 +47,8 @@ enum ControlsViewBooleanParameterWriter {
                 return "the labelled Controls-view AXRow exposes several candidate controls; no control was chosen by position"
             case .accessibilityReadFailed:
                 return "an AX role, child list, or label-value read failed while binding the Controls-view AXRow; no partially classified control was used"
+            case .accessibilityReadMalformed:
+                return "the Controls-view AXRows attribute returned a malformed payload; an undecodable row list is not evidence that the table is empty"
             case .checkboxNotFound:
                 return "the labelled Controls-view AXRow did not resolve to an AXCheckBox"
             case .sliderNotActuable:
@@ -79,6 +82,9 @@ enum ControlsViewBooleanParameterWriter {
         case switcherCensus(AXHelpers.AXStatusError)
         case switcherDescription(AXHelpers.AXStatusError)
         case menuItemCensus(AXHelpers.AXStatusError)
+        case menuItemEnabled(AXHelpers.AXStatusError)
+        case sliderCensus(AXHelpers.AXStatusError)
+        case sliderDescription(AXHelpers.AXStatusError)
 
         var observation: String {
             switch self {
@@ -88,6 +94,12 @@ enum ControlsViewBooleanParameterWriter {
                 return "the plugin-window View-switcher AXDescription read failed (status \(error.diagnosticLabel))"
             case let .menuItemCensus(error):
                 return "the scoped View-menu item census failed (AXChildren/AXRole/AXTitle/AXDescription status \(error.diagnosticLabel))"
+            case let .menuItemEnabled(error):
+                return "the scoped View-menu item's AXEnabled read failed (status \(error.diagnosticLabel))"
+            case let .sliderCensus(error):
+                return "the plugin-window AXSlider census failed (AXChildren/AXRole status \(error.diagnosticLabel))"
+            case let .sliderDescription(error):
+                return "a plugin-window AXSlider AXDescription read failed (status \(error.diagnosticLabel))"
             }
         }
     }
@@ -103,6 +115,7 @@ enum ControlsViewBooleanParameterWriter {
         case viewMenuAmbiguous
         case viewMenuItemNotFound(PluginWindowView)
         case viewMenuItemAmbiguous(PluginWindowView)
+        case viewMenuItemDisabled(PluginWindowView)
         case viewStructureDidNotConfirm(PluginWindowView)
 
         var observation: String {
@@ -127,6 +140,8 @@ enum ControlsViewBooleanParameterWriter {
                 return "the scoped View menu exposed no measured \(view.labels.canonical) item"
             case let .viewMenuItemAmbiguous(view):
                 return "the scoped View menu exposed several measured \(view.labels.canonical) items"
+            case let .viewMenuItemDisabled(view):
+                return "the scoped View menu's measured \(view.labels.canonical) item did not expose AXEnabled == true, so AXPick was refused"
             case let .viewStructureDidNotConfirm(expected):
                 return "after selecting the measured \(expected.labels.canonical) item, the bound plugin window did not expose the expected \(expected.rawValue) structure before the confirmation deadline"
             }
@@ -243,7 +258,12 @@ enum ControlsViewBooleanParameterWriter {
                     entryView: entryView
                 )
             case .refused:
-                let observed = observedView(in: window, runtime: runtime)
+                let observed: PluginWindowView?
+                if case let .success(.some(value)) = observedView(in: window, runtime: runtime) {
+                    observed = value
+                } else {
+                    observed = nil
+                }
                 return ViewRestoration(
                     attempted: true,
                     confirmed: observed == entryView,
@@ -262,6 +282,7 @@ enum ControlsViewBooleanParameterWriter {
     private enum ViewWaitResult {
         case confirmed
         case deadlineExpired
+        case readFailed(ViewEvidenceReadFailure)
     }
 
     struct ToggleResult: Sendable, Equatable {
@@ -271,6 +292,7 @@ enum ControlsViewBooleanParameterWriter {
         let observedAfterPress: Bool?
         let restoreAttempted: Bool
         let restoreObserved: Bool?
+        let restoreObservedValue: Bool?
         let refusal: String?
     }
 
@@ -286,15 +308,20 @@ enum ControlsViewBooleanParameterWriter {
         runtime: AXHelpers.Runtime = .production
     ) -> ViewPreparationResult {
         let entryView: PluginWindowView
-        guard let observed = observedView(in: window, runtime: runtime) else {
+        let entryObservation = observedView(in: window, runtime: runtime)
+        switch entryObservation {
+        case let .success(.some(observed)):
+            entryView = observed
+        case .success(.none):
             return .refused(.entryViewNotConfirmed, restoration: nil)
+        case let .failure(error):
+            return .refused(.viewEvidenceReadFailed(error), restoration: nil)
         }
-        entryView = observed
 
         // A view already confirmed by its own positive evidence needs no
         // switcher read: no switcher will be acted on and there is no view to
-        // restore. This also keeps classifier-only AXDescription failures out
-        // of an otherwise completed Controls or Editor operation.
+        // restore. No further classifier read is needed once the requested
+        // view was positively observed.
         guard entryView != targetView else {
             return .ready(ViewSession(
                 window: window,
@@ -376,7 +403,12 @@ enum ControlsViewBooleanParameterWriter {
                         entryView: entryView
                     )
                 case .refused:
-                    let observed = observedView(in: window, runtime: runtime)
+                    let observed: PluginWindowView?
+                    if case let .success(.some(value)) = observedView(in: window, runtime: runtime) {
+                        observed = value
+                    } else {
+                        observed = nil
+                    }
                     restoration = ViewRestoration(
                         attempted: true,
                         confirmed: observed == entryView,
@@ -398,11 +430,11 @@ enum ControlsViewBooleanParameterWriter {
     /// control in that label's sibling subtree. With no AXTable, Editor is
     /// confirmed by that observed absence.
     ///
-    /// AXDescription failures are deliberately ignored here. On the measured
-    /// Compressor surface those reads fail on Editor and on fourteen Controls
-    /// sliders, so their absence or failure cannot answer this question. They
-    /// never select an element to act on; a successful nonempty description is
-    /// positive Editor evidence, while the table structure decides Controls.
+    /// A successful nonempty AXDescription is positive Editor evidence. Once
+    /// observed, it wins immediately over all later reads. Conversely, when no
+    /// described slider was observed, a slider census or description failure
+    /// leaves the view unknown: an unreadable editor candidate must not be
+    /// erased so an unrelated table can become Controls evidence.
     ///
     /// Measured 2026-09-02, Compressor editor window "Absolute Zero": one
     /// AXTable at depth 2 had AXRows status 0 and 29 rows; every row had exactly
@@ -415,47 +447,61 @@ enum ControlsViewBooleanParameterWriter {
     private static func observedView(
         in window: AXUIElement,
         runtime: AXHelpers.Runtime
-    ) -> PluginWindowView? {
-        if hasDescribedNativeEditorSlider(in: window, runtime: runtime) {
-            return .editor
+    ) -> Result<PluginWindowView?, ViewEvidenceReadFailure> {
+        switch describedNativeEditorSliderEvidence(in: window, runtime: runtime) {
+        case .described:
+            return .success(.editor)
+        case let .readFailed(error):
+            return .failure(error)
+        case .notDescribed:
+            break
         }
         switch controlsViewStateIsBound(in: window, runtime: runtime) {
         case .controls:
-            return .controls
+            return .success(.controls)
         case .noTable:
-            return .editor
+            return .success(.editor)
         case .unconfirmed:
-            return nil
+            return .success(nil)
         }
     }
 
-    /// A description can establish Editor only when it is actually read and
-    /// nonempty. Failed and absent reads are not negative evidence, so scanning
-    /// continues through every slider and reports only a positive observation.
-    private static func hasDescribedNativeEditorSlider(
+    private enum SliderEvidence {
+        case described
+        case notDescribed
+        case readFailed(ViewEvidenceReadFailure)
+    }
+
+    /// Scan until a described slider establishes Editor. Keep reading after an
+    /// earlier failure so a later positive observation wins; if none is found,
+    /// preserve the first failed read instead of treating it as negative evidence.
+    private static func describedNativeEditorSliderEvidence(
         in window: AXUIElement,
         runtime: AXHelpers.Runtime
-    ) -> Bool {
+    ) -> SliderEvidence {
         let sliders: [AXUIElement]
         switch AXHelpers.censusDescendantResult(
             of: window, role: kAXSliderRole, maxDepth: 8, runtime: runtime
         ) {
         case let .success(census):
             sliders = census.matches
-        case .failure:
-            return false
+        case let .failure(error):
+            return .readFailed(.sliderCensus(error))
         }
+        var firstFailure: ViewEvidenceReadFailure?
         for slider in sliders {
             switch descriptionResult(of: slider, runtime: runtime) {
             case let .success(description):
                 if !(description?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true) {
-                    return true
+                    return .described
                 }
-            case .failure:
-                continue
+            case let .failure(error):
+                if firstFailure == nil {
+                    firstFailure = .sliderDescription(error)
+                }
             }
         }
-        return false
+        return firstFailure.map(SliderEvidence.readFailed) ?? .notDescribed
     }
 
     private static func switchView(
@@ -468,8 +514,13 @@ enum ControlsViewBooleanParameterWriter {
         runtime: AXHelpers.Runtime
     ) -> ViewChangeResult {
         if !forceSelection {
-            if observedView(in: window, runtime: runtime) == targetView {
+            switch observedView(in: window, runtime: runtime) {
+            case let .success(.some(observed)) where observed == targetView:
                 return .confirmed(switched: false)
+            case let .failure(error):
+                return .refused(.viewEvidenceReadFailed(error), targetSelectionAttempted: false)
+            case .success:
+                break
             }
         }
 
@@ -513,6 +564,18 @@ enum ControlsViewBooleanParameterWriter {
                 targetSelectionAttempted: false
             )
         }
+        switch AXHelpers.getAttributeResult(
+            target,
+            kAXEnabledAttribute as String,
+            runtime: runtime
+        ) as Result<Bool?, AXHelpers.AXStatusError> {
+        case .success(.some(true)):
+            break
+        case .success:
+            return .refused(.viewMenuItemDisabled(targetView), targetSelectionAttempted: false)
+        case let .failure(error):
+            return .refused(.viewEvidenceReadFailed(.menuItemEnabled(error)), targetSelectionAttempted: false)
+        }
         _ = AXHelpers.performAction(target, kAXPickAction as String, runtime: runtime)
         switch waitForView(
             targetView,
@@ -524,6 +587,8 @@ enum ControlsViewBooleanParameterWriter {
             break
         case .deadlineExpired:
             return .refused(.viewStructureDidNotConfirm(targetView), targetSelectionAttempted: true)
+        case let .readFailed(error):
+            return .refused(.viewEvidenceReadFailed(error), targetSelectionAttempted: true)
         }
         return .confirmed(switched: true)
     }
@@ -633,8 +698,13 @@ enum ControlsViewBooleanParameterWriter {
     ) -> ViewWaitResult {
         let deadline = Date().addingTimeInterval(max(0, timeout))
         repeat {
-            if observedView(in: window, runtime: runtime) == expected {
+            switch observedView(in: window, runtime: runtime) {
+            case let .success(.some(observed)) where observed == expected:
                 return .confirmed
+            case let .failure(error):
+                return .readFailed(error)
+            case .success:
+                break
             }
             let remaining = deadline.timeIntervalSinceNow
             guard remaining > 0 else { break }
@@ -724,8 +794,10 @@ enum ControlsViewBooleanParameterWriter {
         switch controlsRows(in: table, runtime: runtime) {
         case let .success(observed):
             rows = observed
-        case .failure:
-            return .refused(.accessibilityReadFailed)
+        case let .failure(error):
+            return .refused(error == .malformedAttribute
+                ? .accessibilityReadMalformed
+                : .accessibilityReadFailed)
         }
         guard !rows.isEmpty else {
             return .refused(.controlsViewTableNotFound)
@@ -818,14 +890,18 @@ enum ControlsViewBooleanParameterWriter {
 
     /// A press status of zero is not success evidence. The checkbox must read
     /// back as *changed* and equal to the requested state. Any failed
-    /// verification causes one compensating press, followed by a readback that
-    /// reports whether restoration to the before state was actually observed.
+    /// verification compensates only when the observed first read differs from
+    /// the readable pre-press state; a no-op needs no second actuation.
     static func pressAndVerify(
         _ checkbox: AXUIElement,
         requested: Bool,
         runtime: AXHelpers.Runtime = .production
     ) -> ToggleResult {
-        guard let before = AXValueExtractors.extractButtonState(checkbox, runtime: runtime) else {
+        let before: Bool
+        switch AXValueExtractors.extractButtonStateResult(checkbox, runtime: runtime) {
+        case let .success(.some(observed)):
+            before = observed
+        case .success(.none):
             return ToggleResult(
                 verified: false,
                 pressAttempted: false,
@@ -833,23 +909,45 @@ enum ControlsViewBooleanParameterWriter {
                 observedAfterPress: nil,
                 restoreAttempted: false,
                 restoreObserved: nil,
+                restoreObservedValue: nil,
                 refusal: "the Controls-view AXCheckBox AXValue could not be read before AXPress"
+            )
+        case let .failure(error):
+            return ToggleResult(
+                verified: false,
+                pressAttempted: false,
+                before: nil,
+                observedAfterPress: nil,
+                restoreAttempted: false,
+                restoreObserved: nil,
+                restoreObservedValue: nil,
+                refusal: "the Controls-view AXCheckBox AXValue read failed before AXPress (status \(error.diagnosticLabel))"
             )
         }
         guard before != requested else {
             return ToggleResult(
-                verified: false,
+                verified: true,
                 pressAttempted: false,
                 before: before,
                 observedAfterPress: before,
                 restoreAttempted: false,
                 restoreObserved: before,
-                refusal: "the Controls-view AXCheckBox already has the requested state; AXPress would change it away, so no write was attempted"
+                restoreObservedValue: before,
+                refusal: nil
             )
         }
 
         _ = AXHelpers.performAction(checkbox, kAXPressAction as String, runtime: runtime)
-        let after = AXValueExtractors.extractButtonState(checkbox, runtime: runtime)
+        let after: Bool?
+        let afterReadFailure: AXHelpers.AXStatusError?
+        switch AXValueExtractors.extractButtonStateResult(checkbox, runtime: runtime) {
+        case let .success(observed):
+            after = observed
+            afterReadFailure = nil
+        case let .failure(error):
+            after = nil
+            afterReadFailure = error
+        }
         if after == requested, after != before {
             return ToggleResult(
                 verified: true,
@@ -858,7 +956,24 @@ enum ControlsViewBooleanParameterWriter {
                 observedAfterPress: after,
                 restoreAttempted: false,
                 restoreObserved: nil,
+                restoreObservedValue: nil,
                 refusal: nil
+            )
+        }
+
+        // A readable pre-press state proves this first press was a no-op. Do
+        // not send an unnecessary second press: it could be the first one that
+        // lands and would change a request that must return failure.
+        if after == before {
+            return ToggleResult(
+                verified: false,
+                pressAttempted: true,
+                before: before,
+                observedAfterPress: after,
+                restoreAttempted: false,
+                restoreObserved: true,
+                restoreObservedValue: before,
+                refusal: "the Controls-view AXCheckBox did not change to the requested state after AXPress; the observed state already equals the pre-press state, so no compensating press was sent"
             )
         }
 
@@ -866,7 +981,24 @@ enum ControlsViewBooleanParameterWriter {
         // One inverse press is the only available compensation; it is not a
         // retry of the requested write, and its result is observed separately.
         _ = AXHelpers.performAction(checkbox, kAXPressAction as String, runtime: runtime)
-        let restored = AXValueExtractors.extractButtonState(checkbox, runtime: runtime)
+        let restored: Bool?
+        let restorationReadFailure: AXHelpers.AXStatusError?
+        switch AXValueExtractors.extractButtonStateResult(checkbox, runtime: runtime) {
+        case let .success(observed):
+            restored = observed
+            restorationReadFailure = nil
+        case let .failure(error):
+            restored = nil
+            restorationReadFailure = error
+        }
+        let refusal: String
+        if let afterReadFailure {
+            refusal = "the Controls-view AXCheckBox AXValue read failed after AXPress (status \(afterReadFailure.diagnosticLabel)); restoration was attempted once"
+        } else if let restorationReadFailure {
+            refusal = "the Controls-view AXCheckBox restoration AXValue read failed (status \(restorationReadFailure.diagnosticLabel)) after one compensating AXPress"
+        } else {
+            refusal = "the Controls-view AXCheckBox did not change to the requested state after AXPress; AX status is not confirmation, and restoration was attempted once"
+        }
         return ToggleResult(
             verified: false,
             pressAttempted: true,
@@ -874,9 +1006,8 @@ enum ControlsViewBooleanParameterWriter {
             observedAfterPress: after,
             restoreAttempted: true,
             restoreObserved: restored.map { $0 == before },
-            refusal: after == nil
-                ? "the Controls-view AXCheckBox value could not be read after AXPress; restoration was attempted once"
-                : "the Controls-view AXCheckBox did not change to the requested state after AXPress; AX status is not confirmation, and restoration was attempted once"
+            restoreObservedValue: restored,
+            refusal: refusal
         )
     }
 
@@ -908,7 +1039,7 @@ enum ControlsViewBooleanParameterWriter {
                 }
             }
         case .success(.malformed):
-            return .success([])
+            return .failure(.malformedAttribute)
         case let .failure(error):
             return .failure(error)
         }

--- a/Sources/LogicProMCP/HostParameters/ControlsViewBooleanParameterWriter.swift
+++ b/Sources/LogicProMCP/HostParameters/ControlsViewBooleanParameterWriter.swift
@@ -72,11 +72,47 @@ enum ControlsViewBooleanParameterWriter {
         }
     }
 
+    /// A classifier census is evidence for a view transition, not a search
+    /// convenience. Keep its failed reads distinct from an empty census so an
+    /// unreadable Editor signal or table cannot authorise a Controls write.
+    enum ViewEvidenceReadFailure: Error, Sendable, Equatable {
+        case switcherCensus(AXHelpers.AXStatusError)
+        case switcherDescription(AXHelpers.AXStatusError)
+        case sliderCensus(AXHelpers.AXStatusError)
+        case sliderDescription(AXHelpers.AXStatusError)
+        case menuItemCensus(AXHelpers.AXStatusError)
+        case controlsTableCensus(AXHelpers.AXStatusError)
+        case controlsTableRows(AXHelpers.AXStatusError)
+        case controlsTableRow(AXHelpers.AXStatusError)
+
+        var observation: String {
+            switch self {
+            case let .switcherCensus(error):
+                return "the plugin-window View-switcher census failed (AXChildren/AXRole status \(error.diagnosticLabel))"
+            case let .switcherDescription(error):
+                return "the plugin-window View-switcher AXDescription read failed (status \(error.diagnosticLabel))"
+            case let .sliderCensus(error):
+                return "the native-editor AXSlider census failed (AXChildren/AXRole status \(error.diagnosticLabel))"
+            case let .sliderDescription(error):
+                return "a native-editor AXSlider AXDescription read failed (status \(error.diagnosticLabel))"
+            case let .menuItemCensus(error):
+                return "the scoped View-menu item census failed (AXChildren/AXRole/AXTitle/AXDescription status \(error.diagnosticLabel))"
+            case let .controlsTableCensus(error):
+                return "the Controls-table census failed (AXChildren/AXRole status \(error.diagnosticLabel))"
+            case let .controlsTableRows(error):
+                return "the candidate Controls table AXRows read failed (status \(error.diagnosticLabel))"
+            case let .controlsTableRow(error):
+                return "a candidate Controls-table row read failed (status \(error.diagnosticLabel))"
+            }
+        }
+    }
+
     enum ViewSwitchFailure: Sendable, Equatable {
         case viewSwitcherNotFound
         case viewSwitcherAmbiguous
         case unmeasuredLocale
         case entryViewNotConfirmed
+        case viewEvidenceReadFailed(ViewEvidenceReadFailure)
         case viewMenuDidNotAppearBeforeDeadline
         case viewMenuReadFailed(AXHelpers.AXStatusError)
         case viewMenuAmbiguous
@@ -94,6 +130,8 @@ enum ControlsViewBooleanParameterWriter {
                 return "the plugin-window View AXDescription is not measured for this locale; no view name was guessed"
             case .entryViewNotConfirmed:
                 return "the bound plugin window exposed neither a described native-editor AXSlider nor a Controls-view label-and-sibling-control row with no described AXSlider; its entry view was not confirmed"
+            case let .viewEvidenceReadFailed(error):
+                return "view classification refused because \(error.observation); this is distinct from a missing switcher, menu item, slider, or table"
             case .viewMenuDidNotAppearBeforeDeadline:
                 return "the measured View switcher exposed no scoped AXMenu before the menu-appearance deadline after AXPress"
             case let .viewMenuReadFailed(error):
@@ -204,7 +242,13 @@ enum ControlsViewBooleanParameterWriter {
                     observedStructure: entryView.rawValue
                 )
             case .refused:
-                let observed = observedView(in: window, runtime: runtime)
+                let observed: PluginWindowView?
+                switch observedView(in: window, runtime: runtime) {
+                case let .success(view):
+                    observed = view
+                case .failure:
+                    observed = nil
+                }
                 return ViewRestoration(
                     attempted: true,
                     confirmed: observed == entryView,
@@ -217,6 +261,14 @@ enum ControlsViewBooleanParameterWriter {
     private enum ViewChangeResult {
         case confirmed(switched: Bool)
         case refused(ViewSwitchFailure, targetSelectionAttempted: Bool)
+    }
+
+    private typealias ObservedViewResult = Result<PluginWindowView?, ViewEvidenceReadFailure>
+
+    private enum ViewWaitResult {
+        case confirmed
+        case deadlineExpired
+        case readFailed(ViewEvidenceReadFailure)
     }
 
     struct ToggleResult: Sendable, Equatable {
@@ -240,14 +292,27 @@ enum ControlsViewBooleanParameterWriter {
         confirmationTimeout: TimeInterval = viewConfirmationTimeout,
         runtime: AXHelpers.Runtime = .production
     ) -> ViewPreparationResult {
-        let menuButtons = AXHelpers.censusDescendant(
+        let menuButtons: [AXUIElement]
+        switch AXHelpers.censusDescendantResult(
             of: window, role: kAXMenuButtonRole, maxDepth: 5, runtime: runtime
-        ).matches
-        let measured = menuButtons.filter {
-            AXLocalePolicy.pluginWindowViewSwitcher.matches(
-                AXHelpers.getDescription($0, runtime: runtime),
-                mode: .exact
-            )
+        ) {
+        case let .success(census):
+            menuButtons = census.matches
+        case let .failure(error):
+            return .refused(.viewEvidenceReadFailed(.switcherCensus(error)), restoration: nil)
+        }
+        var measured: [AXUIElement] = []
+        for menuButton in menuButtons {
+            let description: String?
+            switch descriptionResult(of: menuButton, runtime: runtime) {
+            case let .success(observed):
+                description = observed
+            case let .failure(error):
+                return .refused(.viewEvidenceReadFailed(.switcherDescription(error)), restoration: nil)
+            }
+            if AXLocalePolicy.pluginWindowViewSwitcher.matches(description, mode: .exact) {
+                measured.append(menuButton)
+            }
         }
         guard measured.count == 1, let switcher = measured.first else {
             if measured.count > 1 {
@@ -256,8 +321,14 @@ enum ControlsViewBooleanParameterWriter {
             return .refused(menuButtons.isEmpty ? .viewSwitcherNotFound : .unmeasuredLocale, restoration: nil)
         }
 
-        guard let entryView = observedView(in: window, runtime: runtime) else {
+        let entryView: PluginWindowView
+        switch observedView(in: window, runtime: runtime) {
+        case let .success(.some(observed)):
+            entryView = observed
+        case .success(nil):
             return .refused(.entryViewNotConfirmed, restoration: nil)
+        case let .failure(error):
+            return .refused(.viewEvidenceReadFailed(error), restoration: nil)
         }
 
         switch switchView(
@@ -300,7 +371,13 @@ enum ControlsViewBooleanParameterWriter {
                         observedStructure: entryView.rawValue
                     )
                 case .refused:
-                    let observed = observedView(in: window, runtime: runtime)
+                    let observed: PluginWindowView?
+                    switch observedView(in: window, runtime: runtime) {
+                    case let .success(view):
+                        observed = view
+                    case .failure:
+                        observed = nil
+                    }
                     restoration = ViewRestoration(
                         attempted: true,
                         confirmed: observed == entryView,
@@ -318,10 +395,9 @@ enum ControlsViewBooleanParameterWriter {
     /// slider anywhere in the window is Editor evidence and wins over every
     /// table shape. Controls is then recognized by at least one row with one
     /// cell, one nonempty AXStaticText label, and a control in that label's
-    /// sibling subtree. This is deliberately not an identity proof for an
-    /// arbitrary label/control table: without the described-slider evidence,
-    /// AX exposes no structural fact that distinguishes such a table from
-    /// Controls.
+    /// sibling subtree. Every census and description read is status-preserving:
+    /// an unreadable Editor signal refuses instead of disappearing and turning
+    /// an arbitrary one-cell table into Controls evidence.
     ///
     /// Measured 2026-09-02, Compressor editor window "Absolute Zero": one
     /// AXTable at depth 2 had AXRows status 0 and 29 rows; every row had exactly
@@ -334,22 +410,57 @@ enum ControlsViewBooleanParameterWriter {
     private static func observedView(
         in window: AXUIElement,
         runtime: AXHelpers.Runtime
-    ) -> PluginWindowView? {
-        let sliders = AXHelpers.censusDescendant(
+    ) -> ObservedViewResult {
+        let sliderDescriptions: [String]
+        switch nativeEditorSliderEvidence(in: window, runtime: runtime) {
+        case let .success(observed):
+            sliderDescriptions = observed
+        case let .failure(error):
+            return .failure(error)
+        }
+        if sliderDescriptions.contains(where: { !$0.isEmpty }) {
+            return .success(.editor)
+        }
+        switch controlsViewStateIsBound(in: window, runtime: runtime) {
+        case .success(true):
+            return .success(.controls)
+        case .success(false):
+            return .success(sliderDescriptions.isEmpty ? nil : .editor)
+        case let .failure(error):
+            return .failure(error)
+        }
+    }
+
+    /// Returns every native-editor slider description, preserving the exact
+    /// census/description failure that would otherwise erase Editor evidence.
+    /// A present-but-empty description is deliberately retained: bare sliders
+    /// still distinguish an unconfirmed window from a Controls table, while
+    /// only nonempty descriptions establish the native Editor view.
+    private static func nativeEditorSliderEvidence(
+        in window: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> Result<[String], ViewEvidenceReadFailure> {
+        let sliders: [AXUIElement]
+        switch AXHelpers.censusDescendantResult(
             of: window, role: kAXSliderRole, maxDepth: 8, runtime: runtime
-        ).matches
-        if sliders.contains(where: { slider in
-            guard let description = AXHelpers.getDescription(slider, runtime: runtime) else {
-                return false
+        ) {
+        case let .success(census):
+            sliders = census.matches
+        case let .failure(error):
+            return .failure(.sliderCensus(error))
+        }
+        var descriptions: [String] = []
+        for slider in sliders {
+            let description: String?
+            switch descriptionResult(of: slider, runtime: runtime) {
+            case let .success(observed):
+                description = observed
+            case let .failure(error):
+                return .failure(.sliderDescription(error))
             }
-            return !description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        }) {
-            return .editor
+            descriptions.append(description?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "")
         }
-        if controlsViewStateIsBound(in: window, runtime: runtime) {
-            return .controls
-        }
-        return sliders.isEmpty ? nil : .editor
+        return .success(descriptions)
     }
 
     private static func switchView(
@@ -361,8 +472,15 @@ enum ControlsViewBooleanParameterWriter {
         forceSelection: Bool = false,
         runtime: AXHelpers.Runtime
     ) -> ViewChangeResult {
-        guard forceSelection || observedView(in: window, runtime: runtime) != targetView else {
-            return .confirmed(switched: false)
+        if !forceSelection {
+            switch observedView(in: window, runtime: runtime) {
+            case let .success(observed) where observed == targetView:
+                return .confirmed(switched: false)
+            case .success:
+                break
+            case let .failure(error):
+                return .refused(.viewEvidenceReadFailed(error), targetSelectionAttempted: false)
+            }
         }
 
         // AX's action status is intentionally not the verdict. Live Logic
@@ -385,13 +503,19 @@ enum ControlsViewBooleanParameterWriter {
         guard menus.count == 1, let menu = menus.first else {
             return .refused(.viewMenuAmbiguous, targetSelectionAttempted: false)
         }
-        let entries = AXLocalePolicy.censusDescendant(
+        let entries: [AXUIElement]
+        switch AXLocalePolicy.censusDescendantResult(
             of: menu,
             role: kAXMenuItemRole,
             matching: targetView.labels,
             maxDepth: 3,
             runtime: runtime
-        ).matches
+        ) {
+        case let .success(census):
+            entries = census.matches
+        case let .failure(error):
+            return .refused(.viewEvidenceReadFailed(.menuItemCensus(error)), targetSelectionAttempted: false)
+        }
         guard entries.count == 1, let target = entries.first else {
             return .refused(entries.isEmpty
                 ? .viewMenuItemNotFound(targetView)
@@ -400,13 +524,18 @@ enum ControlsViewBooleanParameterWriter {
             )
         }
         _ = AXHelpers.performAction(target, kAXPickAction as String, runtime: runtime)
-        guard waitForView(
+        switch waitForView(
             targetView,
             in: window,
             timeout: confirmationTimeout,
             runtime: runtime
-        ) else {
+        ) {
+        case .confirmed:
+            break
+        case .deadlineExpired:
             return .refused(.viewStructureDidNotConfirm(targetView), targetSelectionAttempted: true)
+        case let .readFailed(error):
+            return .refused(.viewEvidenceReadFailed(error), targetSelectionAttempted: true)
         }
         return .confirmed(switched: true)
     }
@@ -513,62 +642,100 @@ enum ControlsViewBooleanParameterWriter {
         in window: AXUIElement,
         timeout: TimeInterval,
         runtime: AXHelpers.Runtime
-    ) -> Bool {
+    ) -> ViewWaitResult {
         let deadline = Date().addingTimeInterval(max(0, timeout))
         repeat {
-            if observedView(in: window, runtime: runtime) == expected {
-                return true
+            switch observedView(in: window, runtime: runtime) {
+            case let .success(observed) where observed == expected:
+                return .confirmed
+            case .success:
+                break
+            case let .failure(error):
+                return .readFailed(error)
             }
             let remaining = deadline.timeIntervalSinceNow
             guard remaining > 0 else { break }
             Thread.sleep(forTimeInterval: min(viewConfirmationPollInterval, remaining))
         } while Date() < deadline
-        return false
+        return .deadlineExpired
     }
 
     private static func controlsViewStateIsBound(
         in window: AXUIElement,
         runtime: AXHelpers.Runtime
-    ) -> Bool {
-        let tables = AXHelpers.censusDescendant(
+    ) -> Result<Bool, ViewEvidenceReadFailure> {
+        let tables: [AXUIElement]
+        switch AXHelpers.censusDescendantResult(
             of: window, role: kAXTableRole, maxDepth: 8, runtime: runtime
-        ).matches
-        guard tables.count == 1, let table = tables.first else { return false }
-        guard case let .success(rows) = controlsRows(in: table, runtime: runtime) else { return false }
+        ) {
+        case let .success(census):
+            tables = census.matches
+        case let .failure(error):
+            return .failure(.controlsTableCensus(error))
+        }
+        guard tables.count == 1, let table = tables.first else { return .success(false) }
+        let rows: [AXUIElement]
+        switch controlsRows(in: table, runtime: runtime) {
+        case let .success(observed):
+            rows = observed
+        case let .failure(error):
+            return .failure(.controlsTableRows(error))
+        }
         // Heading and section rows have no interactive control in the live
         // table. A Controls view is bound by the presence of at least one
         // measured label/control pair, not by requiring every row to be one.
         for row in rows {
             switch rowCarriesParameterPair(row, runtime: runtime) {
             case .success(true):
-                return true
-            case .success(false), .failure:
+                return .success(true)
+            case .success(false):
                 continue
+            case let .failure(error):
+                return .failure(.controlsTableRow(error))
             }
         }
-        return false
+        return .success(false)
     }
 
     /// Resolve a row-label address without positional fallbacks. A candidate
     /// means any interactive AX role that could share the row, so a checkbox
     /// cannot win merely because it happened to be first beside an unqualified
     /// control.
+    ///
+    /// An AXTable is not structurally self-identifying as the parameter table.
+    /// This method accepts one only when the caller has already bound this
+    /// window to the requested plug-in by header identity, this window has one
+    /// table, no described native-editor slider, and one row whose catalogued
+    /// requested label has one sibling control. AX exposes no stronger table
+    /// identity fact; any failed part of that evidence refuses rather than
+    /// weakening it to a missing match.
     static func locate(
         label requestedLabel: String,
         in window: AXUIElement,
         runtime: AXHelpers.Runtime = .production
     ) -> LocateResult {
         let tables: [AXUIElement]
-        switch descendantElements(of: window, maxDepth: 8, runtime: runtime) {
-        case let .success(elements):
-            tables = elements.compactMap { element, role in
-                role == (kAXTableRole as String) ? element : nil
-            }
+        switch AXHelpers.censusDescendantResult(
+            of: window,
+            role: kAXTableRole,
+            maxDepth: 8,
+            runtime: runtime
+        ) {
+        case let .success(census):
+            tables = census.matches
         case .failure:
             return .refused(.accessibilityReadFailed)
         }
         guard tables.count == 1, let table = tables.first else {
             return .refused(tables.isEmpty ? .controlsViewTableNotFound : .controlsViewTableAmbiguous)
+        }
+        switch nativeEditorSliderEvidence(in: window, runtime: runtime) {
+        case let .success(descriptions) where descriptions.allSatisfy(\.isEmpty):
+            break
+        case .success:
+            return .refused(.controlsViewTableNotFound)
+        case .failure:
+            return .refused(.accessibilityReadFailed)
         }
         let rows: [AXUIElement]
         switch controlsRows(in: table, runtime: runtime) {
@@ -910,6 +1077,25 @@ enum ControlsViewBooleanParameterWriter {
         switch read {
         case let .success(value):
             return .success(value as? String)
+        case let .failure(error) where error.isDefinitiveAbsence:
+            return .success(nil)
+        case let .failure(error):
+            return .failure(error)
+        }
+    }
+
+    private static func descriptionResult(
+        of element: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> Result<String?, AXHelpers.AXStatusError> {
+        let read: Result<String?, AXHelpers.AXStatusError> = AXHelpers.getAttributeResult(
+            element,
+            kAXDescriptionAttribute as String,
+            runtime: runtime
+        )
+        switch read {
+        case let .success(value):
+            return .success(value)
         case let .failure(error) where error.isDefinitiveAbsence:
             return .success(nil)
         case let .failure(error):

--- a/Sources/LogicProMCP/HostParameters/ControlsViewBooleanParameterWriter.swift
+++ b/Sources/LogicProMCP/HostParameters/ControlsViewBooleanParameterWriter.swift
@@ -104,6 +104,16 @@ enum ControlsViewBooleanParameterWriter {
         }
     }
 
+    struct ViewStructureObservation: Sendable, Equatable {
+        /// Counts are taken by a fresh classifier census at the structure
+        /// deadline. `nil` means that exact count could not be read then; it is
+        /// not a zero inferred from an unreadable AX subtree.
+        let tableCount: Int?
+        let rowCount: Int?
+        let describedSliderCount: Int?
+        let waitedMilliseconds: Int
+    }
+
     enum ViewSwitchFailure: Sendable, Equatable {
         case viewSwitcherNotFound
         case viewSwitcherAmbiguous
@@ -116,7 +126,7 @@ enum ControlsViewBooleanParameterWriter {
         case viewMenuItemNotFound(PluginWindowView)
         case viewMenuItemAmbiguous(PluginWindowView)
         case viewMenuItemDisabled(PluginWindowView)
-        case viewStructureDidNotConfirm(PluginWindowView)
+        case viewStructureDidNotConfirm(PluginWindowView, ViewStructureObservation)
 
         var observation: String {
             switch self {
@@ -142,8 +152,46 @@ enum ControlsViewBooleanParameterWriter {
                 return "the scoped View menu exposed several measured \(view.labels.canonical) items"
             case let .viewMenuItemDisabled(view):
                 return "the scoped View menu's measured \(view.labels.canonical) item did not expose AXEnabled == true, so AXPick was refused"
-            case let .viewStructureDidNotConfirm(expected):
+            case let .viewStructureDidNotConfirm(expected, _):
                 return "after selecting the measured \(expected.labels.canonical) item, the bound plugin window did not expose the expected \(expected.rawValue) structure before the confirmation deadline"
+            }
+        }
+
+        /// Structured observations for a `plugin_view_not_confirmed` envelope.
+        /// Keep the phase separate from the prose observation so an intermittent
+        /// refusal can be grouped without parsing a user-facing sentence.
+        var responseDiagnostics: [String: Any] {
+            switch self {
+            case .viewMenuDidNotAppearBeforeDeadline:
+                return ["plugin_view_switch_phase": "menu_never_appeared"]
+            case .viewMenuAmbiguous:
+                return ["plugin_view_switch_phase": "menu_ambiguous"]
+            case .viewMenuItemNotFound:
+                return ["plugin_view_switch_phase": "item_not_found"]
+            case .viewMenuItemAmbiguous:
+                return ["plugin_view_switch_phase": "item_ambiguous"]
+            case .viewMenuItemDisabled:
+                return ["plugin_view_switch_phase": "item_not_enabled"]
+            case let .viewStructureDidNotConfirm(_, observed):
+                return [
+                    "plugin_view_switch_phase": "pick_performed_structure_never_confirmed",
+                    "plugin_view_structure_table_count": observed.tableCount ?? NSNull(),
+                    "plugin_view_structure_row_count": observed.rowCount ?? NSNull(),
+                    "plugin_view_structure_described_slider_count": observed.describedSliderCount ?? NSNull(),
+                    "plugin_view_structure_waited_ms": observed.waitedMilliseconds,
+                ]
+            case .viewSwitcherNotFound:
+                return ["plugin_view_switch_phase": "switcher_not_found"]
+            case .viewSwitcherAmbiguous:
+                return ["plugin_view_switch_phase": "switcher_ambiguous"]
+            case .unmeasuredLocale:
+                return ["plugin_view_switch_phase": "switcher_locale_unmeasured"]
+            case .entryViewNotConfirmed:
+                return ["plugin_view_switch_phase": "entry_view_not_confirmed"]
+            case .viewEvidenceReadFailed:
+                return ["plugin_view_switch_phase": "view_evidence_read_failed"]
+            case .viewMenuReadFailed:
+                return ["plugin_view_switch_phase": "menu_read_failed"]
             }
         }
     }
@@ -197,7 +245,7 @@ enum ControlsViewBooleanParameterWriter {
     /// exact entry view on every exit path, including a locator refusal.
     final class ViewSession: @unchecked Sendable {
         private let window: AXUIElement
-        private let switcher: AXUIElement?
+        private let windowRefresher: () -> AXUIElement?
         private let entryView: PluginWindowView
         private let didSwitch: Bool
         private let menuAppearanceTimeout: TimeInterval
@@ -206,14 +254,14 @@ enum ControlsViewBooleanParameterWriter {
 
         fileprivate init(
             window: AXUIElement,
-            switcher: AXUIElement?,
+            windowRefresher: @escaping () -> AXUIElement?,
             entryView: PluginWindowView,
             didSwitch: Bool,
             menuAppearanceTimeout: TimeInterval,
             runtime: AXHelpers.Runtime
         ) {
             self.window = window
-            self.switcher = switcher
+            self.windowRefresher = windowRefresher
             self.entryView = entryView
             self.didSwitch = didSwitch
             self.menuAppearanceTimeout = menuAppearanceTimeout
@@ -234,7 +282,7 @@ enum ControlsViewBooleanParameterWriter {
                 )
             }
             restorationFinished = true
-            guard didSwitch, let switcher else {
+            guard didSwitch else {
                 return ViewRestoration(
                     attempted: false,
                     confirmed: true,
@@ -245,7 +293,7 @@ enum ControlsViewBooleanParameterWriter {
             switch switchView(
                 to: entryView,
                 in: window,
-                switcher: switcher,
+                windowRefresher: windowRefresher,
                 menuAppearanceTimeout: menuAppearanceTimeout,
                 confirmationTimeout: viewConfirmationTimeout,
                 runtime: runtime
@@ -259,7 +307,8 @@ enum ControlsViewBooleanParameterWriter {
                 )
             case .refused:
                 let observed: PluginWindowView?
-                if case let .success(.some(value)) = observedView(in: window, runtime: runtime) {
+                let currentWindow = refreshedWindow(window, windowRefresher: windowRefresher)
+                if case let .success(.some(value)) = observedView(in: currentWindow, runtime: runtime) {
                     observed = value
                 } else {
                     observed = nil
@@ -281,7 +330,7 @@ enum ControlsViewBooleanParameterWriter {
 
     private enum ViewWaitResult {
         case confirmed
-        case deadlineExpired
+        case deadlineExpired(ViewStructureObservation)
         case readFailed(ViewEvidenceReadFailure)
     }
 
@@ -305,10 +354,15 @@ enum ControlsViewBooleanParameterWriter {
         in window: AXUIElement,
         menuAppearanceTimeout: TimeInterval = viewMenuAppearanceTimeout,
         confirmationTimeout: TimeInterval = viewConfirmationTimeout,
+        windowRefresher: (() -> AXUIElement?)? = nil,
         runtime: AXHelpers.Runtime = .production
     ) -> ViewPreparationResult {
+        let effectiveWindowRefresher = windowRefresher ?? { window }
         let entryView: PluginWindowView
-        let entryObservation = observedView(in: window, runtime: runtime)
+        let entryObservation = observedView(
+            in: refreshedWindow(window, windowRefresher: effectiveWindowRefresher),
+            runtime: runtime
+        )
         switch entryObservation {
         case let .success(.some(observed)):
             entryView = observed
@@ -325,7 +379,7 @@ enum ControlsViewBooleanParameterWriter {
         guard entryView != targetView else {
             return .ready(ViewSession(
                 window: window,
-                switcher: nil,
+                windowRefresher: effectiveWindowRefresher,
                 entryView: entryView,
                 didSwitch: false,
                 menuAppearanceTimeout: menuAppearanceTimeout,
@@ -333,47 +387,10 @@ enum ControlsViewBooleanParameterWriter {
             ))
         }
 
-        let menuButtons: [AXUIElement]
-        switch AXHelpers.censusDescendantResult(
-            of: window, role: kAXMenuButtonRole, maxDepth: 5, runtime: runtime
-        ) {
-        case let .success(census):
-            menuButtons = census.matches
-        case let .failure(error):
-            return .refused(.viewEvidenceReadFailed(.switcherCensus(error)), restoration: nil)
-        }
-        var measured: [AXUIElement] = []
-        var firstSwitcherDescriptionReadFailure: AXHelpers.AXStatusError?
-        for menuButton in menuButtons {
-            let description: String?
-            switch descriptionResult(of: menuButton, runtime: runtime) {
-            case let .success(observed):
-                description = observed
-            case let .failure(error):
-                firstSwitcherDescriptionReadFailure = firstSwitcherDescriptionReadFailure ?? error
-                continue
-            }
-            if AXLocalePolicy.pluginWindowViewSwitcher.matches(description, mode: .exact) {
-                measured.append(menuButton)
-            }
-        }
-        guard measured.count == 1, let switcher = measured.first else {
-            if measured.count > 1 {
-                return .refused(.viewSwitcherAmbiguous, restoration: nil)
-            }
-            if let firstSwitcherDescriptionReadFailure {
-                return .refused(
-                    .viewEvidenceReadFailed(.switcherDescription(firstSwitcherDescriptionReadFailure)),
-                    restoration: nil
-                )
-            }
-            return .refused(menuButtons.isEmpty ? .viewSwitcherNotFound : .unmeasuredLocale, restoration: nil)
-        }
-
         switch switchView(
             to: targetView,
             in: window,
-            switcher: switcher,
+            windowRefresher: effectiveWindowRefresher,
             menuAppearanceTimeout: menuAppearanceTimeout,
             confirmationTimeout: confirmationTimeout,
             runtime: runtime
@@ -381,7 +398,7 @@ enum ControlsViewBooleanParameterWriter {
         case let .confirmed(switched):
             return .ready(ViewSession(
                 window: window,
-                switcher: switcher,
+                windowRefresher: effectiveWindowRefresher,
                 entryView: entryView,
                 didSwitch: switched,
                 menuAppearanceTimeout: menuAppearanceTimeout,
@@ -397,7 +414,7 @@ enum ControlsViewBooleanParameterWriter {
                 switch switchView(
                     to: entryView,
                     in: window,
-                    switcher: switcher,
+                    windowRefresher: effectiveWindowRefresher,
                     menuAppearanceTimeout: menuAppearanceTimeout,
                     confirmationTimeout: confirmationTimeout,
                     forceSelection: true,
@@ -412,7 +429,8 @@ enum ControlsViewBooleanParameterWriter {
                     )
                 case .refused:
                     let observed: PluginWindowView?
-                    if case let .success(.some(value)) = observedView(in: window, runtime: runtime) {
+                    let currentWindow = refreshedWindow(window, windowRefresher: effectiveWindowRefresher)
+                    if case let .success(.some(value)) = observedView(in: currentWindow, runtime: runtime) {
                         observed = value
                     } else {
                         observed = nil
@@ -512,17 +530,84 @@ enum ControlsViewBooleanParameterWriter {
         return firstFailure.map(SliderEvidence.readFailed) ?? .notDescribed
     }
 
+    /// A view pick can re-render the editor subtree. Never carry the old
+    /// AXMenuButton over that boundary: bind a current, uniquely described
+    /// switcher immediately before every AXPress, including restoration.
+    private enum MeasuredViewSwitcherResult {
+        case found(AXUIElement)
+        case refused(ViewSwitchFailure)
+    }
+
+    private static func measuredViewSwitcher(
+        in window: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> MeasuredViewSwitcherResult {
+        let menuButtons: [AXUIElement]
+        switch AXHelpers.censusDescendantResult(
+            of: window, role: kAXMenuButtonRole, maxDepth: 5, runtime: runtime
+        ) {
+        case let .success(census):
+            menuButtons = census.matches
+        case let .failure(error):
+            return .refused(.viewEvidenceReadFailed(.switcherCensus(error)))
+        }
+        var measured: [AXUIElement] = []
+        var firstSwitcherDescriptionReadFailure: AXHelpers.AXStatusError?
+        for menuButton in menuButtons {
+            let description: String?
+            switch descriptionResult(of: menuButton, runtime: runtime) {
+            case let .success(observed):
+                description = observed
+            case let .failure(error):
+                firstSwitcherDescriptionReadFailure = firstSwitcherDescriptionReadFailure ?? error
+                continue
+            }
+            if AXLocalePolicy.pluginWindowViewSwitcher.matches(description, mode: .exact) {
+                measured.append(menuButton)
+            }
+        }
+        guard measured.count == 1, let switcher = measured.first else {
+            if measured.count > 1 {
+                return .refused(.viewSwitcherAmbiguous)
+            }
+            if let firstSwitcherDescriptionReadFailure {
+                return .refused(.viewEvidenceReadFailed(.switcherDescription(firstSwitcherDescriptionReadFailure)))
+            }
+            return .refused(menuButtons.isEmpty ? .viewSwitcherNotFound : .unmeasuredLocale)
+        }
+        return .found(switcher)
+    }
+
+    private static func refreshedWindow(
+        _ fallback: AXUIElement,
+        windowRefresher: @escaping () -> AXUIElement?
+    ) -> AXUIElement {
+        windowRefresher() ?? fallback
+    }
+
     private static func switchView(
         to targetView: PluginWindowView,
         in window: AXUIElement,
-        switcher: AXUIElement,
+        windowRefresher: @escaping () -> AXUIElement?,
         menuAppearanceTimeout: TimeInterval,
         confirmationTimeout: TimeInterval,
         forceSelection: Bool = false,
         runtime: AXHelpers.Runtime
     ) -> ViewChangeResult {
+        let currentWindow = refreshedWindow(window, windowRefresher: windowRefresher)
         if !forceSelection {
-            switch observedView(in: window, runtime: runtime) {
+            // Preserve the fail-closed preflight: if no uniquely described
+            // switcher can be read, refuse before treating a concurrent view
+            // observation as a reason to skip selection. Do not retain this
+            // element, though; the action below measures it again after the
+            // view check in case Logic re-rendered in between.
+            switch measuredViewSwitcher(in: currentWindow, runtime: runtime) {
+            case .found:
+                break
+            case let .refused(error):
+                return .refused(error, targetSelectionAttempted: false)
+            }
+            switch observedView(in: currentWindow, runtime: runtime) {
             case let .success(.some(observed)) where observed == targetView:
                 return .confirmed(switched: false)
             case let .failure(error):
@@ -530,6 +615,15 @@ enum ControlsViewBooleanParameterWriter {
             case .success:
                 break
             }
+        }
+
+        let switcher: AXUIElement
+        let actionWindow = refreshedWindow(window, windowRefresher: windowRefresher)
+        switch measuredViewSwitcher(in: actionWindow, runtime: runtime) {
+        case let .found(observed):
+            switcher = observed
+        case let .refused(error):
+            return .refused(error, targetSelectionAttempted: false)
         }
 
         // AX's action status is intentionally not the verdict. Live Logic
@@ -588,22 +682,34 @@ enum ControlsViewBooleanParameterWriter {
         switch waitForView(
             targetView,
             in: window,
+            windowRefresher: windowRefresher,
             timeout: confirmationTimeout,
             runtime: runtime
         ) {
         case .confirmed:
             break
-        case .deadlineExpired:
-            return .refused(.viewStructureDidNotConfirm(targetView), targetSelectionAttempted: true)
+        case let .deadlineExpired(observed):
+            return .refused(
+                .viewStructureDidNotConfirm(targetView, observed),
+                targetSelectionAttempted: true
+            )
         case let .readFailed(error):
             return .refused(.viewEvidenceReadFailed(error), targetSelectionAttempted: true)
         }
         return .confirmed(switched: true)
     }
 
+    /// Measured on the live Compressor on 2026-09-03 with a 25 ms poll:
+    /// AXPress → scoped View menu was 28–46 ms across ten switches (and 32–46
+    /// ms across five first switches immediately after opening the editor).
     private static let viewMenuAppearanceTimeout: TimeInterval = 2.0
     private static let viewMenuAppearancePollInterval: TimeInterval = 0.05
-    private static let viewConfirmationTimeout: TimeInterval = 1.5
+    /// Measured on the live Compressor on 2026-09-03 with a 25 ms poll:
+    /// AXPick → structural confirmation was 527–785 ms across ten switches;
+    /// five first switches immediately after opening the editor were 529–711
+    /// ms. Three seconds is about a 4× margin over the 785 ms maximum, not an
+    /// unmeasured timing increase.
+    private static let viewConfirmationTimeout: TimeInterval = 3.0
     private static let viewConfirmationPollInterval: TimeInterval = 0.05
 
     private enum ScopedViewMenuWaitResult {
@@ -701,12 +807,15 @@ enum ControlsViewBooleanParameterWriter {
     private static func waitForView(
         _ expected: PluginWindowView,
         in window: AXUIElement,
+        windowRefresher: @escaping () -> AXUIElement?,
         timeout: TimeInterval,
         runtime: AXHelpers.Runtime
     ) -> ViewWaitResult {
-        let deadline = Date().addingTimeInterval(max(0, timeout))
+        let started = Date()
+        let deadline = started.addingTimeInterval(max(0, timeout))
         repeat {
-            switch observedView(in: window, runtime: runtime) {
+            let currentWindow = refreshedWindow(window, windowRefresher: windowRefresher)
+            switch observedView(in: currentWindow, runtime: runtime) {
             case let .success(.some(observed)) where observed == expected:
                 return .confirmed
             case let .failure(error):
@@ -718,7 +827,80 @@ enum ControlsViewBooleanParameterWriter {
             guard remaining > 0 else { break }
             Thread.sleep(forTimeInterval: min(viewConfirmationPollInterval, remaining))
         } while Date() < deadline
-        return .deadlineExpired
+        // Read a fresh structural snapshot *after* the deadline, rather than
+        // reporting the previous poll as though it were an end-of-wait fact.
+        let deadlineWindow = refreshedWindow(window, windowRefresher: windowRefresher)
+        return .deadlineExpired(viewStructureObservation(
+            in: deadlineWindow,
+            waitedMilliseconds: Int((Date().timeIntervalSince(started) * 1_000).rounded()),
+            runtime: runtime
+        ))
+    }
+
+    private static func viewStructureObservation(
+        in window: AXUIElement,
+        waitedMilliseconds: Int,
+        runtime: AXHelpers.Runtime
+    ) -> ViewStructureObservation {
+        let sliders: [AXUIElement]?
+        switch AXHelpers.censusDescendantResult(
+            of: window, role: kAXSliderRole, maxDepth: 8, runtime: runtime
+        ) {
+        case let .success(census):
+            sliders = census.matches
+        case .failure:
+            sliders = nil
+        }
+        let describedSliderCount: Int?
+        if let sliders {
+            var count = 0
+            var descriptionWasUnreadable = false
+            for slider in sliders {
+                switch descriptionResult(of: slider, runtime: runtime) {
+                case let .success(description):
+                    if !(description?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true) {
+                        count += 1
+                    }
+                case .failure:
+                    descriptionWasUnreadable = true
+                }
+            }
+            describedSliderCount = descriptionWasUnreadable ? nil : count
+        } else {
+            describedSliderCount = nil
+        }
+
+        let tables: [AXUIElement]?
+        switch AXHelpers.censusDescendantResult(
+            of: window, role: kAXTableRole, maxDepth: 8, runtime: runtime
+        ) {
+        case let .success(census):
+            tables = census.matches
+        case .failure:
+            tables = nil
+        }
+        let rowCount: Int?
+        if let tables {
+            var count = 0
+            var rowsWereUnreadable = false
+            for table in tables {
+                switch controlsRows(in: table, runtime: runtime) {
+                case let .success(rows):
+                    count += rows.count
+                case .failure:
+                    rowsWereUnreadable = true
+                }
+            }
+            rowCount = rowsWereUnreadable ? nil : count
+        } else {
+            rowCount = nil
+        }
+        return ViewStructureObservation(
+            tableCount: tables?.count,
+            rowCount: rowCount,
+            describedSliderCount: describedSliderCount,
+            waitedMilliseconds: waitedMilliseconds
+        )
     }
 
     private enum ControlsTableEvidence {

--- a/Sources/LogicProMCP/HostParameters/ControlsViewBooleanParameterWriter.swift
+++ b/Sources/LogicProMCP/HostParameters/ControlsViewBooleanParameterWriter.swift
@@ -79,12 +79,22 @@ enum ControlsViewBooleanParameterWriter {
     /// read therefore refuses instead of silently dropping a candidate and
     /// risking an action on a different element.
     enum ViewEvidenceReadFailure: Error, Sendable, Equatable {
+        enum Source: Sendable, Equatable {
+            case switcherCensus
+            case switcherDescription
+            case menuItemCensus
+            case menuItemEnabled
+            case sliderCensus
+            case sliderDescription
+        }
+
         case switcherCensus(AXHelpers.AXStatusError)
         case switcherDescription(AXHelpers.AXStatusError)
         case menuItemCensus(AXHelpers.AXStatusError)
         case menuItemEnabled(AXHelpers.AXStatusError)
         case sliderCensus(AXHelpers.AXStatusError)
         case sliderDescription(AXHelpers.AXStatusError)
+        case invalidUIElementRereadExhausted(Source, attempts: Int)
 
         var observation: String {
             switch self {
@@ -100,6 +110,57 @@ enum ControlsViewBooleanParameterWriter {
                 return "the plugin-window AXSlider census failed (AXChildren/AXRole status \(error.diagnosticLabel))"
             case let .sliderDescription(error):
                 return "a plugin-window AXSlider AXDescription read failed (status \(error.diagnosticLabel))"
+            case let .invalidUIElementRereadExhausted(source, attempts):
+                return "\(Self.observation(for: source, status: AXError.invalidUIElement.rawValue)) after \(attempts) attempts; the bound plugin window was re-resolved before each re-read"
+            }
+        }
+
+        /// `kAXErrorInvalidUIElement` means Logic replaced part of this view's
+        /// AX tree while its census was walking it (2026-09-03). The read says
+        /// neither that a candidate is absent nor that the window is durably
+        /// unreadable, so the honest response is to re-resolve the bound window
+        /// and take the structural evidence again.
+        var invalidUIElementSource: Source? {
+            switch self {
+            case let .switcherCensus(error) where error.raw == AXError.invalidUIElement.rawValue:
+                return .switcherCensus
+            case let .switcherDescription(error) where error.raw == AXError.invalidUIElement.rawValue:
+                return .switcherDescription
+            case let .menuItemCensus(error) where error.raw == AXError.invalidUIElement.rawValue:
+                return .menuItemCensus
+            case let .menuItemEnabled(error) where error.raw == AXError.invalidUIElement.rawValue:
+                return .menuItemEnabled
+            case let .sliderCensus(error) where error.raw == AXError.invalidUIElement.rawValue:
+                return .sliderCensus
+            case let .sliderDescription(error) where error.raw == AXError.invalidUIElement.rawValue:
+                return .sliderDescription
+            case .switcherCensus, .switcherDescription, .menuItemCensus, .menuItemEnabled,
+                 .sliderCensus, .sliderDescription, .invalidUIElementRereadExhausted:
+                return nil
+            }
+        }
+
+        var invalidUIElementRereadAttempts: Int? {
+            guard case let .invalidUIElementRereadExhausted(_, attempts) = self else {
+                return nil
+            }
+            return attempts
+        }
+
+        private static func observation(for source: Source, status: Int32) -> String {
+            switch source {
+            case .switcherCensus:
+                return "the plugin-window View-switcher census failed (AXChildren/AXRole status \(status))"
+            case .switcherDescription:
+                return "the plugin-window View-switcher AXDescription read failed (status \(status))"
+            case .menuItemCensus:
+                return "the scoped View-menu item census failed (AXChildren/AXRole/AXTitle/AXDescription status \(status))"
+            case .menuItemEnabled:
+                return "the scoped View-menu item's AXEnabled read failed (status \(status))"
+            case .sliderCensus:
+                return "the plugin-window AXSlider census failed (AXChildren/AXRole status \(status))"
+            case .sliderDescription:
+                return "a plugin-window AXSlider AXDescription read failed (status \(status))"
             }
         }
     }
@@ -114,7 +175,7 @@ enum ControlsViewBooleanParameterWriter {
         let waitedMilliseconds: Int
     }
 
-    enum ViewSwitchFailure: Sendable, Equatable {
+    enum ViewSwitchFailure: Error, Sendable, Equatable {
         case viewSwitcherNotFound
         case viewSwitcherAmbiguous
         case unmeasuredLocale
@@ -188,11 +249,22 @@ enum ControlsViewBooleanParameterWriter {
                 return ["plugin_view_switch_phase": "switcher_locale_unmeasured"]
             case .entryViewNotConfirmed:
                 return ["plugin_view_switch_phase": "entry_view_not_confirmed"]
-            case .viewEvidenceReadFailed:
-                return ["plugin_view_switch_phase": "view_evidence_read_failed"]
+            case let .viewEvidenceReadFailed(error):
+                var diagnostics: [String: Any] = ["plugin_view_switch_phase": "view_evidence_read_failed"]
+                if let attempts = error.invalidUIElementRereadAttempts {
+                    diagnostics["plugin_view_evidence_read_attempts"] = attempts
+                }
+                return diagnostics
             case .viewMenuReadFailed:
                 return ["plugin_view_switch_phase": "menu_read_failed"]
             }
+        }
+
+        fileprivate var invalidUIElementSource: ViewEvidenceReadFailure.Source? {
+            guard case let .viewEvidenceReadFailed(error) = self else {
+                return nil
+            }
+            return error.invalidUIElementSource
         }
     }
 
@@ -307,8 +379,11 @@ enum ControlsViewBooleanParameterWriter {
                 )
             case .refused:
                 let observed: PluginWindowView?
-                let currentWindow = refreshedWindow(window, windowRefresher: windowRefresher)
-                if case let .success(.some(value)) = observedView(in: currentWindow, runtime: runtime) {
+                if case let .success(.some(value)) = observedView(
+                    in: window,
+                    windowRefresher: windowRefresher,
+                    runtime: runtime
+                ) {
                     observed = value
                 } else {
                     observed = nil
@@ -360,7 +435,8 @@ enum ControlsViewBooleanParameterWriter {
         let effectiveWindowRefresher = windowRefresher ?? { window }
         let entryView: PluginWindowView
         let entryObservation = observedView(
-            in: refreshedWindow(window, windowRefresher: effectiveWindowRefresher),
+            in: window,
+            windowRefresher: effectiveWindowRefresher,
             runtime: runtime
         )
         switch entryObservation {
@@ -429,8 +505,11 @@ enum ControlsViewBooleanParameterWriter {
                     )
                 case .refused:
                     let observed: PluginWindowView?
-                    let currentWindow = refreshedWindow(window, windowRefresher: effectiveWindowRefresher)
-                    if case let .success(.some(value)) = observedView(in: currentWindow, runtime: runtime) {
+                    if case let .success(.some(value)) = observedView(
+                        in: window,
+                        windowRefresher: effectiveWindowRefresher,
+                        runtime: runtime
+                    ) {
                         observed = value
                     } else {
                         observed = nil
@@ -471,6 +550,31 @@ enum ControlsViewBooleanParameterWriter {
     /// label/control. The two slider-shaped candidates are intentionally still
     /// ambiguous; this locator never chooses one by traversal position.
     private static func observedView(
+        in window: AXUIElement,
+        windowRefresher: @escaping () -> AXUIElement?,
+        runtime: AXHelpers.Runtime
+    ) -> Result<PluginWindowView?, ViewEvidenceReadFailure> {
+        var attempts = 0
+        while true {
+            attempts += 1
+            let currentWindow = refreshedWindow(window, windowRefresher: windowRefresher)
+            let observation = observedViewOnce(in: currentWindow, runtime: runtime)
+            switch observation {
+            case .success:
+                return observation
+            case let .failure(error):
+                guard let source = error.invalidUIElementSource else {
+                    return observation
+                }
+                guard attempts <= viewEvidenceInvalidUIElementExtraAttempts else {
+                    return .failure(.invalidUIElementRereadExhausted(source, attempts: attempts))
+                }
+                Thread.sleep(forTimeInterval: viewEvidenceInvalidUIElementRereadPause)
+            }
+        }
+    }
+
+    private static func observedViewOnce(
         in window: AXUIElement,
         runtime: AXHelpers.Runtime
     ) -> Result<PluginWindowView?, ViewEvidenceReadFailure> {
@@ -540,6 +644,28 @@ enum ControlsViewBooleanParameterWriter {
 
     private static func measuredViewSwitcher(
         in window: AXUIElement,
+        windowRefresher: @escaping () -> AXUIElement?,
+        runtime: AXHelpers.Runtime
+    ) -> MeasuredViewSwitcherResult {
+        let retried = retryInvalidUIElementViewEvidence {
+            let currentWindow = refreshedWindow(window, windowRefresher: windowRefresher)
+            switch measuredViewSwitcherOnce(in: currentWindow, runtime: runtime) {
+            case let .found(switcher):
+                return .success(switcher)
+            case let .refused(failure):
+                return .failure(failure)
+            }
+        }
+        switch retried {
+        case let .success(switcher):
+            return .found(switcher)
+        case let .failure(failure):
+            return .refused(failure)
+        }
+    }
+
+    private static func measuredViewSwitcherOnce(
+        in window: AXUIElement,
         runtime: AXHelpers.Runtime
     ) -> MeasuredViewSwitcherResult {
         let menuButtons: [AXUIElement]
@@ -578,6 +704,30 @@ enum ControlsViewBooleanParameterWriter {
         return .found(switcher)
     }
 
+    private static func retryInvalidUIElementViewEvidence<Value>(
+        _ read: () -> Result<Value, ViewSwitchFailure>
+    ) -> Result<Value, ViewSwitchFailure> {
+        var attempts = 0
+        while true {
+            attempts += 1
+            let result = read()
+            switch result {
+            case .success:
+                return result
+            case let .failure(failure):
+                guard let source = failure.invalidUIElementSource else {
+                    return result
+                }
+                guard attempts <= viewEvidenceInvalidUIElementExtraAttempts else {
+                    return .failure(.viewEvidenceReadFailed(
+                        .invalidUIElementRereadExhausted(source, attempts: attempts)
+                    ))
+                }
+                Thread.sleep(forTimeInterval: viewEvidenceInvalidUIElementRereadPause)
+            }
+        }
+    }
+
     private static func refreshedWindow(
         _ fallback: AXUIElement,
         windowRefresher: @escaping () -> AXUIElement?
@@ -594,20 +744,27 @@ enum ControlsViewBooleanParameterWriter {
         forceSelection: Bool = false,
         runtime: AXHelpers.Runtime
     ) -> ViewChangeResult {
-        let currentWindow = refreshedWindow(window, windowRefresher: windowRefresher)
         if !forceSelection {
             // Preserve the fail-closed preflight: if no uniquely described
             // switcher can be read, refuse before treating a concurrent view
             // observation as a reason to skip selection. Do not retain this
             // element, though; the action below measures it again after the
             // view check in case Logic re-rendered in between.
-            switch measuredViewSwitcher(in: currentWindow, runtime: runtime) {
+            switch measuredViewSwitcher(
+                in: window,
+                windowRefresher: windowRefresher,
+                runtime: runtime
+            ) {
             case .found:
                 break
             case let .refused(error):
                 return .refused(error, targetSelectionAttempted: false)
             }
-            switch observedView(in: currentWindow, runtime: runtime) {
+            switch observedView(
+                in: window,
+                windowRefresher: windowRefresher,
+                runtime: runtime
+            ) {
             case let .success(.some(observed)) where observed == targetView:
                 return .confirmed(switched: false)
             case let .failure(error):
@@ -618,8 +775,11 @@ enum ControlsViewBooleanParameterWriter {
         }
 
         let switcher: AXUIElement
-        let actionWindow = refreshedWindow(window, windowRefresher: windowRefresher)
-        switch measuredViewSwitcher(in: actionWindow, runtime: runtime) {
+        switch measuredViewSwitcher(
+            in: window,
+            windowRefresher: windowRefresher,
+            runtime: runtime
+        ) {
         case let .found(observed):
             switcher = observed
         case let .refused(error):
@@ -711,6 +871,12 @@ enum ControlsViewBooleanParameterWriter {
     /// unmeasured timing increase.
     private static let viewConfirmationTimeout: TimeInterval = 3.0
     private static let viewConfirmationPollInterval: TimeInterval = 0.05
+    /// `kAXErrorInvalidUIElement` (-25202) is a view re-render invalidating an
+    /// in-flight structural census, not proof of an absent control. On
+    /// 2026-09-03 AXPick → structure settled in 527–785 ms, so each of the two
+    /// bounded re-reads pauses for this measured 50 ms confirmation-poll step.
+    private static let viewEvidenceInvalidUIElementExtraAttempts = 2
+    private static let viewEvidenceInvalidUIElementRereadPause = viewConfirmationPollInterval
 
     private enum ScopedViewMenuWaitResult {
         case found([AXUIElement])
@@ -814,8 +980,11 @@ enum ControlsViewBooleanParameterWriter {
         let started = Date()
         let deadline = started.addingTimeInterval(max(0, timeout))
         repeat {
-            let currentWindow = refreshedWindow(window, windowRefresher: windowRefresher)
-            switch observedView(in: currentWindow, runtime: runtime) {
+            switch observedView(
+                in: window,
+                windowRefresher: windowRefresher,
+                runtime: runtime
+            ) {
             case let .success(.some(observed)) where observed == expected:
                 return .confirmed
             case let .failure(error):

--- a/Sources/LogicProMCP/HostParameters/ControlsViewBooleanParameterWriter.swift
+++ b/Sources/LogicProMCP/HostParameters/ControlsViewBooleanParameterWriter.swift
@@ -20,6 +20,7 @@ enum ControlsViewBooleanParameterWriter {
         case rowStructureInvalid
         case controlMissing
         case controlAmbiguous
+        case accessibilityReadFailed
         case checkboxNotFound
         case sliderNotActuable
         case popupUnmeasured
@@ -38,11 +39,13 @@ enum ControlsViewBooleanParameterWriter {
             case .rowLabelNotFound:
                 return "no Controls-view AXRow label matched the requested parameter"
             case .rowStructureInvalid:
-                return "the labelled Controls-view AXRow did not place its label and control in sibling AXCells"
+                return "the labelled Controls-view AXRow did not expose one AXCell with its label and control as siblings"
             case .controlMissing:
                 return "the labelled Controls-view AXRow exposes no candidate control"
             case .controlAmbiguous:
                 return "the labelled Controls-view AXRow exposes several candidate controls; no control was chosen by position"
+            case .accessibilityReadFailed:
+                return "an AX role, child list, or label-value read failed while binding the Controls-view AXRow; no partially classified control was used"
             case .checkboxNotFound:
                 return "the labelled Controls-view AXRow did not resolve to an AXCheckBox"
             case .sliderNotActuable:
@@ -134,7 +137,7 @@ enum ControlsViewBooleanParameterWriter {
 
     enum ViewPreparationResult {
         case ready(ViewSession)
-        case refused(ViewSwitchFailure)
+        case refused(ViewSwitchFailure, restoration: ViewRestoration?)
     }
 
     struct ViewRestoration: Sendable, Equatable {
@@ -170,9 +173,10 @@ enum ControlsViewBooleanParameterWriter {
             self.runtime = runtime
         }
 
-        /// Restoration is idempotent. A failed restore is logged and exposed
-        /// in successful write metadata by the caller; the already-observed
-        /// parameter-write verdict is never recast as though it had not run.
+        /// Restoration is idempotent. Its observed outcome is serialized by the
+        /// caller before it returns either a successful write or a State C; the
+        /// already-observed parameter-write verdict is never recast as though it
+        /// had not run.
         func restore() -> ViewRestoration {
             guard !restorationFinished else {
                 return ViewRestoration(attempted: false, confirmed: true, observedStructure: nil)
@@ -200,10 +204,11 @@ enum ControlsViewBooleanParameterWriter {
                     observedStructure: entryView.rawValue
                 )
             case .refused:
+                let observed = observedView(in: window, runtime: runtime)
                 return ViewRestoration(
                     attempted: true,
-                    confirmed: false,
-                    observedStructure: observedView(in: window, runtime: runtime)?.rawValue
+                    confirmed: observed == entryView,
+                    observedStructure: observed?.rawValue
                 )
             }
         }
@@ -246,13 +251,13 @@ enum ControlsViewBooleanParameterWriter {
         }
         guard measured.count == 1, let switcher = measured.first else {
             if measured.count > 1 {
-                return .refused(.viewSwitcherAmbiguous)
+                return .refused(.viewSwitcherAmbiguous, restoration: nil)
             }
-            return .refused(menuButtons.isEmpty ? .viewSwitcherNotFound : .unmeasuredLocale)
+            return .refused(menuButtons.isEmpty ? .viewSwitcherNotFound : .unmeasuredLocale, restoration: nil)
         }
 
         guard let entryView = observedView(in: window, runtime: runtime) else {
-            return .refused(.entryViewNotConfirmed)
+            return .refused(.entryViewNotConfirmed, restoration: nil)
         }
 
         switch switchView(
@@ -277,8 +282,9 @@ enum ControlsViewBooleanParameterWriter {
             // target structure did not settle before its deadline. Re-select
             // the entry view best-effort before refusing, so failed selection
             // paths do not strand it.
+            let restoration: ViewRestoration?
             if targetSelectionAttempted {
-                _ = switchView(
+                switch switchView(
                     to: entryView,
                     in: window,
                     switcher: switcher,
@@ -286,18 +292,45 @@ enum ControlsViewBooleanParameterWriter {
                     confirmationTimeout: confirmationTimeout,
                     forceSelection: true,
                     runtime: runtime
-                )
+                ) {
+                case let .confirmed(switched):
+                    restoration = ViewRestoration(
+                        attempted: switched,
+                        confirmed: true,
+                        observedStructure: entryView.rawValue
+                    )
+                case .refused:
+                    let observed = observedView(in: window, runtime: runtime)
+                    restoration = ViewRestoration(
+                        attempted: true,
+                        confirmed: observed == entryView,
+                        observedStructure: observed?.rawValue
+                    )
+                }
+            } else {
+                restoration = nil
             }
-            return .refused(failure)
+            return .refused(failure, restoration: restoration)
         }
     }
 
-    /// The native editor is signaled by a parameter-bearing slider. Controls
-    /// requires at least one AXRow with a nonempty AXStaticText label in one
-    /// AXCell and an interactive control in a sibling AXCell; a browser/preset
-    /// table has no such parameter-control pair, so its rows cannot prove
-    /// Controls. A title-only slider is Editor evidence only when that Controls
-    /// discriminator is absent.
+    /// The native editor is signaled by a parameter-bearing slider. A described
+    /// slider anywhere in the window is Editor evidence and wins over every
+    /// table shape. Controls is then recognized by at least one row with one
+    /// cell, one nonempty AXStaticText label, and a control in that label's
+    /// sibling subtree. This is deliberately not an identity proof for an
+    /// arbitrary label/control table: without the described-slider evidence,
+    /// AX exposes no structural fact that distinguishes such a table from
+    /// Controls.
+    ///
+    /// Measured 2026-09-02, Compressor editor window "Absolute Zero": one
+    /// AXTable at depth 2 had AXRows status 0 and 29 rows; every row had exactly
+    /// one AXCell. `row[12]` was AXRow → AXCell → AXStaticText "Limiter On:"
+    /// and AXCheckBox value "0" as siblings. `row[0]` was AXRow → AXCell →
+    /// AXStaticText "Threshold:", an AXGroup-wrapped AXSlider, and a bare
+    /// AXSlider with AXValueIndicator. No measured row used sibling AXCells for
+    /// label/control. The two slider-shaped candidates are intentionally still
+    /// ambiguous; this locator never chooses one by traversal position.
     private static func observedView(
         in window: AXUIElement,
         runtime: AXHelpers.Runtime
@@ -501,11 +534,19 @@ enum ControlsViewBooleanParameterWriter {
             of: window, role: kAXTableRole, maxDepth: 8, runtime: runtime
         ).matches
         guard tables.count == 1, let table = tables.first else { return false }
-        guard let rows = controlsRows(in: table, runtime: runtime) else { return false }
+        guard case let .success(rows) = controlsRows(in: table, runtime: runtime) else { return false }
         // Heading and section rows have no interactive control in the live
         // table. A Controls view is bound by the presence of at least one
         // measured label/control pair, not by requiring every row to be one.
-        return rows.contains { rowCarriesParameterPair($0, runtime: runtime) }
+        for row in rows {
+            switch rowCarriesParameterPair(row, runtime: runtime) {
+            case .success(true):
+                return true
+            case .success(false), .failure:
+                continue
+            }
+        }
+        return false
     }
 
     /// Resolve a row-label address without positional fallbacks. A candidate
@@ -517,13 +558,26 @@ enum ControlsViewBooleanParameterWriter {
         in window: AXUIElement,
         runtime: AXHelpers.Runtime = .production
     ) -> LocateResult {
-        let tables = AXHelpers.censusDescendant(
-            of: window, role: kAXTableRole, maxDepth: 8, runtime: runtime
-        ).matches
+        let tables: [AXUIElement]
+        switch descendantElements(of: window, maxDepth: 8, runtime: runtime) {
+        case let .success(elements):
+            tables = elements.compactMap { element, role in
+                role == (kAXTableRole as String) ? element : nil
+            }
+        case .failure:
+            return .refused(.accessibilityReadFailed)
+        }
         guard tables.count == 1, let table = tables.first else {
             return .refused(tables.isEmpty ? .controlsViewTableNotFound : .controlsViewTableAmbiguous)
         }
-        guard let rows = controlsRows(in: table, runtime: runtime) else {
+        let rows: [AXUIElement]
+        switch controlsRows(in: table, runtime: runtime) {
+        case let .success(observed):
+            rows = observed
+        case .failure:
+            return .refused(.accessibilityReadFailed)
+        }
+        guard !rows.isEmpty else {
             return .refused(.controlsViewTableNotFound)
         }
 
@@ -531,26 +585,54 @@ enum ControlsViewBooleanParameterWriter {
         var matchingRows: [[AXUIElement]] = []
         var sawMissingLabel = false
         var sawAmbiguousLabel = false
-        for row in rows where AXHelpers.getRole(row, runtime: runtime) == (kAXRowRole as String) {
-            guard let cells = rowCells(in: row, runtime: runtime) else {
+        for row in rows {
+            let rowRole: String?
+            switch roleResult(of: row, runtime: runtime) {
+            case let .success(observed):
+                rowRole = observed
+            case .failure:
+                return .refused(.accessibilityReadFailed)
+            }
+            guard rowRole == (kAXRowRole as String) else { continue }
+            let cells: [AXUIElement]
+            switch rowCells(in: row, runtime: runtime) {
+            case let .success(observed):
+                cells = observed
+            case .failure:
+                return .refused(.accessibilityReadFailed)
+            }
+            guard !cells.isEmpty else {
                 sawMissingLabel = true
                 continue
             }
-            let labels = rowLabels(in: cells, runtime: runtime)
+            let labels: [RowLabel]
+            switch rowLabels(in: cells, runtime: runtime) {
+            case let .success(observed):
+                labels = observed
+            case .failure:
+                return .refused(.accessibilityReadFailed)
+            }
             guard labels.count == 1, let label = labels.first else {
                 sawMissingLabel = sawMissingLabel || labels.isEmpty
                 sawAmbiguousLabel = sawAmbiguousLabel || labels.count > 1
                 continue
             }
             if normalizedLabel(label.value) == target {
-                guard controlsAreConfinedToCells(in: row, cells: cells, runtime: runtime) else {
+                guard cells.count == 1 else {
                     return .refused(.rowStructureInvalid)
                 }
-                guard candidateControls(in: label.cell, runtime: runtime).isEmpty else {
-                    return .refused(.rowStructureInvalid)
+                let controls: [AXUIElement]
+                switch candidateControls(
+                    beside: label.element,
+                    in: label.cell,
+                    runtime: runtime
+                ) {
+                case let .success(observed):
+                    controls = observed
+                case .failure:
+                    return .refused(.accessibilityReadFailed)
                 }
-                let siblingCells = cells.filter { !CFEqual($0, label.cell) }
-                matchingRows.append(candidateControls(in: siblingCells, runtime: runtime))
+                matchingRows.append(controls)
             }
         }
 
@@ -565,7 +647,13 @@ enum ControlsViewBooleanParameterWriter {
         guard controls.count == 1, let control = controls.first else {
             return .refused(controls.isEmpty ? .controlMissing : .controlAmbiguous)
         }
-        let role = AXHelpers.getRole(control, runtime: runtime)
+        let role: String?
+        switch roleResult(of: control, runtime: runtime) {
+        case let .success(observed):
+            role = observed
+        case .failure:
+            return .refused(.accessibilityReadFailed)
+        }
         if role == (kAXCheckBoxRole as String) {
             return .found(.checkBox(control))
         }
@@ -649,128 +737,294 @@ enum ControlsViewBooleanParameterWriter {
     private static func controlsRows(
         in table: AXUIElement,
         runtime: AXHelpers.Runtime
-    ) -> [AXUIElement]? {
+    ) -> Result<[AXUIElement], AXHelpers.AXStatusError> {
         switch AXHelpers.getAXUIElementArrayRead(
             table,
             kAXRowsAttribute as String,
             runtime: runtime
         ) {
         case let .success(.elements(rows)):
-            return rows
+            return .success(rows)
         case .success(.absent):
-            switch AXHelpers.childrenResult(table, runtime: runtime) {
-            case let .success(children):
-                return children.filter {
-                    AXHelpers.getRole($0, runtime: runtime) == (kAXRowRole as String)
+            return directChildrenWithRoles(of: table, runtime: runtime).map { children in
+                children.compactMap { element, role in
+                    role == (kAXRowRole as String) ? element : nil
                 }
-            case .failure:
-                return nil
             }
         case .failure(let error) where error.isDefinitiveAbsence:
-            switch AXHelpers.childrenResult(table, runtime: runtime) {
-            case let .success(children):
-                return children.filter {
-                    AXHelpers.getRole($0, runtime: runtime) == (kAXRowRole as String)
+            return directChildrenWithRoles(of: table, runtime: runtime).map { children in
+                children.compactMap { element, role in
+                    role == (kAXRowRole as String) ? element : nil
                 }
-            case .failure:
-                return nil
             }
-        case .success(.malformed), .failure:
-            return nil
+        case .success(.malformed):
+            return .success([])
+        case let .failure(error):
+            return .failure(error)
         }
     }
 
     private struct RowLabel {
         let cell: AXUIElement
+        let element: AXUIElement
         let value: String
     }
+
+    private typealias ElementRole = (element: AXUIElement, role: String?)
 
     private static func rowCells(
         in row: AXUIElement,
         runtime: AXHelpers.Runtime
-    ) -> [AXUIElement]? {
-        switch AXHelpers.childrenResult(row, runtime: runtime) {
-        case let .success(children):
-            return children.filter {
-                AXHelpers.getRole($0, runtime: runtime) == (kAXCellRole as String)
+    ) -> Result<[AXUIElement], AXHelpers.AXStatusError> {
+        directChildrenWithRoles(of: row, runtime: runtime).map { children in
+            children.compactMap { element, role in
+                role == (kAXCellRole as String) ? element : nil
             }
-        case .failure:
-            return nil
         }
     }
 
     private static func rowLabels(
         in cells: [AXUIElement],
         runtime: AXHelpers.Runtime
-    ) -> [RowLabel] {
-        cells.flatMap { cell in
-            AXHelpers.findAllDescendants(
-                of: cell,
-                role: kAXStaticTextRole,
-                maxDepth: 4,
-                runtime: runtime
-            ).compactMap { text in
-                let value = AXValueExtractors.extractTextValue(text, runtime: runtime)
+    ) -> Result<[RowLabel], AXHelpers.AXStatusError> {
+        var labels: [RowLabel] = []
+        for cell in cells {
+            let children: [ElementRole]
+            switch directChildrenWithRoles(of: cell, runtime: runtime) {
+            case let .success(observed):
+                children = observed
+            case let .failure(error):
+                return .failure(error)
+            }
+            for (element, role) in children where role == (kAXStaticTextRole as String) {
+                let value: String?
+                switch textValueResult(of: element, runtime: runtime) {
+                case let .success(observed):
+                    value = observed
+                case let .failure(error):
+                    return .failure(error)
+                }
                 let normalized = normalizedLabel(value ?? "")
-                return normalized.isEmpty ? nil : RowLabel(cell: cell, value: normalized)
+                if !normalized.isEmpty {
+                    labels.append(RowLabel(cell: cell, element: element, value: normalized))
+                }
             }
         }
+        return .success(labels)
     }
 
     private static func candidateControls(
-        in element: AXUIElement,
+        beside label: AXUIElement,
+        in cell: AXUIElement,
         runtime: AXHelpers.Runtime
-    ) -> [AXUIElement] {
-        AXHelpers.findAllDescendants(of: element, maxDepth: 5, runtime: runtime).filter { candidate in
-            let role = AXHelpers.getRole(candidate, runtime: runtime)
-            return interactiveControlRoles.contains(role ?? "")
+    ) -> Result<[AXUIElement], AXHelpers.AXStatusError> {
+        let siblings: [ElementRole]
+        switch directChildrenWithRoles(of: cell, runtime: runtime) {
+        case let .success(observed):
+            siblings = observed
+        case let .failure(error):
+            return .failure(error)
         }
-    }
-
-    private static func candidateControls(
-        in cells: [AXUIElement],
-        runtime: AXHelpers.Runtime
-    ) -> [AXUIElement] {
-        cells.flatMap { candidateControls(in: $0, runtime: runtime) }
-    }
-
-    private static func controlsAreConfinedToCells(
-        in row: AXUIElement,
-        cells: [AXUIElement],
-        runtime: AXHelpers.Runtime
-    ) -> Bool {
-        let controlsInCells = candidateControls(in: cells, runtime: runtime)
-        let controlsInRow = candidateControls(in: row, runtime: runtime)
-        guard controlsInCells.count == controlsInRow.count else { return false }
-        return controlsInRow.allSatisfy { candidate in
-            controlsInCells.contains { CFEqual($0, candidate) }
+        var controls: [AXUIElement] = []
+        for sibling in siblings where !CFEqual(sibling.element, label) {
+            switch collectCandidateControls(
+                from: sibling.element,
+                knownRole: sibling.role,
+                remainingDepth: 5,
+                runtime: runtime,
+                into: &controls
+            ) {
+            case .success:
+                continue
+            case let .failure(error):
+                return .failure(error)
+            }
         }
+        return .success(controls)
     }
 
     private static func rowCarriesParameterPair(
         _ row: AXUIElement,
         runtime: AXHelpers.Runtime
-    ) -> Bool {
-        guard let cells = rowCells(in: row, runtime: runtime) else {
-            return false
+    ) -> Result<Bool, AXHelpers.AXStatusError> {
+        let role: String?
+        switch roleResult(of: row, runtime: runtime) {
+        case let .success(observed):
+            role = observed
+        case let .failure(error):
+            return .failure(error)
         }
-        let labels = rowLabels(in: cells, runtime: runtime)
-        guard labels.count == 1,
-              let label = labels.first,
-              controlsAreConfinedToCells(in: row, cells: cells, runtime: runtime) else {
-            return false
+        guard role == (kAXRowRole as String) else { return .success(false) }
+        let cells: [AXUIElement]
+        switch rowCells(in: row, runtime: runtime) {
+        case let .success(observed):
+            cells = observed
+        case let .failure(error):
+            return .failure(error)
         }
-        // Keep the classifier's discriminator identical to `locate`'s binding:
-        // a control beside the label in its own AXCell is not a parameter pair.
-        // Otherwise an invalid row could certify Controls even though writes
-        // correctly refuse to bind it.
-        guard candidateControls(in: label.cell, runtime: runtime).isEmpty else {
-            return false
+        guard cells.count == 1 else { return .success(false) }
+        let labels: [RowLabel]
+        switch rowLabels(in: cells, runtime: runtime) {
+        case let .success(observed):
+            labels = observed
+        case let .failure(error):
+            return .failure(error)
         }
-        return candidateControls(
-            in: cells.filter { !CFEqual($0, label.cell) },
+        guard labels.count == 1, let label = labels.first else { return .success(false) }
+        // The classifier intentionally requires only a label/control relation,
+        // while `locate` requires exactly one candidate before it can bind a
+        // write. Thus the measured Threshold row helps prove Controls even
+        // though its two slider-shaped candidates still refuse actuation.
+        return candidateControls(beside: label.element, in: label.cell, runtime: runtime)
+            .map { !$0.isEmpty }
+    }
+
+    private static func roleResult(
+        of element: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> Result<String?, AXHelpers.AXStatusError> {
+        let read: Result<String?, AXHelpers.AXStatusError> = AXHelpers.getAttributeResult(
+            element,
+            kAXRoleAttribute as String,
             runtime: runtime
-        ).count == 1
+        )
+        switch read {
+        case let .success(role):
+            return .success(role)
+        case let .failure(error) where error.isDefinitiveAbsence:
+            return .success(nil)
+        case let .failure(error):
+            return .failure(error)
+        }
+    }
+
+    private static func textValueResult(
+        of element: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> Result<String?, AXHelpers.AXStatusError> {
+        let read: Result<AnyObject?, AXHelpers.AXStatusError> = AXHelpers.getAttributeResult(
+            element,
+            kAXValueAttribute as String,
+            runtime: runtime
+        )
+        switch read {
+        case let .success(value):
+            return .success(value as? String)
+        case let .failure(error) where error.isDefinitiveAbsence:
+            return .success(nil)
+        case let .failure(error):
+            return .failure(error)
+        }
+    }
+
+    private static func directChildrenWithRoles(
+        of element: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> Result<[ElementRole], AXHelpers.AXStatusError> {
+        let children: [AXUIElement]
+        switch AXHelpers.childrenResult(element, runtime: runtime) {
+        case let .success(observed):
+            children = observed
+        case let .failure(error) where error.isDefinitiveAbsence:
+            children = []
+        case let .failure(error):
+            return .failure(error)
+        }
+        var observed: [ElementRole] = []
+        for child in children {
+            switch roleResult(of: child, runtime: runtime) {
+            case let .success(role):
+                observed.append((child, role))
+            case let .failure(error):
+                return .failure(error)
+            }
+        }
+        return .success(observed)
+    }
+
+    private static func descendantElements(
+        of element: AXUIElement,
+        maxDepth: Int,
+        runtime: AXHelpers.Runtime
+    ) -> Result<[ElementRole], AXHelpers.AXStatusError> {
+        var found: [ElementRole] = []
+        switch collectDescendantElements(
+            below: element,
+            remainingDepth: maxDepth,
+            runtime: runtime,
+            into: &found
+        ) {
+        case .success:
+            return .success(found)
+        case let .failure(error):
+            return .failure(error)
+        }
+    }
+
+    private static func collectDescendantElements(
+        below element: AXUIElement,
+        remainingDepth: Int,
+        runtime: AXHelpers.Runtime,
+        into found: inout [ElementRole]
+    ) -> Result<Void, AXHelpers.AXStatusError> {
+        guard remainingDepth > 0 else { return .success(()) }
+        let children: [ElementRole]
+        switch directChildrenWithRoles(of: element, runtime: runtime) {
+        case let .success(observed):
+            children = observed
+        case let .failure(error):
+            return .failure(error)
+        }
+        for child in children {
+            found.append(child)
+            switch collectDescendantElements(
+                below: child.element,
+                remainingDepth: remainingDepth - 1,
+                runtime: runtime,
+                into: &found
+            ) {
+            case .success:
+                continue
+            case let .failure(error):
+                return .failure(error)
+            }
+        }
+        return .success(())
+    }
+
+    private static func collectCandidateControls(
+        from element: AXUIElement,
+        knownRole: String?,
+        remainingDepth: Int,
+        runtime: AXHelpers.Runtime,
+        into controls: inout [AXUIElement]
+    ) -> Result<Void, AXHelpers.AXStatusError> {
+        guard remainingDepth > 0 else { return .success(()) }
+        if interactiveControlRoles.contains(knownRole ?? "") {
+            controls.append(element)
+        }
+        let children: [ElementRole]
+        switch directChildrenWithRoles(of: element, runtime: runtime) {
+        case let .success(observed):
+            children = observed
+        case let .failure(error):
+            return .failure(error)
+        }
+        for child in children {
+            switch collectCandidateControls(
+                from: child.element,
+                knownRole: child.role,
+                remainingDepth: remainingDepth - 1,
+                runtime: runtime,
+                into: &controls
+            ) {
+            case .success:
+                continue
+            case let .failure(error):
+                return .failure(error)
+            }
+        }
+        return .success(())
     }
 
     /// The first four roles are the Controls-view roles observed on 2026-09-02.

--- a/Sources/LogicProMCP/HostParameters/ControlsViewBooleanParameterWriter.swift
+++ b/Sources/LogicProMCP/HostParameters/ControlsViewBooleanParameterWriter.swift
@@ -1,0 +1,584 @@
+import ApplicationServices
+import Foundation
+
+/// The measured, deliberately small write surface for Logic's host-provided
+/// Controls view. A parameter name belongs to its AXRow, not to the control:
+/// this locator binds the row's AXStaticText label to exactly one control in
+/// that row and never inherits AX traversal position.
+///
+/// Only AXCheckBox actuation is qualified. AXSlider's advertised settable
+/// value/increment actions were measured on 2026-09-02 to be inert;
+/// AXPopUpButton selection has not been measured. Both roles are returned as
+/// explicit refusals and are never actuated here.
+enum ControlsViewBooleanParameterWriter {
+    enum LocatorFailure: String, Sendable, Equatable {
+        case controlsViewTableNotFound
+        case controlsViewTableAmbiguous
+        case rowLabelMissing
+        case rowLabelAmbiguous
+        case rowLabelNotFound
+        case controlMissing
+        case controlAmbiguous
+        case checkboxNotFound
+        case sliderNotActuable
+        case popupUnmeasured
+        case unsupportedControlRole
+
+        var observation: String {
+            switch self {
+            case .controlsViewTableNotFound:
+                return "no unique AXTable was available after selecting Controls view"
+            case .controlsViewTableAmbiguous:
+                return "more than one AXTable was available after selecting Controls view"
+            case .rowLabelMissing:
+                return "the Controls-view AXRow exposes no AXStaticText label inside an AXCell"
+            case .rowLabelAmbiguous:
+                return "the Controls-view AXRow exposes more than one AXStaticText label inside its cells"
+            case .rowLabelNotFound:
+                return "no Controls-view AXRow label matched the requested parameter"
+            case .controlMissing:
+                return "the labelled Controls-view AXRow exposes no candidate control"
+            case .controlAmbiguous:
+                return "the labelled Controls-view AXRow exposes several candidate controls; no control was chosen by position"
+            case .checkboxNotFound:
+                return "the labelled Controls-view AXRow did not resolve to an AXCheckBox"
+            case .sliderNotActuable:
+                return "Controls-view AXSlider actuation is refused: on 2026-09-02 direct AXValue set and AXIncrement both reported success but the measured slider did not change"
+            case .popupUnmeasured:
+                return "Controls-view AXPopUpButton actuation is refused: selection has not been measured, so no menu action is guessed"
+            case .unsupportedControlRole:
+                return "the labelled Controls-view row resolved to an unsupported control role"
+            }
+        }
+    }
+
+    enum PluginWindowView: String, Sendable, Equatable {
+        case controls
+        case editor
+
+        fileprivate var labels: AXLocalePolicy.LabelSet {
+            switch self {
+            case .controls:
+                AXLocalePolicy.pluginWindowControlsViewMenuItem
+            case .editor:
+                AXLocalePolicy.pluginWindowEditorViewMenuItem
+            }
+        }
+    }
+
+    enum ViewSwitchFailure: Sendable, Equatable {
+        case viewSwitcherNotFound
+        case viewSwitcherAmbiguous
+        case unmeasuredLocale
+        case entryViewNotConfirmed
+        case viewMenuNotFound
+        case viewMenuAmbiguous
+        case viewMenuItemNotFound(PluginWindowView)
+        case viewMenuItemAmbiguous(PluginWindowView)
+        case viewStructureDidNotConfirm(PluginWindowView)
+
+        var observation: String {
+            switch self {
+            case .viewSwitcherNotFound:
+                return "no plugin-window AXMenuButton was available to resolve the Controls view switcher"
+            case .viewSwitcherAmbiguous:
+                return "more than one AXMenuButton matched the measured View AXDescription"
+            case .unmeasuredLocale:
+                return "the plugin-window View AXDescription is not measured for this locale; no view name was guessed"
+            case .entryViewNotConfirmed:
+                return "the bound plugin window exposed neither a described native-editor AXSlider nor Controls-view rows with no described AXSlider; its entry view was not confirmed"
+            case .viewMenuNotFound:
+                return "the measured View switcher exposed no scoped AXMenu after AXShowMenu"
+            case .viewMenuAmbiguous:
+                return "the measured View switcher exposed several scoped AXMenus"
+            case let .viewMenuItemNotFound(view):
+                return "the scoped View menu exposed no measured \(view.labels.canonical) item"
+            case let .viewMenuItemAmbiguous(view):
+                return "the scoped View menu exposed several measured \(view.labels.canonical) items"
+            case let .viewStructureDidNotConfirm(expected):
+                return "after selecting the measured \(expected.labels.canonical) item, the bound plugin window did not expose the expected \(expected.rawValue) structure before the confirmation deadline"
+            }
+        }
+    }
+
+    enum LocatedControl {
+        case checkBox(AXUIElement)
+        case slider
+        case popup
+        case unsupported
+
+        var failure: LocatorFailure? {
+            switch self {
+            case .checkBox:
+                return nil
+            case .slider:
+                return .sliderNotActuable
+            case .popup:
+                return .popupUnmeasured
+            case .unsupported:
+                return .unsupportedControlRole
+            }
+        }
+    }
+
+    enum LocateResult {
+        case found(LocatedControl)
+        case refused(LocatorFailure)
+    }
+
+    enum ViewPreparationResult {
+        case ready(ViewSession)
+        case refused(ViewSwitchFailure)
+    }
+
+    struct ViewRestoration: Sendable, Equatable {
+        let attempted: Bool
+        let confirmed: Bool
+        let observedStructure: String?
+    }
+
+    /// Owns one confirmed temporary view selection. Its caller restores this
+    /// exact entry view on every exit path, including a locator refusal.
+    final class ViewSession: @unchecked Sendable {
+        private let window: AXUIElement
+        private let switcher: AXUIElement
+        private let entryView: PluginWindowView
+        private let didSwitch: Bool
+        private let runtime: AXHelpers.Runtime
+        private var restorationFinished = false
+
+        fileprivate init(
+            window: AXUIElement,
+            switcher: AXUIElement,
+            entryView: PluginWindowView,
+            didSwitch: Bool,
+            runtime: AXHelpers.Runtime
+        ) {
+            self.window = window
+            self.switcher = switcher
+            self.entryView = entryView
+            self.didSwitch = didSwitch
+            self.runtime = runtime
+        }
+
+        /// Restoration is idempotent. A failed restore is logged and exposed
+        /// in successful write metadata by the caller; the already-observed
+        /// parameter-write verdict is never recast as though it had not run.
+        func restore() -> ViewRestoration {
+            guard !restorationFinished else {
+                return ViewRestoration(attempted: false, confirmed: true, observedStructure: nil)
+            }
+            restorationFinished = true
+            guard didSwitch else {
+                return ViewRestoration(
+                    attempted: false,
+                    confirmed: true,
+                    observedStructure: entryView.rawValue
+                )
+            }
+            switch switchView(
+                to: entryView,
+                in: window,
+                switcher: switcher,
+                confirmationTimeout: viewConfirmationTimeout,
+                runtime: runtime
+            ) {
+            case let .confirmed(switched):
+                return ViewRestoration(
+                    attempted: switched,
+                    confirmed: true,
+                    observedStructure: entryView.rawValue
+                )
+            case .refused:
+                return ViewRestoration(
+                    attempted: true,
+                    confirmed: false,
+                    observedStructure: observedView(in: window, runtime: runtime)?.rawValue
+                )
+            }
+        }
+    }
+
+    private enum ViewChangeResult {
+        case confirmed(switched: Bool)
+        case refused(ViewSwitchFailure)
+    }
+
+    struct ToggleResult: Sendable, Equatable {
+        let verified: Bool
+        let pressAttempted: Bool
+        let before: Bool?
+        let observedAfterPress: Bool?
+        let restoreAttempted: Bool
+        let restoreObserved: Bool?
+        let refusal: String?
+    }
+
+    /// Identify the entry view from the bound window's measured structure, then
+    /// enter the requested view only when necessary. AXPress status and AXTitle
+    /// are not confirmation: the requested structure must appear before the
+    /// bounded confirmation deadline.
+    static func prepareView(
+        _ targetView: PluginWindowView,
+        in window: AXUIElement,
+        confirmationTimeout: TimeInterval = viewConfirmationTimeout,
+        runtime: AXHelpers.Runtime = .production
+    ) -> ViewPreparationResult {
+        let menuButtons = AXHelpers.censusDescendant(
+            of: window, role: kAXMenuButtonRole, maxDepth: 5, runtime: runtime
+        ).matches
+        let measured = menuButtons.filter {
+            AXLocalePolicy.pluginWindowViewSwitcher.matches(
+                AXHelpers.getDescription($0, runtime: runtime),
+                mode: .exact
+            )
+        }
+        guard measured.count == 1, let switcher = measured.first else {
+            if measured.count > 1 {
+                return .refused(.viewSwitcherAmbiguous)
+            }
+            return .refused(menuButtons.isEmpty ? .viewSwitcherNotFound : .unmeasuredLocale)
+        }
+
+        guard let entryView = observedView(in: window, runtime: runtime) else {
+            return .refused(.entryViewNotConfirmed)
+        }
+
+        switch switchView(
+            to: targetView,
+            in: window,
+            switcher: switcher,
+            confirmationTimeout: confirmationTimeout,
+            runtime: runtime
+        ) {
+        case let .confirmed(switched):
+            return .ready(ViewSession(
+                window: window,
+                switcher: switcher,
+                entryView: entryView,
+                didSwitch: switched,
+                runtime: runtime
+            ))
+        case let .refused(failure):
+            // A pressed menu item can have changed the view even when the
+            // target structure did not settle before its deadline. Re-select
+            // the entry view best-effort before refusing, so failed selection
+            // paths do not strand it.
+            _ = switchView(
+                to: entryView,
+                in: window,
+                switcher: switcher,
+                confirmationTimeout: confirmationTimeout,
+                runtime: runtime
+            )
+            return .refused(failure)
+        }
+    }
+
+    /// The native editor is signaled by a parameter-bearing slider. Controls
+    /// is signaled only by its table rows *and* the absence of every slider
+    /// description, so a stale title or a shared zoom/view menu cannot alter
+    /// this result.
+    private static func observedView(
+        in window: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> PluginWindowView? {
+        let sliders = AXHelpers.censusDescendant(
+            of: window, role: kAXSliderRole, maxDepth: 8, runtime: runtime
+        ).matches
+        if sliders.contains(where: { slider in
+            guard let description = AXHelpers.getDescription(slider, runtime: runtime) else {
+                return false
+            }
+            return !description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }) {
+            return .editor
+        }
+        return controlsViewRowsArePresent(in: window, runtime: runtime) ? .controls : nil
+    }
+
+    private static func switchView(
+        to targetView: PluginWindowView,
+        in window: AXUIElement,
+        switcher: AXUIElement,
+        confirmationTimeout: TimeInterval,
+        runtime: AXHelpers.Runtime
+    ) -> ViewChangeResult {
+        guard observedView(in: window, runtime: runtime) != targetView else {
+            return .confirmed(switched: false)
+        }
+
+        // AX's action status is intentionally not the verdict. The scoped menu
+        // tree is observed after this one request; no retry ladder can turn an
+        // unmeasured locale or a missing menu into evidence.
+        _ = AXHelpers.performAction(switcher, kAXShowMenuAction as String, runtime: runtime)
+        let menus = AXHelpers.censusDescendant(
+            of: switcher, role: kAXMenuRole, maxDepth: 4, runtime: runtime
+        ).matches
+        guard menus.count == 1, let menu = menus.first else {
+            return .refused(menus.isEmpty ? .viewMenuNotFound : .viewMenuAmbiguous)
+        }
+        let entries = AXLocalePolicy.censusDescendant(
+            of: menu,
+            role: kAXMenuItemRole,
+            matching: targetView.labels,
+            maxDepth: 3,
+            runtime: runtime
+        ).matches
+        guard entries.count == 1, let target = entries.first else {
+            return .refused(entries.isEmpty
+                ? .viewMenuItemNotFound(targetView)
+                : .viewMenuItemAmbiguous(targetView)
+            )
+        }
+        _ = AXHelpers.performAction(target, kAXPressAction as String, runtime: runtime)
+        guard waitForView(
+            targetView,
+            in: window,
+            timeout: confirmationTimeout,
+            runtime: runtime
+        ) else {
+            return .refused(.viewStructureDidNotConfirm(targetView))
+        }
+        return .confirmed(switched: true)
+    }
+
+    private static let viewConfirmationTimeout: TimeInterval = 1.5
+    private static let viewConfirmationPollInterval: TimeInterval = 0.05
+
+    private static func waitForView(
+        _ expected: PluginWindowView,
+        in window: AXUIElement,
+        timeout: TimeInterval,
+        runtime: AXHelpers.Runtime
+    ) -> Bool {
+        let deadline = Date().addingTimeInterval(max(0, timeout))
+        repeat {
+            if observedView(in: window, runtime: runtime) == expected {
+                return true
+            }
+            let remaining = deadline.timeIntervalSinceNow
+            guard remaining > 0 else { break }
+            Thread.sleep(forTimeInterval: min(viewConfirmationPollInterval, remaining))
+        } while Date() < deadline
+        return false
+    }
+
+    private static func controlsViewRowsArePresent(
+        in window: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> Bool {
+        let tables = AXHelpers.censusDescendant(
+            of: window, role: kAXTableRole, maxDepth: 8, runtime: runtime
+        ).matches
+        guard tables.count == 1, let table = tables.first else { return false }
+        let rows: [AXUIElement]
+        switch AXHelpers.getAXUIElementArrayRead(
+            table,
+            kAXRowsAttribute as String,
+            runtime: runtime
+        ) {
+        case let .success(.elements(observed)):
+            rows = observed
+        case .success(.absent):
+            rows = AXHelpers.getChildren(table, runtime: runtime).filter {
+                AXHelpers.getRole($0, runtime: runtime) == (kAXRowRole as String)
+            }
+        case .success(.malformed), .failure:
+            return false
+        }
+        return rows.contains { AXHelpers.getRole($0, runtime: runtime) == (kAXRowRole as String) }
+    }
+
+    /// Resolve a row-label address without positional fallbacks. A candidate
+    /// means any interactive AX role that could share the row, so a checkbox
+    /// cannot win merely because it happened to be first beside an unqualified
+    /// control.
+    static func locate(
+        label requestedLabel: String,
+        in window: AXUIElement,
+        runtime: AXHelpers.Runtime = .production
+    ) -> LocateResult {
+        let tables = AXHelpers.censusDescendant(
+            of: window, role: kAXTableRole, maxDepth: 8, runtime: runtime
+        ).matches
+        guard tables.count == 1, let table = tables.first else {
+            return .refused(tables.isEmpty ? .controlsViewTableNotFound : .controlsViewTableAmbiguous)
+        }
+        let rows: [AXUIElement]
+        switch AXHelpers.getAXUIElementArrayRead(
+            table,
+            kAXRowsAttribute as String,
+            runtime: runtime
+        ) {
+        case let .success(.elements(observed)):
+            rows = observed
+        case .success(.absent):
+            rows = AXHelpers.getChildren(table, runtime: runtime).filter {
+                AXHelpers.getRole($0, runtime: runtime) == (kAXRowRole as String)
+            }
+        case .success(.malformed), .failure:
+            return .refused(.controlsViewTableNotFound)
+        }
+
+        let target = normalizedLabel(requestedLabel)
+        var matchingRows: [[AXUIElement]] = []
+        var sawMissingLabel = false
+        var sawAmbiguousLabel = false
+        for row in rows where AXHelpers.getRole(row, runtime: runtime) == (kAXRowRole as String) {
+            let labels = rowLabels(in: row, runtime: runtime)
+            guard labels.count == 1, let label = labels.first else {
+                sawMissingLabel = sawMissingLabel || labels.isEmpty
+                sawAmbiguousLabel = sawAmbiguousLabel || labels.count > 1
+                continue
+            }
+            if normalizedLabel(label) == target {
+                matchingRows.append(candidateControls(in: row, runtime: runtime))
+            }
+        }
+
+        guard matchingRows.count == 1, let controls = matchingRows.first else {
+            if matchingRows.count > 1 {
+                return .refused(.rowLabelAmbiguous)
+            }
+            if sawAmbiguousLabel { return .refused(.rowLabelAmbiguous) }
+            if sawMissingLabel { return .refused(.rowLabelMissing) }
+            return .refused(.rowLabelNotFound)
+        }
+        guard controls.count == 1, let control = controls.first else {
+            return .refused(controls.isEmpty ? .controlMissing : .controlAmbiguous)
+        }
+        let role = AXHelpers.getRole(control, runtime: runtime)
+        if role == (kAXCheckBoxRole as String) {
+            return .found(.checkBox(control))
+        }
+        if role == (kAXSliderRole as String) {
+            return .found(.slider)
+        }
+        if role == (kAXPopUpButtonRole as String) {
+            return .found(.popup)
+        }
+        return .found(.unsupported)
+    }
+
+    /// A press status of zero is not success evidence. The checkbox must read
+    /// back as *changed* and equal to the requested state. Any failed
+    /// verification causes one compensating press, followed by a readback that
+    /// reports whether restoration to the before state was actually observed.
+    static func pressAndVerify(
+        _ checkbox: AXUIElement,
+        requested: Bool,
+        runtime: AXHelpers.Runtime = .production
+    ) -> ToggleResult {
+        guard let before = AXValueExtractors.extractButtonState(checkbox, runtime: runtime) else {
+            return ToggleResult(
+                verified: false,
+                pressAttempted: false,
+                before: nil,
+                observedAfterPress: nil,
+                restoreAttempted: false,
+                restoreObserved: nil,
+                refusal: "the Controls-view AXCheckBox AXValue could not be read before AXPress"
+            )
+        }
+        guard before != requested else {
+            return ToggleResult(
+                verified: false,
+                pressAttempted: false,
+                before: before,
+                observedAfterPress: before,
+                restoreAttempted: false,
+                restoreObserved: before,
+                refusal: "the Controls-view AXCheckBox already has the requested state; AXPress would change it away, so no write was attempted"
+            )
+        }
+
+        _ = AXHelpers.performAction(checkbox, kAXPressAction as String, runtime: runtime)
+        let after = AXValueExtractors.extractButtonState(checkbox, runtime: runtime)
+        if after == requested, after != before {
+            return ToggleResult(
+                verified: true,
+                pressAttempted: true,
+                before: before,
+                observedAfterPress: after,
+                restoreAttempted: false,
+                restoreObserved: nil,
+                refusal: nil
+            )
+        }
+
+        // The first press may have landed even though its state did not verify.
+        // One inverse press is the only available compensation; it is not a
+        // retry of the requested write, and its result is observed separately.
+        _ = AXHelpers.performAction(checkbox, kAXPressAction as String, runtime: runtime)
+        let restored = AXValueExtractors.extractButtonState(checkbox, runtime: runtime)
+        return ToggleResult(
+            verified: false,
+            pressAttempted: true,
+            before: before,
+            observedAfterPress: after,
+            restoreAttempted: true,
+            restoreObserved: restored.map { $0 == before },
+            refusal: after == nil
+                ? "the Controls-view AXCheckBox value could not be read after AXPress; restoration was attempted once"
+                : "the Controls-view AXCheckBox did not change to the requested state after AXPress; AX status is not confirmation, and restoration was attempted once"
+        )
+    }
+
+    private static func rowLabels(
+        in row: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> [String] {
+        let cells = AXHelpers.findAllDescendants(
+            of: row,
+            role: kAXCellRole,
+            maxDepth: 4,
+            runtime: runtime
+        )
+        return cells.flatMap { cell in
+            AXHelpers.findAllDescendants(
+                of: cell,
+                role: kAXStaticTextRole,
+                maxDepth: 4,
+                runtime: runtime
+            ).compactMap { text in
+                let value = AXValueExtractors.extractTextValue(text, runtime: runtime)
+                let normalized = normalizedLabel(value ?? "")
+                return normalized.isEmpty ? nil : normalized
+            }
+        }
+    }
+
+    private static func candidateControls(
+        in row: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> [AXUIElement] {
+        AXHelpers.findAllDescendants(of: row, maxDepth: 5, runtime: runtime).filter { element in
+            let role = AXHelpers.getRole(element, runtime: runtime)
+            return interactiveControlRoles.contains(role ?? "")
+        }
+    }
+
+    /// The first four roles are the Controls-view roles observed on 2026-09-02.
+    /// The remaining standard interactive roles keep the cardinality rule
+    /// fail-closed if a future UI exposes another control next to the checkbox.
+    private static let interactiveControlRoles: Set<String> = [
+        kAXCheckBoxRole as String,
+        kAXSliderRole as String,
+        kAXPopUpButtonRole as String,
+        kAXRadioButtonRole as String,
+        kAXButtonRole as String,
+        kAXMenuButtonRole as String,
+        kAXTextFieldRole as String,
+        "AXComboBox",
+        "AXIncrementor",
+        "AXValueIndicator",
+        "AXScrollBar",
+    ]
+
+    private static func normalizedLabel(_ value: String) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        let withoutColon = trimmed.hasSuffix(":") ? String(trimmed.dropLast()) : trimmed
+        return withoutColon.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+}

--- a/Sources/LogicProMCP/HostParameters/ControlsViewBooleanParameterWriter.swift
+++ b/Sources/LogicProMCP/HostParameters/ControlsViewBooleanParameterWriter.swift
@@ -17,6 +17,7 @@ enum ControlsViewBooleanParameterWriter {
         case rowLabelMissing
         case rowLabelAmbiguous
         case rowLabelNotFound
+        case rowStructureInvalid
         case controlMissing
         case controlAmbiguous
         case checkboxNotFound
@@ -36,6 +37,8 @@ enum ControlsViewBooleanParameterWriter {
                 return "the Controls-view AXRow exposes more than one AXStaticText label inside its cells"
             case .rowLabelNotFound:
                 return "no Controls-view AXRow label matched the requested parameter"
+            case .rowStructureInvalid:
+                return "the labelled Controls-view AXRow did not place its label and control in sibling AXCells"
             case .controlMissing:
                 return "the labelled Controls-view AXRow exposes no candidate control"
             case .controlAmbiguous:
@@ -88,7 +91,7 @@ enum ControlsViewBooleanParameterWriter {
             case .entryViewNotConfirmed:
                 return "the bound plugin window exposed neither a described native-editor AXSlider nor Controls-view rows with no described AXSlider; its entry view was not confirmed"
             case .viewMenuNotFound:
-                return "the measured View switcher exposed no scoped AXMenu after AXShowMenu"
+                return "the measured View switcher exposed no scoped AXMenu after AXPress"
             case .viewMenuAmbiguous:
                 return "the measured View switcher exposed several scoped AXMenus"
             case let .viewMenuItemNotFound(view):
@@ -276,9 +279,11 @@ enum ControlsViewBooleanParameterWriter {
     }
 
     /// The native editor is signaled by a parameter-bearing slider. Controls
-    /// is signaled only by its table rows *and* the absence of every slider
-    /// description, so a stale title or a shared zoom/view menu cannot alter
-    /// this result.
+    /// requires at least one AXRow with a nonempty AXStaticText label in one
+    /// AXCell and an interactive control in a sibling AXCell; a browser/preset
+    /// table has no such parameter-control pair, so its rows cannot prove
+    /// Controls. A title-only slider is Editor evidence only when that Controls
+    /// discriminator is absent.
     private static func observedView(
         in window: AXUIElement,
         runtime: AXHelpers.Runtime
@@ -294,7 +299,10 @@ enum ControlsViewBooleanParameterWriter {
         }) {
             return .editor
         }
-        return controlsViewRowsArePresent(in: window, runtime: runtime) ? .controls : nil
+        if controlsViewRowsArePresent(in: window, runtime: runtime) {
+            return .controls
+        }
+        return sliders.isEmpty ? nil : .editor
     }
 
     private static func switchView(
@@ -308,10 +316,10 @@ enum ControlsViewBooleanParameterWriter {
             return .confirmed(switched: false)
         }
 
-        // AX's action status is intentionally not the verdict. The scoped menu
-        // tree is observed after this one request; no retry ladder can turn an
-        // unmeasured locale or a missing menu into evidence.
-        _ = AXHelpers.performAction(switcher, kAXShowMenuAction as String, runtime: runtime)
+        // AX's action status is intentionally not the verdict. Live Logic
+        // reveals this app-wide menu after AXPress, and its entry accepts only
+        // AXPick; no retry ladder can turn another protocol into evidence.
+        _ = AXHelpers.performAction(switcher, kAXPressAction as String, runtime: runtime)
         let menus = AXHelpers.censusDescendant(
             of: switcher, role: kAXMenuRole, maxDepth: 4, runtime: runtime
         ).matches
@@ -331,7 +339,7 @@ enum ControlsViewBooleanParameterWriter {
                 : .viewMenuItemAmbiguous(targetView)
             )
         }
-        _ = AXHelpers.performAction(target, kAXPressAction as String, runtime: runtime)
+        _ = AXHelpers.performAction(target, kAXPickAction as String, runtime: runtime)
         guard waitForView(
             targetView,
             in: window,
@@ -372,22 +380,8 @@ enum ControlsViewBooleanParameterWriter {
             of: window, role: kAXTableRole, maxDepth: 8, runtime: runtime
         ).matches
         guard tables.count == 1, let table = tables.first else { return false }
-        let rows: [AXUIElement]
-        switch AXHelpers.getAXUIElementArrayRead(
-            table,
-            kAXRowsAttribute as String,
-            runtime: runtime
-        ) {
-        case let .success(.elements(observed)):
-            rows = observed
-        case .success(.absent):
-            rows = AXHelpers.getChildren(table, runtime: runtime).filter {
-                AXHelpers.getRole($0, runtime: runtime) == (kAXRowRole as String)
-            }
-        case .success(.malformed), .failure:
-            return false
-        }
-        return rows.contains { AXHelpers.getRole($0, runtime: runtime) == (kAXRowRole as String) }
+        guard let rows = controlsRows(in: table, runtime: runtime) else { return false }
+        return rows.contains { rowCarriesParameterPair($0, runtime: runtime) }
     }
 
     /// Resolve a row-label address without positional fallbacks. A candidate
@@ -405,19 +399,7 @@ enum ControlsViewBooleanParameterWriter {
         guard tables.count == 1, let table = tables.first else {
             return .refused(tables.isEmpty ? .controlsViewTableNotFound : .controlsViewTableAmbiguous)
         }
-        let rows: [AXUIElement]
-        switch AXHelpers.getAXUIElementArrayRead(
-            table,
-            kAXRowsAttribute as String,
-            runtime: runtime
-        ) {
-        case let .success(.elements(observed)):
-            rows = observed
-        case .success(.absent):
-            rows = AXHelpers.getChildren(table, runtime: runtime).filter {
-                AXHelpers.getRole($0, runtime: runtime) == (kAXRowRole as String)
-            }
-        case .success(.malformed), .failure:
+        guard let rows = controlsRows(in: table, runtime: runtime) else {
             return .refused(.controlsViewTableNotFound)
         }
 
@@ -426,14 +408,25 @@ enum ControlsViewBooleanParameterWriter {
         var sawMissingLabel = false
         var sawAmbiguousLabel = false
         for row in rows where AXHelpers.getRole(row, runtime: runtime) == (kAXRowRole as String) {
-            let labels = rowLabels(in: row, runtime: runtime)
+            guard let cells = rowCells(in: row, runtime: runtime) else {
+                sawMissingLabel = true
+                continue
+            }
+            let labels = rowLabels(in: cells, runtime: runtime)
             guard labels.count == 1, let label = labels.first else {
                 sawMissingLabel = sawMissingLabel || labels.isEmpty
                 sawAmbiguousLabel = sawAmbiguousLabel || labels.count > 1
                 continue
             }
-            if normalizedLabel(label) == target {
-                matchingRows.append(candidateControls(in: row, runtime: runtime))
+            if normalizedLabel(label.value) == target {
+                guard controlsAreConfinedToCells(in: row, cells: cells, runtime: runtime) else {
+                    return .refused(.rowStructureInvalid)
+                }
+                guard candidateControls(in: label.cell, runtime: runtime).isEmpty else {
+                    return .refused(.rowStructureInvalid)
+                }
+                let siblingCells = cells.filter { !CFEqual($0, label.cell) }
+                matchingRows.append(candidateControls(in: siblingCells, runtime: runtime))
             }
         }
 
@@ -525,17 +518,68 @@ enum ControlsViewBooleanParameterWriter {
         )
     }
 
-    private static func rowLabels(
+    /// `AXRows` has two absence answers: a successful empty attribute and the
+    /// `noValue`/`attributeUnsupported` AX statuses. Only those answers may use
+    /// AXChildren as the alternate table representation; every other status is
+    /// a read failure and therefore cannot establish a Controls table.
+    private static func controlsRows(
+        in table: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> [AXUIElement]? {
+        switch AXHelpers.getAXUIElementArrayRead(
+            table,
+            kAXRowsAttribute as String,
+            runtime: runtime
+        ) {
+        case let .success(.elements(rows)):
+            return rows
+        case .success(.absent):
+            switch AXHelpers.childrenResult(table, runtime: runtime) {
+            case let .success(children):
+                return children.filter {
+                    AXHelpers.getRole($0, runtime: runtime) == (kAXRowRole as String)
+                }
+            case .failure:
+                return nil
+            }
+        case .failure(let error) where error.isDefinitiveAbsence:
+            switch AXHelpers.childrenResult(table, runtime: runtime) {
+            case let .success(children):
+                return children.filter {
+                    AXHelpers.getRole($0, runtime: runtime) == (kAXRowRole as String)
+                }
+            case .failure:
+                return nil
+            }
+        case .success(.malformed), .failure:
+            return nil
+        }
+    }
+
+    private struct RowLabel {
+        let cell: AXUIElement
+        let value: String
+    }
+
+    private static func rowCells(
         in row: AXUIElement,
         runtime: AXHelpers.Runtime
-    ) -> [String] {
-        let cells = AXHelpers.findAllDescendants(
-            of: row,
-            role: kAXCellRole,
-            maxDepth: 4,
-            runtime: runtime
-        )
-        return cells.flatMap { cell in
+    ) -> [AXUIElement]? {
+        switch AXHelpers.childrenResult(row, runtime: runtime) {
+        case let .success(children):
+            return children.filter {
+                AXHelpers.getRole($0, runtime: runtime) == (kAXCellRole as String)
+            }
+        case .failure:
+            return nil
+        }
+    }
+
+    private static func rowLabels(
+        in cells: [AXUIElement],
+        runtime: AXHelpers.Runtime
+    ) -> [RowLabel] {
+        cells.flatMap { cell in
             AXHelpers.findAllDescendants(
                 of: cell,
                 role: kAXStaticTextRole,
@@ -544,19 +588,65 @@ enum ControlsViewBooleanParameterWriter {
             ).compactMap { text in
                 let value = AXValueExtractors.extractTextValue(text, runtime: runtime)
                 let normalized = normalizedLabel(value ?? "")
-                return normalized.isEmpty ? nil : normalized
+                return normalized.isEmpty ? nil : RowLabel(cell: cell, value: normalized)
             }
         }
     }
 
     private static func candidateControls(
-        in row: AXUIElement,
+        in element: AXUIElement,
         runtime: AXHelpers.Runtime
     ) -> [AXUIElement] {
-        AXHelpers.findAllDescendants(of: row, maxDepth: 5, runtime: runtime).filter { element in
-            let role = AXHelpers.getRole(element, runtime: runtime)
+        AXHelpers.findAllDescendants(of: element, maxDepth: 5, runtime: runtime).filter { candidate in
+            let role = AXHelpers.getRole(candidate, runtime: runtime)
             return interactiveControlRoles.contains(role ?? "")
         }
+    }
+
+    private static func candidateControls(
+        in cells: [AXUIElement],
+        runtime: AXHelpers.Runtime
+    ) -> [AXUIElement] {
+        cells.flatMap { candidateControls(in: $0, runtime: runtime) }
+    }
+
+    private static func controlsAreConfinedToCells(
+        in row: AXUIElement,
+        cells: [AXUIElement],
+        runtime: AXHelpers.Runtime
+    ) -> Bool {
+        let controlsInCells = candidateControls(in: cells, runtime: runtime)
+        let controlsInRow = candidateControls(in: row, runtime: runtime)
+        guard controlsInCells.count == controlsInRow.count else { return false }
+        return controlsInRow.allSatisfy { candidate in
+            controlsInCells.contains { CFEqual($0, candidate) }
+        }
+    }
+
+    private static func rowCarriesParameterPair(
+        _ row: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> Bool {
+        guard let cells = rowCells(in: row, runtime: runtime) else {
+            return false
+        }
+        let labels = rowLabels(in: cells, runtime: runtime)
+        guard labels.count == 1,
+              let label = labels.first,
+              controlsAreConfinedToCells(in: row, cells: cells, runtime: runtime) else {
+            return false
+        }
+        // Keep the classifier's discriminator identical to `locate`'s binding:
+        // a control beside the label in its own AXCell is not a parameter pair.
+        // Otherwise an invalid row could certify Controls even though writes
+        // correctly refuse to bind it.
+        guard candidateControls(in: label.cell, runtime: runtime).isEmpty else {
+            return false
+        }
+        return candidateControls(
+            in: cells.filter { !CFEqual($0, label.cell) },
+            runtime: runtime
+        ).count == 1
     }
 
     /// The first four roles are the Controls-view roles observed on 2026-09-02.

--- a/Sources/LogicProMCP/HostParameters/ControlsViewBooleanParameterWriter.swift
+++ b/Sources/LogicProMCP/HostParameters/ControlsViewBooleanParameterWriter.swift
@@ -343,13 +343,15 @@ enum ControlsViewBooleanParameterWriter {
             return .refused(.viewEvidenceReadFailed(.switcherCensus(error)), restoration: nil)
         }
         var measured: [AXUIElement] = []
+        var firstSwitcherDescriptionReadFailure: AXHelpers.AXStatusError?
         for menuButton in menuButtons {
             let description: String?
             switch descriptionResult(of: menuButton, runtime: runtime) {
             case let .success(observed):
                 description = observed
             case let .failure(error):
-                return .refused(.viewEvidenceReadFailed(.switcherDescription(error)), restoration: nil)
+                firstSwitcherDescriptionReadFailure = firstSwitcherDescriptionReadFailure ?? error
+                continue
             }
             if AXLocalePolicy.pluginWindowViewSwitcher.matches(description, mode: .exact) {
                 measured.append(menuButton)
@@ -358,6 +360,12 @@ enum ControlsViewBooleanParameterWriter {
         guard measured.count == 1, let switcher = measured.first else {
             if measured.count > 1 {
                 return .refused(.viewSwitcherAmbiguous, restoration: nil)
+            }
+            if let firstSwitcherDescriptionReadFailure {
+                return .refused(
+                    .viewEvidenceReadFailed(.switcherDescription(firstSwitcherDescriptionReadFailure)),
+                    restoration: nil
+                )
             }
             return .refused(menuButtons.isEmpty ? .viewSwitcherNotFound : .unmeasuredLocale, restoration: nil)
         }

--- a/Sources/LogicProMCP/HostParameters/ControlsViewBooleanParameterWriter.swift
+++ b/Sources/LogicProMCP/HostParameters/ControlsViewBooleanParameterWriter.swift
@@ -72,18 +72,13 @@ enum ControlsViewBooleanParameterWriter {
         }
     }
 
-    /// A classifier census is evidence for a view transition, not a search
-    /// convenience. Keep its failed reads distinct from an empty census so an
-    /// unreadable Editor signal or table cannot authorise a Controls write.
+    /// These reads select the AX element that will receive an action. A failed
+    /// read therefore refuses instead of silently dropping a candidate and
+    /// risking an action on a different element.
     enum ViewEvidenceReadFailure: Error, Sendable, Equatable {
         case switcherCensus(AXHelpers.AXStatusError)
         case switcherDescription(AXHelpers.AXStatusError)
-        case sliderCensus(AXHelpers.AXStatusError)
-        case sliderDescription(AXHelpers.AXStatusError)
         case menuItemCensus(AXHelpers.AXStatusError)
-        case controlsTableCensus(AXHelpers.AXStatusError)
-        case controlsTableRows(AXHelpers.AXStatusError)
-        case controlsTableRow(AXHelpers.AXStatusError)
 
         var observation: String {
             switch self {
@@ -91,18 +86,8 @@ enum ControlsViewBooleanParameterWriter {
                 return "the plugin-window View-switcher census failed (AXChildren/AXRole status \(error.diagnosticLabel))"
             case let .switcherDescription(error):
                 return "the plugin-window View-switcher AXDescription read failed (status \(error.diagnosticLabel))"
-            case let .sliderCensus(error):
-                return "the native-editor AXSlider census failed (AXChildren/AXRole status \(error.diagnosticLabel))"
-            case let .sliderDescription(error):
-                return "a native-editor AXSlider AXDescription read failed (status \(error.diagnosticLabel))"
             case let .menuItemCensus(error):
                 return "the scoped View-menu item census failed (AXChildren/AXRole/AXTitle/AXDescription status \(error.diagnosticLabel))"
-            case let .controlsTableCensus(error):
-                return "the Controls-table census failed (AXChildren/AXRole status \(error.diagnosticLabel))"
-            case let .controlsTableRows(error):
-                return "the candidate Controls table AXRows read failed (status \(error.diagnosticLabel))"
-            case let .controlsTableRow(error):
-                return "a candidate Controls-table row read failed (status \(error.diagnosticLabel))"
             }
         }
     }
@@ -129,9 +114,9 @@ enum ControlsViewBooleanParameterWriter {
             case .unmeasuredLocale:
                 return "the plugin-window View AXDescription is not measured for this locale; no view name was guessed"
             case .entryViewNotConfirmed:
-                return "the bound plugin window exposed neither a described native-editor AXSlider nor a Controls-view label-and-sibling-control row with no described AXSlider; its entry view was not confirmed"
+                return "the bound plugin window exposed neither a described native-editor AXSlider, an absent AXTable, nor one Controls-view AXTable with a label-and-sibling-control row; its entry view was not confirmed"
             case let .viewEvidenceReadFailed(error):
-                return "view classification refused because \(error.observation); this is distinct from a missing switcher, menu item, slider, or table"
+                return "view selection refused because \(error.observation); this is distinct from a missing switcher or menu item"
             case .viewMenuDidNotAppearBeforeDeadline:
                 return "the measured View switcher exposed no scoped AXMenu before the menu-appearance deadline after AXPress"
             case let .viewMenuReadFailed(error):
@@ -182,13 +167,22 @@ enum ControlsViewBooleanParameterWriter {
         let attempted: Bool
         let confirmed: Bool
         let observedStructure: String?
+        let entryView: PluginWindowView
+
+        /// Only an observed structure different from the recorded entry view
+        /// proves that the operation left the plug-in view changed. A failed
+        /// restoration confirmation with no readable current view is unobserved,
+        /// not evidence of a changed view.
+        var leftViewChanged: Bool {
+            observedStructure.map { $0 != entryView.rawValue } ?? false
+        }
     }
 
     /// Owns one confirmed temporary view selection. Its caller restores this
     /// exact entry view on every exit path, including a locator refusal.
     final class ViewSession: @unchecked Sendable {
         private let window: AXUIElement
-        private let switcher: AXUIElement
+        private let switcher: AXUIElement?
         private let entryView: PluginWindowView
         private let didSwitch: Bool
         private let menuAppearanceTimeout: TimeInterval
@@ -197,7 +191,7 @@ enum ControlsViewBooleanParameterWriter {
 
         fileprivate init(
             window: AXUIElement,
-            switcher: AXUIElement,
+            switcher: AXUIElement?,
             entryView: PluginWindowView,
             didSwitch: Bool,
             menuAppearanceTimeout: TimeInterval,
@@ -217,14 +211,20 @@ enum ControlsViewBooleanParameterWriter {
         /// had not run.
         func restore() -> ViewRestoration {
             guard !restorationFinished else {
-                return ViewRestoration(attempted: false, confirmed: true, observedStructure: nil)
-            }
-            restorationFinished = true
-            guard didSwitch else {
                 return ViewRestoration(
                     attempted: false,
                     confirmed: true,
-                    observedStructure: entryView.rawValue
+                    observedStructure: nil,
+                    entryView: entryView
+                )
+            }
+            restorationFinished = true
+            guard didSwitch, let switcher else {
+                return ViewRestoration(
+                    attempted: false,
+                    confirmed: true,
+                    observedStructure: entryView.rawValue,
+                    entryView: entryView
                 )
             }
             switch switchView(
@@ -239,20 +239,16 @@ enum ControlsViewBooleanParameterWriter {
                 return ViewRestoration(
                     attempted: switched,
                     confirmed: true,
-                    observedStructure: entryView.rawValue
+                    observedStructure: entryView.rawValue,
+                    entryView: entryView
                 )
             case .refused:
-                let observed: PluginWindowView?
-                switch observedView(in: window, runtime: runtime) {
-                case let .success(view):
-                    observed = view
-                case .failure:
-                    observed = nil
-                }
+                let observed = observedView(in: window, runtime: runtime)
                 return ViewRestoration(
                     attempted: true,
                     confirmed: observed == entryView,
-                    observedStructure: observed?.rawValue
+                    observedStructure: observed?.rawValue,
+                    entryView: entryView
                 )
             }
         }
@@ -263,12 +259,9 @@ enum ControlsViewBooleanParameterWriter {
         case refused(ViewSwitchFailure, targetSelectionAttempted: Bool)
     }
 
-    private typealias ObservedViewResult = Result<PluginWindowView?, ViewEvidenceReadFailure>
-
     private enum ViewWaitResult {
         case confirmed
         case deadlineExpired
-        case readFailed(ViewEvidenceReadFailure)
     }
 
     struct ToggleResult: Sendable, Equatable {
@@ -292,6 +285,27 @@ enum ControlsViewBooleanParameterWriter {
         confirmationTimeout: TimeInterval = viewConfirmationTimeout,
         runtime: AXHelpers.Runtime = .production
     ) -> ViewPreparationResult {
+        let entryView: PluginWindowView
+        guard let observed = observedView(in: window, runtime: runtime) else {
+            return .refused(.entryViewNotConfirmed, restoration: nil)
+        }
+        entryView = observed
+
+        // A view already confirmed by its own positive evidence needs no
+        // switcher read: no switcher will be acted on and there is no view to
+        // restore. This also keeps classifier-only AXDescription failures out
+        // of an otherwise completed Controls or Editor operation.
+        guard entryView != targetView else {
+            return .ready(ViewSession(
+                window: window,
+                switcher: nil,
+                entryView: entryView,
+                didSwitch: false,
+                menuAppearanceTimeout: menuAppearanceTimeout,
+                runtime: runtime
+            ))
+        }
+
         let menuButtons: [AXUIElement]
         switch AXHelpers.censusDescendantResult(
             of: window, role: kAXMenuButtonRole, maxDepth: 5, runtime: runtime
@@ -319,16 +333,6 @@ enum ControlsViewBooleanParameterWriter {
                 return .refused(.viewSwitcherAmbiguous, restoration: nil)
             }
             return .refused(menuButtons.isEmpty ? .viewSwitcherNotFound : .unmeasuredLocale, restoration: nil)
-        }
-
-        let entryView: PluginWindowView
-        switch observedView(in: window, runtime: runtime) {
-        case let .success(.some(observed)):
-            entryView = observed
-        case .success(nil):
-            return .refused(.entryViewNotConfirmed, restoration: nil)
-        case let .failure(error):
-            return .refused(.viewEvidenceReadFailed(error), restoration: nil)
         }
 
         switch switchView(
@@ -368,20 +372,16 @@ enum ControlsViewBooleanParameterWriter {
                     restoration = ViewRestoration(
                         attempted: switched,
                         confirmed: true,
-                        observedStructure: entryView.rawValue
+                        observedStructure: entryView.rawValue,
+                        entryView: entryView
                     )
                 case .refused:
-                    let observed: PluginWindowView?
-                    switch observedView(in: window, runtime: runtime) {
-                    case let .success(view):
-                        observed = view
-                    case .failure:
-                        observed = nil
-                    }
+                    let observed = observedView(in: window, runtime: runtime)
                     restoration = ViewRestoration(
                         attempted: true,
                         confirmed: observed == entryView,
-                        observedStructure: observed?.rawValue
+                        observedStructure: observed?.rawValue,
+                        entryView: entryView
                     )
                 }
             } else {
@@ -393,11 +393,16 @@ enum ControlsViewBooleanParameterWriter {
 
     /// The native editor is signaled by a parameter-bearing slider. A described
     /// slider anywhere in the window is Editor evidence and wins over every
-    /// table shape. Controls is then recognized by at least one row with one
-    /// cell, one nonempty AXStaticText label, and a control in that label's
-    /// sibling subtree. Every census and description read is status-preserving:
-    /// an unreadable Editor signal refuses instead of disappearing and turning
-    /// an arbitrary one-cell table into Controls evidence.
+    /// table shape. Controls is confirmed only by one AXTable containing at
+    /// least one row with one cell, one nonempty AXStaticText label, and a
+    /// control in that label's sibling subtree. With no AXTable, Editor is
+    /// confirmed by that observed absence.
+    ///
+    /// AXDescription failures are deliberately ignored here. On the measured
+    /// Compressor surface those reads fail on Editor and on fourteen Controls
+    /// sliders, so their absence or failure cannot answer this question. They
+    /// never select an element to act on; a successful nonempty description is
+    /// positive Editor evidence, while the table structure decides Controls.
     ///
     /// Measured 2026-09-02, Compressor editor window "Absolute Zero": one
     /// AXTable at depth 2 had AXRows status 0 and 29 rows; every row had exactly
@@ -410,57 +415,47 @@ enum ControlsViewBooleanParameterWriter {
     private static func observedView(
         in window: AXUIElement,
         runtime: AXHelpers.Runtime
-    ) -> ObservedViewResult {
-        let sliderDescriptions: [String]
-        switch nativeEditorSliderEvidence(in: window, runtime: runtime) {
-        case let .success(observed):
-            sliderDescriptions = observed
-        case let .failure(error):
-            return .failure(error)
-        }
-        if sliderDescriptions.contains(where: { !$0.isEmpty }) {
-            return .success(.editor)
+    ) -> PluginWindowView? {
+        if hasDescribedNativeEditorSlider(in: window, runtime: runtime) {
+            return .editor
         }
         switch controlsViewStateIsBound(in: window, runtime: runtime) {
-        case .success(true):
-            return .success(.controls)
-        case .success(false):
-            return .success(sliderDescriptions.isEmpty ? nil : .editor)
-        case let .failure(error):
-            return .failure(error)
+        case .controls:
+            return .controls
+        case .noTable:
+            return .editor
+        case .unconfirmed:
+            return nil
         }
     }
 
-    /// Returns every native-editor slider description, preserving the exact
-    /// census/description failure that would otherwise erase Editor evidence.
-    /// A present-but-empty description is deliberately retained: bare sliders
-    /// still distinguish an unconfirmed window from a Controls table, while
-    /// only nonempty descriptions establish the native Editor view.
-    private static func nativeEditorSliderEvidence(
+    /// A description can establish Editor only when it is actually read and
+    /// nonempty. Failed and absent reads are not negative evidence, so scanning
+    /// continues through every slider and reports only a positive observation.
+    private static func hasDescribedNativeEditorSlider(
         in window: AXUIElement,
         runtime: AXHelpers.Runtime
-    ) -> Result<[String], ViewEvidenceReadFailure> {
+    ) -> Bool {
         let sliders: [AXUIElement]
         switch AXHelpers.censusDescendantResult(
             of: window, role: kAXSliderRole, maxDepth: 8, runtime: runtime
         ) {
         case let .success(census):
             sliders = census.matches
-        case let .failure(error):
-            return .failure(.sliderCensus(error))
+        case .failure:
+            return false
         }
-        var descriptions: [String] = []
         for slider in sliders {
-            let description: String?
             switch descriptionResult(of: slider, runtime: runtime) {
-            case let .success(observed):
-                description = observed
-            case let .failure(error):
-                return .failure(.sliderDescription(error))
+            case let .success(description):
+                if !(description?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true) {
+                    return true
+                }
+            case .failure:
+                continue
             }
-            descriptions.append(description?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "")
         }
-        return .success(descriptions)
+        return false
     }
 
     private static func switchView(
@@ -473,13 +468,8 @@ enum ControlsViewBooleanParameterWriter {
         runtime: AXHelpers.Runtime
     ) -> ViewChangeResult {
         if !forceSelection {
-            switch observedView(in: window, runtime: runtime) {
-            case let .success(observed) where observed == targetView:
+            if observedView(in: window, runtime: runtime) == targetView {
                 return .confirmed(switched: false)
-            case .success:
-                break
-            case let .failure(error):
-                return .refused(.viewEvidenceReadFailed(error), targetSelectionAttempted: false)
             }
         }
 
@@ -534,8 +524,6 @@ enum ControlsViewBooleanParameterWriter {
             break
         case .deadlineExpired:
             return .refused(.viewStructureDidNotConfirm(targetView), targetSelectionAttempted: true)
-        case let .readFailed(error):
-            return .refused(.viewEvidenceReadFailed(error), targetSelectionAttempted: true)
         }
         return .confirmed(switched: true)
     }
@@ -645,13 +633,8 @@ enum ControlsViewBooleanParameterWriter {
     ) -> ViewWaitResult {
         let deadline = Date().addingTimeInterval(max(0, timeout))
         repeat {
-            switch observedView(in: window, runtime: runtime) {
-            case let .success(observed) where observed == expected:
+            if observedView(in: window, runtime: runtime) == expected {
                 return .confirmed
-            case .success:
-                break
-            case let .failure(error):
-                return .readFailed(error)
             }
             let remaining = deadline.timeIntervalSinceNow
             guard remaining > 0 else { break }
@@ -660,41 +643,49 @@ enum ControlsViewBooleanParameterWriter {
         return .deadlineExpired
     }
 
+    private enum ControlsTableEvidence {
+        case controls
+        case noTable
+        case unconfirmed
+    }
+
     private static func controlsViewStateIsBound(
         in window: AXUIElement,
         runtime: AXHelpers.Runtime
-    ) -> Result<Bool, ViewEvidenceReadFailure> {
+    ) -> ControlsTableEvidence {
         let tables: [AXUIElement]
         switch AXHelpers.censusDescendantResult(
             of: window, role: kAXTableRole, maxDepth: 8, runtime: runtime
         ) {
         case let .success(census):
             tables = census.matches
-        case let .failure(error):
-            return .failure(.controlsTableCensus(error))
+        case .failure:
+            return .unconfirmed
         }
-        guard tables.count == 1, let table = tables.first else { return .success(false) }
+        if tables.isEmpty { return .noTable }
+        guard tables.count == 1, let table = tables.first else { return .unconfirmed }
         let rows: [AXUIElement]
         switch controlsRows(in: table, runtime: runtime) {
         case let .success(observed):
             rows = observed
-        case let .failure(error):
-            return .failure(.controlsTableRows(error))
+        case .failure:
+            return .unconfirmed
         }
         // Heading and section rows have no interactive control in the live
         // table. A Controls view is bound by the presence of at least one
         // measured label/control pair, not by requiring every row to be one.
+        // A failed row read is not negative evidence and cannot erase a pair
+        // observed in another row; without a pair, the table remains
+        // unconfirmed rather than becoming Editor evidence.
         for row in rows {
             switch rowCarriesParameterPair(row, runtime: runtime) {
             case .success(true):
-                return .success(true)
-            case .success(false):
+                return .controls
+            case .success(false), .failure:
                 continue
-            case let .failure(error):
-                return .failure(.controlsTableRow(error))
             }
         }
-        return .success(false)
+        return .unconfirmed
     }
 
     /// Resolve a row-label address without positional fallbacks. A candidate
@@ -703,12 +694,12 @@ enum ControlsViewBooleanParameterWriter {
     /// control.
     ///
     /// An AXTable is not structurally self-identifying as the parameter table.
-    /// This method accepts one only when the caller has already bound this
-    /// window to the requested plug-in by header identity, this window has one
-    /// table, no described native-editor slider, and one row whose catalogued
-    /// requested label has one sibling control. AX exposes no stronger table
-    /// identity fact; any failed part of that evidence refuses rather than
-    /// weakening it to a missing match.
+    /// The guarantee here is deliberately limited: the caller has already
+    /// bound the window by plug-in header identity, this window has exactly one
+    /// AXTable, and the selected AXRow label equals the catalogued parameter's
+    /// `controlsViewRowLabel`. AX exposes no stronger table identity fact. In
+    /// particular, this does not claim that an unrelated one-table plug-in
+    /// window can be distinguished by table structure alone.
     static func locate(
         label requestedLabel: String,
         in window: AXUIElement,
@@ -728,14 +719,6 @@ enum ControlsViewBooleanParameterWriter {
         }
         guard tables.count == 1, let table = tables.first else {
             return .refused(tables.isEmpty ? .controlsViewTableNotFound : .controlsViewTableAmbiguous)
-        }
-        switch nativeEditorSliderEvidence(in: window, runtime: runtime) {
-        case let .success(descriptions) where descriptions.allSatisfy(\.isEmpty):
-            break
-        case .success:
-            return .refused(.controlsViewTableNotFound)
-        case .failure:
-            return .refused(.accessibilityReadFailed)
         }
         let rows: [AXUIElement]
         switch controlsRows(in: table, runtime: runtime) {

--- a/Sources/LogicProMCP/HostParameters/ControlsViewBooleanParameterWriter.swift
+++ b/Sources/LogicProMCP/HostParameters/ControlsViewBooleanParameterWriter.swift
@@ -74,7 +74,8 @@ enum ControlsViewBooleanParameterWriter {
         case viewSwitcherAmbiguous
         case unmeasuredLocale
         case entryViewNotConfirmed
-        case viewMenuNotFound
+        case viewMenuDidNotAppearBeforeDeadline
+        case viewMenuReadFailed(AXHelpers.AXStatusError)
         case viewMenuAmbiguous
         case viewMenuItemNotFound(PluginWindowView)
         case viewMenuItemAmbiguous(PluginWindowView)
@@ -89,9 +90,11 @@ enum ControlsViewBooleanParameterWriter {
             case .unmeasuredLocale:
                 return "the plugin-window View AXDescription is not measured for this locale; no view name was guessed"
             case .entryViewNotConfirmed:
-                return "the bound plugin window exposed neither a described native-editor AXSlider nor Controls-view rows with no described AXSlider; its entry view was not confirmed"
-            case .viewMenuNotFound:
-                return "the measured View switcher exposed no scoped AXMenu after AXPress"
+                return "the bound plugin window exposed neither a described native-editor AXSlider nor a Controls-view label-and-sibling-control row with no described AXSlider; its entry view was not confirmed"
+            case .viewMenuDidNotAppearBeforeDeadline:
+                return "the measured View switcher exposed no scoped AXMenu before the menu-appearance deadline after AXPress"
+            case let .viewMenuReadFailed(error):
+                return "the measured View switcher's scoped AXMenu read failed after AXPress (AXChildren/AXRole status \(error.diagnosticLabel)); this is distinct from a menu-appearance deadline"
             case .viewMenuAmbiguous:
                 return "the measured View switcher exposed several scoped AXMenus"
             case let .viewMenuItemNotFound(view):
@@ -147,6 +150,7 @@ enum ControlsViewBooleanParameterWriter {
         private let switcher: AXUIElement
         private let entryView: PluginWindowView
         private let didSwitch: Bool
+        private let menuAppearanceTimeout: TimeInterval
         private let runtime: AXHelpers.Runtime
         private var restorationFinished = false
 
@@ -155,12 +159,14 @@ enum ControlsViewBooleanParameterWriter {
             switcher: AXUIElement,
             entryView: PluginWindowView,
             didSwitch: Bool,
+            menuAppearanceTimeout: TimeInterval,
             runtime: AXHelpers.Runtime
         ) {
             self.window = window
             self.switcher = switcher
             self.entryView = entryView
             self.didSwitch = didSwitch
+            self.menuAppearanceTimeout = menuAppearanceTimeout
             self.runtime = runtime
         }
 
@@ -183,6 +189,7 @@ enum ControlsViewBooleanParameterWriter {
                 to: entryView,
                 in: window,
                 switcher: switcher,
+                menuAppearanceTimeout: menuAppearanceTimeout,
                 confirmationTimeout: viewConfirmationTimeout,
                 runtime: runtime
             ) {
@@ -204,7 +211,7 @@ enum ControlsViewBooleanParameterWriter {
 
     private enum ViewChangeResult {
         case confirmed(switched: Bool)
-        case refused(ViewSwitchFailure)
+        case refused(ViewSwitchFailure, targetSelectionAttempted: Bool)
     }
 
     struct ToggleResult: Sendable, Equatable {
@@ -224,6 +231,7 @@ enum ControlsViewBooleanParameterWriter {
     static func prepareView(
         _ targetView: PluginWindowView,
         in window: AXUIElement,
+        menuAppearanceTimeout: TimeInterval = viewMenuAppearanceTimeout,
         confirmationTimeout: TimeInterval = viewConfirmationTimeout,
         runtime: AXHelpers.Runtime = .production
     ) -> ViewPreparationResult {
@@ -251,6 +259,7 @@ enum ControlsViewBooleanParameterWriter {
             to: targetView,
             in: window,
             switcher: switcher,
+            menuAppearanceTimeout: menuAppearanceTimeout,
             confirmationTimeout: confirmationTimeout,
             runtime: runtime
         ) {
@@ -260,20 +269,25 @@ enum ControlsViewBooleanParameterWriter {
                 switcher: switcher,
                 entryView: entryView,
                 didSwitch: switched,
+                menuAppearanceTimeout: menuAppearanceTimeout,
                 runtime: runtime
             ))
-        case let .refused(failure):
+        case let .refused(failure, targetSelectionAttempted):
             // A pressed menu item can have changed the view even when the
             // target structure did not settle before its deadline. Re-select
             // the entry view best-effort before refusing, so failed selection
             // paths do not strand it.
-            _ = switchView(
-                to: entryView,
-                in: window,
-                switcher: switcher,
-                confirmationTimeout: confirmationTimeout,
-                runtime: runtime
-            )
+            if targetSelectionAttempted {
+                _ = switchView(
+                    to: entryView,
+                    in: window,
+                    switcher: switcher,
+                    menuAppearanceTimeout: menuAppearanceTimeout,
+                    confirmationTimeout: confirmationTimeout,
+                    forceSelection: true,
+                    runtime: runtime
+                )
+            }
             return .refused(failure)
         }
     }
@@ -299,7 +313,7 @@ enum ControlsViewBooleanParameterWriter {
         }) {
             return .editor
         }
-        if controlsViewRowsArePresent(in: window, runtime: runtime) {
+        if controlsViewStateIsBound(in: window, runtime: runtime) {
             return .controls
         }
         return sliders.isEmpty ? nil : .editor
@@ -309,10 +323,12 @@ enum ControlsViewBooleanParameterWriter {
         to targetView: PluginWindowView,
         in window: AXUIElement,
         switcher: AXUIElement,
+        menuAppearanceTimeout: TimeInterval,
         confirmationTimeout: TimeInterval,
+        forceSelection: Bool = false,
         runtime: AXHelpers.Runtime
     ) -> ViewChangeResult {
-        guard observedView(in: window, runtime: runtime) != targetView else {
+        guard forceSelection || observedView(in: window, runtime: runtime) != targetView else {
             return .confirmed(switched: false)
         }
 
@@ -320,11 +336,21 @@ enum ControlsViewBooleanParameterWriter {
         // reveals this app-wide menu after AXPress, and its entry accepts only
         // AXPick; no retry ladder can turn another protocol into evidence.
         _ = AXHelpers.performAction(switcher, kAXPressAction as String, runtime: runtime)
-        let menus = AXHelpers.censusDescendant(
-            of: switcher, role: kAXMenuRole, maxDepth: 4, runtime: runtime
-        ).matches
+        let menus: [AXUIElement]
+        switch waitForScopedViewMenu(
+            under: switcher,
+            timeout: menuAppearanceTimeout,
+            runtime: runtime
+        ) {
+        case let .found(observed):
+            menus = observed
+        case .deadlineExpired:
+            return .refused(.viewMenuDidNotAppearBeforeDeadline, targetSelectionAttempted: false)
+        case let .readFailed(error):
+            return .refused(.viewMenuReadFailed(error), targetSelectionAttempted: false)
+        }
         guard menus.count == 1, let menu = menus.first else {
-            return .refused(menus.isEmpty ? .viewMenuNotFound : .viewMenuAmbiguous)
+            return .refused(.viewMenuAmbiguous, targetSelectionAttempted: false)
         }
         let entries = AXLocalePolicy.censusDescendant(
             of: menu,
@@ -336,7 +362,8 @@ enum ControlsViewBooleanParameterWriter {
         guard entries.count == 1, let target = entries.first else {
             return .refused(entries.isEmpty
                 ? .viewMenuItemNotFound(targetView)
-                : .viewMenuItemAmbiguous(targetView)
+                : .viewMenuItemAmbiguous(targetView),
+                targetSelectionAttempted: false
             )
         }
         _ = AXHelpers.performAction(target, kAXPickAction as String, runtime: runtime)
@@ -346,13 +373,107 @@ enum ControlsViewBooleanParameterWriter {
             timeout: confirmationTimeout,
             runtime: runtime
         ) else {
-            return .refused(.viewStructureDidNotConfirm(targetView))
+            return .refused(.viewStructureDidNotConfirm(targetView), targetSelectionAttempted: true)
         }
         return .confirmed(switched: true)
     }
 
+    private static let viewMenuAppearanceTimeout: TimeInterval = 2.0
+    private static let viewMenuAppearancePollInterval: TimeInterval = 0.05
     private static let viewConfirmationTimeout: TimeInterval = 1.5
     private static let viewConfirmationPollInterval: TimeInterval = 0.05
+
+    private enum ScopedViewMenuWaitResult {
+        case found([AXUIElement])
+        case deadlineExpired
+        case readFailed(AXHelpers.AXStatusError)
+    }
+
+    /// The view menu is created below the switcher asynchronously. Preserve an
+    /// unreadable AX subtree as a refusal instead of treating it as an empty
+    /// menu and incorrectly claiming its appearance timed out.
+    private static func waitForScopedViewMenu(
+        under switcher: AXUIElement,
+        timeout: TimeInterval,
+        runtime: AXHelpers.Runtime
+    ) -> ScopedViewMenuWaitResult {
+        let deadline = Date().addingTimeInterval(max(0, timeout))
+        repeat {
+            switch scopedViewMenus(under: switcher, runtime: runtime) {
+            case let .success(menus) where !menus.isEmpty:
+                return .found(menus)
+            case .success:
+                break
+            case let .failure(error):
+                return .readFailed(error)
+            }
+            let remaining = deadline.timeIntervalSinceNow
+            guard remaining > 0 else { break }
+            Thread.sleep(forTimeInterval: min(viewMenuAppearancePollInterval, remaining))
+        } while Date() < deadline
+        return .deadlineExpired
+    }
+
+    private static func scopedViewMenus(
+        under switcher: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> Result<[AXUIElement], AXHelpers.AXStatusError> {
+        var menus: [AXUIElement] = []
+        if let error = collectScopedViewMenus(
+            below: switcher,
+            remainingDepth: 4,
+            runtime: runtime,
+            into: &menus
+        ) {
+            return .failure(error)
+        }
+        return .success(menus)
+    }
+
+    private static func collectScopedViewMenus(
+        below element: AXUIElement,
+        remainingDepth: Int,
+        runtime: AXHelpers.Runtime,
+        into menus: inout [AXUIElement]
+    ) -> AXHelpers.AXStatusError? {
+        guard remainingDepth > 0 else { return nil }
+        let children: [AXUIElement]
+        switch AXHelpers.childrenResult(element, runtime: runtime) {
+        case let .success(observed):
+            children = observed
+        case let .failure(error) where error.isDefinitiveAbsence:
+            return nil
+        case let .failure(error):
+            return error
+        }
+        for child in children {
+            let role: String?
+            switch AXHelpers.getAttributeResult(
+                child,
+                kAXRoleAttribute as String,
+                runtime: runtime
+            ) as Result<String?, AXHelpers.AXStatusError> {
+            case let .success(observed):
+                role = observed
+            case let .failure(error) where error.isDefinitiveAbsence:
+                role = nil
+            case let .failure(error):
+                return error
+            }
+            if role == (kAXMenuRole as String) {
+                menus.append(child)
+            }
+            if let error = collectScopedViewMenus(
+                below: child,
+                remainingDepth: remainingDepth - 1,
+                runtime: runtime,
+                into: &menus
+            ) {
+                return error
+            }
+        }
+        return nil
+    }
 
     private static func waitForView(
         _ expected: PluginWindowView,
@@ -372,7 +493,7 @@ enum ControlsViewBooleanParameterWriter {
         return false
     }
 
-    private static func controlsViewRowsArePresent(
+    private static func controlsViewStateIsBound(
         in window: AXUIElement,
         runtime: AXHelpers.Runtime
     ) -> Bool {
@@ -381,6 +502,9 @@ enum ControlsViewBooleanParameterWriter {
         ).matches
         guard tables.count == 1, let table = tables.first else { return false }
         guard let rows = controlsRows(in: table, runtime: runtime) else { return false }
+        // Heading and section rows have no interactive control in the live
+        // table. A Controls view is bound by the presence of at least one
+        // measured label/control pair, not by requiring every row to be one.
         return rows.contains { rowCarriesParameterPair($0, runtime: runtime) }
     }
 

--- a/Sources/LogicProMCP/Plugins/StockPluginCatalog.swift
+++ b/Sources/LogicProMCP/Plugins/StockPluginCatalog.swift
@@ -521,13 +521,20 @@ enum StockPluginCatalogValidator {
                     path: "\(base).parameters[\(paramIndex)].provenance",
                     issues: &issues
                 )
-                if parameter.availabilityState == .verified,
-                   (parameter.readbackMethod?.isEmpty ?? true) || !parameter.provenance.evidence.contains("parameter_readback") {
-                    issues.append(issue(
-                        "verified_parameter_missing_readback",
-                        "\(base).parameters[\(paramIndex)]",
-                        "verified parameters require readback method and parameter_readback evidence"
-                    ))
+                if parameter.availabilityState == .verified {
+                    if parameter.readbackMethod?.isEmpty ?? true {
+                        issues.append(issue(
+                            "verified_parameter_missing_readback",
+                            "\(base).parameters[\(paramIndex)]",
+                            "verified parameters require a readback method"
+                        ))
+                    } else if !hasVerifiedParameterWriteObservation(parameter) {
+                        issues.append(issue(
+                            "verified_parameter_missing_write_observation",
+                            "\(base).parameters[\(paramIndex)]",
+                            "verified parameter evidence must parse operation=logic_plugins.set_param_verified, write_method=<declared method>, and reciprocal observed_transition=<from>-><to> records"
+                        ))
+                    }
                 }
             }
         }
@@ -539,6 +546,73 @@ enum StockPluginCatalogValidator {
     private static func hasPresetProvenance(_ provenance: StockPluginProvenance) -> Bool {
         provenance.evidence.contains("factory_preset_filenames") ||
             provenance.evidence.contains("preset_names_observed")
+    }
+
+    /// Verified parameter evidence is deliberately structured rather than a
+    /// reassuring free-form token. A verifier can check the named public
+    /// operation, bind the observation to this parameter's declared write
+    /// method, and require a measured transition plus its reverse. This proves
+    /// bidirectional actuation without pretending the catalog can inspect a
+    /// live artifact path at validation time.
+    private static func hasVerifiedParameterWriteObservation(_ parameter: StockPluginParameterMetadata) -> Bool {
+        guard let declaredWriteMethod = parameter.writeMethod,
+              !declaredWriteMethod.isEmpty else {
+            return false
+        }
+        let parsed = VerifiedParameterEvidence.parse(parameter.provenance.evidence)
+        guard parsed.operations.contains("logic_plugins.set_param_verified"),
+              parsed.writeMethods.contains(declaredWriteMethod) else {
+            return false
+        }
+        return parsed.transitions.contains { transition in
+            transition.from != transition.to && parsed.transitions.contains(
+                VerifiedParameterEvidence.Transition(
+                    from: transition.to,
+                    to: transition.from
+                )
+            )
+        }
+    }
+
+    private struct VerifiedParameterEvidence {
+        struct Transition: Hashable {
+            let from: Double
+            let to: Double
+        }
+
+        var operations = Set<String>()
+        var writeMethods = Set<String>()
+        var transitions = Set<Transition>()
+
+        static func parse(_ records: [String]) -> Self {
+            var parsed = Self()
+            for record in records {
+                let pieces = record.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+                guard pieces.count == 2 else { continue }
+                let key = String(pieces[0])
+                let value = String(pieces[1])
+                guard !value.isEmpty else { continue }
+                switch key {
+                case "operation":
+                    parsed.operations.insert(value)
+                case "write_method":
+                    parsed.writeMethods.insert(value)
+                case "observed_transition":
+                    let endpoints = value.split(separator: "->", maxSplits: 1, omittingEmptySubsequences: false)
+                    guard endpoints.count == 2,
+                          let from = Double(endpoints[0]),
+                          let to = Double(endpoints[1]),
+                          from.isFinite,
+                          to.isFinite else {
+                        continue
+                    }
+                    parsed.transitions.insert(Transition(from: from, to: to))
+                default:
+                    continue
+                }
+            }
+            return parsed
+        }
     }
 
     private static func validateProvenance(
@@ -975,20 +1049,19 @@ enum StockPluginCatalog {
             editorWindowAnchorAXDescription: "Threshold",
             availabilityState: .verified,
             provenance: StockPluginProvenance(
-                source: "live_logic",
-                method: "controls_view_axcheckbox_press_readback",
+                source: "release_binary_live_drive",
+                method: "logic_plugins.set_param_verified.ax_controls_view_checkbox_press",
                 observedAt: "2026-09-02T11:30:17+09:00",
                 logicVersion: nil,
                 locale: "ko-KR",
-                sourcePath: "/Users/isaac/lpm-evidence/controls-view-write-20260902-113017/",
+                sourcePath: nil,
                 inferenceReason: nil,
                 evidence: [
-                    // The token the catalog validator requires for a VERIFIED parameter: it means a
-                    // write/readback round trip was observed, not merely that a readback method
-                    // was named. Measured 2026-09-02 on the live Controls view.
-                    "parameter_readback",
-                    "controls-view-write-20260902-113017",
-                    "Limiter On AXPress 0.00 -> 1.00 and 1.00 -> 0.00 observed",
+                    "operation=logic_plugins.set_param_verified",
+                    "write_method=ax_controls_view_checkbox_press",
+                    "observed_transition=0->1",
+                    "observed_transition=1->0",
+                    "artifact=release_binary_head_67ba2e8d_2026-09-02",
                 ]
             )
         ),
@@ -1005,20 +1078,19 @@ enum StockPluginCatalog {
             editorWindowAnchorAXDescription: "Threshold",
             availabilityState: .verified,
             provenance: StockPluginProvenance(
-                source: "live_logic",
-                method: "controls_view_axcheckbox_press_readback",
+                source: "release_binary_live_drive",
+                method: "logic_plugins.set_param_verified.ax_controls_view_checkbox_press",
                 observedAt: "2026-09-02T11:30:17+09:00",
                 logicVersion: nil,
                 locale: "ko-KR",
-                sourcePath: "/Users/isaac/lpm-evidence/controls-view-write-20260902-113017/",
+                sourcePath: nil,
                 inferenceReason: nil,
                 evidence: [
-                    // The token the catalog validator requires for a VERIFIED parameter: it means a
-                    // write/readback round trip was observed, not merely that a readback method
-                    // was named. Measured 2026-09-02 on the live Controls view.
-                    "parameter_readback",
-                    "controls-view-write-20260902-113017",
-                    "Auto Release AXPress 1.00 -> 0.00 and 0.00 -> 1.00 observed",
+                    "operation=logic_plugins.set_param_verified",
+                    "write_method=ax_controls_view_checkbox_press",
+                    "observed_transition=0->1",
+                    "observed_transition=1->0",
+                    "artifact=release_binary_head_67ba2e8d_2026-09-02",
                 ]
             )
         ),

--- a/Sources/LogicProMCP/Plugins/StockPluginCatalog.swift
+++ b/Sources/LogicProMCP/Plugins/StockPluginCatalog.swift
@@ -1114,9 +1114,9 @@ enum StockPluginCatalog {
                 logicVersion: nil,
                 locale: "ko-KR",
                 evidence: [
-                    // The token the catalog validator requires for a VERIFIED parameter: it means a
-                    // write/readback round trip was observed, not merely that a readback method
-                    // was named. Measured 2026-09-02 on the live Controls view.
+                    // Evidence from the observed Controls-view probe. The catalog
+                    // validator requires corroborating write/readback evidence;
+                    // this token alone is not sufficient to verify a parameter.
                     "parameter_readback",
                     "controls-view-write-20260902-113017",
                     "AXValue set and AXIncrement x5 reported success while Gain remained 48.0000",
@@ -1169,9 +1169,9 @@ enum StockPluginCatalog {
                 logicVersion: nil,
                 locale: "ko-KR",
                 evidence: [
-                    // The token the catalog validator requires for a VERIFIED parameter: it means a
-                    // write/readback round trip was observed, not merely that a readback method
-                    // was named. Measured 2026-09-02 on the live Controls view.
+                    // Evidence from the observed Controls-view probe. The catalog
+                    // validator requires corroborating write/readback evidence;
+                    // this token alone is not sufficient to verify a parameter.
                     "parameter_readback",
                     "controls-view-write-20260902-113017",
                     "Circuit Type AXValue Platinum Digital observed; popup selection was not measured",

--- a/Sources/LogicProMCP/Plugins/StockPluginCatalog.swift
+++ b/Sources/LogicProMCP/Plugins/StockPluginCatalog.swift
@@ -24,6 +24,14 @@ enum StockPluginSafeWriteCapability: String, Codable, Sendable {
     case parameterWriteReadback = "parameter_write_readback"
 }
 
+/// What live evidence establishes about a named control in Logic's Controls
+/// view. This is deliberately independent of `availabilityState`: an observed
+/// non-actuation is useful safety evidence, but it is never a write capability.
+enum ControlsViewActuationState: String, Codable, Sendable, Equatable {
+    case measuredNotActuable = "measured_not_actuable"
+    case unmeasured
+}
+
 struct StockPluginProvenance: Codable, Sendable, Equatable {
     let source: String
     let method: String
@@ -188,6 +196,21 @@ struct StockPluginParameterMetadata: Codable, Sendable, Equatable {
     /// parameters without one stay write-unsupported. nil ⇒ not
     /// AX-addressable by description.
     let axDescription: String?
+    /// The Controls-view AXRow label for parameters whose name lives beside
+    /// their control rather than on it. nil means this catalog item has no
+    /// measured Controls-view row address.
+    let controlsViewRowLabel: String?
+    /// The observed Controls-view control role. This records an addressing
+    /// fact even for roles that have deliberately not been qualified to write.
+    let controlsViewControlRole: String?
+    /// The Controls-view role's explicit write qualification. In particular,
+    /// `measured_not_actuable` means its refusal must take precedence over the
+    /// generic missing-write/readback capability response.
+    let controlsViewActuationState: ControlsViewActuationState?
+    /// A separately measured editor-view slider description that authenticates
+    /// the Compressor window before this parameter switches it into Controls
+    /// view. It is not the parameter's control locator.
+    let editorWindowAnchorAXDescription: String?
     let availabilityState: StockPluginTruthState
     let provenance: StockPluginProvenance
 
@@ -201,6 +224,10 @@ struct StockPluginParameterMetadata: Codable, Sendable, Equatable {
         case readbackMethod = "readback_method"
         case tolerance
         case axDescription = "ax_description"
+        case controlsViewRowLabel = "controls_view_row_label"
+        case controlsViewControlRole = "controls_view_control_role"
+        case controlsViewActuationState = "controls_view_actuation_state"
+        case editorWindowAnchorAXDescription = "editor_window_anchor_ax_description"
         case availabilityState = "availability_state"
         case provenance
     }
@@ -215,6 +242,10 @@ struct StockPluginParameterMetadata: Codable, Sendable, Equatable {
         readbackMethod: String?,
         tolerance: Double? = nil,
         axDescription: String? = nil,
+        controlsViewRowLabel: String? = nil,
+        controlsViewControlRole: String? = nil,
+        controlsViewActuationState: ControlsViewActuationState? = nil,
+        editorWindowAnchorAXDescription: String? = nil,
         availabilityState: StockPluginTruthState,
         provenance: StockPluginProvenance
     ) {
@@ -227,6 +258,10 @@ struct StockPluginParameterMetadata: Codable, Sendable, Equatable {
         self.readbackMethod = readbackMethod
         self.tolerance = tolerance
         self.axDescription = axDescription
+        self.controlsViewRowLabel = controlsViewRowLabel
+        self.controlsViewControlRole = controlsViewControlRole
+        self.controlsViewActuationState = controlsViewActuationState
+        self.editorWindowAnchorAXDescription = editorWindowAnchorAXDescription
         self.availabilityState = availabilityState
         self.provenance = provenance
     }
@@ -921,6 +956,156 @@ enum StockPluginCatalog {
                 evidence: ["parameter_write_readback", "CHANGELOG.md"]
             )
         ),
+        // ADR-011 / ADR-018, measured on this machine 2026-09-02. In the
+        // Compressor's Controls view the name is the AXRow's AXStaticText,
+        // while the AXCheckBox itself exposes only AXValue. AXPress 0→1 and
+        // 1→0 both completed with observed readback. The editor anchor remains
+        // Threshold only for acquiring the already-known Compressor window;
+        // it is never used to address either checkbox.
+        StockPluginParameterMetadata(
+            id: "limiter_on",
+            displayName: "Limiter On",
+            unit: "boolean",
+            valueRange: StockPluginValueRange(min: 0, max: 1, defaultValue: nil),
+            writeMethod: "ax_controls_view_checkbox_press",
+            readbackMethod: "ax_controls_view_checkbox_value",
+            tolerance: 0,
+            controlsViewRowLabel: "Limiter On",
+            controlsViewControlRole: "AXCheckBox",
+            editorWindowAnchorAXDescription: "Threshold",
+            availabilityState: .verified,
+            provenance: StockPluginProvenance(
+                source: "live_logic",
+                method: "controls_view_axcheckbox_press_readback",
+                observedAt: "2026-09-02T11:30:17+09:00",
+                logicVersion: nil,
+                locale: "ko-KR",
+                sourcePath: "/Users/isaac/lpm-evidence/controls-view-write-20260902-113017/",
+                inferenceReason: nil,
+                evidence: [
+                    // The token the catalog validator requires for a VERIFIED parameter: it means a
+                    // write/readback round trip was observed, not merely that a readback method
+                    // was named. Measured 2026-09-02 on the live Controls view.
+                    "parameter_readback",
+                    "controls-view-write-20260902-113017",
+                    "Limiter On AXPress 0.00 -> 1.00 and 1.00 -> 0.00 observed",
+                ]
+            )
+        ),
+        StockPluginParameterMetadata(
+            id: "auto_release",
+            displayName: "Auto Release",
+            unit: "boolean",
+            valueRange: StockPluginValueRange(min: 0, max: 1, defaultValue: nil),
+            writeMethod: "ax_controls_view_checkbox_press",
+            readbackMethod: "ax_controls_view_checkbox_value",
+            tolerance: 0,
+            controlsViewRowLabel: "Auto Release",
+            controlsViewControlRole: "AXCheckBox",
+            editorWindowAnchorAXDescription: "Threshold",
+            availabilityState: .verified,
+            provenance: StockPluginProvenance(
+                source: "live_logic",
+                method: "controls_view_axcheckbox_press_readback",
+                observedAt: "2026-09-02T11:30:17+09:00",
+                logicVersion: nil,
+                locale: "ko-KR",
+                sourcePath: "/Users/isaac/lpm-evidence/controls-view-write-20260902-113017/",
+                inferenceReason: nil,
+                evidence: [
+                    // The token the catalog validator requires for a VERIFIED parameter: it means a
+                    // write/readback round trip was observed, not merely that a readback method
+                    // was named. Measured 2026-09-02 on the live Controls view.
+                    "parameter_readback",
+                    "controls-view-write-20260902-113017",
+                    "Auto Release AXPress 1.00 -> 0.00 and 0.00 -> 1.00 observed",
+                ]
+            )
+        ),
+        // This is not a write capability. It preserves the negative live
+        // measurement so a caller requesting Gain gets the reason that was
+        // established instead of an optimistic generic AX-settable path.
+        StockPluginParameterMetadata(
+            id: "gain",
+            displayName: "Gain",
+            unit: "raw_ax_value",
+            valueRange: nil,
+            writeMethod: nil,
+            readbackMethod: "ax_value_observed",
+            controlsViewRowLabel: "Gain",
+            controlsViewControlRole: "AXSlider",
+            controlsViewActuationState: .measuredNotActuable,
+            availabilityState: .observed,
+            provenance: .observed(
+                method: "controls_view_axslider_nonactuation_measurement",
+                observedAt: "2026-09-02T11:30:17+09:00",
+                logicVersion: nil,
+                locale: "ko-KR",
+                evidence: [
+                    // The token the catalog validator requires for a VERIFIED parameter: it means a
+                    // write/readback round trip was observed, not merely that a readback method
+                    // was named. Measured 2026-09-02 on the live Controls view.
+                    "parameter_readback",
+                    "controls-view-write-20260902-113017",
+                    "AXValue set and AXIncrement x5 reported success while Gain remained 48.0000",
+                ]
+            )
+        ),
+        // Ratio has the same observed Controls-view AXSlider non-actuation.
+        // It is intentionally catalogued as a refusal target, not as a
+        // verified parameter, so callers receive the established measurement
+        // rather than the generic "not in the verified allowlist" response.
+        StockPluginParameterMetadata(
+            id: "ratio",
+            displayName: "Ratio",
+            unit: "raw_ax_value",
+            valueRange: nil,
+            writeMethod: nil,
+            readbackMethod: "ax_value_observed",
+            controlsViewRowLabel: "Ratio",
+            controlsViewControlRole: "AXSlider",
+            controlsViewActuationState: .measuredNotActuable,
+            availabilityState: .observed,
+            provenance: .observed(
+                method: "controls_view_axslider_nonactuation_measurement",
+                observedAt: "2026-09-02T11:30:17+09:00",
+                logicVersion: nil,
+                locale: "ko-KR",
+                evidence: [
+                    "controls-view-write-20260902-113017",
+                    "Ratio AXSlider direct AXValue set and AXIncrement were observed non-actuating",
+                ]
+            )
+        ),
+        // This records readability only. No popup menu actuation was measured,
+        // so it contains no write method and exists solely to refuse by that
+        // missing measurement.
+        StockPluginParameterMetadata(
+            id: "circuit_type",
+            displayName: "Circuit Type",
+            unit: "enumerated",
+            valueRange: nil,
+            writeMethod: nil,
+            readbackMethod: "ax_value_observed",
+            controlsViewRowLabel: "Circuit Type",
+            controlsViewControlRole: "AXPopUpButton",
+            controlsViewActuationState: .unmeasured,
+            availabilityState: .observed,
+            provenance: .observed(
+                method: "controls_view_axpopup_read_measurement",
+                observedAt: "2026-09-02T11:30:17+09:00",
+                logicVersion: nil,
+                locale: "ko-KR",
+                evidence: [
+                    // The token the catalog validator requires for a VERIFIED parameter: it means a
+                    // write/readback round trip was observed, not merely that a readback method
+                    // was named. Measured 2026-09-02 on the live Controls view.
+                    "parameter_readback",
+                    "controls-view-write-20260902-113017",
+                    "Circuit Type AXValue Platinum Digital observed; popup selection was not measured",
+                ]
+            )
+        ),
     ]
 
     /// Curated stock catalog seeds. Display names double as probe keys for the
@@ -950,7 +1135,7 @@ enum StockPluginCatalog {
         // Dynamics
         fx("adaptive_limiter", "Adaptive Limiter", "Dynamics"),
         fx("compressor", "Compressor", "Dynamics", write: .parameterWriteReadback, parameters: compressorParameters,
-           notes: ["threshold parameter is verified-writable via AX (normalized %); other params are insert-only"]),
+           notes: ["Threshold is verified-writable via its AXSlider (normalized %). Limiter On and Auto Release are verified-writable via measured Controls-view AXCheckBox press/readback; Controls-view sliders and popups remain refused."]),
         fx("deesser_2", "DeEsser 2", "Dynamics"),
         fx("enveloper", "Enveloper", "Dynamics"),
         fx("expander", "Expander", "Dynamics"),

--- a/Sources/LogicProMCP/Plugins/VerifiedPluginCatalog.swift
+++ b/Sources/LogicProMCP/Plugins/VerifiedPluginCatalog.swift
@@ -59,6 +59,17 @@ enum VerifiedPluginCatalog {
         // `threshold` (normalized %, NOT dB) — see `StockPluginCatalog`.
         "logic.stock.effect.compressor": [
             "threshold": "threshold",
+            "limiter_on": "limiter_on",
+            "limiter on": "limiter_on",
+            "auto_release": "auto_release",
+            "auto release": "auto_release",
+            // Negative Controls-view measurements have canonical aliases too,
+            // so callers get their established refusal rather than an
+            // addressability guess or a generic unknown-param response.
+            "gain": "gain",
+            "ratio": "ratio",
+            "circuit_type": "circuit_type",
+            "circuit type": "circuit_type",
         ],
     ]
 
@@ -169,6 +180,42 @@ enum VerifiedPluginCatalog {
     ) -> String? {
         entryLookup(pluginID)?
             .parameters.first(where: { $0.id == paramKey })?.axDescription
+    }
+
+    /// A Controls-view parameter's row label. This is distinct from
+    /// `paramAXDescription`: Controls-view names live in AXRows while the
+    /// controls themselves are unnamed.
+    static func controlsViewRowLabel(
+        pluginID: String,
+        paramKey: String,
+        entryLookup: EntryLookup = productionEntryLookup
+    ) -> String? {
+        entryLookup(pluginID)?
+            .parameters.first(where: { $0.id == paramKey })?.controlsViewRowLabel
+    }
+
+    /// The parameter role observed on its Controls-view row. A value here is
+    /// not an actuation claim; consult the paired actuation state before any
+    /// Controls-view write is considered.
+    static func controlsViewControlRole(
+        pluginID: String,
+        paramKey: String,
+        entryLookup: EntryLookup = productionEntryLookup
+    ) -> String? {
+        entryLookup(pluginID)?
+            .parameters.first(where: { $0.id == paramKey })?.controlsViewControlRole
+    }
+
+    /// An editor-view control used only to acquire a known plug-in window
+    /// before switching it to Controls view. It must never be mistaken for the
+    /// requested parameter's locator.
+    static func editorWindowAnchorAXDescription(
+        pluginID: String,
+        paramKey: String,
+        entryLookup: EntryLookup = productionEntryLookup
+    ) -> String? {
+        entryLookup(pluginID)?
+            .parameters.first(where: { $0.id == paramKey })?.editorWindowAnchorAXDescription
     }
 
     /// The verified write/readback tolerance (in the parameter's own unit) for a

--- a/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
+++ b/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
@@ -1424,30 +1424,34 @@ enum SemanticOracleTable {
 
     // AccessibilityChannel+VerifiedPlugins `defaultSetParamVerified` →
     // encodeV2StateA(extras). HC v2 (the verified-plugin superset): the envelope
-    // additionally carries `hc_schema:2`, pinned here. State A is the tolerance
-    // gate `abs(after − requested) <= tolerance` (VerifiedPlugins line 1056), and
-    // `tolerance` is PER-PARAMETER in the parameter's OWN unit (0..1 for some
-    // controls, 0..100 for others — e.g. Compressor Threshold, tolerance 1.0), so
-    // no single constant could bound it. It is pinned as
-    // `.numericNear(observed_normalized, requested_normalized, .field("tolerance"))`
-    // — reading the bound from the payload's OWN emitted tolerance, the faithful
-    // request↔readback proof (observed_normalized is the achieved slider read,
-    // requested_normalized the input). Plus the hardcoded same-surface
-    // write/verify (no cross-surface laundering), display_unit, operation
-    // identity, and target_identity/param shapes.
+    // additionally carries `hc_schema:2`, pinned here. It has two measured,
+    // mutually exclusive verified write planes. The slider plane retains its
+    // unit/tolerance gate exactly; the Controls-view checkbox plane requires
+    // genuine requested/observed Bool fields and its own same-surface sources.
     static let pluginsSetParamVerified = SafeMutationOracle.oracle(
         .pluginsSetParamVerified,
         semantics: [
             .valueEquals(key: "hc_schema", expected: .number(2)),
             .valueEquals(key: "operation", expected: .string("logic_plugins.set_param_verified")),
-            .valueEquals(key: "write_source", expected: .string("ax_plugin_window")),
-            .valueEquals(key: "verify_source", expected: .string("ax_plugin_window")),
-            .valueEquals(key: "display_unit", expected: .string("%")),
-            .numericNear(
-                keyA: "observed_normalized",
-                keyB: "requested_normalized",
-                within: .field("tolerance")
-            ),
+            .anyOf([
+                [
+                    .valueEquals(key: "write_source", expected: .string("ax_plugin_window")),
+                    .valueEquals(key: "verify_source", expected: .string("ax_plugin_window")),
+                    .valueEquals(key: "display_unit", expected: .string("%")),
+                    .numericNear(
+                        keyA: "observed_normalized",
+                        keyB: "requested_normalized",
+                        within: .field("tolerance")
+                    ),
+                ],
+                [
+                    .valueEquals(key: "write_source", expected: .string("ax_controls_view_checkbox")),
+                    .valueEquals(key: "verify_source", expected: .string("ax_controls_view_checkbox")),
+                    .typedField(key: "requested_boolean", type: .bool),
+                    .typedField(key: "observed_boolean", type: .bool),
+                    .fieldsEqual(keyA: "requested_boolean", keyB: "observed_boolean"),
+                ],
+            ]),
             .typedField(key: "target_identity", type: .object),
             .typedField(key: "param", type: .string),
         ]

--- a/Sources/LogicProMCP/Qualification/SemanticOracles.swift
+++ b/Sources/LogicProMCP/Qualification/SemanticOracles.swift
@@ -147,6 +147,11 @@ enum OracleConstraint: Sendable {
     /// fails. NUMBERS ONLY, with the same bool-vs-number discipline as the rest of the model,
     /// and fails closed on a missing key or a non-number on either side.
     case numericEqualsOffset(keyA: String, keyB: String, offset: Double)
+    /// At least one complete response shape must satisfy all of its constraints.
+    /// This keeps a versioned operation's mutually exclusive verified write
+    /// planes explicit: accepting a checkbox envelope must not relax any slider
+    /// invariant, and vice versa.
+    indirect case anyOf([[OracleConstraint]])
 
     /// The primary RESPONSE-side key path — the one the generic mutator drops
     /// and error messages cite. For the relational cases it is the response side
@@ -169,6 +174,10 @@ enum OracleConstraint: Sendable {
              .booleanFlipped(let key, _),
              .numericEqualsOffset(let key, _, _):
             return key
+        case .anyOf:
+            // Alternatives have no single response key. Mutators recurse into
+            // their actual clauses instead of fabricating a root-level field.
+            return ""
         }
     }
 
@@ -184,6 +193,10 @@ enum OracleConstraint: Sendable {
              .readbackArrayExcludesResponseIdentity, .fieldsEqual, .crossCheck, .numericNear,
              .booleanFlipped, .numericEqualsOffset:
             return true
+        case let .anyOf(alternatives):
+            return alternatives.allSatisfy { branch in
+                branch.contains { $0.isValueConstraint }
+            }
         case .nonEmptyArray, .typedField, .emptyArray:
             return false
         }
@@ -321,6 +334,10 @@ enum OracleConstraint: Sendable {
                   let a = JSONInspector.number(of: aValue),
                   let b = JSONInspector.number(of: bValue) else { return false }
             return a == b + offset
+        case let .anyOf(alternatives):
+            return alternatives.contains { alternative in
+                alternative.allSatisfy { $0.isSatisfied(by: root, readback: readback) }
+            }
         }
     }
 

--- a/Sources/LogicProMCP/Utilities/HonestContract.swift
+++ b/Sources/LogicProMCP/Utilities/HonestContract.swift
@@ -155,6 +155,10 @@ enum HonestContract {
         case stableTargetRequired = "stable_target_required"
         case windowOpenFailed = "window_open_failed"
         case windowIdentityUnresolved = "window_identity_unresolved"
+        /// The bound plug-in editor could not prove the native/Controls view
+        /// required by the selected write plane. This is distinct from a
+        /// missing parameter control: the locator was never allowed to run.
+        case pluginViewNotConfirmed = "plugin_view_not_confirmed"
         case paramControlNotFound = "param_control_not_found"
         case readbackLostAfterWrite = "readback_lost_after_write"
         /// An AXValue nudge was accepted but the readback did not establish
@@ -456,6 +460,7 @@ enum HonestContract {
         FailureError.staleTargetReference.rawValue,
         FailureError.windowOpenFailed.rawValue,
         FailureError.windowIdentityUnresolved.rawValue,
+        FailureError.pluginViewNotConfirmed.rawValue,
         FailureError.paramControlNotFound.rawValue,
         FailureError.readbackLostAfterWrite.rawValue,
         FailureError.incrementWalkNoProgress.rawValue,

--- a/Tests/LogicProMCPTests/AXLocalePolicyTests.swift
+++ b/Tests/LogicProMCPTests/AXLocalePolicyTests.swift
@@ -134,6 +134,43 @@ struct AXLocalePolicyTests {
         #expect(AXLocalePolicy.elementMatches(descriptionButton, AXLocalePolicy.cancelButton, runtime: runtime))
     }
 
+    @Test("a matching localized menu item wins over another item's failed label read")
+    func matchingMenuItemWinsOverUnrelatedLabelReadFailure() {
+        let builder = FakeAXRuntimeBuilder()
+        let menu = builder.element(22)
+        let unreadableItem = builder.element(23)
+        let controlsItem = builder.element(24)
+        let readFailure = AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue)
+        builder.setAttribute(unreadableItem, kAXRoleAttribute as String, kAXMenuItemRole as String)
+        builder.setAttribute(controlsItem, kAXRoleAttribute as String, kAXMenuItemRole as String)
+        builder.setAttribute(controlsItem, kAXTitleAttribute as String, "Controls")
+        builder.setChildren(menu, [unreadableItem, controlsItem])
+        let runtime = builder.makeAXRuntime(
+            attributeValueResultHandler: { element, attribute in
+                if CFEqual(element, unreadableItem), attribute == (kAXTitleAttribute as String) {
+                    return .failure(readFailure)
+                }
+                return nil
+            },
+            setAttributeHandler: nil,
+            performActionHandler: nil
+        )
+
+        let result = AXLocalePolicy.censusDescendantResult(
+            of: menu,
+            role: kAXMenuItemRole as String,
+            matching: AXLocalePolicy.pluginWindowControlsViewMenuItem,
+            runtime: runtime
+        )
+        let foundControlsItem: Bool
+        if case let .success(census) = result {
+            foundControlsItem = census.matches.count == 1 && CFEqual(census.matches[0], controlsItem)
+        } else {
+            foundControlsItem = false
+        }
+        #expect(foundControlsItem)
+    }
+
     // MARK: - Deliberate Save/Cancel narrowing (contains -> exact)
 
     /// PR #98 narrowed the Save-As commit match from substring `contains`

--- a/Tests/LogicProMCPTests/AXValueExtractorsTests.swift
+++ b/Tests/LogicProMCPTests/AXValueExtractorsTests.swift
@@ -2,6 +2,32 @@
 import Testing
 @testable import LogicProMCP
 
+@Test func testCheckboxStateResultPreservesAXValueReadFailure() {
+    let builder = FakeAXRuntimeBuilder()
+    let checkbox = builder.element(9_901)
+    builder.setRole(checkbox, kAXCheckBoxRole as String)
+    let expected = AXHelpers.AXStatusError(raw: AXError.failure.rawValue)
+    let runtime = builder.makeAXRuntime(
+        attributeValueResultHandler: { element, attribute in
+            if CFEqual(element, checkbox), attribute == (kAXValueAttribute as String) {
+                return .failure(expected)
+            }
+            return nil
+        },
+        setAttributeHandler: nil,
+        performActionHandler: nil
+    )
+
+    let result = AXValueExtractors.extractButtonStateResult(checkbox, runtime: runtime)
+    let preserved: Bool
+    if case let .failure(observed) = result {
+        preserved = observed == expected
+    } else {
+        preserved = false
+    }
+    #expect(preserved)
+}
+
 @Test func testExtractButtonStateRefusesIndeterminateNSNumber() {
     let builder = FakeAXRuntimeBuilder()
     let checkbox = builder.element(29_902)

--- a/Tests/LogicProMCPTests/AXValueExtractorsTests.swift
+++ b/Tests/LogicProMCPTests/AXValueExtractorsTests.swift
@@ -28,6 +28,31 @@ import Testing
     #expect(preserved)
 }
 
+@Test func testCheckboxStateResultTreatsDefinitiveAXAbsenceAsNoValue() {
+    let absenceStatuses = [AXError.noValue.rawValue, AXError.attributeUnsupported.rawValue]
+    let everyAbsenceWasAnObservedMissingValue = absenceStatuses.allSatisfy { rawStatus in
+        let builder = FakeAXRuntimeBuilder()
+        let checkbox = builder.element(Int(rawStatus.magnitude))
+        builder.setRole(checkbox, kAXCheckBoxRole as String)
+        let runtime = builder.makeAXRuntime(
+            attributeValueResultHandler: { element, attribute in
+                if CFEqual(element, checkbox), attribute == (kAXValueAttribute as String) {
+                    return .failure(AXHelpers.AXStatusError(raw: rawStatus))
+                }
+                return nil
+            },
+            setAttributeHandler: nil,
+            performActionHandler: nil
+        )
+        let result = AXValueExtractors.extractButtonStateResult(checkbox, runtime: runtime)
+        if case .success(nil) = result {
+            return true
+        }
+        return false
+    }
+    #expect(everyAbsenceWasAnObservedMissingValue)
+}
+
 @Test func testExtractButtonStateRefusesIndeterminateNSNumber() {
     let builder = FakeAXRuntimeBuilder()
     let checkbox = builder.element(29_902)

--- a/Tests/LogicProMCPTests/AXValueExtractorsTests.swift
+++ b/Tests/LogicProMCPTests/AXValueExtractorsTests.swift
@@ -2,6 +2,20 @@
 import Testing
 @testable import LogicProMCP
 
+@Test func testExtractButtonStateRefusesIndeterminateNSNumber() {
+    let builder = FakeAXRuntimeBuilder()
+    let checkbox = builder.element(29_902)
+    builder.setRole(checkbox, kAXCheckBoxRole as String)
+    builder.setAttribute(checkbox, kAXValueAttribute as String, NSNumber(value: 2))
+
+    let observed = AXValueExtractors.extractButtonState(
+        checkbox,
+        runtime: builder.makeAXRuntime()
+    )
+    let indeterminateWasNotInterpreted = observed == nil
+    #expect(indeterminateWasNotInterpreted)
+}
+
 @Test func testAXValueExtractorsReadScalarValuesAndRanges() {
     let builder = FakeAXRuntimeBuilder()
     let slider = builder.element(1)

--- a/Tests/LogicProMCPTests/ControlsViewBooleanParameterWriterTests.swift
+++ b/Tests/LogicProMCPTests/ControlsViewBooleanParameterWriterTests.swift
@@ -167,6 +167,27 @@ struct ControlsViewBooleanParameterWriterTests {
         #expect(refused)
     }
 
+    @Test func malformedAXRowsPayloadRefusesInsteadOfClaimingTheTableHasNoRows() {
+        let fixture = fixture(
+            label: "Limiter On",
+            controlRoles: [kAXCheckBoxRole as String],
+            axRowsMalformed: true
+        )
+        let result = ControlsViewBooleanParameterWriter.locate(
+            label: "Limiter On",
+            in: fixture.window,
+            runtime: fixture.runtime
+        )
+
+        let refusedForMalformedRows: Bool
+        if case .refused(.accessibilityReadMalformed) = result {
+            refusedForMalformedRows = true
+        } else {
+            refusedForMalformedRows = false
+        }
+        #expect(refusedForMalformedRows)
+    }
+
     @Test func secondControlWhoseRoleReadFailsRefusesTheWholeBinding() {
         let fixture = fixture(
             label: "Limiter On",
@@ -238,7 +259,7 @@ struct ControlsViewBooleanParameterWriterTests {
         #expect(refusedForUnreadableCell)
     }
 
-    @Test func unchangedReadbackRefusesAndAttemptsOneRestore() {
+    @Test func unchangedReadbackRefusesWithoutAnUnneededCompensatingPress() {
         let builder = FakeAXRuntimeBuilder()
         let checkbox = builder.element(10)
         builder.setRole(checkbox, kAXCheckBoxRole as String)
@@ -257,10 +278,10 @@ struct ControlsViewBooleanParameterWriterTests {
             $0.elementID == builder.elementID(checkbox)
                 && $0.action == (kAXPressAction as String)
         }.count
-        let attemptedExactlyPressAndRestore = actionCount == 2
+        let attemptedOnlyTheInitialPress = actionCount == 1
         #expect(refused)
-        #expect(restoreAttempted)
-        #expect(attemptedExactlyPressAndRestore)
+        #expect(!restoreAttempted)
+        #expect(attemptedOnlyTheInitialPress)
     }
 
     @Test func statusZeroPressWithUnchangedReadbackNeverReportsSuccess() {
@@ -288,9 +309,9 @@ struct ControlsViewBooleanParameterWriterTests {
         )
 
         let refused = !result.verified
-        let attemptedRestore = count.value == 2
+        let noCompensatingPress = count.value == 1
         #expect(refused)
-        #expect(attemptedRestore)
+        #expect(noCompensatingPress)
     }
 
     @Test func unreadableCheckboxValueRefusesBeforeAnyPress() {
@@ -468,7 +489,8 @@ struct ControlsViewBooleanParameterWriterTests {
         #expect(refusedForDescriptionRead)
     }
 
-    @Test func failedSliderCensusDoesNotRefuseEditorConfirmedByNoTable() {
+    @Test func failedSliderCensusRefusesRatherThanTreatingNoTableAsEditorEvidence() {
+        let readFailure = AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue)
         let fixture = viewFixture(
             entry: .editor,
             title: "편집기",
@@ -481,16 +503,17 @@ struct ControlsViewBooleanParameterWriterTests {
             in: fixture.window,
             runtime: fixture.runtime
         )
-        let editorWasConfirmed: Bool
-        if case .ready = result {
-            editorWasConfirmed = true
+        let refusedForTheMeasuredReadFailure: Bool
+        if case let .refused(.viewEvidenceReadFailed(.sliderCensus(observed)), restoration: nil) = result {
+            refusedForTheMeasuredReadFailure = observed == readFailure
         } else {
-            editorWasConfirmed = false
+            refusedForTheMeasuredReadFailure = false
         }
-        #expect(editorWasConfirmed)
+        #expect(refusedForTheMeasuredReadFailure)
     }
 
-    @Test func failedSliderDescriptionDoesNotRefuseControlsConfirmedByTable() {
+    @Test func failedSliderDescriptionRefusesRatherThanConfirmingAnUnrelatedTableAsControls() {
+        let readFailure = AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue)
         let fixture = viewFixture(
             entry: .editor,
             title: "편집기",
@@ -504,18 +527,18 @@ struct ControlsViewBooleanParameterWriterTests {
             in: fixture.window,
             runtime: fixture.runtime
         )
-        let controlsWereConfirmed: Bool
-        if case .ready = result {
-            controlsWereConfirmed = true
+        let refusedForTheSliderDescription: Bool
+        if case let .refused(.viewEvidenceReadFailed(.sliderDescription(observed)), restoration: nil) = result {
+            refusedForTheSliderDescription = observed == readFailure
         } else {
-            controlsWereConfirmed = false
+            refusedForTheSliderDescription = false
         }
-        let tableConfirmedTheAlreadySelectedView = fixture.builder.actionCalls.isEmpty
-        #expect(controlsWereConfirmed)
-        #expect(tableConfirmedTheAlreadySelectedView)
+        let tableDidNotAuthorizeAViewChoice = fixture.builder.actionCalls.isEmpty
+        #expect(refusedForTheSliderDescription)
+        #expect(tableDidNotAuthorizeAViewChoice)
     }
 
-    @Test func allDescriptionFailuresDoNotRefuseControlsConfirmedByTheTable() {
+    @Test func allDescriptionFailuresRefuseControlsClassificationWhenNoDescribedSliderWasObserved() {
         let fixture = viewFixture(
             entry: .controls,
             title: "컨트롤",
@@ -529,18 +552,18 @@ struct ControlsViewBooleanParameterWriterTests {
             runtime: fixture.runtime
         )
 
-        let controlsWereConfirmed: Bool
-        if case .ready = result {
-            controlsWereConfirmed = true
+        let refusedForDescriptionRead: Bool
+        if case .refused(.viewEvidenceReadFailed(.sliderDescription), restoration: nil) = result {
+            refusedForDescriptionRead = true
         } else {
-            controlsWereConfirmed = false
+            refusedForDescriptionRead = false
         }
-        let tableConfirmedTheAlreadySelectedView = fixture.builder.actionCalls.isEmpty
-        #expect(controlsWereConfirmed)
-        #expect(tableConfirmedTheAlreadySelectedView)
+        let tableDidNotConfirmTheView = fixture.builder.actionCalls.isEmpty
+        #expect(refusedForDescriptionRead)
+        #expect(tableDidNotConfirmTheView)
     }
 
-    @Test func allDescriptionFailuresDoNotRefuseEditorConfirmedByNoTable() {
+    @Test func allDescriptionFailuresRefuseEditorClassificationWhenNoDescriptionWasReadable() {
         let fixture = viewFixture(
             entry: .editor,
             title: "편집기",
@@ -554,15 +577,15 @@ struct ControlsViewBooleanParameterWriterTests {
             runtime: fixture.runtime
         )
 
-        let editorWasConfirmed: Bool
-        if case .ready = result {
-            editorWasConfirmed = true
+        let refusedForDescriptionRead: Bool
+        if case .refused(.viewEvidenceReadFailed(.sliderDescription), restoration: nil) = result {
+            refusedForDescriptionRead = true
         } else {
-            editorWasConfirmed = false
+            refusedForDescriptionRead = false
         }
-        let missingTableConfirmedTheAlreadySelectedView = fixture.builder.actionCalls.isEmpty
-        #expect(editorWasConfirmed)
-        #expect(missingTableConfirmedTheAlreadySelectedView)
+        let missingTableDidNotConfirmTheView = fixture.builder.actionCalls.isEmpty
+        #expect(refusedForDescriptionRead)
+        #expect(missingTableDidNotConfirmTheView)
     }
 
     @Test func describedSliderConfirmsEditorAfterAnotherDescriptionReadFails() {
@@ -753,6 +776,53 @@ struct ControlsViewBooleanParameterWriterTests {
         #expect(revealedWithPress)
         #expect(selectedWithPick)
         #expect(menuWasPolledUntilVisible)
+    }
+
+    @Test func disabledViewMenuItemIsNeverPicked() {
+        let fixture = viewFixture(entry: .editor, title: "편집기", behavior: .switchesStructure)
+        fixture.builder.setAttribute(fixture.builder.element(904), kAXEnabledAttribute as String, false)
+
+        let result = ControlsViewBooleanParameterWriter.prepareView(
+            .controls,
+            in: fixture.window,
+            runtime: fixture.runtime
+        )
+
+        let refusedForDisabledItem: Bool
+        if case .refused(.viewMenuItemDisabled(.controls), restoration: nil) = result {
+            refusedForDisabledItem = true
+        } else {
+            refusedForDisabledItem = false
+        }
+        let noMenuItemAction = fixture.menuItemActions.value.isEmpty
+        #expect(refusedForDisabledItem)
+        #expect(noMenuItemAction)
+    }
+
+    @Test func unreadableViewMenuItemEnabledStateIsNeverPicked() {
+        let readFailure = AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue)
+        let fixture = viewFixture(
+            entry: .editor,
+            title: "편집기",
+            behavior: .switchesStructure,
+            menuItemEnabledReadFails: true
+        )
+
+        let result = ControlsViewBooleanParameterWriter.prepareView(
+            .controls,
+            in: fixture.window,
+            runtime: fixture.runtime
+        )
+
+        let refusedForEnabledRead: Bool
+        if case let .refused(.viewEvidenceReadFailed(.menuItemEnabled(observed)), restoration: nil) = result {
+            refusedForEnabledRead = observed == readFailure
+        } else {
+            refusedForEnabledRead = false
+        }
+        let noMenuItemAction = fixture.menuItemActions.value.isEmpty
+        #expect(refusedForEnabledRead)
+        #expect(noMenuItemAction)
     }
 
     @Test func switchThatNeverChangesStructureRefusesWithinDeadlineAndLeavesEntryView() {
@@ -978,6 +1048,7 @@ struct ControlsViewBooleanParameterWriterTests {
         menuRevealAfterPolls: Int? = 3,
         menuReadFailure: AXHelpers.AXStatusError? = nil,
         readFailure: ViewFixtureReadFailure? = nil,
+        menuItemEnabledReadFails: Bool = false,
         includeControlsTableBesideEditor: Bool = false,
         additionalSliderDescriptionFailure: Bool = false,
         allDescriptionReadsFail: Bool = false,
@@ -1020,8 +1091,10 @@ struct ControlsViewBooleanParameterWriterTests {
         builder.setRole(menu, kAXMenuRole as String)
         builder.setRole(controlsMenuItem, kAXMenuItemRole as String)
         builder.setAttribute(controlsMenuItem, kAXTitleAttribute as String, "컨트롤")
+        builder.setAttribute(controlsMenuItem, kAXEnabledAttribute as String, true)
         builder.setRole(editorMenuItem, kAXMenuItemRole as String)
         builder.setAttribute(editorMenuItem, kAXTitleAttribute as String, "편집기")
+        builder.setAttribute(editorMenuItem, kAXEnabledAttribute as String, true)
         builder.setChildren(menu, [controlsMenuItem, editorMenuItem])
 
         builder.setRole(editorSlider, kAXSliderRole as String)
@@ -1089,6 +1162,11 @@ struct ControlsViewBooleanParameterWriterTests {
                    attribute == (kAXTitleAttribute as String) {
                     return .failure(statusFailure)
                 }
+                if menuItemEnabledReadFails,
+                   (CFEqual(element, controlsMenuItem) || CFEqual(element, editorMenuItem)),
+                   attribute == (kAXEnabledAttribute as String) {
+                    return .failure(statusFailure)
+                }
                 return nil
             },
             childrenHandler: { element in
@@ -1118,7 +1196,7 @@ struct ControlsViewBooleanParameterWriterTests {
                 }
                 if readFailure == .sliderCensus, CFEqual(element, editorSlider) {
                     sliderChildrenReadCount.value += 1
-                    if sliderChildrenReadCount.value == 2 {
+                    if sliderChildrenReadCount.value == 1 {
                         return .failure(statusFailure)
                     }
                 }
@@ -1230,6 +1308,7 @@ struct ControlsViewBooleanParameterWriterTests {
         label: String?,
         controlRoles: [String],
         axRowsReadStatus: Int32? = nil,
+        axRowsMalformed: Bool = false,
         roleReadFailureElementIDs: Set<Int> = []
     ) -> (builder: FakeAXRuntimeBuilder, window: AXUIElement, runtime: AXHelpers.Runtime) {
         let builder = FakeAXRuntimeBuilder()
@@ -1262,7 +1341,7 @@ struct ControlsViewBooleanParameterWriterTests {
         builder.setChildren(labelCell, labelContents)
         builder.setChildren(row, [labelCell])
         builder.setChildren(table, [row])
-        builder.setAttribute(table, kAXRowsAttribute as String, [row])
+        builder.setAttribute(table, kAXRowsAttribute as String, axRowsMalformed ? "not an AX element array" : [row])
         builder.setChildren(window, [table])
         let runtime = builder.makeAXRuntime(
             appElement: builder.element(99),

--- a/Tests/LogicProMCPTests/ControlsViewBooleanParameterWriterTests.swift
+++ b/Tests/LogicProMCPTests/ControlsViewBooleanParameterWriterTests.swift
@@ -868,14 +868,14 @@ struct ControlsViewBooleanParameterWriterTests {
         )
 
         let refused: Bool
-        if case .refused(.viewStructureDidNotConfirm(.editor), restoration: _) = result {
+        if case .refused(.viewStructureDidNotConfirm(.editor, _), restoration: _) = result {
             refused = true
         } else {
             refused = false
         }
-        // Menu appearance is now the measured ~150 ms on both the attempted
-        // switch and its compensating restoration; this remains a bounded
-        // deadline test rather than an instant-fixture timing test.
+        // The menu was measured at 28–46 ms with a 25 ms poll. This keeps a
+        // nonzero fixture reveal on both the attempted switch and restoration,
+        // so it remains a bounded-deadline test rather than an instant fixture.
         let completedWithinBoundedRestore = Date().timeIntervalSince(started) < 0.75
         let attemptedEditorSelection = fixture.editorSelections.value == 1
         let entryStructureRemainedControls = controlsStructureIsPresent(fixture)
@@ -939,8 +939,8 @@ struct ControlsViewBooleanParameterWriterTests {
             entry: .controls,
             title: "[100%]",
             behavior: .switchesStructure,
-            // Intentionally instant: this test isolates the 150 ms structure
-            // settle from the separate menu-appearance deadline.
+            // Intentionally shorter than the measured 527–785 ms structural
+            // settle: this test isolates its timeout from menu appearance.
             menuRevealAfterPolls: 0,
             viewSettleDelay: 0.15
         )
@@ -954,7 +954,7 @@ struct ControlsViewBooleanParameterWriterTests {
         )
 
         let refusedForSettleDeadline: Bool
-        if case .refused(.viewStructureDidNotConfirm(.editor), restoration: _) = result {
+        if case .refused(.viewStructureDidNotConfirm(.editor, _), restoration: _) = result {
             refusedForSettleDeadline = true
         } else {
             refusedForSettleDeadline = false
@@ -965,6 +965,103 @@ struct ControlsViewBooleanParameterWriterTests {
         #expect(refusedForSettleDeadline)
         #expect(entryStructureWasRestored)
         #expect(restorationWasExplicitlySelected)
+    }
+
+    @Test func structureSettlingAtTwoPointFiveSecondsConfirmsUnderTheMeasuredDefaultDeadline() {
+        let fixture = viewFixture(
+            entry: .controls,
+            title: "[100%]",
+            behavior: .switchesStructure,
+            menuRevealAfterPolls: 0,
+            viewSettleDelay: 2.5
+        )
+
+        let result = ControlsViewBooleanParameterWriter.prepareView(
+            .editor,
+            in: fixture.window,
+            runtime: fixture.runtime
+        )
+
+        let confirmed: Bool
+        if case .ready = result {
+            confirmed = true
+        } else {
+            confirmed = false
+        }
+        // Mutation: restore `viewConfirmationTimeout` to its former 1.5 s.
+        #expect(confirmed)
+    }
+
+    @Test func structureDeadlineReportsTheFreshClassifierCounts() {
+        let fixture = viewFixture(
+            entry: .controls,
+            title: "[100%]",
+            behavior: .neverChanges,
+            menuRevealAfterPolls: 0,
+            deadlineSnapshotAddsSecondTable: true
+        )
+
+        let result = ControlsViewBooleanParameterWriter.prepareView(
+            .editor,
+            in: fixture.window,
+            menuAppearanceTimeout: 0.025,
+            confirmationTimeout: 0.025,
+            runtime: fixture.runtime
+        )
+
+        let carriesDeadlineObservation: Bool
+        if case let .refused(.viewStructureDidNotConfirm(.editor, observed), restoration: _) = result {
+            carriesDeadlineObservation = observed.tableCount == 2
+                && observed.rowCount == 2
+                && observed.describedSliderCount == 0
+                && observed.waitedMilliseconds >= 20
+        } else {
+            carriesDeadlineObservation = false
+        }
+        // Mutation: return the pre-deadline poll instead of the fresh snapshot.
+        #expect(carriesDeadlineObservation)
+    }
+
+    @Test func viewSessionRebindsTheWindowAndSwitcherAfterAViewRerender() {
+        let fixture = viewFixture(
+            entry: .controls,
+            title: "[100%]",
+            behavior: .switchesStructure,
+            menuRevealAfterPolls: 0,
+            replacesWindowAndSwitcherOnSelection: true,
+            viewSettleDelay: 0
+        )
+
+        let result = ControlsViewBooleanParameterWriter.prepareView(
+            .editor,
+            in: fixture.window,
+            windowRefresher: fixture.windowRefresher,
+            runtime: fixture.runtime
+        )
+        let session: ControlsViewBooleanParameterWriter.ViewSession?
+        if case let .ready(ready) = result {
+            session = ready
+        } else {
+            session = nil
+        }
+        let prepared = session != nil
+        #expect(prepared)
+        guard let session else { return }
+
+        let restoration = session.restore()
+        let switcherPresses = fixture.switcherActionElementIDs.value
+        let reboundSwitcherWasPressed = switcherPresses == [
+            fixture.builder.elementID(fixture.originalSwitcher),
+            fixture.builder.elementID(fixture.refreshedSwitcher),
+        ]
+        let staleSwitcherWasNotReused = !switcherPresses.dropFirst().contains(
+            fixture.builder.elementID(fixture.originalSwitcher)
+        )
+        let restored = restoration.confirmed
+        // Mutation: retain the original switcher/window in ViewSession.
+        #expect(reboundSwitcherWasPressed)
+        #expect(staleSwitcherWasNotReused)
+        #expect(restored)
     }
 
     @Test func confirmedSwitchRestoresTheStructuralEntryView() {
@@ -1010,7 +1107,7 @@ struct ControlsViewBooleanParameterWriterTests {
         )
 
         let refused: Bool
-        if case .refused(.viewStructureDidNotConfirm(.editor), restoration: _) = result {
+        if case .refused(.viewStructureDidNotConfirm(.editor, _), restoration: _) = result {
             refused = true
         } else {
             refused = false
@@ -1058,10 +1155,14 @@ struct ControlsViewBooleanParameterWriterTests {
     private struct ViewFixture {
         let builder: FakeAXRuntimeBuilder
         let window: AXUIElement
+        let originalSwitcher: AXUIElement
+        let refreshedSwitcher: AXUIElement
+        let windowRefresher: () -> AXUIElement?
         let controlsTable: AXUIElement
         let controlsSelections: MutableBox<Int>
         let editorSelections: MutableBox<Int>
         let switcherActions: MutableBox<[String]>
+        let switcherActionElementIDs: MutableBox<[Int]>
         let menuItemActions: MutableBox<[String]>
         let menuCensusPolls: MutableBox<Int>
         let runtime: AXHelpers.Runtime
@@ -1079,6 +1180,8 @@ struct ControlsViewBooleanParameterWriterTests {
         additionalSliderDescriptionFailure: Bool = false,
         additionalSwitcherDescriptionFailure: Bool = false,
         allDescriptionReadsFail: Bool = false,
+        deadlineSnapshotAddsSecondTable: Bool = false,
+        replacesWindowAndSwitcherOnSelection: Bool = false,
         viewSettleDelay: TimeInterval = 0.5
     ) -> ViewFixture {
         let builder = FakeAXRuntimeBuilder()
@@ -1091,6 +1194,9 @@ struct ControlsViewBooleanParameterWriterTests {
         let editorSlider = builder.element(906)
         let additionalSlider = builder.element(916)
         let additionalSwitcher = builder.element(917)
+        let refreshedWindow = builder.element(918)
+        let refreshedSwitcher = builder.element(919)
+        let deadlineSnapshotTable = builder.element(920)
         let controlsTable = builder.element(907)
         let controlsRow = builder.element(908)
         let controlsLabelCell = builder.element(909)
@@ -1102,20 +1208,28 @@ struct ControlsViewBooleanParameterWriterTests {
         let controlsSelections = MutableBox(0)
         let editorSelections = MutableBox(0)
         let switcherActions = MutableBox<[String]>([])
+        let switcherActionElementIDs = MutableBox<[Int]>([])
         let menuItemActions = MutableBox<[String]>([])
         let menuCensusPolls = MutableBox(0)
         let menuOpen = MutableBox(false)
         let menuVisible = MutableBox(false)
         let pendingWindowChildren = MutableBox<(children: [AXUIElement], settlesAt: Date)?>(nil)
+        let currentWindow = MutableBox(window)
         let sliderChildrenReadCount = MutableBox(0)
         let tableChildrenReadCount = MutableBox(0)
         let windowChildrenReadCount = MutableBox(0)
+        let postPickWindowReadCount = MutableBox(0)
         let statusFailure = AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue)
 
         builder.setRole(window, kAXWindowRole as String)
         builder.setRole(switcher, kAXMenuButtonRole as String)
         builder.setAttribute(switcher, kAXDescriptionAttribute as String, "보기")
         builder.setAttribute(switcher, kAXTitleAttribute as String, title)
+        builder.setRole(refreshedWindow, kAXWindowRole as String)
+        builder.setRole(refreshedSwitcher, kAXMenuButtonRole as String)
+        builder.setAttribute(refreshedSwitcher, kAXDescriptionAttribute as String, "보기")
+        builder.setAttribute(refreshedSwitcher, kAXTitleAttribute as String, title)
+        builder.setRole(deadlineSnapshotTable, kAXTableRole as String)
         if additionalSwitcherDescriptionFailure {
             builder.setRole(additionalSwitcher, kAXMenuButtonRole as String)
         }
@@ -1159,9 +1273,15 @@ struct ControlsViewBooleanParameterWriterTests {
             ? switchers + slidersBeforeEditor + [editorSlider, controlsTable]
             : switchers + slidersBeforeEditor + [editorSlider]
         let controlsChildren = switchers + slidersBeforeEditor + [controlsTable]
+        let refreshedEditorChildren = [refreshedSwitcher] + slidersBeforeEditor + [editorSlider]
+        let refreshedControlsChildren = [refreshedSwitcher] + slidersBeforeEditor + [controlsTable]
         builder.setChildren(
             window,
             entry == .editor ? editorChildren : controlsChildren
+        )
+        builder.setChildren(
+            refreshedWindow,
+            entry == .editor ? refreshedEditorChildren : refreshedControlsChildren
         )
 
         let controlsKey = builder.elementID(controlsMenuItem)
@@ -1213,7 +1333,8 @@ struct ControlsViewBooleanParameterWriterTests {
                     builder.setChildren(window, pending.children)
                     pendingWindowChildren.value = nil
                 }
-                if CFEqual(element, switcher), menuOpen.value, menuVisible.value {
+                if (CFEqual(element, switcher) || CFEqual(element, refreshedSwitcher)),
+                   menuOpen.value, menuVisible.value {
                     return [menu]
                 }
                 return nil
@@ -1231,6 +1352,17 @@ struct ControlsViewBooleanParameterWriterTests {
                         return .failure(statusFailure)
                     }
                 }
+                if deadlineSnapshotAddsSecondTable,
+                   CFEqual(element, window),
+                   editorSelections.value > 0 {
+                    postPickWindowReadCount.value += 1
+                    // The post-pick classifier reads the window twice (sliders,
+                    // then tables). Change the tree only for the fresh
+                    // deadline census, after that poll is complete.
+                    if postPickWindowReadCount.value == 3 {
+                        builder.setChildren(window, controlsChildren + [deadlineSnapshotTable])
+                    }
+                }
                 if readFailure == .sliderCensus, CFEqual(element, editorSlider) {
                     sliderChildrenReadCount.value += 1
                     if sliderChildrenReadCount.value == 1 {
@@ -1243,7 +1375,8 @@ struct ControlsViewBooleanParameterWriterTests {
                         return .failure(statusFailure)
                     }
                 }
-                guard CFEqual(element, switcher), menuOpen.value else { return nil }
+                guard (CFEqual(element, switcher) || CFEqual(element, refreshedSwitcher)),
+                      menuOpen.value else { return nil }
                 if let menuReadFailure {
                     return .failure(menuReadFailure)
                 }
@@ -1260,9 +1393,17 @@ struct ControlsViewBooleanParameterWriterTests {
             setAttributeHandler: nil,
             performActionHandler: { element, action in
                 let key = builder.elementID(element)
-                if key == switcherKey {
+                if key == switcherKey || key == builder.elementID(refreshedSwitcher) {
                     switcherActions.value.append(action)
+                    switcherActionElementIDs.value.append(key)
                     guard action == (kAXPressAction as String) else { return false }
+                    // After the first selection the old switcher models a
+                    // stale AXUIElement: it cannot reveal the current menu.
+                    if replacesWindowAndSwitcherOnSelection,
+                       key == switcherKey,
+                       CFEqual(currentWindow.value, refreshedWindow) {
+                        return false
+                    }
                     menuOpen.value = true
                     menuVisible.value = false
                     menuCensusPolls.value = 0
@@ -1276,6 +1417,11 @@ struct ControlsViewBooleanParameterWriterTests {
                 switch key {
                 case editorKey:
                     editorSelections.value += 1
+                    if replacesWindowAndSwitcherOnSelection {
+                        builder.setChildren(refreshedWindow, refreshedEditorChildren)
+                        currentWindow.value = refreshedWindow
+                        return true
+                    }
                     switch behavior {
                     case .switchesStructure:
                         pendingWindowChildren.value = (
@@ -1292,6 +1438,11 @@ struct ControlsViewBooleanParameterWriterTests {
                     }
                 case controlsKey:
                     controlsSelections.value += 1
+                    if replacesWindowAndSwitcherOnSelection {
+                        builder.setChildren(refreshedWindow, refreshedControlsChildren)
+                        currentWindow.value = refreshedWindow
+                        return true
+                    }
                     switch behavior {
                     case .switchesStructure, .becomesUnconfirmedThenControlsRestores:
                         pendingWindowChildren.value = (
@@ -1310,10 +1461,14 @@ struct ControlsViewBooleanParameterWriterTests {
         return ViewFixture(
             builder: builder,
             window: window,
+            originalSwitcher: switcher,
+            refreshedSwitcher: refreshedSwitcher,
+            windowRefresher: { currentWindow.value },
             controlsTable: controlsTable,
             controlsSelections: controlsSelections,
             editorSelections: editorSelections,
             switcherActions: switcherActions,
+            switcherActionElementIDs: switcherActionElementIDs,
             menuItemActions: menuItemActions,
             menuCensusPolls: menuCensusPolls,
             runtime: runtime

--- a/Tests/LogicProMCPTests/ControlsViewBooleanParameterWriterTests.swift
+++ b/Tests/LogicProMCPTests/ControlsViewBooleanParameterWriterTests.swift
@@ -293,6 +293,35 @@ struct ControlsViewBooleanParameterWriterTests {
         #expect(attemptedRestore)
     }
 
+    @Test func unreadableCheckboxValueRefusesBeforeAnyPress() {
+        let builder = FakeAXRuntimeBuilder()
+        let checkbox = builder.element(21)
+        builder.setRole(checkbox, kAXCheckBoxRole as String)
+        builder.setAttribute(checkbox, kAXValueAttribute as String, false)
+        let runtime = builder.makeAXRuntime(
+            appElement: builder.element(2),
+            attributeValueHandler: { element, attribute in
+                if CFEqual(element, checkbox), attribute == (kAXValueAttribute as String) {
+                    return .some(nil)
+                }
+                return nil
+            },
+            setAttributeHandler: nil,
+            performActionHandler: nil
+        )
+
+        let result = ControlsViewBooleanParameterWriter.pressAndVerify(
+            checkbox,
+            requested: true,
+            runtime: runtime
+        )
+
+        let valueReadRefusedTheWrite = !result.verified && !result.pressAttempted
+        let noCheckboxActionWasSent = builder.actionCalls.isEmpty
+        #expect(valueReadRefusedTheWrite)
+        #expect(noCheckboxActionWasSent)
+    }
+
     @Test func controlsViewSliderIsRefusedWithTheMeasuredNonactuationReason() {
         let fixture = fixture(label: "Gain", controlRoles: [kAXSliderRole as String])
         let result = ControlsViewBooleanParameterWriter.locate(
@@ -393,7 +422,7 @@ struct ControlsViewBooleanParameterWriterTests {
         #expect(confirmedEditor)
     }
 
-    @Test func failedSwitcherCensusRefusesInsteadOfReportingNoSwitcher() {
+    @Test func failedSwitcherCensusRefusesBeforeItCanChooseASwitcherToPress() {
         let readFailure = AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue)
         let fixture = viewFixture(
             entry: .editor,
@@ -403,7 +432,7 @@ struct ControlsViewBooleanParameterWriterTests {
         )
 
         let result = ControlsViewBooleanParameterWriter.prepareView(
-            .editor,
+            .controls,
             in: fixture.window,
             runtime: fixture.runtime
         )
@@ -416,7 +445,7 @@ struct ControlsViewBooleanParameterWriterTests {
         #expect(refusedForCensusRead)
     }
 
-    @Test func failedSwitcherDescriptionRefusesInsteadOfReportingUnmeasuredLocale() {
+    @Test func failedSwitcherDescriptionRefusesBeforeItCanChooseASwitcherToPress() {
         let readFailure = AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue)
         let fixture = viewFixture(
             entry: .editor,
@@ -426,7 +455,7 @@ struct ControlsViewBooleanParameterWriterTests {
         )
 
         let result = ControlsViewBooleanParameterWriter.prepareView(
-            .editor,
+            .controls,
             in: fixture.window,
             runtime: fixture.runtime
         )
@@ -439,8 +468,7 @@ struct ControlsViewBooleanParameterWriterTests {
         #expect(refusedForDescriptionRead)
     }
 
-    @Test func failedSliderCensusRefusesInsteadOfErasingEditorEvidence() {
-        let readFailure = AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue)
+    @Test func failedSliderCensusDoesNotRefuseEditorConfirmedByNoTable() {
         let fixture = viewFixture(
             entry: .editor,
             title: "편집기",
@@ -453,17 +481,16 @@ struct ControlsViewBooleanParameterWriterTests {
             in: fixture.window,
             runtime: fixture.runtime
         )
-        let refusedForSliderCensusRead: Bool
-        if case let .refused(.viewEvidenceReadFailed(.sliderCensus(observed)), restoration: nil) = result {
-            refusedForSliderCensusRead = observed == readFailure
+        let editorWasConfirmed: Bool
+        if case .ready = result {
+            editorWasConfirmed = true
         } else {
-            refusedForSliderCensusRead = false
+            editorWasConfirmed = false
         }
-        #expect(refusedForSliderCensusRead)
+        #expect(editorWasConfirmed)
     }
 
-    @Test func failedSliderDescriptionRefusesBeforeAnyTableCanConfirmControls() {
-        let readFailure = AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue)
+    @Test func failedSliderDescriptionDoesNotRefuseControlsConfirmedByTable() {
         let fixture = viewFixture(
             entry: .editor,
             title: "편집기",
@@ -477,13 +504,91 @@ struct ControlsViewBooleanParameterWriterTests {
             in: fixture.window,
             runtime: fixture.runtime
         )
-        let refusedForSliderDescriptionRead: Bool
-        if case let .refused(.viewEvidenceReadFailed(.sliderDescription(observed)), restoration: nil) = result {
-            refusedForSliderDescriptionRead = observed == readFailure
+        let controlsWereConfirmed: Bool
+        if case .ready = result {
+            controlsWereConfirmed = true
         } else {
-            refusedForSliderDescriptionRead = false
+            controlsWereConfirmed = false
         }
-        #expect(refusedForSliderDescriptionRead)
+        let tableConfirmedTheAlreadySelectedView = fixture.builder.actionCalls.isEmpty
+        #expect(controlsWereConfirmed)
+        #expect(tableConfirmedTheAlreadySelectedView)
+    }
+
+    @Test func allDescriptionFailuresDoNotRefuseControlsConfirmedByTheTable() {
+        let fixture = viewFixture(
+            entry: .controls,
+            title: "컨트롤",
+            behavior: .switchesStructure,
+            allDescriptionReadsFail: true
+        )
+
+        let result = ControlsViewBooleanParameterWriter.prepareView(
+            .controls,
+            in: fixture.window,
+            runtime: fixture.runtime
+        )
+
+        let controlsWereConfirmed: Bool
+        if case .ready = result {
+            controlsWereConfirmed = true
+        } else {
+            controlsWereConfirmed = false
+        }
+        let tableConfirmedTheAlreadySelectedView = fixture.builder.actionCalls.isEmpty
+        #expect(controlsWereConfirmed)
+        #expect(tableConfirmedTheAlreadySelectedView)
+    }
+
+    @Test func allDescriptionFailuresDoNotRefuseEditorConfirmedByNoTable() {
+        let fixture = viewFixture(
+            entry: .editor,
+            title: "편집기",
+            behavior: .switchesStructure,
+            allDescriptionReadsFail: true
+        )
+
+        let result = ControlsViewBooleanParameterWriter.prepareView(
+            .editor,
+            in: fixture.window,
+            runtime: fixture.runtime
+        )
+
+        let editorWasConfirmed: Bool
+        if case .ready = result {
+            editorWasConfirmed = true
+        } else {
+            editorWasConfirmed = false
+        }
+        let missingTableConfirmedTheAlreadySelectedView = fixture.builder.actionCalls.isEmpty
+        #expect(editorWasConfirmed)
+        #expect(missingTableConfirmedTheAlreadySelectedView)
+    }
+
+    @Test func describedSliderConfirmsEditorAfterAnotherDescriptionReadFails() {
+        let fixture = viewFixture(
+            entry: .editor,
+            title: "편집기",
+            behavior: .switchesStructure,
+            includeControlsTableBesideEditor: true,
+            additionalSliderDescriptionFailure: true
+        )
+
+        let result = ControlsViewBooleanParameterWriter.prepareView(
+            .editor,
+            in: fixture.window,
+            runtime: fixture.runtime
+        )
+
+        let editorWasConfirmed: Bool
+        if case .ready = result {
+            editorWasConfirmed = true
+        } else {
+            editorWasConfirmed = false
+        }
+        let describedSliderConfirmedTheAlreadySelectedView = fixture.builder.actionCalls.isEmpty
+        #expect(editorWasConfirmed)
+        #expect(describedSliderConfirmedTheAlreadySelectedView)
     }
 
     @Test func failedViewMenuItemCensusRefusesInsteadOfReportingMissingItem() {
@@ -509,8 +614,7 @@ struct ControlsViewBooleanParameterWriterTests {
         #expect(refusedForMenuItemCensusRead)
     }
 
-    @Test func failedControlsTableCensusRefusesInsteadOfReportingEntryViewMissing() {
-        let readFailure = AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue)
+    @Test func failedControlsTableCensusLeavesTheEntryViewUnconfirmed() {
         let fixture = viewFixture(
             entry: .controls,
             title: "컨트롤",
@@ -523,16 +627,16 @@ struct ControlsViewBooleanParameterWriterTests {
             in: fixture.window,
             runtime: fixture.runtime
         )
-        let refusedForTableCensusRead: Bool
-        if case let .refused(.viewEvidenceReadFailed(.controlsTableCensus(observed)), restoration: nil) = result {
-            refusedForTableCensusRead = observed == readFailure
+        let entryViewWasUnconfirmed: Bool
+        if case .refused(.entryViewNotConfirmed, restoration: nil) = result {
+            entryViewWasUnconfirmed = true
         } else {
-            refusedForTableCensusRead = false
+            entryViewWasUnconfirmed = false
         }
-        #expect(refusedForTableCensusRead)
+        #expect(entryViewWasUnconfirmed)
     }
 
-    @Test func failedControlsRowReadRefusesInsteadOfContinuingToTheNextRow() {
+    @Test func failedControlsRowReadLeavesTheTableUnconfirmed() {
         let builder = FakeAXRuntimeBuilder()
         let window = builder.element(29_930)
         let switcher = builder.element(29_931)
@@ -564,13 +668,13 @@ struct ControlsViewBooleanParameterWriterTests {
             in: window,
             runtime: runtime
         )
-        let refusedForRowRead: Bool
-        if case let .refused(.viewEvidenceReadFailed(.controlsTableRow(observed)), restoration: nil) = result {
-            refusedForRowRead = observed == readFailure
+        let entryViewWasUnconfirmed: Bool
+        if case .refused(.entryViewNotConfirmed, restoration: nil) = result {
+            entryViewWasUnconfirmed = true
         } else {
-            refusedForRowRead = false
+            entryViewWasUnconfirmed = false
         }
-        #expect(refusedForRowRead)
+        #expect(entryViewWasUnconfirmed)
     }
 
     @Test func tableWhoseRowsCarryNoLabelControlPairDoesNotConfirmControls() {
@@ -875,6 +979,8 @@ struct ControlsViewBooleanParameterWriterTests {
         menuReadFailure: AXHelpers.AXStatusError? = nil,
         readFailure: ViewFixtureReadFailure? = nil,
         includeControlsTableBesideEditor: Bool = false,
+        additionalSliderDescriptionFailure: Bool = false,
+        allDescriptionReadsFail: Bool = false,
         viewSettleDelay: TimeInterval = 0.5
     ) -> ViewFixture {
         let builder = FakeAXRuntimeBuilder()
@@ -885,6 +991,7 @@ struct ControlsViewBooleanParameterWriterTests {
         let controlsMenuItem = builder.element(904)
         let editorMenuItem = builder.element(905)
         let editorSlider = builder.element(906)
+        let additionalSlider = builder.element(916)
         let controlsTable = builder.element(907)
         let controlsRow = builder.element(908)
         let controlsLabelCell = builder.element(909)
@@ -903,6 +1010,7 @@ struct ControlsViewBooleanParameterWriterTests {
         let pendingWindowChildren = MutableBox<(children: [AXUIElement], settlesAt: Date)?>(nil)
         let sliderChildrenReadCount = MutableBox(0)
         let tableChildrenReadCount = MutableBox(0)
+        let windowChildrenReadCount = MutableBox(0)
         let statusFailure = AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue)
 
         builder.setRole(window, kAXWindowRole as String)
@@ -918,6 +1026,9 @@ struct ControlsViewBooleanParameterWriterTests {
 
         builder.setRole(editorSlider, kAXSliderRole as String)
         builder.setAttribute(editorSlider, kAXDescriptionAttribute as String, "Threshold")
+        if additionalSliderDescriptionFailure || allDescriptionReadsFail {
+            builder.setRole(additionalSlider, kAXSliderRole as String)
+        }
         builder.setRole(controlsTable, kAXTableRole as String)
         builder.setRole(controlsRow, kAXRowRole as String)
         builder.setRole(controlsLabelCell, kAXCellRole as String)
@@ -936,10 +1047,13 @@ struct ControlsViewBooleanParameterWriterTests {
         builder.setChildren(controlsTable, [controlsHeadingRow, controlsRow])
         builder.setAttribute(controlsTable, kAXRowsAttribute as String, [controlsHeadingRow, controlsRow])
 
+        let slidersBeforeEditor = additionalSliderDescriptionFailure || allDescriptionReadsFail
+            ? [additionalSlider]
+            : []
         let editorChildren = includeControlsTableBesideEditor
-            ? [switcher, editorSlider, controlsTable]
-            : [switcher, editorSlider]
-        let controlsChildren = [switcher, controlsTable]
+            ? [switcher] + slidersBeforeEditor + [editorSlider, controlsTable]
+            : [switcher] + slidersBeforeEditor + [editorSlider]
+        let controlsChildren = [switcher] + slidersBeforeEditor + [controlsTable]
         builder.setChildren(
             window,
             entry == .editor ? editorChildren : controlsChildren
@@ -951,8 +1065,17 @@ struct ControlsViewBooleanParameterWriterTests {
         let runtime = builder.makeAXRuntime(
             appElement: app,
             attributeValueResultHandler: { element, attribute in
+                if allDescriptionReadsFail,
+                   attribute == (kAXDescriptionAttribute as String) {
+                    return .failure(statusFailure)
+                }
                 if readFailure == .switcherDescription,
                    CFEqual(element, switcher),
+                   attribute == (kAXDescriptionAttribute as String) {
+                    return .failure(statusFailure)
+                }
+                if additionalSliderDescriptionFailure,
+                   CFEqual(element, additionalSlider),
                    attribute == (kAXDescriptionAttribute as String) {
                     return .failure(statusFailure)
                 }
@@ -988,7 +1111,10 @@ struct ControlsViewBooleanParameterWriterTests {
                     pendingWindowChildren.value = nil
                 }
                 if readFailure == .switcherCensus, CFEqual(element, window) {
-                    return .failure(statusFailure)
+                    windowChildrenReadCount.value += 1
+                    if windowChildrenReadCount.value == 2 {
+                        return .failure(statusFailure)
+                    }
                 }
                 if readFailure == .sliderCensus, CFEqual(element, editorSlider) {
                     sliderChildrenReadCount.value += 1
@@ -998,7 +1124,7 @@ struct ControlsViewBooleanParameterWriterTests {
                 }
                 if readFailure == .tableCensus, CFEqual(element, controlsTable) {
                     tableChildrenReadCount.value += 1
-                    if tableChildrenReadCount.value == 3 {
+                    if tableChildrenReadCount.value == 2 {
                         return .failure(statusFailure)
                     }
                 }

--- a/Tests/LogicProMCPTests/ControlsViewBooleanParameterWriterTests.swift
+++ b/Tests/LogicProMCPTests/ControlsViewBooleanParameterWriterTests.swift
@@ -1,0 +1,453 @@
+@preconcurrency import ApplicationServices
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+@Suite("ADR-011 / ADR-018 Controls-view Boolean parameters")
+struct ControlsViewBooleanParameterWriterTests {
+    @Test func rowStaticTextLabelBindsToItsSingleCheckbox() {
+        let fixture = fixture(label: "Limiter On", controlRoles: [kAXCheckBoxRole as String])
+        let result = ControlsViewBooleanParameterWriter.locate(
+            label: "Limiter On",
+            in: fixture.window,
+            runtime: fixture.runtime
+        )
+
+        let resolved: Bool
+        if case .found(.checkBox) = result {
+            resolved = true
+        } else {
+            resolved = false
+        }
+        #expect(resolved)
+    }
+
+    @Test func rowWithTwoCandidateControlsRefusesWithoutTraversalOrder() {
+        let fixture = fixture(
+            label: "Limiter On",
+            controlRoles: [kAXCheckBoxRole as String, kAXSliderRole as String]
+        )
+        let result = ControlsViewBooleanParameterWriter.locate(
+            label: "Limiter On",
+            in: fixture.window,
+            runtime: fixture.runtime
+        )
+
+        let refused: Bool
+        if case .refused(.controlAmbiguous) = result {
+            refused = true
+        } else {
+            refused = false
+        }
+        #expect(refused)
+    }
+
+    @Test func rowWithoutAXStaticTextLabelRefuses() {
+        let fixture = fixture(label: nil, controlRoles: [kAXCheckBoxRole as String])
+        let result = ControlsViewBooleanParameterWriter.locate(
+            label: "Limiter On",
+            in: fixture.window,
+            runtime: fixture.runtime
+        )
+
+        let refused: Bool
+        if case .refused(.rowLabelMissing) = result {
+            refused = true
+        } else {
+            refused = false
+        }
+        #expect(refused)
+    }
+
+    @Test func unchangedReadbackRefusesAndAttemptsOneRestore() {
+        let builder = FakeAXRuntimeBuilder()
+        let checkbox = builder.element(10)
+        builder.setRole(checkbox, kAXCheckBoxRole as String)
+        builder.setAttribute(checkbox, kAXValueAttribute as String, false)
+        let runtime = builder.makeAXRuntime(appElement: builder.element(1))
+
+        let result = ControlsViewBooleanParameterWriter.pressAndVerify(
+            checkbox,
+            requested: true,
+            runtime: runtime
+        )
+
+        let refused = !result.verified
+        let restoreAttempted = result.restoreAttempted
+        let actionCount = builder.actionCalls.filter {
+            $0.elementID == builder.elementID(checkbox)
+                && $0.action == (kAXPressAction as String)
+        }.count
+        let attemptedExactlyPressAndRestore = actionCount == 2
+        #expect(refused)
+        #expect(restoreAttempted)
+        #expect(attemptedExactlyPressAndRestore)
+    }
+
+    @Test func statusZeroPressWithUnchangedReadbackNeverReportsSuccess() {
+        final class PressCount: @unchecked Sendable { var value = 0 }
+        let count = PressCount()
+        let builder = FakeAXRuntimeBuilder()
+        let checkbox = builder.element(20)
+        builder.setRole(checkbox, kAXCheckBoxRole as String)
+        builder.setAttribute(checkbox, kAXValueAttribute as String, false)
+        let runtime = builder.makeAXRuntime(
+            appElement: builder.element(2),
+            setAttributeHandler: nil,
+            performActionHandler: { element, action in
+                guard element == checkbox, action == (kAXPressAction as String) else { return false }
+                count.value += 1
+                // Models AX status 0: it is accepted, but AXValue never moves.
+                return true
+            }
+        )
+
+        let result = ControlsViewBooleanParameterWriter.pressAndVerify(
+            checkbox,
+            requested: true,
+            runtime: runtime
+        )
+
+        let refused = !result.verified
+        let attemptedRestore = count.value == 2
+        #expect(refused)
+        #expect(attemptedRestore)
+    }
+
+    @Test func controlsViewSliderIsRefusedWithTheMeasuredNonactuationReason() {
+        let fixture = fixture(label: "Gain", controlRoles: [kAXSliderRole as String])
+        let result = ControlsViewBooleanParameterWriter.locate(
+            label: "Gain",
+            in: fixture.window,
+            runtime: fixture.runtime
+        )
+
+        let refused: Bool
+        if case .found(let control) = result,
+           control.failure == .sliderNotActuable {
+            refused = true
+        } else {
+            refused = false
+        }
+        #expect(refused)
+    }
+
+    @Test func controlsViewPopupIsRefusedAsUnmeasuredWithoutAMenuAction() {
+        let fixture = fixture(label: "Circuit Type", controlRoles: [kAXPopUpButtonRole as String])
+        let result = ControlsViewBooleanParameterWriter.locate(
+            label: "Circuit Type",
+            in: fixture.window,
+            runtime: fixture.runtime
+        )
+
+        let refused: Bool
+        if case .found(let control) = result,
+           control.failure == .popupUnmeasured {
+            refused = true
+        } else {
+            refused = false
+        }
+        let tookNoAction = fixture.builder.actionCalls.isEmpty
+        #expect(refused)
+        #expect(tookNoAction)
+    }
+
+    @Test func describedSlidersConfirmNativeEditorDespiteContradictoryTitle() {
+        let fixture = viewFixture(entry: .editor, title: "컨트롤", behavior: .switchesStructure)
+
+        let result = ControlsViewBooleanParameterWriter.prepareView(
+            .editor,
+            in: fixture.window,
+            runtime: fixture.runtime
+        )
+
+        let confirmed: Bool
+        if case .ready = result {
+            confirmed = true
+        } else {
+            confirmed = false
+        }
+        let titleWasNotNeeded = fixture.builder.actionCalls.isEmpty
+        #expect(confirmed)
+        #expect(titleWasNotNeeded)
+    }
+
+    @Test func controlsRowsWithoutDescribedSlidersConfirmControlsDespiteContradictoryTitle() {
+        let fixture = viewFixture(entry: .controls, title: "편집기", behavior: .switchesStructure)
+
+        let result = ControlsViewBooleanParameterWriter.prepareView(
+            .controls,
+            in: fixture.window,
+            runtime: fixture.runtime
+        )
+
+        let confirmed: Bool
+        if case .ready = result {
+            confirmed = true
+        } else {
+            confirmed = false
+        }
+        let titleWasNotNeeded = fixture.builder.actionCalls.isEmpty
+        #expect(confirmed)
+        #expect(titleWasNotNeeded)
+    }
+
+    @Test func switchThatNeverChangesStructureRefusesWithinDeadlineAndLeavesEntryView() {
+        let fixture = viewFixture(entry: .controls, title: "[100%]", behavior: .neverChanges)
+        let started = Date()
+
+        let result = ControlsViewBooleanParameterWriter.prepareView(
+            .editor,
+            in: fixture.window,
+            confirmationTimeout: 0.025,
+            runtime: fixture.runtime
+        )
+
+        let refused: Bool
+        if case .refused(.viewStructureDidNotConfirm(.editor)) = result {
+            refused = true
+        } else {
+            refused = false
+        }
+        let completedWithinDeadline = Date().timeIntervalSince(started) < 0.25
+        let attemptedEditorSelection = fixture.editorSelections.value == 1
+        let entryStructureRemainedControls = controlsStructureIsPresent(fixture)
+        #expect(refused)
+        #expect(completedWithinDeadline)
+        #expect(attemptedEditorSelection)
+        #expect(entryStructureRemainedControls)
+    }
+
+    @Test func confirmedSwitchRestoresTheStructuralEntryView() {
+        let fixture = viewFixture(entry: .controls, title: "[100%]", behavior: .switchesStructure)
+        let result = ControlsViewBooleanParameterWriter.prepareView(
+            .editor,
+            in: fixture.window,
+            runtime: fixture.runtime
+        )
+        let session: ControlsViewBooleanParameterWriter.ViewSession?
+        if case let .ready(ready) = result {
+            session = ready
+        } else {
+            session = nil
+        }
+        let prepared = session != nil
+        #expect(prepared)
+        guard let session else { return }
+
+        let restoration = session.restore()
+        let restorationConfirmed = restoration.confirmed
+        let restoredControlsStructure = controlsStructureIsPresent(fixture)
+        let selectedEditor = fixture.editorSelections.value == 1
+        let restoredControls = fixture.controlsSelections.value == 1
+        #expect(restorationConfirmed)
+        #expect(restoredControlsStructure)
+        #expect(selectedEditor)
+        #expect(restoredControls)
+    }
+
+    @Test func unconfirmedSwitchRestoresTheStructuralEntryView() {
+        let fixture = viewFixture(
+            entry: .controls,
+            title: "[100%]",
+            behavior: .becomesUnconfirmedThenControlsRestores
+        )
+
+        let result = ControlsViewBooleanParameterWriter.prepareView(
+            .editor,
+            in: fixture.window,
+            confirmationTimeout: 0.025,
+            runtime: fixture.runtime
+        )
+
+        let refused: Bool
+        if case .refused(.viewStructureDidNotConfirm(.editor)) = result {
+            refused = true
+        } else {
+            refused = false
+        }
+        let restoredControlsStructure = controlsStructureIsPresent(fixture)
+        let attemptedCompensatingControlsSelection = fixture.controlsSelections.value == 1
+        #expect(refused)
+        #expect(restoredControlsStructure)
+        #expect(attemptedCompensatingControlsSelection)
+    }
+
+    @Test func compressorCatalogExposesOnlyTheTwoMeasuredCheckboxWrites() {
+        let compressor = try! #require(
+            StockPluginCatalog.entry(id: "logic.stock.effect.compressor")
+        )
+        let booleans = compressor.parameters.filter {
+            $0.writeMethod == "ax_controls_view_checkbox_press"
+        }
+        let names = Set(booleans.map(\.displayName))
+        let measuredNames = names == ["Limiter On", "Auto Release"]
+        let allHaveLiveEvidence = booleans.allSatisfy {
+            $0.availabilityState == .verified
+                && $0.provenance.observedAt?.hasPrefix("2026-09-02") == true
+                && !$0.provenance.evidence.isEmpty
+        }
+        #expect(measuredNames)
+        #expect(allHaveLiveEvidence)
+    }
+
+    private enum ViewFixtureBehavior {
+        case switchesStructure
+        case neverChanges
+        case becomesUnconfirmedThenControlsRestores
+    }
+
+    private struct ViewFixture {
+        let builder: FakeAXRuntimeBuilder
+        let window: AXUIElement
+        let controlsTable: AXUIElement
+        let controlsSelections: MutableBox<Int>
+        let editorSelections: MutableBox<Int>
+        let runtime: AXHelpers.Runtime
+    }
+
+    private func viewFixture(
+        entry: ControlsViewBooleanParameterWriter.PluginWindowView,
+        title: String,
+        behavior: ViewFixtureBehavior
+    ) -> ViewFixture {
+        let builder = FakeAXRuntimeBuilder()
+        let app = builder.element(900)
+        let window = builder.element(901)
+        let switcher = builder.element(902)
+        let menu = builder.element(903)
+        let controlsMenuItem = builder.element(904)
+        let editorMenuItem = builder.element(905)
+        let editorSlider = builder.element(906)
+        let controlsTable = builder.element(907)
+        let controlsRow = builder.element(908)
+        let controlsSelections = MutableBox(0)
+        let editorSelections = MutableBox(0)
+
+        builder.setRole(window, kAXWindowRole as String)
+        builder.setRole(switcher, kAXMenuButtonRole as String)
+        builder.setAttribute(switcher, kAXDescriptionAttribute as String, "보기")
+        builder.setAttribute(switcher, kAXTitleAttribute as String, title)
+        builder.setRole(menu, kAXMenuRole as String)
+        builder.setRole(controlsMenuItem, kAXMenuItemRole as String)
+        builder.setAttribute(controlsMenuItem, kAXTitleAttribute as String, "컨트롤")
+        builder.setRole(editorMenuItem, kAXMenuItemRole as String)
+        builder.setAttribute(editorMenuItem, kAXTitleAttribute as String, "편집기")
+        builder.setChildren(menu, [controlsMenuItem, editorMenuItem])
+        builder.setChildren(switcher, [menu])
+
+        builder.setRole(editorSlider, kAXSliderRole as String)
+        builder.setAttribute(editorSlider, kAXDescriptionAttribute as String, "Threshold")
+        builder.setRole(controlsTable, kAXTableRole as String)
+        builder.setRole(controlsRow, kAXRowRole as String)
+        builder.setChildren(controlsTable, [controlsRow])
+        builder.setAttribute(controlsTable, kAXRowsAttribute as String, [controlsRow])
+
+        let editorChildren = [switcher, editorSlider]
+        let controlsChildren = [switcher, controlsTable]
+        builder.setChildren(
+            window,
+            entry == .editor ? editorChildren : controlsChildren
+        )
+
+        let controlsKey = builder.elementID(controlsMenuItem)
+        let editorKey = builder.elementID(editorMenuItem)
+        let runtime = builder.makeAXRuntime(
+            appElement: app,
+            setAttributeHandler: nil,
+            performActionHandler: { element, action in
+                guard action == (kAXPressAction as String) else { return true }
+                switch builder.elementID(element) {
+                case editorKey:
+                    editorSelections.value += 1
+                    switch behavior {
+                    case .switchesStructure:
+                        builder.setChildren(window, editorChildren)
+                    case .neverChanges:
+                        break
+                    case .becomesUnconfirmedThenControlsRestores:
+                        builder.setChildren(window, [switcher])
+                    }
+                case controlsKey:
+                    controlsSelections.value += 1
+                    switch behavior {
+                    case .switchesStructure, .becomesUnconfirmedThenControlsRestores:
+                        builder.setChildren(window, controlsChildren)
+                    case .neverChanges:
+                        break
+                    }
+                default:
+                    break
+                }
+                return true
+            }
+        )
+        return ViewFixture(
+            builder: builder,
+            window: window,
+            controlsTable: controlsTable,
+            controlsSelections: controlsSelections,
+            editorSelections: editorSelections,
+            runtime: runtime
+        )
+    }
+
+    private func controlsStructureIsPresent(_ fixture: ViewFixture) -> Bool {
+        let visibleTables = AXHelpers.censusDescendant(
+            of: fixture.window,
+            role: kAXTableRole,
+            maxDepth: 8,
+            runtime: fixture.runtime
+        ).matches
+        let describedSliders = AXHelpers.censusDescendant(
+            of: fixture.window,
+            role: kAXSliderRole,
+            maxDepth: 8,
+            runtime: fixture.runtime
+        ).matches.filter { slider in
+            let description = AXHelpers.getDescription(slider, runtime: fixture.runtime) ?? ""
+            return !description.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+        return visibleTables.count == 1
+            && visibleTables.first == fixture.controlsTable
+            && describedSliders.isEmpty
+    }
+
+    private func fixture(
+        label: String?,
+        controlRoles: [String]
+    ) -> (builder: FakeAXRuntimeBuilder, window: AXUIElement, runtime: AXHelpers.Runtime) {
+        let builder = FakeAXRuntimeBuilder()
+        let window = builder.element(100)
+        let table = builder.element(101)
+        let row = builder.element(102)
+        let labelCell = builder.element(103)
+        let controlCell = builder.element(104)
+
+        builder.setRole(window, kAXWindowRole as String)
+        builder.setRole(table, kAXTableRole as String)
+        builder.setRole(row, kAXRowRole as String)
+        builder.setRole(labelCell, kAXCellRole as String)
+        builder.setRole(controlCell, kAXCellRole as String)
+        if let label {
+            let text = builder.element(105)
+            builder.setRole(text, kAXStaticTextRole as String)
+            builder.setAttribute(text, kAXValueAttribute as String, label)
+            builder.setChildren(labelCell, [text])
+        } else {
+            builder.setChildren(labelCell, [])
+        }
+        let controls = controlRoles.enumerated().map { offset, role -> AXUIElement in
+            let control = builder.element(110 + offset)
+            builder.setRole(control, role)
+            builder.setAttribute(control, kAXValueAttribute as String, 0)
+            return control
+        }
+        builder.setChildren(controlCell, controls)
+        builder.setChildren(row, [labelCell, controlCell])
+        builder.setChildren(table, [row])
+        builder.setAttribute(table, kAXRowsAttribute as String, [row])
+        builder.setChildren(window, [table])
+        return (builder, window, builder.makeAXRuntime(appElement: builder.element(99)))
+    }
+}

--- a/Tests/LogicProMCPTests/ControlsViewBooleanParameterWriterTests.swift
+++ b/Tests/LogicProMCPTests/ControlsViewBooleanParameterWriterTests.swift
@@ -271,7 +271,7 @@ struct ControlsViewBooleanParameterWriterTests {
         #expect(confirmedEditor)
     }
 
-    @Test func controlsRowsWithoutDescribedSlidersConfirmControlsDespiteContradictoryTitle() {
+    @Test func controlsTableWithHeadingRowsAndParameterPairConfirmsControls() {
         let fixture = viewFixture(entry: .controls, title: "편집기", behavior: .switchesStructure)
 
         let result = ControlsViewBooleanParameterWriter.prepareView(
@@ -306,13 +306,21 @@ struct ControlsViewBooleanParameterWriterTests {
         }
         let revealedWithPress = fixture.switcherActions.value == [kAXPressAction as String]
         let selectedWithPick = fixture.menuItemActions.value == [kAXPickAction as String]
+        let menuWasPolledUntilVisible = fixture.menuCensusPolls.value > 1
         #expect(confirmed)
         #expect(revealedWithPress)
         #expect(selectedWithPick)
+        #expect(menuWasPolledUntilVisible)
     }
 
     @Test func switchThatNeverChangesStructureRefusesWithinDeadlineAndLeavesEntryView() {
-        let fixture = viewFixture(entry: .controls, title: "[100%]", behavior: .neverChanges)
+        let fixture = viewFixture(
+            entry: .controls,
+            title: "[100%]",
+            behavior: .neverChanges,
+            menuRevealAfterPolls: 0,
+            viewSettleDelay: 0
+        )
         let started = Date()
 
         let result = ControlsViewBooleanParameterWriter.prepareView(
@@ -335,6 +343,86 @@ struct ControlsViewBooleanParameterWriterTests {
         #expect(completedWithinDeadline)
         #expect(attemptedEditorSelection)
         #expect(entryStructureRemainedControls)
+    }
+
+    @Test func menuThatNeverAppearsRefusesWithTheAppearanceDeadline() {
+        let fixture = viewFixture(
+            entry: .editor,
+            title: "[100%]",
+            behavior: .switchesStructure,
+            menuRevealAfterPolls: nil
+        )
+
+        let result = ControlsViewBooleanParameterWriter.prepareView(
+            .controls,
+            in: fixture.window,
+            menuAppearanceTimeout: 0.025,
+            runtime: fixture.runtime
+        )
+
+        let refusedForAppearanceDeadline: Bool
+        if case .refused(.viewMenuDidNotAppearBeforeDeadline) = result {
+            refusedForAppearanceDeadline = true
+        } else {
+            refusedForAppearanceDeadline = false
+        }
+        #expect(refusedForAppearanceDeadline)
+    }
+
+    @Test func unreadableMenuRefusesWithTheReadFailureRatherThanTheDeadline() {
+        let readFailure = AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue)
+        let fixture = viewFixture(
+            entry: .editor,
+            title: "[100%]",
+            behavior: .switchesStructure,
+            menuReadFailure: readFailure
+        )
+
+        let result = ControlsViewBooleanParameterWriter.prepareView(
+            .controls,
+            in: fixture.window,
+            menuAppearanceTimeout: 0.025,
+            runtime: fixture.runtime
+        )
+
+        let refusedForTheObservedReadFailure: Bool
+        if case let .refused(.viewMenuReadFailed(observed)) = result {
+            refusedForTheObservedReadFailure = observed == readFailure
+        } else {
+            refusedForTheObservedReadFailure = false
+        }
+        #expect(refusedForTheObservedReadFailure)
+    }
+
+    @Test func slowerThanConfirmationDeadlineRefusesAndRestoresTheEntryView() {
+        let fixture = viewFixture(
+            entry: .controls,
+            title: "[100%]",
+            behavior: .switchesStructure,
+            menuRevealAfterPolls: 0,
+            viewSettleDelay: 0.15
+        )
+
+        let result = ControlsViewBooleanParameterWriter.prepareView(
+            .editor,
+            in: fixture.window,
+            menuAppearanceTimeout: 0.025,
+            confirmationTimeout: 0.025,
+            runtime: fixture.runtime
+        )
+
+        let refusedForSettleDeadline: Bool
+        if case .refused(.viewStructureDidNotConfirm(.editor)) = result {
+            refusedForSettleDeadline = true
+        } else {
+            refusedForSettleDeadline = false
+        }
+        Thread.sleep(forTimeInterval: 0.175)
+        let entryStructureWasRestored = controlsStructureIsPresent(fixture)
+        let restorationWasExplicitlySelected = fixture.controlsSelections.value == 1
+        #expect(refusedForSettleDeadline)
+        #expect(entryStructureWasRestored)
+        #expect(restorationWasExplicitlySelected)
     }
 
     @Test func confirmedSwitchRestoresTheStructuralEntryView() {
@@ -424,13 +512,17 @@ struct ControlsViewBooleanParameterWriterTests {
         let editorSelections: MutableBox<Int>
         let switcherActions: MutableBox<[String]>
         let menuItemActions: MutableBox<[String]>
+        let menuCensusPolls: MutableBox<Int>
         let runtime: AXHelpers.Runtime
     }
 
     private func viewFixture(
         entry: ControlsViewBooleanParameterWriter.PluginWindowView,
         title: String,
-        behavior: ViewFixtureBehavior
+        behavior: ViewFixtureBehavior,
+        menuRevealAfterPolls: Int? = 4,
+        menuReadFailure: AXHelpers.AXStatusError? = nil,
+        viewSettleDelay: TimeInterval = 0.5
     ) -> ViewFixture {
         let builder = FakeAXRuntimeBuilder()
         let app = builder.element(900)
@@ -446,10 +538,17 @@ struct ControlsViewBooleanParameterWriterTests {
         let controlsControlCell = builder.element(910)
         let controlsLabel = builder.element(911)
         let controlsCheckbox = builder.element(912)
+        let controlsHeadingRow = builder.element(913)
+        let controlsHeadingCell = builder.element(914)
+        let controlsHeadingLabel = builder.element(915)
         let controlsSelections = MutableBox(0)
         let editorSelections = MutableBox(0)
         let switcherActions = MutableBox<[String]>([])
         let menuItemActions = MutableBox<[String]>([])
+        let menuCensusPolls = MutableBox(0)
+        let menuOpen = MutableBox(false)
+        let menuVisible = MutableBox(false)
+        let pendingWindowChildren = MutableBox<(children: [AXUIElement], settlesAt: Date)?>(nil)
 
         builder.setRole(window, kAXWindowRole as String)
         builder.setRole(switcher, kAXMenuButtonRole as String)
@@ -475,8 +574,14 @@ struct ControlsViewBooleanParameterWriterTests {
         builder.setChildren(controlsLabelCell, [controlsLabel])
         builder.setChildren(controlsControlCell, [controlsCheckbox])
         builder.setChildren(controlsRow, [controlsLabelCell, controlsControlCell])
-        builder.setChildren(controlsTable, [controlsRow])
-        builder.setAttribute(controlsTable, kAXRowsAttribute as String, [controlsRow])
+        builder.setRole(controlsHeadingRow, kAXRowRole as String)
+        builder.setRole(controlsHeadingCell, kAXCellRole as String)
+        builder.setRole(controlsHeadingLabel, kAXStaticTextRole as String)
+        builder.setAttribute(controlsHeadingLabel, kAXValueAttribute as String, "Dynamics")
+        builder.setChildren(controlsHeadingCell, [controlsHeadingLabel])
+        builder.setChildren(controlsHeadingRow, [controlsHeadingCell])
+        builder.setChildren(controlsTable, [controlsHeadingRow, controlsRow])
+        builder.setAttribute(controlsTable, kAXRowsAttribute as String, [controlsHeadingRow, controlsRow])
 
         let editorChildren = [switcher, editorSlider]
         let controlsChildren = [switcher, controlsTable]
@@ -490,35 +595,74 @@ struct ControlsViewBooleanParameterWriterTests {
         let switcherKey = builder.elementID(switcher)
         let runtime = builder.makeAXRuntime(
             appElement: app,
+            childrenHandler: { element in
+                if CFEqual(element, window),
+                   let pending = pendingWindowChildren.value,
+                   Date() >= pending.settlesAt {
+                    builder.setChildren(window, pending.children)
+                    pendingWindowChildren.value = nil
+                }
+                if CFEqual(element, switcher), menuOpen.value, menuVisible.value {
+                    return [menu]
+                }
+                return nil
+            },
+            childrenResultHandler: { element in
+                guard CFEqual(element, switcher), menuOpen.value else { return nil }
+                if let menuReadFailure {
+                    return .failure(menuReadFailure)
+                }
+                guard let revealAfterPolls = menuRevealAfterPolls else {
+                    return .success([])
+                }
+                if menuCensusPolls.value < max(0, revealAfterPolls) {
+                    menuCensusPolls.value += 1
+                    return .success([])
+                }
+                menuVisible.value = true
+                return .success([menu])
+            },
             setAttributeHandler: nil,
             performActionHandler: { element, action in
                 let key = builder.elementID(element)
                 if key == switcherKey {
                     switcherActions.value.append(action)
                     guard action == (kAXPressAction as String) else { return false }
-                    builder.setChildren(switcher, [menu])
+                    menuOpen.value = true
+                    menuVisible.value = false
+                    menuCensusPolls.value = 0
                     return true
                 }
                 guard key == editorKey || key == controlsKey else { return true }
                 menuItemActions.value.append(action)
                 guard action == (kAXPickAction as String) else { return false }
-                builder.setChildren(switcher, [])
+                menuOpen.value = false
+                menuVisible.value = false
                 switch key {
                 case editorKey:
                     editorSelections.value += 1
                     switch behavior {
                     case .switchesStructure:
-                        builder.setChildren(window, editorChildren)
+                        pendingWindowChildren.value = (
+                            children: editorChildren,
+                            settlesAt: Date().addingTimeInterval(max(0, viewSettleDelay))
+                        )
                     case .neverChanges:
                         break
                     case .becomesUnconfirmedThenControlsRestores:
-                        builder.setChildren(window, [switcher])
+                        pendingWindowChildren.value = (
+                            children: [switcher],
+                            settlesAt: Date().addingTimeInterval(max(0, viewSettleDelay))
+                        )
                     }
                 case controlsKey:
                     controlsSelections.value += 1
                     switch behavior {
                     case .switchesStructure, .becomesUnconfirmedThenControlsRestores:
-                        builder.setChildren(window, controlsChildren)
+                        pendingWindowChildren.value = (
+                            children: controlsChildren,
+                            settlesAt: Date().addingTimeInterval(max(0, viewSettleDelay))
+                        )
                     case .neverChanges:
                         break
                     }
@@ -536,6 +680,7 @@ struct ControlsViewBooleanParameterWriterTests {
             editorSelections: editorSelections,
             switcherActions: switcherActions,
             menuItemActions: menuItemActions,
+            menuCensusPolls: menuCensusPolls,
             runtime: runtime
         )
     }

--- a/Tests/LogicProMCPTests/ControlsViewBooleanParameterWriterTests.swift
+++ b/Tests/LogicProMCPTests/ControlsViewBooleanParameterWriterTests.swift
@@ -59,6 +59,69 @@ struct ControlsViewBooleanParameterWriterTests {
         #expect(refused)
     }
 
+    @Test func checkboxInsideTheLabelCellRefusesRatherThanBindingTheRow() {
+        let fixture = fixture(label: "Limiter On", controlRoles: [kAXCheckBoxRole as String])
+        let labelCell = fixture.builder.element(103)
+        let controlCell = fixture.builder.element(104)
+        let label = fixture.builder.element(105)
+        let checkbox = fixture.builder.element(110)
+        fixture.builder.setChildren(labelCell, [label, checkbox])
+        fixture.builder.setChildren(controlCell, [])
+
+        let result = ControlsViewBooleanParameterWriter.locate(
+            label: "Limiter On",
+            in: fixture.window,
+            runtime: fixture.runtime
+        )
+        let refused: Bool
+        if case .refused(.rowStructureInvalid) = result {
+            refused = true
+        } else {
+            refused = false
+        }
+        #expect(refused)
+    }
+
+    @Test func AXRowsUnsupportedFallsBackToAXChildrenForTheLabelledRow() {
+        let fixture = fixture(
+            label: "Limiter On",
+            controlRoles: [kAXCheckBoxRole as String],
+            axRowsReadStatus: AXError.attributeUnsupported.rawValue
+        )
+        let result = ControlsViewBooleanParameterWriter.locate(
+            label: "Limiter On",
+            in: fixture.window,
+            runtime: fixture.runtime
+        )
+        let found: Bool
+        if case .found(.checkBox) = result {
+            found = true
+        } else {
+            found = false
+        }
+        #expect(found)
+    }
+
+    @Test func AXRowsReadFailureOtherThanAbsenceRefusesInsteadOfUsingChildren() {
+        let fixture = fixture(
+            label: "Limiter On",
+            controlRoles: [kAXCheckBoxRole as String],
+            axRowsReadStatus: AXError.cannotComplete.rawValue
+        )
+        let result = ControlsViewBooleanParameterWriter.locate(
+            label: "Limiter On",
+            in: fixture.window,
+            runtime: fixture.runtime
+        )
+        let refused: Bool
+        if case .refused(.controlsViewTableNotFound) = result {
+            refused = true
+        } else {
+            refused = false
+        }
+        #expect(refused)
+    }
+
     @Test func unchangedReadbackRefusesAndAttemptsOneRestore() {
         let builder = FakeAXRuntimeBuilder()
         let checkbox = builder.element(10)
@@ -172,6 +235,42 @@ struct ControlsViewBooleanParameterWriterTests {
         #expect(titleWasNotNeeded)
     }
 
+    @Test func titleOnlyEditorSlidersAndABrowserRowDoNotQualifyAsControls() {
+        let builder = FakeAXRuntimeBuilder()
+        let window = builder.element(29_910)
+        let switcher = builder.element(29_911)
+        let slider = builder.element(29_912)
+        let browserTable = builder.element(29_913)
+        let browserRow = builder.element(29_914)
+        let browserTitle = builder.element(29_915)
+        builder.setRole(window, kAXWindowRole as String)
+        builder.setRole(switcher, kAXMenuButtonRole as String)
+        builder.setAttribute(switcher, kAXDescriptionAttribute as String, "보기")
+        builder.setRole(slider, kAXSliderRole as String)
+        builder.setAttribute(slider, kAXDescriptionAttribute as String, "")
+        builder.setRole(browserTable, kAXTableRole as String)
+        builder.setRole(browserRow, kAXRowRole as String)
+        builder.setRole(browserTitle, kAXStaticTextRole as String)
+        builder.setAttribute(browserTitle, kAXValueAttribute as String, "Factory Preset")
+        builder.setChildren(browserRow, [browserTitle])
+        builder.setChildren(browserTable, [browserRow])
+        builder.setAttribute(browserTable, kAXRowsAttribute as String, [browserRow])
+        builder.setChildren(window, [switcher, slider, browserTable])
+
+        let result = ControlsViewBooleanParameterWriter.prepareView(
+            .editor,
+            in: window,
+            runtime: builder.makeAXRuntime(appElement: builder.element(29_900))
+        )
+        let confirmedEditor: Bool
+        if case .ready = result {
+            confirmedEditor = true
+        } else {
+            confirmedEditor = false
+        }
+        #expect(confirmedEditor)
+    }
+
     @Test func controlsRowsWithoutDescribedSlidersConfirmControlsDespiteContradictoryTitle() {
         let fixture = viewFixture(entry: .controls, title: "편집기", behavior: .switchesStructure)
 
@@ -190,6 +289,26 @@ struct ControlsViewBooleanParameterWriterTests {
         let titleWasNotNeeded = fixture.builder.actionCalls.isEmpty
         #expect(confirmed)
         #expect(titleWasNotNeeded)
+    }
+
+    @Test func viewFixtureRequiresAXPressToRevealAndAXPickToSelect() {
+        let fixture = viewFixture(entry: .editor, title: "편집기", behavior: .switchesStructure)
+        let result = ControlsViewBooleanParameterWriter.prepareView(
+            .controls,
+            in: fixture.window,
+            runtime: fixture.runtime
+        )
+        let confirmed: Bool
+        if case .ready = result {
+            confirmed = true
+        } else {
+            confirmed = false
+        }
+        let revealedWithPress = fixture.switcherActions.value == [kAXPressAction as String]
+        let selectedWithPick = fixture.menuItemActions.value == [kAXPickAction as String]
+        #expect(confirmed)
+        #expect(revealedWithPress)
+        #expect(selectedWithPick)
     }
 
     @Test func switchThatNeverChangesStructureRefusesWithinDeadlineAndLeavesEntryView() {
@@ -303,6 +422,8 @@ struct ControlsViewBooleanParameterWriterTests {
         let controlsTable: AXUIElement
         let controlsSelections: MutableBox<Int>
         let editorSelections: MutableBox<Int>
+        let switcherActions: MutableBox<[String]>
+        let menuItemActions: MutableBox<[String]>
         let runtime: AXHelpers.Runtime
     }
 
@@ -321,8 +442,14 @@ struct ControlsViewBooleanParameterWriterTests {
         let editorSlider = builder.element(906)
         let controlsTable = builder.element(907)
         let controlsRow = builder.element(908)
+        let controlsLabelCell = builder.element(909)
+        let controlsControlCell = builder.element(910)
+        let controlsLabel = builder.element(911)
+        let controlsCheckbox = builder.element(912)
         let controlsSelections = MutableBox(0)
         let editorSelections = MutableBox(0)
+        let switcherActions = MutableBox<[String]>([])
+        let menuItemActions = MutableBox<[String]>([])
 
         builder.setRole(window, kAXWindowRole as String)
         builder.setRole(switcher, kAXMenuButtonRole as String)
@@ -334,12 +461,20 @@ struct ControlsViewBooleanParameterWriterTests {
         builder.setRole(editorMenuItem, kAXMenuItemRole as String)
         builder.setAttribute(editorMenuItem, kAXTitleAttribute as String, "편집기")
         builder.setChildren(menu, [controlsMenuItem, editorMenuItem])
-        builder.setChildren(switcher, [menu])
 
         builder.setRole(editorSlider, kAXSliderRole as String)
         builder.setAttribute(editorSlider, kAXDescriptionAttribute as String, "Threshold")
         builder.setRole(controlsTable, kAXTableRole as String)
         builder.setRole(controlsRow, kAXRowRole as String)
+        builder.setRole(controlsLabelCell, kAXCellRole as String)
+        builder.setRole(controlsControlCell, kAXCellRole as String)
+        builder.setRole(controlsLabel, kAXStaticTextRole as String)
+        builder.setRole(controlsCheckbox, kAXCheckBoxRole as String)
+        builder.setAttribute(controlsLabel, kAXValueAttribute as String, "Limiter On")
+        builder.setAttribute(controlsCheckbox, kAXValueAttribute as String, false)
+        builder.setChildren(controlsLabelCell, [controlsLabel])
+        builder.setChildren(controlsControlCell, [controlsCheckbox])
+        builder.setChildren(controlsRow, [controlsLabelCell, controlsControlCell])
         builder.setChildren(controlsTable, [controlsRow])
         builder.setAttribute(controlsTable, kAXRowsAttribute as String, [controlsRow])
 
@@ -352,12 +487,23 @@ struct ControlsViewBooleanParameterWriterTests {
 
         let controlsKey = builder.elementID(controlsMenuItem)
         let editorKey = builder.elementID(editorMenuItem)
+        let switcherKey = builder.elementID(switcher)
         let runtime = builder.makeAXRuntime(
             appElement: app,
             setAttributeHandler: nil,
             performActionHandler: { element, action in
-                guard action == (kAXPressAction as String) else { return true }
-                switch builder.elementID(element) {
+                let key = builder.elementID(element)
+                if key == switcherKey {
+                    switcherActions.value.append(action)
+                    guard action == (kAXPressAction as String) else { return false }
+                    builder.setChildren(switcher, [menu])
+                    return true
+                }
+                guard key == editorKey || key == controlsKey else { return true }
+                menuItemActions.value.append(action)
+                guard action == (kAXPickAction as String) else { return false }
+                builder.setChildren(switcher, [])
+                switch key {
                 case editorKey:
                     editorSelections.value += 1
                     switch behavior {
@@ -388,6 +534,8 @@ struct ControlsViewBooleanParameterWriterTests {
             controlsTable: controlsTable,
             controlsSelections: controlsSelections,
             editorSelections: editorSelections,
+            switcherActions: switcherActions,
+            menuItemActions: menuItemActions,
             runtime: runtime
         )
     }
@@ -415,7 +563,8 @@ struct ControlsViewBooleanParameterWriterTests {
 
     private func fixture(
         label: String?,
-        controlRoles: [String]
+        controlRoles: [String],
+        axRowsReadStatus: Int32? = nil
     ) -> (builder: FakeAXRuntimeBuilder, window: AXUIElement, runtime: AXHelpers.Runtime) {
         let builder = FakeAXRuntimeBuilder()
         let window = builder.element(100)
@@ -448,6 +597,19 @@ struct ControlsViewBooleanParameterWriterTests {
         builder.setChildren(table, [row])
         builder.setAttribute(table, kAXRowsAttribute as String, [row])
         builder.setChildren(window, [table])
-        return (builder, window, builder.makeAXRuntime(appElement: builder.element(99)))
+        let runtime = builder.makeAXRuntime(
+            appElement: builder.element(99),
+            attributeValueResultHandler: { element, attribute in
+                guard let axRowsReadStatus,
+                      builder.elementID(element) == builder.elementID(table),
+                      attribute == (kAXRowsAttribute as String) else {
+                    return nil
+                }
+                return .failure(AXHelpers.AXStatusError(raw: axRowsReadStatus))
+            },
+            setAttributeHandler: nil,
+            performActionHandler: nil
+        )
+        return (builder, window, runtime)
     }
 }

--- a/Tests/LogicProMCPTests/ControlsViewBooleanParameterWriterTests.swift
+++ b/Tests/LogicProMCPTests/ControlsViewBooleanParameterWriterTests.swift
@@ -59,14 +59,16 @@ struct ControlsViewBooleanParameterWriterTests {
         #expect(refused)
     }
 
-    @Test func checkboxInsideTheLabelCellRefusesRatherThanBindingTheRow() {
+    @Test func rowWithTwoCellsRefusesRatherThanBindingTheRow() {
         let fixture = fixture(label: "Limiter On", controlRoles: [kAXCheckBoxRole as String])
         let labelCell = fixture.builder.element(103)
         let controlCell = fixture.builder.element(104)
         let label = fixture.builder.element(105)
         let checkbox = fixture.builder.element(110)
-        fixture.builder.setChildren(labelCell, [label, checkbox])
-        fixture.builder.setChildren(controlCell, [])
+        fixture.builder.setRole(controlCell, kAXCellRole as String)
+        fixture.builder.setChildren(labelCell, [label])
+        fixture.builder.setChildren(controlCell, [checkbox])
+        fixture.builder.setChildren(fixture.builder.element(102), [labelCell, controlCell])
 
         let result = ControlsViewBooleanParameterWriter.locate(
             label: "Limiter On",
@@ -75,6 +77,29 @@ struct ControlsViewBooleanParameterWriterTests {
         )
         let refused: Bool
         if case .refused(.rowStructureInvalid) = result {
+            refused = true
+        } else {
+            refused = false
+        }
+        #expect(refused)
+    }
+
+    @Test func rowWithTwoNonemptyStaticTextLabelsRefuses() {
+        let fixture = fixture(label: "Limiter On", controlRoles: [kAXCheckBoxRole as String])
+        let secondLabel = fixture.builder.element(106)
+        let cell = fixture.builder.element(103)
+        fixture.builder.setRole(secondLabel, kAXStaticTextRole as String)
+        fixture.builder.setAttribute(secondLabel, kAXValueAttribute as String, "Auto Release")
+        fixture.builder.setChildren(cell, [fixture.builder.element(105), secondLabel, fixture.builder.element(110)])
+
+        let result = ControlsViewBooleanParameterWriter.locate(
+            label: "Limiter On",
+            in: fixture.window,
+            runtime: fixture.runtime
+        )
+
+        let refused: Bool
+        if case .refused(.rowLabelAmbiguous) = result {
             refused = true
         } else {
             refused = false
@@ -102,6 +127,26 @@ struct ControlsViewBooleanParameterWriterTests {
         #expect(found)
     }
 
+    @Test func AXRowsNoValueFallsBackToAXChildrenForTheLabelledRow() {
+        let fixture = fixture(
+            label: "Limiter On",
+            controlRoles: [kAXCheckBoxRole as String],
+            axRowsReadStatus: AXError.noValue.rawValue
+        )
+        let result = ControlsViewBooleanParameterWriter.locate(
+            label: "Limiter On",
+            in: fixture.window,
+            runtime: fixture.runtime
+        )
+        let found: Bool
+        if case .found(.checkBox) = result {
+            found = true
+        } else {
+            found = false
+        }
+        #expect(found)
+    }
+
     @Test func AXRowsReadFailureOtherThanAbsenceRefusesInsteadOfUsingChildren() {
         let fixture = fixture(
             label: "Limiter On",
@@ -114,12 +159,83 @@ struct ControlsViewBooleanParameterWriterTests {
             runtime: fixture.runtime
         )
         let refused: Bool
-        if case .refused(.controlsViewTableNotFound) = result {
+        if case .refused(.accessibilityReadFailed) = result {
             refused = true
         } else {
             refused = false
         }
         #expect(refused)
+    }
+
+    @Test func secondControlWhoseRoleReadFailsRefusesTheWholeBinding() {
+        let fixture = fixture(
+            label: "Limiter On",
+            controlRoles: [kAXCheckBoxRole as String, kAXButtonRole as String],
+            roleReadFailureElementIDs: [111]
+        )
+        let result = ControlsViewBooleanParameterWriter.locate(
+            label: "Limiter On",
+            in: fixture.window,
+            runtime: fixture.runtime
+        )
+        let refusedForUnreadableCandidate: Bool
+        if case .refused(.accessibilityReadFailed) = result {
+            refusedForUnreadableCandidate = true
+        } else {
+            refusedForUnreadableCandidate = false
+        }
+        #expect(refusedForUnreadableCandidate)
+    }
+
+    @Test func unreadableRoleWhileFilteringFallbackRowsRefusesTheWholeBinding() {
+        let fixture = fixture(
+            label: "Limiter On",
+            controlRoles: [kAXCheckBoxRole as String],
+            axRowsReadStatus: AXError.attributeUnsupported.rawValue,
+            roleReadFailureElementIDs: [112]
+        )
+        let table = fixture.builder.element(101)
+        let unreadableNonRow = fixture.builder.element(112)
+        fixture.builder.setChildren(table, [fixture.builder.element(102), unreadableNonRow])
+
+        let result = ControlsViewBooleanParameterWriter.locate(
+            label: "Limiter On",
+            in: fixture.window,
+            runtime: fixture.runtime
+        )
+
+        let refusedForUnreadableFallbackRow: Bool
+        if case .refused(.accessibilityReadFailed) = result {
+            refusedForUnreadableFallbackRow = true
+        } else {
+            refusedForUnreadableFallbackRow = false
+        }
+        #expect(refusedForUnreadableFallbackRow)
+    }
+
+    @Test func unreadableRoleWhileFilteringCellsRefusesTheWholeBinding() {
+        let fixture = fixture(
+            label: "Limiter On",
+            controlRoles: [kAXCheckBoxRole as String],
+            roleReadFailureElementIDs: [113]
+        )
+        let row = fixture.builder.element(102)
+        let unreadableNonCell = fixture.builder.element(113)
+        fixture.builder.setChildren(row, [fixture.builder.element(103), unreadableNonCell])
+
+        let result = ControlsViewBooleanParameterWriter.locate(
+            label: "Limiter On",
+            in: fixture.window,
+            runtime: fixture.runtime
+        )
+
+        let refusedForUnreadableCell: Bool
+        if case .refused(.accessibilityReadFailed) = result {
+            refusedForUnreadableCell = true
+        } else {
+            refusedForUnreadableCell = false
+        }
+        #expect(refusedForUnreadableCell)
     }
 
     @Test func unchangedReadbackRefusesAndAttemptsOneRestore() {
@@ -235,24 +351,30 @@ struct ControlsViewBooleanParameterWriterTests {
         #expect(titleWasNotNeeded)
     }
 
-    @Test func titleOnlyEditorSlidersAndABrowserRowDoNotQualifyAsControls() {
+    @Test func describedEditorSliderWinsOverTheStrongestLabelControlTableShape() {
         let builder = FakeAXRuntimeBuilder()
         let window = builder.element(29_910)
         let switcher = builder.element(29_911)
         let slider = builder.element(29_912)
         let browserTable = builder.element(29_913)
         let browserRow = builder.element(29_914)
-        let browserTitle = builder.element(29_915)
+        let browserCell = builder.element(29_915)
+        let browserTitle = builder.element(29_916)
+        let browserCheckbox = builder.element(29_917)
         builder.setRole(window, kAXWindowRole as String)
         builder.setRole(switcher, kAXMenuButtonRole as String)
         builder.setAttribute(switcher, kAXDescriptionAttribute as String, "보기")
         builder.setRole(slider, kAXSliderRole as String)
-        builder.setAttribute(slider, kAXDescriptionAttribute as String, "")
+        builder.setAttribute(slider, kAXDescriptionAttribute as String, "Threshold")
         builder.setRole(browserTable, kAXTableRole as String)
         builder.setRole(browserRow, kAXRowRole as String)
+        builder.setRole(browserCell, kAXCellRole as String)
         builder.setRole(browserTitle, kAXStaticTextRole as String)
-        builder.setAttribute(browserTitle, kAXValueAttribute as String, "Factory Preset")
-        builder.setChildren(browserRow, [browserTitle])
+        builder.setAttribute(browserTitle, kAXValueAttribute as String, "Limiter On")
+        builder.setRole(browserCheckbox, kAXCheckBoxRole as String)
+        builder.setAttribute(browserCheckbox, kAXValueAttribute as String, false)
+        builder.setChildren(browserCell, [browserTitle, browserCheckbox])
+        builder.setChildren(browserRow, [browserCell])
         builder.setChildren(browserTable, [browserRow])
         builder.setAttribute(browserTable, kAXRowsAttribute as String, [browserRow])
         builder.setChildren(window, [switcher, slider, browserTable])
@@ -269,6 +391,42 @@ struct ControlsViewBooleanParameterWriterTests {
             confirmedEditor = false
         }
         #expect(confirmedEditor)
+    }
+
+    @Test func tableWhoseRowsCarryNoLabelControlPairDoesNotConfirmControls() {
+        let builder = FakeAXRuntimeBuilder()
+        let window = builder.element(29_920)
+        let switcher = builder.element(29_921)
+        let table = builder.element(29_922)
+        let row = builder.element(29_923)
+        let cell = builder.element(29_924)
+        let heading = builder.element(29_925)
+        builder.setRole(window, kAXWindowRole as String)
+        builder.setRole(switcher, kAXMenuButtonRole as String)
+        builder.setAttribute(switcher, kAXDescriptionAttribute as String, "보기")
+        builder.setRole(table, kAXTableRole as String)
+        builder.setRole(row, kAXRowRole as String)
+        builder.setRole(cell, kAXCellRole as String)
+        builder.setRole(heading, kAXStaticTextRole as String)
+        builder.setAttribute(heading, kAXValueAttribute as String, "Dynamics")
+        builder.setChildren(cell, [heading])
+        builder.setChildren(row, [cell])
+        builder.setChildren(table, [row])
+        builder.setAttribute(table, kAXRowsAttribute as String, [row])
+        builder.setChildren(window, [switcher, table])
+
+        let result = ControlsViewBooleanParameterWriter.prepareView(
+            .controls,
+            in: window,
+            runtime: builder.makeAXRuntime(appElement: builder.element(29_900))
+        )
+        let refusedBecauseTheTableCannotProveControls: Bool
+        if case .refused(.entryViewNotConfirmed, restoration: nil) = result {
+            refusedBecauseTheTableCannotProveControls = true
+        } else {
+            refusedBecauseTheTableCannotProveControls = false
+        }
+        #expect(refusedBecauseTheTableCannotProveControls)
     }
 
     @Test func controlsTableWithHeadingRowsAndParameterPairConfirmsControls() {
@@ -331,7 +489,7 @@ struct ControlsViewBooleanParameterWriterTests {
         )
 
         let refused: Bool
-        if case .refused(.viewStructureDidNotConfirm(.editor)) = result {
+        if case .refused(.viewStructureDidNotConfirm(.editor), restoration: _) = result {
             refused = true
         } else {
             refused = false
@@ -361,7 +519,7 @@ struct ControlsViewBooleanParameterWriterTests {
         )
 
         let refusedForAppearanceDeadline: Bool
-        if case .refused(.viewMenuDidNotAppearBeforeDeadline) = result {
+        if case .refused(.viewMenuDidNotAppearBeforeDeadline, restoration: _) = result {
             refusedForAppearanceDeadline = true
         } else {
             refusedForAppearanceDeadline = false
@@ -386,7 +544,7 @@ struct ControlsViewBooleanParameterWriterTests {
         )
 
         let refusedForTheObservedReadFailure: Bool
-        if case let .refused(.viewMenuReadFailed(observed)) = result {
+        if case let .refused(.viewMenuReadFailed(observed), restoration: _) = result {
             refusedForTheObservedReadFailure = observed == readFailure
         } else {
             refusedForTheObservedReadFailure = false
@@ -412,7 +570,7 @@ struct ControlsViewBooleanParameterWriterTests {
         )
 
         let refusedForSettleDeadline: Bool
-        if case .refused(.viewStructureDidNotConfirm(.editor)) = result {
+        if case .refused(.viewStructureDidNotConfirm(.editor), restoration: _) = result {
             refusedForSettleDeadline = true
         } else {
             refusedForSettleDeadline = false
@@ -468,7 +626,7 @@ struct ControlsViewBooleanParameterWriterTests {
         )
 
         let refused: Bool
-        if case .refused(.viewStructureDidNotConfirm(.editor)) = result {
+        if case .refused(.viewStructureDidNotConfirm(.editor), restoration: _) = result {
             refused = true
         } else {
             refused = false
@@ -535,7 +693,6 @@ struct ControlsViewBooleanParameterWriterTests {
         let controlsTable = builder.element(907)
         let controlsRow = builder.element(908)
         let controlsLabelCell = builder.element(909)
-        let controlsControlCell = builder.element(910)
         let controlsLabel = builder.element(911)
         let controlsCheckbox = builder.element(912)
         let controlsHeadingRow = builder.element(913)
@@ -566,14 +723,12 @@ struct ControlsViewBooleanParameterWriterTests {
         builder.setRole(controlsTable, kAXTableRole as String)
         builder.setRole(controlsRow, kAXRowRole as String)
         builder.setRole(controlsLabelCell, kAXCellRole as String)
-        builder.setRole(controlsControlCell, kAXCellRole as String)
         builder.setRole(controlsLabel, kAXStaticTextRole as String)
         builder.setRole(controlsCheckbox, kAXCheckBoxRole as String)
         builder.setAttribute(controlsLabel, kAXValueAttribute as String, "Limiter On")
         builder.setAttribute(controlsCheckbox, kAXValueAttribute as String, false)
-        builder.setChildren(controlsLabelCell, [controlsLabel])
-        builder.setChildren(controlsControlCell, [controlsCheckbox])
-        builder.setChildren(controlsRow, [controlsLabelCell, controlsControlCell])
+        builder.setChildren(controlsLabelCell, [controlsLabel, controlsCheckbox])
+        builder.setChildren(controlsRow, [controlsLabelCell])
         builder.setRole(controlsHeadingRow, kAXRowRole as String)
         builder.setRole(controlsHeadingCell, kAXCellRole as String)
         builder.setRole(controlsHeadingLabel, kAXStaticTextRole as String)
@@ -709,27 +864,23 @@ struct ControlsViewBooleanParameterWriterTests {
     private func fixture(
         label: String?,
         controlRoles: [String],
-        axRowsReadStatus: Int32? = nil
+        axRowsReadStatus: Int32? = nil,
+        roleReadFailureElementIDs: Set<Int> = []
     ) -> (builder: FakeAXRuntimeBuilder, window: AXUIElement, runtime: AXHelpers.Runtime) {
         let builder = FakeAXRuntimeBuilder()
         let window = builder.element(100)
         let table = builder.element(101)
         let row = builder.element(102)
         let labelCell = builder.element(103)
-        let controlCell = builder.element(104)
 
         builder.setRole(window, kAXWindowRole as String)
         builder.setRole(table, kAXTableRole as String)
         builder.setRole(row, kAXRowRole as String)
         builder.setRole(labelCell, kAXCellRole as String)
-        builder.setRole(controlCell, kAXCellRole as String)
         if let label {
             let text = builder.element(105)
             builder.setRole(text, kAXStaticTextRole as String)
             builder.setAttribute(text, kAXValueAttribute as String, label)
-            builder.setChildren(labelCell, [text])
-        } else {
-            builder.setChildren(labelCell, [])
         }
         let controls = controlRoles.enumerated().map { offset, role -> AXUIElement in
             let control = builder.element(110 + offset)
@@ -737,14 +888,26 @@ struct ControlsViewBooleanParameterWriterTests {
             builder.setAttribute(control, kAXValueAttribute as String, 0)
             return control
         }
-        builder.setChildren(controlCell, controls)
-        builder.setChildren(row, [labelCell, controlCell])
+        let labelContents: [AXUIElement]
+        if label == nil {
+            labelContents = controls
+        } else {
+            labelContents = [builder.element(105)] + controls
+        }
+        builder.setChildren(labelCell, labelContents)
+        builder.setChildren(row, [labelCell])
         builder.setChildren(table, [row])
         builder.setAttribute(table, kAXRowsAttribute as String, [row])
         builder.setChildren(window, [table])
         let runtime = builder.makeAXRuntime(
             appElement: builder.element(99),
             attributeValueResultHandler: { element, attribute in
+                if attribute == (kAXRoleAttribute as String),
+                   roleReadFailureElementIDs.contains(where: {
+                       CFEqual(element, builder.element($0))
+                   }) {
+                    return .failure(AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue))
+                }
                 guard let axRowsReadStatus,
                       builder.elementID(element) == builder.elementID(table),
                       attribute == (kAXRowsAttribute as String) else {

--- a/Tests/LogicProMCPTests/ControlsViewBooleanParameterWriterTests.swift
+++ b/Tests/LogicProMCPTests/ControlsViewBooleanParameterWriterTests.swift
@@ -489,6 +489,32 @@ struct ControlsViewBooleanParameterWriterTests {
         #expect(refusedForDescriptionRead)
     }
 
+    @Test func describedSwitcherWinsOverAnUnrelatedSwitcherDescriptionReadFailure() {
+        let fixture = viewFixture(
+            entry: .editor,
+            title: "편집기",
+            behavior: .switchesStructure,
+            additionalSwitcherDescriptionFailure: true,
+            viewSettleDelay: 0
+        )
+
+        let result = ControlsViewBooleanParameterWriter.prepareView(
+            .controls,
+            in: fixture.window,
+            runtime: fixture.runtime
+        )
+
+        let preparedControls: Bool
+        if case .ready = result {
+            preparedControls = true
+        } else {
+            preparedControls = false
+        }
+        let pressedOnlyTheDescribedSwitcher = fixture.switcherActions.value == [kAXPressAction as String]
+        #expect(preparedControls)
+        #expect(pressedOnlyTheDescribedSwitcher)
+    }
+
     @Test func failedSliderCensusRefusesRatherThanTreatingNoTableAsEditorEvidence() {
         let readFailure = AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue)
         let fixture = viewFixture(
@@ -1051,6 +1077,7 @@ struct ControlsViewBooleanParameterWriterTests {
         menuItemEnabledReadFails: Bool = false,
         includeControlsTableBesideEditor: Bool = false,
         additionalSliderDescriptionFailure: Bool = false,
+        additionalSwitcherDescriptionFailure: Bool = false,
         allDescriptionReadsFail: Bool = false,
         viewSettleDelay: TimeInterval = 0.5
     ) -> ViewFixture {
@@ -1063,6 +1090,7 @@ struct ControlsViewBooleanParameterWriterTests {
         let editorMenuItem = builder.element(905)
         let editorSlider = builder.element(906)
         let additionalSlider = builder.element(916)
+        let additionalSwitcher = builder.element(917)
         let controlsTable = builder.element(907)
         let controlsRow = builder.element(908)
         let controlsLabelCell = builder.element(909)
@@ -1088,6 +1116,9 @@ struct ControlsViewBooleanParameterWriterTests {
         builder.setRole(switcher, kAXMenuButtonRole as String)
         builder.setAttribute(switcher, kAXDescriptionAttribute as String, "보기")
         builder.setAttribute(switcher, kAXTitleAttribute as String, title)
+        if additionalSwitcherDescriptionFailure {
+            builder.setRole(additionalSwitcher, kAXMenuButtonRole as String)
+        }
         builder.setRole(menu, kAXMenuRole as String)
         builder.setRole(controlsMenuItem, kAXMenuItemRole as String)
         builder.setAttribute(controlsMenuItem, kAXTitleAttribute as String, "컨트롤")
@@ -1123,10 +1154,11 @@ struct ControlsViewBooleanParameterWriterTests {
         let slidersBeforeEditor = additionalSliderDescriptionFailure || allDescriptionReadsFail
             ? [additionalSlider]
             : []
+        let switchers = additionalSwitcherDescriptionFailure ? [additionalSwitcher, switcher] : [switcher]
         let editorChildren = includeControlsTableBesideEditor
-            ? [switcher] + slidersBeforeEditor + [editorSlider, controlsTable]
-            : [switcher] + slidersBeforeEditor + [editorSlider]
-        let controlsChildren = [switcher] + slidersBeforeEditor + [controlsTable]
+            ? switchers + slidersBeforeEditor + [editorSlider, controlsTable]
+            : switchers + slidersBeforeEditor + [editorSlider]
+        let controlsChildren = switchers + slidersBeforeEditor + [controlsTable]
         builder.setChildren(
             window,
             entry == .editor ? editorChildren : controlsChildren
@@ -1144,6 +1176,11 @@ struct ControlsViewBooleanParameterWriterTests {
                 }
                 if readFailure == .switcherDescription,
                    CFEqual(element, switcher),
+                   attribute == (kAXDescriptionAttribute as String) {
+                    return .failure(statusFailure)
+                }
+                if additionalSwitcherDescriptionFailure,
+                   CFEqual(element, additionalSwitcher),
                    attribute == (kAXDescriptionAttribute as String) {
                     return .failure(statusFailure)
                 }

--- a/Tests/LogicProMCPTests/ControlsViewBooleanParameterWriterTests.swift
+++ b/Tests/LogicProMCPTests/ControlsViewBooleanParameterWriterTests.swift
@@ -343,6 +343,47 @@ struct ControlsViewBooleanParameterWriterTests {
         #expect(noCheckboxActionWasSent)
     }
 
+    @Test func invalidCheckboxValueRefusesWithoutAReread() {
+        final class ReadCount: @unchecked Sendable { var value = 0 }
+        let reads = ReadCount()
+        let invalidElement = AXHelpers.AXStatusError(raw: AXError.invalidUIElement.rawValue)
+        let builder = FakeAXRuntimeBuilder()
+        let checkbox = builder.element(22)
+        builder.setRole(checkbox, kAXCheckBoxRole as String)
+        builder.setAttribute(checkbox, kAXValueAttribute as String, false)
+        let runtime = builder.makeAXRuntime(
+            appElement: builder.element(2),
+            attributeValueResultHandler: { element, attribute in
+                guard CFEqual(element, checkbox), attribute == (kAXValueAttribute as String) else {
+                    return nil
+                }
+                reads.value += 1
+                return .failure(invalidElement)
+            },
+            setAttributeHandler: nil,
+            performActionHandler: nil
+        )
+
+        let result = ControlsViewBooleanParameterWriter.pressAndVerify(
+            checkbox,
+            requested: true,
+            runtime: runtime
+        )
+
+        let refusedBeforeWriting = !result.verified && !result.pressAttempted
+        let valueWasReadOnce = reads.value == 1
+        let namesInvalidElementStatus: Bool
+        if let refusal = result.refusal {
+            namesInvalidElementStatus = refusal.contains("-25202")
+        } else {
+            namesInvalidElementStatus = false
+        }
+        // Mutation: route checkbox AXValue through the structural re-read loop.
+        #expect(refusedBeforeWriting)
+        #expect(valueWasReadOnce)
+        #expect(namesInvalidElementStatus)
+    }
+
     @Test func controlsViewSliderIsRefusedWithTheMeasuredNonactuationReason() {
         let fixture = fixture(label: "Gain", controlRoles: [kAXSliderRole as String])
         let result = ControlsViewBooleanParameterWriter.locate(
@@ -536,6 +577,75 @@ struct ControlsViewBooleanParameterWriterTests {
             refusedForTheMeasuredReadFailure = false
         }
         #expect(refusedForTheMeasuredReadFailure)
+    }
+
+    @Test func invalidSliderCensusIsRereadAndTheControlsCheckboxWriteProceeds() {
+        let fixture = viewFixture(
+            entry: .editor,
+            title: "편집기",
+            behavior: .switchesStructure,
+            menuRevealAfterPolls: 0,
+            readFailure: .sliderCensusInvalidOnce,
+            viewSettleDelay: 0
+        )
+
+        let prepared = ControlsViewBooleanParameterWriter.prepareView(
+            .controls,
+            in: fixture.window,
+            windowRefresher: fixture.windowRefresher,
+            runtime: fixture.runtime
+        )
+        let writeProceeded: Bool
+        if case let .ready(session) = prepared,
+           case let .found(.checkBox(checkbox)) = ControlsViewBooleanParameterWriter.locate(
+               label: "Limiter On",
+               in: fixture.window,
+               runtime: fixture.runtime
+           ) {
+            let toggle = ControlsViewBooleanParameterWriter.pressAndVerify(
+                checkbox,
+                requested: true,
+                runtime: fixture.runtime
+            )
+            _ = session.restore()
+            writeProceeded = toggle.verified
+        } else {
+            writeProceeded = false
+        }
+        let selectedControls = fixture.controlsSelections.value == 1
+        // Mutation: return the first -25202 instead of re-resolving and rereading.
+        #expect(writeProceeded)
+        #expect(selectedControls)
+    }
+
+    @Test func invalidSliderCensusThatPersistsRefusesWithItsPhaseAndAttemptCount() {
+        let fixture = viewFixture(
+            entry: .editor,
+            title: "편집기",
+            behavior: .switchesStructure,
+            readFailure: .sliderCensusInvalidAlways
+        )
+
+        let result = ControlsViewBooleanParameterWriter.prepareView(
+            .controls,
+            in: fixture.window,
+            windowRefresher: fixture.windowRefresher,
+            runtime: fixture.runtime
+        )
+        let reportsRetriedEvidenceFailure: Bool
+        if case let .refused(failure, restoration: nil) = result {
+            let diagnostics = failure.responseDiagnostics
+            let phase = diagnostics["plugin_view_switch_phase"] as? String
+            let attempts = diagnostics["plugin_view_evidence_read_attempts"] as? Int
+            reportsRetriedEvidenceFailure = phase == "view_evidence_read_failed"
+                && attempts == 3
+                && failure.observation.contains("after 3 attempts")
+        } else {
+            reportsRetriedEvidenceFailure = false
+        }
+        // Mutation: raise the retry bound above two extra re-reads, or return
+        // the first invalid-element census directly.
+        #expect(reportsRetriedEvidenceFailure)
     }
 
     @Test func failedSliderDescriptionRefusesRatherThanConfirmingAnUnrelatedTableAsControls() {
@@ -1147,6 +1257,8 @@ struct ControlsViewBooleanParameterWriterTests {
         case switcherCensus
         case switcherDescription
         case sliderCensus
+        case sliderCensusInvalidOnce
+        case sliderCensusInvalidAlways
         case sliderDescription
         case menuItemCensus
         case tableCensus
@@ -1220,6 +1332,7 @@ struct ControlsViewBooleanParameterWriterTests {
         let windowChildrenReadCount = MutableBox(0)
         let postPickWindowReadCount = MutableBox(0)
         let statusFailure = AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue)
+        let invalidElementFailure = AXHelpers.AXStatusError(raw: AXError.invalidUIElement.rawValue)
 
         builder.setRole(window, kAXWindowRole as String)
         builder.setRole(switcher, kAXMenuButtonRole as String)
@@ -1287,6 +1400,7 @@ struct ControlsViewBooleanParameterWriterTests {
         let controlsKey = builder.elementID(controlsMenuItem)
         let editorKey = builder.elementID(editorMenuItem)
         let switcherKey = builder.elementID(switcher)
+        let controlsCheckboxKey = builder.elementID(controlsCheckbox)
         let runtime = builder.makeAXRuntime(
             appElement: app,
             attributeValueResultHandler: { element, attribute in
@@ -1369,6 +1483,14 @@ struct ControlsViewBooleanParameterWriterTests {
                         return .failure(statusFailure)
                     }
                 }
+                if (readFailure == .sliderCensusInvalidOnce
+                    || readFailure == .sliderCensusInvalidAlways),
+                   CFEqual(element, editorSlider) {
+                    sliderChildrenReadCount.value += 1
+                    if readFailure == .sliderCensusInvalidAlways || sliderChildrenReadCount.value == 1 {
+                        return .failure(invalidElementFailure)
+                    }
+                }
                 if readFailure == .tableCensus, CFEqual(element, controlsTable) {
                     tableChildrenReadCount.value += 1
                     if tableChildrenReadCount.value == 2 {
@@ -1407,6 +1529,18 @@ struct ControlsViewBooleanParameterWriterTests {
                     menuOpen.value = true
                     menuVisible.value = false
                     menuCensusPolls.value = 0
+                    return true
+                }
+                if key == controlsCheckboxKey, action == (kAXPressAction as String) {
+                    let current = (builder.attributeValue(
+                        controlsCheckbox,
+                        kAXValueAttribute as String
+                    ) as? NSNumber)?.boolValue ?? false
+                    builder.setAttribute(
+                        controlsCheckbox,
+                        kAXValueAttribute as String,
+                        !current
+                    )
                     return true
                 }
                 guard key == editorKey || key == controlsKey else { return true }

--- a/Tests/LogicProMCPTests/ControlsViewBooleanParameterWriterTests.swift
+++ b/Tests/LogicProMCPTests/ControlsViewBooleanParameterWriterTests.swift
@@ -393,6 +393,186 @@ struct ControlsViewBooleanParameterWriterTests {
         #expect(confirmedEditor)
     }
 
+    @Test func failedSwitcherCensusRefusesInsteadOfReportingNoSwitcher() {
+        let readFailure = AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue)
+        let fixture = viewFixture(
+            entry: .editor,
+            title: "편집기",
+            behavior: .switchesStructure,
+            readFailure: .switcherCensus
+        )
+
+        let result = ControlsViewBooleanParameterWriter.prepareView(
+            .editor,
+            in: fixture.window,
+            runtime: fixture.runtime
+        )
+        let refusedForCensusRead: Bool
+        if case let .refused(.viewEvidenceReadFailed(.switcherCensus(observed)), restoration: nil) = result {
+            refusedForCensusRead = observed == readFailure
+        } else {
+            refusedForCensusRead = false
+        }
+        #expect(refusedForCensusRead)
+    }
+
+    @Test func failedSwitcherDescriptionRefusesInsteadOfReportingUnmeasuredLocale() {
+        let readFailure = AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue)
+        let fixture = viewFixture(
+            entry: .editor,
+            title: "편집기",
+            behavior: .switchesStructure,
+            readFailure: .switcherDescription
+        )
+
+        let result = ControlsViewBooleanParameterWriter.prepareView(
+            .editor,
+            in: fixture.window,
+            runtime: fixture.runtime
+        )
+        let refusedForDescriptionRead: Bool
+        if case let .refused(.viewEvidenceReadFailed(.switcherDescription(observed)), restoration: nil) = result {
+            refusedForDescriptionRead = observed == readFailure
+        } else {
+            refusedForDescriptionRead = false
+        }
+        #expect(refusedForDescriptionRead)
+    }
+
+    @Test func failedSliderCensusRefusesInsteadOfErasingEditorEvidence() {
+        let readFailure = AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue)
+        let fixture = viewFixture(
+            entry: .editor,
+            title: "편집기",
+            behavior: .switchesStructure,
+            readFailure: .sliderCensus
+        )
+
+        let result = ControlsViewBooleanParameterWriter.prepareView(
+            .editor,
+            in: fixture.window,
+            runtime: fixture.runtime
+        )
+        let refusedForSliderCensusRead: Bool
+        if case let .refused(.viewEvidenceReadFailed(.sliderCensus(observed)), restoration: nil) = result {
+            refusedForSliderCensusRead = observed == readFailure
+        } else {
+            refusedForSliderCensusRead = false
+        }
+        #expect(refusedForSliderCensusRead)
+    }
+
+    @Test func failedSliderDescriptionRefusesBeforeAnyTableCanConfirmControls() {
+        let readFailure = AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue)
+        let fixture = viewFixture(
+            entry: .editor,
+            title: "편집기",
+            behavior: .switchesStructure,
+            readFailure: .sliderDescription,
+            includeControlsTableBesideEditor: true
+        )
+
+        let result = ControlsViewBooleanParameterWriter.prepareView(
+            .controls,
+            in: fixture.window,
+            runtime: fixture.runtime
+        )
+        let refusedForSliderDescriptionRead: Bool
+        if case let .refused(.viewEvidenceReadFailed(.sliderDescription(observed)), restoration: nil) = result {
+            refusedForSliderDescriptionRead = observed == readFailure
+        } else {
+            refusedForSliderDescriptionRead = false
+        }
+        #expect(refusedForSliderDescriptionRead)
+    }
+
+    @Test func failedViewMenuItemCensusRefusesInsteadOfReportingMissingItem() {
+        let readFailure = AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue)
+        let fixture = viewFixture(
+            entry: .editor,
+            title: "편집기",
+            behavior: .switchesStructure,
+            readFailure: .menuItemCensus
+        )
+
+        let result = ControlsViewBooleanParameterWriter.prepareView(
+            .controls,
+            in: fixture.window,
+            runtime: fixture.runtime
+        )
+        let refusedForMenuItemCensusRead: Bool
+        if case let .refused(.viewEvidenceReadFailed(.menuItemCensus(observed)), restoration: nil) = result {
+            refusedForMenuItemCensusRead = observed == readFailure
+        } else {
+            refusedForMenuItemCensusRead = false
+        }
+        #expect(refusedForMenuItemCensusRead)
+    }
+
+    @Test func failedControlsTableCensusRefusesInsteadOfReportingEntryViewMissing() {
+        let readFailure = AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue)
+        let fixture = viewFixture(
+            entry: .controls,
+            title: "컨트롤",
+            behavior: .switchesStructure,
+            readFailure: .tableCensus
+        )
+
+        let result = ControlsViewBooleanParameterWriter.prepareView(
+            .controls,
+            in: fixture.window,
+            runtime: fixture.runtime
+        )
+        let refusedForTableCensusRead: Bool
+        if case let .refused(.viewEvidenceReadFailed(.controlsTableCensus(observed)), restoration: nil) = result {
+            refusedForTableCensusRead = observed == readFailure
+        } else {
+            refusedForTableCensusRead = false
+        }
+        #expect(refusedForTableCensusRead)
+    }
+
+    @Test func failedControlsRowReadRefusesInsteadOfContinuingToTheNextRow() {
+        let builder = FakeAXRuntimeBuilder()
+        let window = builder.element(29_930)
+        let switcher = builder.element(29_931)
+        let table = builder.element(29_932)
+        let unreadableRow = builder.element(29_933)
+        let readFailure = AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue)
+        builder.setRole(window, kAXWindowRole as String)
+        builder.setRole(switcher, kAXMenuButtonRole as String)
+        builder.setAttribute(switcher, kAXDescriptionAttribute as String, "보기")
+        builder.setRole(table, kAXTableRole as String)
+        // Keep the AXRows-only row outside AXChildren so the three preceding
+        // censuses complete; this isolates the classifier's row loop.
+        builder.setAttribute(table, kAXRowsAttribute as String, [unreadableRow])
+        builder.setChildren(window, [switcher, table])
+        let runtime = builder.makeAXRuntime(
+            appElement: builder.element(29_900),
+            attributeValueResultHandler: { element, attribute in
+                if CFEqual(element, unreadableRow), attribute == (kAXRoleAttribute as String) {
+                    return .failure(readFailure)
+                }
+                return nil
+            },
+            setAttributeHandler: nil,
+            performActionHandler: nil
+        )
+
+        let result = ControlsViewBooleanParameterWriter.prepareView(
+            .controls,
+            in: window,
+            runtime: runtime
+        )
+        let refusedForRowRead: Bool
+        if case let .refused(.viewEvidenceReadFailed(.controlsTableRow(observed)), restoration: nil) = result {
+            refusedForRowRead = observed == readFailure
+        } else {
+            refusedForRowRead = false
+        }
+        #expect(refusedForRowRead)
+    }
+
     @Test func tableWhoseRowsCarryNoLabelControlPairDoesNotConfirmControls() {
         let builder = FakeAXRuntimeBuilder()
         let window = builder.element(29_920)
@@ -476,8 +656,7 @@ struct ControlsViewBooleanParameterWriterTests {
             entry: .controls,
             title: "[100%]",
             behavior: .neverChanges,
-            menuRevealAfterPolls: 0,
-            viewSettleDelay: 0
+            menuRevealAfterPolls: 3
         )
         let started = Date()
 
@@ -494,11 +673,14 @@ struct ControlsViewBooleanParameterWriterTests {
         } else {
             refused = false
         }
-        let completedWithinDeadline = Date().timeIntervalSince(started) < 0.25
+        // Menu appearance is now the measured ~150 ms on both the attempted
+        // switch and its compensating restoration; this remains a bounded
+        // deadline test rather than an instant-fixture timing test.
+        let completedWithinBoundedRestore = Date().timeIntervalSince(started) < 0.75
         let attemptedEditorSelection = fixture.editorSelections.value == 1
         let entryStructureRemainedControls = controlsStructureIsPresent(fixture)
         #expect(refused)
-        #expect(completedWithinDeadline)
+        #expect(completedWithinBoundedRestore)
         #expect(attemptedEditorSelection)
         #expect(entryStructureRemainedControls)
     }
@@ -557,6 +739,8 @@ struct ControlsViewBooleanParameterWriterTests {
             entry: .controls,
             title: "[100%]",
             behavior: .switchesStructure,
+            // Intentionally instant: this test isolates the 150 ms structure
+            // settle from the separate menu-appearance deadline.
             menuRevealAfterPolls: 0,
             viewSettleDelay: 0.15
         )
@@ -662,6 +846,15 @@ struct ControlsViewBooleanParameterWriterTests {
         case becomesUnconfirmedThenControlsRestores
     }
 
+    private enum ViewFixtureReadFailure {
+        case switcherCensus
+        case switcherDescription
+        case sliderCensus
+        case sliderDescription
+        case menuItemCensus
+        case tableCensus
+    }
+
     private struct ViewFixture {
         let builder: FakeAXRuntimeBuilder
         let window: AXUIElement
@@ -678,8 +871,10 @@ struct ControlsViewBooleanParameterWriterTests {
         entry: ControlsViewBooleanParameterWriter.PluginWindowView,
         title: String,
         behavior: ViewFixtureBehavior,
-        menuRevealAfterPolls: Int? = 4,
+        menuRevealAfterPolls: Int? = 3,
         menuReadFailure: AXHelpers.AXStatusError? = nil,
+        readFailure: ViewFixtureReadFailure? = nil,
+        includeControlsTableBesideEditor: Bool = false,
         viewSettleDelay: TimeInterval = 0.5
     ) -> ViewFixture {
         let builder = FakeAXRuntimeBuilder()
@@ -706,6 +901,9 @@ struct ControlsViewBooleanParameterWriterTests {
         let menuOpen = MutableBox(false)
         let menuVisible = MutableBox(false)
         let pendingWindowChildren = MutableBox<(children: [AXUIElement], settlesAt: Date)?>(nil)
+        let sliderChildrenReadCount = MutableBox(0)
+        let tableChildrenReadCount = MutableBox(0)
+        let statusFailure = AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue)
 
         builder.setRole(window, kAXWindowRole as String)
         builder.setRole(switcher, kAXMenuButtonRole as String)
@@ -738,7 +936,9 @@ struct ControlsViewBooleanParameterWriterTests {
         builder.setChildren(controlsTable, [controlsHeadingRow, controlsRow])
         builder.setAttribute(controlsTable, kAXRowsAttribute as String, [controlsHeadingRow, controlsRow])
 
-        let editorChildren = [switcher, editorSlider]
+        let editorChildren = includeControlsTableBesideEditor
+            ? [switcher, editorSlider, controlsTable]
+            : [switcher, editorSlider]
         let controlsChildren = [switcher, controlsTable]
         builder.setChildren(
             window,
@@ -750,6 +950,24 @@ struct ControlsViewBooleanParameterWriterTests {
         let switcherKey = builder.elementID(switcher)
         let runtime = builder.makeAXRuntime(
             appElement: app,
+            attributeValueResultHandler: { element, attribute in
+                if readFailure == .switcherDescription,
+                   CFEqual(element, switcher),
+                   attribute == (kAXDescriptionAttribute as String) {
+                    return .failure(statusFailure)
+                }
+                if readFailure == .sliderDescription,
+                   CFEqual(element, editorSlider),
+                   attribute == (kAXDescriptionAttribute as String) {
+                    return .failure(statusFailure)
+                }
+                if readFailure == .menuItemCensus,
+                   (CFEqual(element, controlsMenuItem) || CFEqual(element, editorMenuItem)),
+                   attribute == (kAXTitleAttribute as String) {
+                    return .failure(statusFailure)
+                }
+                return nil
+            },
             childrenHandler: { element in
                 if CFEqual(element, window),
                    let pending = pendingWindowChildren.value,
@@ -763,6 +981,27 @@ struct ControlsViewBooleanParameterWriterTests {
                 return nil
             },
             childrenResultHandler: { element in
+                if CFEqual(element, window),
+                   let pending = pendingWindowChildren.value,
+                   Date() >= pending.settlesAt {
+                    builder.setChildren(window, pending.children)
+                    pendingWindowChildren.value = nil
+                }
+                if readFailure == .switcherCensus, CFEqual(element, window) {
+                    return .failure(statusFailure)
+                }
+                if readFailure == .sliderCensus, CFEqual(element, editorSlider) {
+                    sliderChildrenReadCount.value += 1
+                    if sliderChildrenReadCount.value == 2 {
+                        return .failure(statusFailure)
+                    }
+                }
+                if readFailure == .tableCensus, CFEqual(element, controlsTable) {
+                    tableChildrenReadCount.value += 1
+                    if tableChildrenReadCount.value == 3 {
+                        return .failure(statusFailure)
+                    }
+                }
                 guard CFEqual(element, switcher), menuOpen.value else { return nil }
                 if let menuReadFailure {
                     return .failure(menuReadFailure)

--- a/Tests/LogicProMCPTests/HonestContractV2Tests.swift
+++ b/Tests/LogicProMCPTests/HonestContractV2Tests.swift
@@ -83,6 +83,7 @@ private func decode(_ json: String) -> [String: Any] {
         (.staleSnapshot, "stale_snapshot"),
         (.windowOpenFailed, "window_open_failed"),
         (.windowIdentityUnresolved, "window_identity_unresolved"),
+        (.pluginViewNotConfirmed, "plugin_view_not_confirmed"),
         (.paramControlNotFound, "param_control_not_found"),
         (.readbackLostAfterWrite, "readback_lost_after_write"),
         (.postInsertPluginMismatch, "post_insert_plugin_mismatch"),

--- a/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
+++ b/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
@@ -34,6 +34,13 @@ private enum SliderWriteBehavior: Sendable {
     case scripted([Double?])
 }
 
+private enum ControlsCheckboxWriteBehavior: Sendable, Equatable {
+    case toggle
+    /// AXPress reports status 0/accepted but the checkbox AXValue is inert.
+    /// This is the exact observation that prevents a status-only success.
+    case statusZeroUnchanged
+}
+
 /// A live-path fixture. The slider's AXValueDescription is recomputed from its
 /// AXValue on every write so a write updates the readback the way Logic does
 /// ("60 %"). `forcedAfterValue` models a sticky/taper mismatch; `otherTracks`
@@ -45,6 +52,9 @@ private final class LiveFixture: @unchecked Sendable {
     let targetOpenControlPressCount: MutableBox<Int>
     let pluginCloseControlPressCount: MutableBox<Int>
     let sliderWriteCount: MutableBox<Int>
+    let controlsCheckboxPressCount: MutableBox<Int>
+    let controlsViewMenuPressCount: MutableBox<Int>
+    let editorViewMenuPressCount: MutableBox<Int>
     let runtime: AXLogicProElements.Runtime
 
     init(
@@ -76,13 +86,24 @@ private final class LiveFixture: @unchecked Sendable {
         // Model an editor whose close control is pressed but which stays in
         // AXWindows. The close must be judged by the observed window list, not
         // by the press returning true.
-        pluginCloseControlFailsToClose: Bool = false
+        pluginCloseControlFailsToClose: Bool = false,
+        controlsViewRowLabel: String? = nil,
+        controlsViewControlRole: String = kAXCheckBoxRole as String,
+        controlsCheckboxBefore: Bool = false,
+        controlsCheckboxWriteBehavior: ControlsCheckboxWriteBehavior = .toggle,
+        controlsViewInitiallySelected: Bool = false,
+        pluginWindowViewSwitcherDescription: String = "보기",
+        viewMenuPressChangesStructure: Bool = true,
+        viewMenuPressChangesTitle: Bool = true
     ) {
         let b = builder
         let windowsAddedOnSlotPress = MutableBox<[AXUIElement]>([])
         let targetOpenControlPressCount = MutableBox(0)
         let pluginCloseControlPressCount = MutableBox(0)
         let sliderWriteCount = MutableBox(0)
+        let controlsCheckboxPressCount = MutableBox(0)
+        let controlsViewMenuPressCount = MutableBox(0)
+        let editorViewMenuPressCount = MutableBox(0)
         let app = b.element(1000)
         let arrangeWindow = b.element(1001)
         let headersGroup = b.element(1002)
@@ -92,6 +113,16 @@ private final class LiveFixture: @unchecked Sendable {
         let pluginClose = b.element(1006)
         let pluginBypass = b.element(1007)
         let pluginLink = b.element(1008)
+        let controlsViewSwitcher = b.element(1009)
+        let controlsViewMenu = b.element(100_901)
+        let controlsViewMenuItem = b.element(100_902)
+        let editorViewMenuItem = b.element(100_909)
+        let controlsTable = b.element(100_903)
+        let controlsRow = b.element(100_904)
+        let controlsLabelCell = b.element(100_905)
+        let controlsControlCell = b.element(100_906)
+        let controlsLabel = b.element(100_907)
+        let controlsCheckbox = b.element(100_908)
 
         // --- Track headers: one row per track, selected-state on the target. ---
         var headerRows: [AXUIElement] = []
@@ -198,7 +229,54 @@ private final class LiveFixture: @unchecked Sendable {
                 b.setAttribute(text, kAXValueAttribute as String, value)
                 return text
             }
-        b.setChildren(pluginWindow, [pluginBypass, pluginLink, slider] + staticTexts)
+        var pluginWindowChildren = [pluginBypass, pluginLink, slider] + staticTexts
+        b.setRole(controlsViewSwitcher, kAXMenuButtonRole as String)
+        b.setAttribute(
+            controlsViewSwitcher,
+            kAXDescriptionAttribute as String,
+            pluginWindowViewSwitcherDescription
+        )
+        b.setAttribute(
+            controlsViewSwitcher,
+            kAXTitleAttribute as String,
+            controlsViewInitiallySelected ? "컨트롤" : "편집기"
+        )
+        b.setRole(controlsViewMenu, kAXMenuRole as String)
+        b.setRole(controlsViewMenuItem, kAXMenuItemRole as String)
+        b.setAttribute(controlsViewMenuItem, kAXTitleAttribute as String, "컨트롤")
+        b.setRole(editorViewMenuItem, kAXMenuItemRole as String)
+        b.setAttribute(editorViewMenuItem, kAXTitleAttribute as String, "편집기")
+        b.setChildren(controlsViewMenu, [controlsViewMenuItem, editorViewMenuItem])
+        b.setChildren(controlsViewSwitcher, [controlsViewMenu])
+        pluginWindowChildren += [controlsViewSwitcher]
+        var controlsViewWindowChildren = [pluginBypass, pluginLink]
+            + staticTexts
+            + [controlsViewSwitcher]
+        // Controls view itself is identified by its rows, whether or not this
+        // particular test also supplies a writable labelled control.
+        b.setRole(controlsTable, kAXTableRole as String)
+        b.setRole(controlsRow, kAXRowRole as String)
+        b.setChildren(controlsTable, [controlsRow])
+        b.setAttribute(controlsTable, kAXRowsAttribute as String, [controlsRow])
+        controlsViewWindowChildren += [controlsTable]
+        if let controlsViewRowLabel {
+            b.setRole(controlsLabelCell, kAXCellRole as String)
+            b.setRole(controlsControlCell, kAXCellRole as String)
+            b.setRole(controlsLabel, kAXStaticTextRole as String)
+            b.setAttribute(controlsLabel, kAXValueAttribute as String, controlsViewRowLabel)
+            b.setRole(controlsCheckbox, controlsViewControlRole)
+            b.setAttribute(controlsCheckbox, kAXValueAttribute as String, controlsCheckboxBefore)
+            b.setChildren(controlsLabelCell, [controlsLabel])
+            b.setChildren(controlsControlCell, [controlsCheckbox])
+            b.setChildren(controlsRow, [controlsLabelCell, controlsControlCell])
+            // Controls view has rows, but no editor-view slider descriptions.
+            // Keep its shape distinct from the native editor so a test cannot
+            // accidentally keep relying on Threshold after the view changes.
+        }
+        b.setChildren(
+            pluginWindow,
+            controlsViewInitiallySelected ? controlsViewWindowChildren : pluginWindowChildren
+        )
 
         let windows = pluginWindowPresent ? [arrangeWindow, pluginWindow] : [arrangeWindow]
         b.setAttribute(app, kAXWindowsAttribute as String, windows)
@@ -212,6 +290,11 @@ private final class LiveFixture: @unchecked Sendable {
         let targetSlotKey = targetSlot.map { b.elementID($0) }
         let targetOpenButtonKey = targetOpenButton.map { b.elementID($0) }
         let pluginCloseKey = b.elementID(pluginClose)
+        let controlsCheckboxKey = b.elementID(controlsCheckbox)
+        let controlsViewMenuItemKey = b.elementID(controlsViewMenuItem)
+        let editorViewMenuItemKey = b.elementID(editorViewMenuItem)
+        let controlsWindowChildren = controlsViewWindowChildren
+        let editorWindowChildren = pluginWindowChildren
         let forced = forcedAfterValue
         let writeBehavior = sliderWriteBehavior
         let runtime = b.makeLogicRuntime(
@@ -273,6 +356,41 @@ private final class LiveFixture: @unchecked Sendable {
                     }
                     return true
                 }
+                if key == controlsViewMenuItemKey {
+                    controlsViewMenuPressCount.value += 1
+                    if viewMenuPressChangesStructure {
+                        b.setChildren(pluginWindow, controlsWindowChildren)
+                    }
+                    if viewMenuPressChangesTitle {
+                        b.setAttribute(controlsViewSwitcher, kAXTitleAttribute as String, "컨트롤")
+                    }
+                    return true
+                }
+                if key == editorViewMenuItemKey {
+                    editorViewMenuPressCount.value += 1
+                    if viewMenuPressChangesStructure {
+                        b.setChildren(pluginWindow, editorWindowChildren)
+                    }
+                    if viewMenuPressChangesTitle {
+                        b.setAttribute(controlsViewSwitcher, kAXTitleAttribute as String, "편집기")
+                    }
+                    return true
+                }
+                if key == controlsCheckboxKey,
+                   controlsViewRowLabel != nil {
+                    controlsCheckboxPressCount.value += 1
+                    if controlsCheckboxWriteBehavior == .toggle {
+                        let old = (b.attributeValue(controlsCheckbox, kAXValueAttribute as String) as? NSNumber)?.boolValue
+                            ?? (b.attributeValue(controlsCheckbox, kAXValueAttribute as String) as? Bool)
+                            ?? false
+                        b.setAttribute(controlsCheckbox, kAXValueAttribute as String, !old)
+                        return true
+                    }
+                    // Core AX returns status 0 for a successful action. Keep
+                    // AXValue inert while still reporting that status so this
+                    // fixture proves status alone cannot certify a write.
+                    return true
+                }
                 guard key == targetSlotKey || key == targetOpenButtonKey else {
                     return true
                 }
@@ -302,6 +420,9 @@ private final class LiveFixture: @unchecked Sendable {
         self.targetOpenControlPressCount = targetOpenControlPressCount
         self.pluginCloseControlPressCount = pluginCloseControlPressCount
         self.sliderWriteCount = sliderWriteCount
+        self.controlsCheckboxPressCount = controlsCheckboxPressCount
+        self.controlsViewMenuPressCount = controlsViewMenuPressCount
+        self.editorViewMenuPressCount = editorViewMenuPressCount
         self.runtime = runtime
     }
 
@@ -330,6 +451,10 @@ private final class LiveFixture: @unchecked Sendable {
 
     var currentSliderValue: Double? {
         builder.attributeValue(builder.element(1005), kAXValueAttribute as String) as? Double
+    }
+
+    var currentPluginViewTitle: String? {
+        builder.attributeValue(builder.element(1009), kAXTitleAttribute as String) as? String
     }
 }
 
@@ -360,7 +485,8 @@ private func runLive(
 /// identity attribute the live editors share.
 private func matchingCompressorEditorWindow(
     fixture: LiveFixture,
-    baseID: Int
+    baseID: Int,
+    trackName editorTrackName: String = trackName
 ) -> (window: AXUIElement, slider: AXUIElement) {
     let b = fixture.builder
     let window = b.element(baseID)
@@ -381,10 +507,59 @@ private func matchingCompressorEditorWindow(
     b.setAttribute(pluginName, kAXValueAttribute as String, "Compressor")
     b.setAttribute(window, kAXRoleAttribute as String, kAXWindowRole as String)
     b.setAttribute(window, kAXSubroleAttribute as String, kAXDialogSubrole as String)
-    b.setAttribute(window, kAXTitleAttribute as String, trackName)
+    b.setAttribute(window, kAXTitleAttribute as String, editorTrackName)
     b.setAttribute(window, kAXCloseButtonAttribute as String, close)
     b.setChildren(window, [bypass, link, slider, pluginName])
     return (window, slider)
+}
+
+/// A Controls-view editor on another strip. It intentionally has no described
+/// slider: header identity, not the native-editor anchor, must keep this
+/// window out of the requested strip's checkbox write.
+private func controlsViewCompressorEditorWindow(
+    fixture: LiveFixture,
+    baseID: Int,
+    trackName editorTrackName: String
+) -> (window: AXUIElement, checkbox: AXUIElement) {
+    let b = fixture.builder
+    let window = b.element(baseID)
+    let close = b.element(baseID + 1)
+    let bypass = b.element(baseID + 2)
+    let pluginName = b.element(baseID + 3)
+    let headerTrackName = b.element(baseID + 4)
+    let table = b.element(baseID + 5)
+    let row = b.element(baseID + 6)
+    let labelCell = b.element(baseID + 7)
+    let controlCell = b.element(baseID + 8)
+    let label = b.element(baseID + 9)
+    let checkbox = b.element(baseID + 10)
+
+    b.setRole(close, kAXButtonRole as String)
+    b.setRole(bypass, kAXCheckBoxRole as String)
+    b.setAttribute(bypass, kAXDescriptionAttribute as String, "bypass")
+    b.setRole(pluginName, kAXStaticTextRole as String)
+    b.setAttribute(pluginName, kAXValueAttribute as String, "Compressor")
+    b.setRole(headerTrackName, kAXStaticTextRole as String)
+    b.setAttribute(headerTrackName, kAXValueAttribute as String, editorTrackName)
+    b.setRole(table, kAXTableRole as String)
+    b.setRole(row, kAXRowRole as String)
+    b.setRole(labelCell, kAXCellRole as String)
+    b.setRole(controlCell, kAXCellRole as String)
+    b.setRole(label, kAXStaticTextRole as String)
+    b.setAttribute(label, kAXValueAttribute as String, "Limiter On")
+    b.setRole(checkbox, kAXCheckBoxRole as String)
+    b.setAttribute(checkbox, kAXValueAttribute as String, false)
+    b.setChildren(labelCell, [label])
+    b.setChildren(controlCell, [checkbox])
+    b.setChildren(row, [labelCell, controlCell])
+    b.setChildren(table, [row])
+    b.setAttribute(table, kAXRowsAttribute as String, [row])
+    b.setRole(window, kAXWindowRole as String)
+    b.setAttribute(window, kAXSubroleAttribute as String, kAXDialogSubrole as String)
+    b.setAttribute(window, kAXTitleAttribute as String, editorTrackName)
+    b.setAttribute(window, kAXCloseButtonAttribute as String, close)
+    b.setChildren(window, [bypass, pluginName, headerTrackName, table])
+    return (window, checkbox)
 }
 
 private func thresholdParams(
@@ -402,6 +577,15 @@ private func thresholdParams(
     ]
     if let path { p["project_expected_path"] = path }
     return p
+}
+
+private func controlsBooleanParams(
+    param: String = "limiter_on",
+    value: String = "1"
+) -> [String: String] {
+    thresholdParams(value: value, unit: "boolean").merging([
+        "param": param,
+    ]) { _, new in new }
 }
 
 private let channelEQFixtureParamID = "__test_channel_eq_band_gain"
@@ -573,6 +757,348 @@ private func namedEQBandParams(
     #expect(identity?["insert"] as? Int == 6)
     // The live slider actually changed.
     #expect(fixture.currentSliderValue == 60)
+    let noViewMenuSelection = fixture.controlsViewMenuPressCount.value == 0
+        && fixture.editorViewMenuPressCount.value == 0
+    #expect(noViewMenuSelection)
+}
+
+@Test func testCompressorThresholdSwitchesControlsToEditorThenRestoresControls() async throws {
+    let fixture = LiveFixture(
+        beforeValue: 51,
+        controlsViewInitiallySelected: true
+    )
+    let result = await runLive(fixture: fixture, params: thresholdParams(value: "60"))
+
+    let state = try #require(result["state"] as? String)
+    let observedDisplay = try #require(result["observed_display"] as? String)
+    let selectedEditorOnce = fixture.editorViewMenuPressCount.value == 1
+    let restoredControlsOnce = fixture.controlsViewMenuPressCount.value == 1
+    let restoredEntryTitle = fixture.currentPluginViewTitle == "컨트롤"
+    let sliderWasFoundAndWritten = fixture.currentSliderValue == 60
+    let stateIsA = state == "A"
+    let observedDisplayMatches = observedDisplay == "60 %"
+    #expect(stateIsA)
+    #expect(observedDisplayMatches)
+    #expect(selectedEditorOnce)
+    #expect(restoredControlsOnce)
+    #expect(restoredEntryTitle)
+    #expect(sliderWasFoundAndWritten)
+}
+
+@Test func testCompressorThresholdEnsuresAndSearchesBoundEditorNotOtherOpenCompressor() async throws {
+    let fixture = LiveFixture(
+        beforeValue: 51,
+        controlsViewInitiallySelected: true
+    )
+    // A duplicate-applyback session can leave another Compressor editor open.
+    // It shares the plug-in header identity but belongs to another track, so
+    // only the target editor may be switched, searched, and written.
+    let other = matchingCompressorEditorWindow(
+        fixture: fixture,
+        baseID: 8_700,
+        trackName: "Other Strip"
+    )
+    let existingWindows = fixture.builder.attributeValue(
+        fixture.app,
+        kAXWindowsAttribute as String
+    ) as? [AXUIElement] ?? []
+    fixture.builder.setAttribute(
+        fixture.app,
+        kAXWindowsAttribute as String,
+        existingWindows + [other.window]
+    )
+
+    let result = await runLive(fixture: fixture, params: thresholdParams(value: "60"))
+
+    let state = try #require(result["state"] as? String)
+    let otherSliderValue = try #require(
+        fixture.builder.attributeValue(other.slider, kAXValueAttribute as String) as? Double
+    )
+    let targetSelectedEditorOnce = fixture.editorViewMenuPressCount.value == 1
+    let targetRestoredControlsOnce = fixture.controlsViewMenuPressCount.value == 1
+    let stateIsA = state == "A"
+    let targetSliderWasWritten = fixture.currentSliderValue == 60
+    let otherSliderWasUntouched = otherSliderValue == 51
+    #expect(stateIsA)
+    #expect(targetSliderWasWritten)
+    #expect(otherSliderWasUntouched)
+    #expect(targetSelectedEditorOnce)
+    #expect(targetRestoredControlsOnce)
+}
+
+@Test func testCompressorThresholdConfirmsEditorStructureDespiteUnchangedContradictoryTitle() async throws {
+    let fixture = LiveFixture(
+        beforeValue: 51,
+        controlsViewInitiallySelected: true,
+        viewMenuPressChangesTitle: false
+    )
+    let result = await runLive(fixture: fixture, params: thresholdParams(value: "60"))
+
+    let state = try #require(result["state"] as? String)
+    let titleStayedContradictory = fixture.currentPluginViewTitle == "컨트롤"
+    let selectedEditor = fixture.editorViewMenuPressCount.value == 1
+    let restoredControls = fixture.controlsViewMenuPressCount.value == 1
+    let sliderWasWritten = fixture.currentSliderValue == 60
+    let stateIsA = state == "A"
+    #expect(stateIsA)
+    #expect(titleStayedContradictory)
+    #expect(selectedEditor)
+    #expect(restoredControls)
+    #expect(sliderWasWritten)
+}
+
+@Test func testCompressorThresholdRefusesWhenEditorStructureNeverAppears() async throws {
+    let fixture = LiveFixture(
+        beforeValue: 51,
+        controlsViewInitiallySelected: true,
+        viewMenuPressChangesStructure: false
+    )
+    let result = await runLive(fixture: fixture, params: thresholdParams(value: "60"))
+
+    let error = try #require(result["error"] as? String)
+    let observed = try #require(result["what_was_observed"] as? String)
+    let reportsUnconfirmedView = error == "plugin_view_not_confirmed"
+    let reportsStructureDeadline = observed.contains("expected editor structure")
+    let sliderWasNotWritten = fixture.sliderWriteCount.value == 0
+    let entryViewWasPreserved = fixture.editorViewMenuPressCount.value == 1
+        && fixture.controlsViewMenuPressCount.value == 0
+    #expect(reportsUnconfirmedView)
+    #expect(reportsStructureDeadline)
+    #expect(sliderWasNotWritten)
+    #expect(entryViewWasPreserved)
+}
+
+@Test func testCompressorThresholdRestoresControlsAfterSliderLookupRefusal() async throws {
+    let fixture = LiveFixture(
+        thresholdDescription: "Native-only non-anchor",
+        controlsViewInitiallySelected: true
+    )
+    let result = await runLive(fixture: fixture, params: thresholdParams(value: "60"))
+
+    let error = try #require(result["error"] as? String)
+    let switchedToEditorOnce = fixture.editorViewMenuPressCount.value == 1
+    let restoredControlsOnce = fixture.controlsViewMenuPressCount.value == 1
+    let restoredEntryTitle = fixture.currentPluginViewTitle == "컨트롤"
+    let reportsSliderLookupRefusal = error == "param_control_not_found"
+    #expect(reportsSliderLookupRefusal)
+    #expect(switchedToEditorOnce)
+    #expect(restoredControlsOnce)
+    #expect(restoredEntryTitle)
+}
+
+@Test func testCompressorThresholdRefusesUnmeasuredViewSwitcherLocale() async throws {
+    let fixture = LiveFixture(
+        controlsViewInitiallySelected: true,
+        pluginWindowViewSwitcherDescription: "Ansicht"
+    )
+    let result = await runLive(fixture: fixture, params: thresholdParams(value: "60"))
+
+    let error = try #require(result["error"] as? String)
+    let observed = try #require(result["what_was_observed"] as? String)
+    let noViewMenuSelection = fixture.controlsViewMenuPressCount.value == 0
+        && fixture.editorViewMenuPressCount.value == 0
+    let noSliderWrite = fixture.sliderWriteCount.value == 0
+    let reportsUnconfirmedView = error == "plugin_view_not_confirmed"
+    let reportsUnmeasuredLocale = observed.contains("not measured for this locale")
+    #expect(reportsUnconfirmedView)
+    #expect(reportsUnmeasuredLocale)
+    #expect(noViewMenuSelection)
+    #expect(noSliderWrite)
+}
+
+@Test func testCompressorControlsViewCheckboxUsesRowLabelPressAndChangedReadback() async throws {
+    let fixture = LiveFixture(
+        controlsViewRowLabel: "Limiter On",
+        controlsCheckboxBefore: false
+    )
+    let result = await runLive(fixture: fixture, params: controlsBooleanParams())
+
+    let state = try #require(result["state"] as? String)
+    let verified = try #require(result["verified"] as? Bool)
+    let observed = try #require(result["observed_boolean"] as? Bool)
+    let rowLabel = try #require(result["controls_view_row_label"] as? String)
+    let presses = fixture.controlsCheckboxPressCount.value
+    let oneVerifiedPress = presses == 1
+    let selectedControlsOnce = fixture.controlsViewMenuPressCount.value == 1
+    let restoredEditorOnce = fixture.editorViewMenuPressCount.value == 1
+    let restoredEntryTitle = fixture.currentPluginViewTitle == "편집기"
+    #expect(state == "A")
+    #expect(verified)
+    #expect(observed)
+    #expect(rowLabel == "Limiter On")
+    #expect(oneVerifiedPress)
+    #expect(selectedControlsOnce)
+    #expect(restoredEditorOnce)
+    #expect(restoredEntryTitle)
+}
+
+@Test func testControlsViewAlreadyOpenWithoutDescribedSlidersBindsHeaderAndReachesCheckbox() async throws {
+    let fixture = LiveFixture(
+        controlsViewRowLabel: "Limiter On",
+        controlsCheckboxBefore: false,
+        controlsViewInitiallySelected: true
+    )
+
+    let result = await runLive(fixture: fixture, params: controlsBooleanParams())
+
+    let state = try #require(result["state"] as? String)
+    let verified = try #require(result["verified"] as? Bool)
+    let checkboxPresses = fixture.controlsCheckboxPressCount.value
+    let viewMenuPresses = fixture.controlsViewMenuPressCount.value
+    let editorViewMenuPresses = fixture.editorViewMenuPressCount.value
+    #expect(state == "A")
+    #expect(verified)
+    #expect(checkboxPresses == 1)
+    #expect(viewMenuPresses == 0)
+    #expect(editorViewMenuPresses == 0)
+}
+
+@Test func testNativeEditorWithoutThresholdAnchorBindsHeaderThenSelectsControls() async throws {
+    let fixture = LiveFixture(
+        thresholdDescription: "Native-only non-anchor",
+        controlsViewRowLabel: "Limiter On",
+        controlsCheckboxBefore: false
+    )
+
+    let result = await runLive(fixture: fixture, params: controlsBooleanParams())
+
+    let state = try #require(result["state"] as? String)
+    let verified = try #require(result["verified"] as? Bool)
+    let checkboxPresses = fixture.controlsCheckboxPressCount.value
+    let viewMenuPresses = fixture.controlsViewMenuPressCount.value
+    let editorViewMenuPresses = fixture.editorViewMenuPressCount.value
+    #expect(state == "A")
+    #expect(verified)
+    #expect(checkboxPresses == 1)
+    #expect(viewMenuPresses == 1)
+    #expect(editorViewMenuPresses == 1)
+}
+
+@Test func testControlsViewHeaderBindingChoosesRequestedStripAndLeavesOtherEditorUntouched() async throws {
+    let fixture = LiveFixture(
+        controlsViewRowLabel: "Limiter On",
+        controlsCheckboxBefore: false,
+        controlsViewInitiallySelected: true
+    )
+    let other = controlsViewCompressorEditorWindow(
+        fixture: fixture,
+        baseID: 8_600,
+        trackName: "Other Strip"
+    )
+    let existingWindows = fixture.builder.attributeValue(
+        fixture.app,
+        kAXWindowsAttribute as String
+    ) as? [AXUIElement] ?? []
+    fixture.builder.setAttribute(
+        fixture.app,
+        kAXWindowsAttribute as String,
+        existingWindows + [other.window]
+    )
+
+    let result = await runLive(fixture: fixture, params: controlsBooleanParams())
+
+    let state = try #require(result["state"] as? String)
+    let targetCheckboxPresses = fixture.controlsCheckboxPressCount.value
+    let otherCheckboxState = try #require(
+        fixture.builder.attributeValue(other.checkbox, kAXValueAttribute as String) as? Bool
+    )
+    #expect(state == "A")
+    #expect(targetCheckboxPresses == 1)
+    #expect(!otherCheckboxState)
+}
+
+@Test func testControlsViewMismatchedHeaderRefusesBeforeCheckboxActuation() async throws {
+    let fixture = LiveFixture(
+        thresholdDescription: "Native-only non-anchor",
+        pluginWindowStaticTextValues: ["보기:", "Noise Gate", trackName],
+        controlsViewRowLabel: "Limiter On",
+        controlsCheckboxBefore: false,
+        controlsViewInitiallySelected: true
+    )
+
+    let result = await runLive(fixture: fixture, params: controlsBooleanParams())
+
+    let error = try #require(result["error"] as? String)
+    let writeAttempted = try #require(result["write_attempted"] as? Bool)
+    let checkboxPresses = fixture.controlsCheckboxPressCount.value
+    #expect(error == "plugin_window_plugin_mismatch")
+    #expect(!writeAttempted)
+    #expect(checkboxPresses == 0)
+}
+
+@Test func testControlsViewCheckboxBindsTargetHeaderBeforeSharedThresholdAnchor() async throws {
+    let fixture = LiveFixture(
+        controlsViewRowLabel: "Limiter On",
+        controlsCheckboxBefore: false
+    )
+    let unrelatedEditors = ["Drums", "Reverb", "Piano", "Vox"].enumerated().map { offset, otherTrack in
+        matchingCompressorEditorWindow(
+            fixture: fixture,
+            baseID: 8_000 + offset * 10,
+            trackName: otherTrack
+        ).window
+    }
+    let existingWindows = fixture.builder.attributeValue(
+        fixture.app,
+        kAXWindowsAttribute as String
+    ) as? [AXUIElement] ?? []
+    fixture.builder.setAttribute(
+        fixture.app,
+        kAXWindowsAttribute as String,
+        existingWindows + unrelatedEditors
+    )
+
+    let result = await runLive(fixture: fixture, params: controlsBooleanParams())
+
+    // Every added editor exposes the same Threshold slider. Success proves the
+    // target track/plugin header binding selected the intended editor before
+    // treating Threshold as its secondary Controls-view witness.
+    #expect(result["state"] as? String == "A")
+    #expect(fixture.controlsCheckboxPressCount.value == 1)
+}
+
+@Test func testCompressorControlsViewAutoReleaseUsesItsOwnRowLabel() async throws {
+    let fixture = LiveFixture(
+        controlsViewRowLabel: "Auto Release",
+        controlsCheckboxBefore: true
+    )
+    let result = await runLive(
+        fixture: fixture,
+        params: controlsBooleanParams(param: "auto_release", value: "0")
+    )
+
+    let state = try #require(result["state"] as? String)
+    let verified = try #require(result["verified"] as? Bool)
+    let observed = try #require(result["observed_boolean"] as? Bool)
+    let rowLabel = try #require(result["controls_view_row_label"] as? String)
+    let oneVerifiedPress = fixture.controlsCheckboxPressCount.value == 1
+    #expect(state == "A")
+    #expect(verified)
+    #expect(!observed)
+    #expect(rowLabel == "Auto Release")
+    #expect(oneVerifiedPress)
+}
+
+@Test func testCompressorControlsViewStatusZeroUnchangedReadbackRefusesAndRestores() async throws {
+    let fixture = LiveFixture(
+        controlsViewRowLabel: "Limiter On",
+        controlsCheckboxBefore: false,
+        controlsCheckboxWriteBehavior: .statusZeroUnchanged
+    )
+    let result = await runLive(fixture: fixture, params: controlsBooleanParams())
+
+    let error = try #require(result["error"] as? String)
+    let restoreAttempted = try #require(result["restore_attempted"] as? Bool)
+    let restoreObserved = try #require(result["restore_observed"] as? Bool)
+    let writeAttempted = try #require(result["write_attempted"] as? Bool)
+    let statusOnlyWasNotSuccess = result["state"] as? String != "A"
+    let pressAndRestore = fixture.controlsCheckboxPressCount.value == 2
+    #expect(error == "readback_mismatch")
+    #expect(restoreAttempted)
+    #expect(restoreObserved)
+    #expect(writeAttempted)
+    #expect(statusOnlyWasNotSuccess)
+    #expect(pressAndRestore)
 }
 
 @Test func testWithinToleranceStillStateA() async {
@@ -1409,7 +1935,7 @@ private func namedEQBandParams(
     #expect(fixture.currentSliderValue == 60)
 }
 
-@Test func testProductionOpenerRejectsOpenedWindowWithoutRequestedSlider() async throws {
+@Test func testProductionOpenerReportsOpenedNativeWindowWithoutRequestedSlider() async throws {
     let fixture = LiveFixture(
         thresholdDescription: "Output Gain",
         beforeValue: 51,
@@ -1419,15 +1945,11 @@ private func namedEQBandParams(
     let obj = await runLive(fixture: fixture, params: thresholdParams())
 
     #expect(obj["state"] as? String == "C")
-    #expect(obj["error"] as? String == "window_open_failed")
+    #expect(obj["error"] as? String == "param_control_not_found")
     let v1 = try #require(obj["write_attempted"] as? Bool)
     #expect(!v1)
-    let v2 = try #require(obj["opener_action_attempted"] as? Bool)
-    #expect(v2)
-    let windowCandidates = obj["window_candidates"] as? [[String: Any]]
-    let sliders = windowCandidates?.last?["slider_descriptions"] as? [String]
-    let v3 = try #require(sliders?.contains("Output Gain"))
-    #expect(v3)
+    let observed = try #require(obj["what_was_observed"] as? String)
+    #expect(observed.contains("no slider with that AX description"))
     #expect(fixture.currentSliderValue == 51)
 }
 
@@ -1520,7 +2042,11 @@ private func namedEQBandParams(
 }
 
 @Test func testAmbiguousWindowAppearingAfterSlotPressFailsClosed() async throws {
-    let fixture = LiveFixture(beforeValue: 51, openWindowOnSlotPress: true)
+    let fixture = LiveFixture(
+        beforeValue: 51,
+        pluginWindowPresent: false,
+        openWindowOnSlotPress: true
+    )
     let b = fixture.builder
     let duplicateWindow = b.element(3300)
     let duplicateSlider = b.element(3301)
@@ -1564,7 +2090,10 @@ private func namedEQBandParams(
     b.setAttribute(duplicateSlider, kAXRoleAttribute as String, kAXSliderRole as String)
     b.setAttribute(duplicateSlider, kAXDescriptionAttribute as String, "Threshold")
     b.setAttribute(duplicateSlider, kAXValueAttribute as String, 51.0)
-    b.setChildren(b.element(1004), [b.element(1007), b.element(1008), b.element(1005), duplicateSlider])
+    b.setChildren(b.element(1004), [
+        b.element(1007), b.element(1008), b.element(1005), duplicateSlider,
+        b.element(1011), b.element(1009),
+    ])
 
     let obj = await runLive(fixture: fixture, params: thresholdParams())
 
@@ -1591,6 +2120,7 @@ private func namedEQBandParams(
     let openedBypass = b.element(2003)
     let openedLink = b.element(2004)
     let openedPluginName = b.element(2005)
+    let openedViewSwitcher = b.element(2006)
     b.setAttribute(openedClose, kAXRoleAttribute as String, kAXButtonRole as String)
     b.setAttribute(openedBypass, kAXRoleAttribute as String, kAXCheckBoxRole as String)
     b.setAttribute(openedBypass, kAXDescriptionAttribute as String, "bypass")
@@ -1598,13 +2128,18 @@ private func namedEQBandParams(
     b.setAttribute(openedLink, kAXDescriptionAttribute as String, "link")
     b.setAttribute(openedPluginName, kAXRoleAttribute as String, kAXStaticTextRole as String)
     b.setAttribute(openedPluginName, kAXValueAttribute as String, "Compressor")
+    b.setAttribute(openedViewSwitcher, kAXRoleAttribute as String, kAXMenuButtonRole as String)
+    b.setAttribute(openedViewSwitcher, kAXDescriptionAttribute as String, "보기")
+    b.setAttribute(openedViewSwitcher, kAXTitleAttribute as String, "편집기")
     b.setAttribute(openedWindow, kAXRoleAttribute as String, kAXWindowRole as String)
     b.setAttribute(openedWindow, kAXSubroleAttribute as String, kAXDialogSubrole as String)
     b.setAttribute(openedWindow, kAXTitleAttribute as String, trackName)
     b.setAttribute(openedWindow, kAXCloseButtonAttribute as String, openedClose)
     b.setAttribute(openedWindow, kAXMainAttribute as String, true)
     b.setAttribute(openedWindow, kAXFocusedAttribute as String, true)
-    b.setChildren(openedWindow, [openedBypass, openedLink, openedSlider, openedPluginName])
+    b.setChildren(openedWindow, [
+        openedBypass, openedLink, openedSlider, openedPluginName, openedViewSwitcher,
+    ])
     b.setAttribute(fixture.app, kAXWindowsAttribute as String, [b.element(1001), openedWindow])
     let sendable = AXUIElementSendable(openedWindow)
 
@@ -1795,6 +2330,7 @@ private final class OneShotStickyFixture: @unchecked Sendable {
         let pluginBypass = b.element(3007)
         let pluginLink = b.element(3008)
         let pluginName = b.element(3009)
+        let viewSwitcher = b.element(3010)
         b.setAttribute(pluginClose, kAXRoleAttribute as String, kAXButtonRole as String)
         b.setAttribute(pluginBypass, kAXRoleAttribute as String, kAXCheckBoxRole as String)
         b.setAttribute(pluginBypass, kAXDescriptionAttribute as String, "bypass")
@@ -1802,10 +2338,13 @@ private final class OneShotStickyFixture: @unchecked Sendable {
         b.setAttribute(pluginLink, kAXDescriptionAttribute as String, "link")
         b.setAttribute(pluginName, kAXRoleAttribute as String, kAXStaticTextRole as String)
         b.setAttribute(pluginName, kAXValueAttribute as String, "Compressor")
+        b.setAttribute(viewSwitcher, kAXRoleAttribute as String, kAXMenuButtonRole as String)
+        b.setAttribute(viewSwitcher, kAXDescriptionAttribute as String, "보기")
+        b.setAttribute(viewSwitcher, kAXTitleAttribute as String, "편집기")
         b.setAttribute(pluginWindow, kAXCloseButtonAttribute as String, pluginClose)
         b.setAttribute(pluginWindow, kAXMainAttribute as String, true)
         b.setAttribute(pluginWindow, kAXFocusedAttribute as String, true)
-        b.setChildren(pluginWindow, [pluginBypass, pluginLink, slider, pluginName])
+        b.setChildren(pluginWindow, [pluginBypass, pluginLink, slider, pluginName, viewSwitcher])
 
         b.setAttribute(app, kAXWindowsAttribute as String, [arrangeWindow, pluginWindow])
         b.setAttribute(app, kAXMainWindowAttribute as String, arrangeWindow)

--- a/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
+++ b/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
@@ -116,6 +116,9 @@ private final class LiveFixture: @unchecked Sendable {
         mutatePluginHeaderAfterViewSelection: Bool = false,
         ambiguousEditorSliderAfterViewSelection: Bool = false,
         viewMenuRevealAfterPolls: Int? = 3,
+        viewMenuDuplicatesOnReveal: Bool = false,
+        viewMenuOmitsEditorItem: Bool = false,
+        viewMenuEditorItemEnabled: Bool = true,
         viewSettleDelay: TimeInterval = 0.5
     ) {
         let b = builder
@@ -137,6 +140,7 @@ private final class LiveFixture: @unchecked Sendable {
         let pluginLink = b.element(1008)
         let controlsViewSwitcher = b.element(1009)
         let controlsViewMenu = b.element(100_901)
+        let duplicateControlsViewMenu = b.element(100_914)
         let controlsViewMenuItem = b.element(100_902)
         let editorViewMenuItem = b.element(100_909)
         let controlsTable = b.element(100_903)
@@ -283,8 +287,13 @@ private final class LiveFixture: @unchecked Sendable {
         b.setAttribute(controlsViewMenuItem, kAXEnabledAttribute as String, true)
         b.setRole(editorViewMenuItem, kAXMenuItemRole as String)
         b.setAttribute(editorViewMenuItem, kAXTitleAttribute as String, "편집기")
-        b.setAttribute(editorViewMenuItem, kAXEnabledAttribute as String, true)
-        b.setChildren(controlsViewMenu, [controlsViewMenuItem, editorViewMenuItem])
+        b.setAttribute(editorViewMenuItem, kAXEnabledAttribute as String, viewMenuEditorItemEnabled)
+        let viewMenuItems = viewMenuOmitsEditorItem
+            ? [controlsViewMenuItem]
+            : [controlsViewMenuItem, editorViewMenuItem]
+        b.setChildren(controlsViewMenu, viewMenuItems)
+        b.setRole(duplicateControlsViewMenu, kAXMenuRole as String)
+        b.setChildren(duplicateControlsViewMenu, viewMenuItems)
         pluginWindowChildren += [controlsViewSwitcher]
         var controlsViewWindowChildren = [pluginBypass, pluginLink]
             + staticTexts
@@ -419,7 +428,10 @@ private final class LiveFixture: @unchecked Sendable {
                     return .success([])
                 }
                 menuVisible.value = true
-                return .success([controlsViewMenu])
+                    return .success(viewMenuDuplicatesOnReveal
+                        ? [controlsViewMenu, duplicateControlsViewMenu]
+                        : [controlsViewMenu]
+                    )
             },
             setAttributeHandler: { [b] el, attribute, value in
                 if pluginWindowRejectsDirectDemotion,
@@ -1055,6 +1067,91 @@ private func namedEQBandParams(
     #expect(reportsStructureDeadline)
     #expect(sliderWasNotWritten)
     #expect(entryViewWasExplicitlyReselected)
+}
+
+@Test func testPluginViewRefusalNamesTheMenuNeverAppearedPhase() async throws {
+    let fixture = LiveFixture(
+        controlsViewInitiallySelected: true,
+        viewMenuRevealAfterPolls: nil
+    )
+    let result = await runLive(fixture: fixture, params: thresholdParams(value: "60"))
+
+    let phase = try #require(result["plugin_view_switch_phase"] as? String)
+    let writeAttempted = try #require(result["write_attempted"] as? Bool)
+    let namesTheObservedPhase = phase == "menu_never_appeared"
+    let refusedBeforeWrite = !writeAttempted
+    // Mutation: drop the menu-appearance diagnostic mapping.
+    #expect(namesTheObservedPhase)
+    #expect(refusedBeforeWrite)
+}
+
+@Test func testPluginViewRefusalNamesTheMenuAmbiguousPhase() async throws {
+    let fixture = LiveFixture(
+        controlsViewInitiallySelected: true,
+        viewMenuRevealAfterPolls: 0,
+        viewMenuDuplicatesOnReveal: true
+    )
+    let result = await runLive(fixture: fixture, params: thresholdParams(value: "60"))
+
+    let phase = try #require(result["plugin_view_switch_phase"] as? String)
+    let namesTheObservedPhase = phase == "menu_ambiguous"
+    // Mutation: drop the scoped-menu ambiguity diagnostic mapping.
+    #expect(namesTheObservedPhase)
+}
+
+@Test func testPluginViewRefusalNamesTheItemNotFoundPhase() async throws {
+    let fixture = LiveFixture(
+        controlsViewInitiallySelected: true,
+        viewMenuRevealAfterPolls: 0,
+        viewMenuOmitsEditorItem: true
+    )
+    let result = await runLive(fixture: fixture, params: thresholdParams(value: "60"))
+
+    let phase = try #require(result["plugin_view_switch_phase"] as? String)
+    let namesTheObservedPhase = phase == "item_not_found"
+    // Mutation: drop the scoped-item-not-found diagnostic mapping.
+    #expect(namesTheObservedPhase)
+}
+
+@Test func testPluginViewRefusalNamesTheItemNotEnabledPhase() async throws {
+    let fixture = LiveFixture(
+        controlsViewInitiallySelected: true,
+        viewMenuRevealAfterPolls: 0,
+        viewMenuEditorItemEnabled: false
+    )
+    let result = await runLive(fixture: fixture, params: thresholdParams(value: "60"))
+
+    let phase = try #require(result["plugin_view_switch_phase"] as? String)
+    let namesTheObservedPhase = phase == "item_not_enabled"
+    // Mutation: drop the AXEnabled refusal diagnostic mapping.
+    #expect(namesTheObservedPhase)
+}
+
+@Test func testPluginViewRefusalNamesThePostPickStructurePhaseAndDeadlineSnapshot() async throws {
+    let fixture = LiveFixture(
+        controlsViewInitiallySelected: true,
+        viewMenuPressChangesStructure: false,
+        viewMenuRevealAfterPolls: 0
+    )
+    let result = await runLive(fixture: fixture, params: thresholdParams(value: "60"))
+
+    let phase = try #require(result["plugin_view_switch_phase"] as? String)
+    let tables = try #require(result["plugin_view_structure_table_count"] as? Int)
+    let rows = try #require(result["plugin_view_structure_row_count"] as? Int)
+    let describedSliders = try #require(result["plugin_view_structure_described_slider_count"] as? Int)
+    let waitedMilliseconds = try #require(result["plugin_view_structure_waited_ms"] as? Int)
+    let restorationAttempted = try #require(result["plugin_view_restore_attempted"] as? Bool)
+    let restorationObserved = try #require(result["plugin_view_restore_observed"] as? Bool)
+    let namesTheObservedPhase = phase == "pick_performed_structure_never_confirmed"
+    let capturesDeadlineClassifierState = tables == 1
+        && rows == 2
+        && describedSliders == 0
+        && waitedMilliseconds >= 2_900
+    let entryViewRestorationSurvived = restorationAttempted && restorationObserved
+    // Mutation: omit `failure.responseDiagnostics` from the State-C envelope.
+    #expect(namesTheObservedPhase)
+    #expect(capturesDeadlineClassifierState)
+    #expect(entryViewRestorationSurvived)
 }
 
 @Test func testCompressorThresholdRestoresControlsAfterSliderLookupRefusal() async throws {

--- a/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
+++ b/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
@@ -98,7 +98,9 @@ private final class LiveFixture: @unchecked Sendable {
         pluginWindowViewSwitcherDescription: String = "보기",
         viewMenuPressChangesStructure: Bool = true,
         viewMenuPressChangesTitle: Bool = true,
-        viewMenuBecomesUnavailableAfterControlsSelection: Bool = false
+        viewMenuBecomesUnavailableAfterControlsSelection: Bool = false,
+        viewMenuRevealAfterPolls: Int? = 4,
+        viewSettleDelay: TimeInterval = 0.5
     ) {
         let b = builder
         let windowsAddedOnSlotPress = MutableBox<[AXUIElement]>([])
@@ -127,6 +129,9 @@ private final class LiveFixture: @unchecked Sendable {
         let controlsControlCell = b.element(100_906)
         let controlsLabel = b.element(100_907)
         let controlsCheckbox = b.element(100_908)
+        let controlsHeadingRow = b.element(100_910)
+        let controlsHeadingCell = b.element(100_911)
+        let controlsHeadingLabel = b.element(100_912)
 
         // --- Track headers: one row per track, selected-state on the target. ---
         var headerRows: [AXUIElement] = []
@@ -261,8 +266,14 @@ private final class LiveFixture: @unchecked Sendable {
         // a Controls-view checkbox write.
         b.setRole(controlsTable, kAXTableRole as String)
         b.setRole(controlsRow, kAXRowRole as String)
-        b.setChildren(controlsTable, [controlsRow])
-        b.setAttribute(controlsTable, kAXRowsAttribute as String, [controlsRow])
+        b.setRole(controlsHeadingRow, kAXRowRole as String)
+        b.setRole(controlsHeadingCell, kAXCellRole as String)
+        b.setRole(controlsHeadingLabel, kAXStaticTextRole as String)
+        b.setAttribute(controlsHeadingLabel, kAXValueAttribute as String, "Dynamics")
+        b.setChildren(controlsHeadingCell, [controlsHeadingLabel])
+        b.setChildren(controlsHeadingRow, [controlsHeadingCell])
+        b.setChildren(controlsTable, [controlsHeadingRow, controlsRow])
+        b.setAttribute(controlsTable, kAXRowsAttribute as String, [controlsHeadingRow, controlsRow])
         controlsViewWindowChildren += [controlsTable]
         b.setRole(controlsLabelCell, kAXCellRole as String)
         b.setRole(controlsControlCell, kAXCellRole as String)
@@ -305,8 +316,36 @@ private final class LiveFixture: @unchecked Sendable {
         let editorWindowChildren = pluginWindowChildren
         let forced = forcedAfterValue
         let writeBehavior = sliderWriteBehavior
+        let menuOpen = MutableBox(false)
+        let menuVisible = MutableBox(false)
+        let menuCensusPolls = MutableBox(0)
+        let pendingPluginWindowChildren = MutableBox<(children: [AXUIElement], settlesAt: Date)?>(nil)
         let runtime = b.makeLogicRuntime(
             appElement: app,
+            childrenHandler: { element in
+                if CFEqual(element, pluginWindow),
+                   let pending = pendingPluginWindowChildren.value,
+                   Date() >= pending.settlesAt {
+                    b.setChildren(pluginWindow, pending.children)
+                    pendingPluginWindowChildren.value = nil
+                }
+                if CFEqual(element, controlsViewSwitcher), menuOpen.value, menuVisible.value {
+                    return [controlsViewMenu]
+                }
+                return nil
+            },
+            childrenResultHandler: { element in
+                guard CFEqual(element, controlsViewSwitcher), menuOpen.value else { return nil }
+                guard let revealAfterPolls = viewMenuRevealAfterPolls else {
+                    return .success([])
+                }
+                if menuCensusPolls.value < max(0, revealAfterPolls) {
+                    menuCensusPolls.value += 1
+                    return .success([])
+                }
+                menuVisible.value = true
+                return .success([controlsViewMenu])
+            },
             setAttributeHandler: { [b] el, attribute, value in
                 if pluginWindowRejectsDirectDemotion,
                    b.elementID(el) == b.elementID(pluginWindow),
@@ -360,16 +399,22 @@ private final class LiveFixture: @unchecked Sendable {
                         && controlsViewMenuPressCount.value > 0) else {
                         return true
                     }
-                    b.setChildren(controlsViewSwitcher, [controlsViewMenu])
+                    menuOpen.value = true
+                    menuVisible.value = false
+                    menuCensusPolls.value = 0
                     return true
                 }
                 if key == controlsViewMenuItemKey || key == editorViewMenuItemKey {
                     guard action == (kAXPickAction as String) else { return false }
-                    b.setChildren(controlsViewSwitcher, [])
+                    menuOpen.value = false
+                    menuVisible.value = false
                     if key == controlsViewMenuItemKey {
                         controlsViewMenuPressCount.value += 1
                         if viewMenuPressChangesStructure {
-                            b.setChildren(pluginWindow, controlsWindowChildren)
+                            pendingPluginWindowChildren.value = (
+                                children: controlsWindowChildren,
+                                settlesAt: Date().addingTimeInterval(max(0, viewSettleDelay))
+                            )
                         }
                         if viewMenuPressChangesTitle {
                             b.setAttribute(controlsViewSwitcher, kAXTitleAttribute as String, "컨트롤")
@@ -378,7 +423,10 @@ private final class LiveFixture: @unchecked Sendable {
                     }
                     editorViewMenuPressCount.value += 1
                     if viewMenuPressChangesStructure {
-                        b.setChildren(pluginWindow, editorWindowChildren)
+                        pendingPluginWindowChildren.value = (
+                            children: editorWindowChildren,
+                            settlesAt: Date().addingTimeInterval(max(0, viewSettleDelay))
+                        )
                     }
                     if viewMenuPressChangesTitle {
                         b.setAttribute(controlsViewSwitcher, kAXTitleAttribute as String, "편집기")
@@ -881,12 +929,12 @@ private func namedEQBandParams(
     let reportsUnconfirmedView = error == "plugin_view_not_confirmed"
     let reportsStructureDeadline = observed.contains("expected editor structure")
     let sliderWasNotWritten = fixture.sliderWriteCount.value == 0
-    let entryViewWasPreserved = fixture.editorViewMenuPressCount.value == 1
-        && fixture.controlsViewMenuPressCount.value == 0
+    let entryViewWasExplicitlyReselected = fixture.editorViewMenuPressCount.value == 1
+        && fixture.controlsViewMenuPressCount.value == 1
     #expect(reportsUnconfirmedView)
     #expect(reportsStructureDeadline)
     #expect(sliderWasNotWritten)
-    #expect(entryViewWasPreserved)
+    #expect(entryViewWasExplicitlyReselected)
 }
 
 @Test func testCompressorThresholdRestoresControlsAfterSliderLookupRefusal() async throws {

--- a/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
+++ b/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
@@ -68,6 +68,7 @@ private final class LiveFixture: @unchecked Sendable {
         thresholdDescription: String = "Threshold",
         pluginSlotName: String = "Compressor",
         beforeValue: Double = 51,
+        sliderBeforeReadable: Bool = true,
         pluginWindowPresent: Bool = true,
         openWindowOnSlotPress: Bool = false,
         forcedAfterValue: Double? = nil,
@@ -78,6 +79,7 @@ private final class LiveFixture: @unchecked Sendable {
         pluginWindowRejectsDirectDemotion: Bool = false,
         slotPressReturnsFalse: Bool = false,
         sliderWriteBehavior: SliderWriteBehavior = .direct,
+        rejectSliderWrites: Bool = false,
         sliderDisplayUnit: String = "%",
         sliderUsesSignedPositiveDisplay: Bool = false,
         pluginWindowStaticTextValues: [String]? = nil,
@@ -98,7 +100,12 @@ private final class LiveFixture: @unchecked Sendable {
         pluginWindowViewSwitcherDescription: String = "보기",
         viewMenuPressChangesStructure: Bool = true,
         viewMenuPressChangesTitle: Bool = true,
+        viewMenuSelectionSetsUnconfirmedStructure: Bool = false,
         viewMenuBecomesUnavailableAfterControlsSelection: Bool = false,
+        viewMenuReadFailsAfterFirstSelection: Bool = false,
+        invalidateTargetSlotAfterViewSelection: Bool = false,
+        mutatePluginHeaderAfterViewSelection: Bool = false,
+        ambiguousEditorSliderAfterViewSelection: Bool = false,
         viewMenuRevealAfterPolls: Int? = 4,
         viewSettleDelay: TimeInterval = 0.5
     ) {
@@ -126,7 +133,6 @@ private final class LiveFixture: @unchecked Sendable {
         let controlsTable = b.element(100_903)
         let controlsRow = b.element(100_904)
         let controlsLabelCell = b.element(100_905)
-        let controlsControlCell = b.element(100_906)
         let controlsLabel = b.element(100_907)
         let controlsCheckbox = b.element(100_908)
         let controlsHeadingRow = b.element(100_910)
@@ -207,7 +213,11 @@ private final class LiveFixture: @unchecked Sendable {
         //     include the plug-in display name at no fixed index. ---
         b.setAttribute(slider, kAXRoleAttribute as String, kAXSliderRole as String)
         b.setAttribute(slider, kAXDescriptionAttribute as String, thresholdDescription)
-        b.setAttribute(slider, kAXValueAttribute as String, beforeValue)
+        b.setAttribute(
+            slider,
+            kAXValueAttribute as String,
+            sliderBeforeReadable ? beforeValue : NSNull()
+        )
         b.setAttribute(slider, kAXMinValueAttribute as String, 0.0)
         b.setAttribute(slider, kAXMaxValueAttribute as String, 100.0)
         let formatSliderDisplay: @Sendable (Double) -> String = { value in
@@ -238,7 +248,15 @@ private final class LiveFixture: @unchecked Sendable {
                 b.setAttribute(text, kAXValueAttribute as String, value)
                 return text
             }
-        var pluginWindowChildren = [pluginBypass, pluginLink, slider] + staticTexts
+        let ambiguousEditorSlider = b.element(100_913)
+        if ambiguousEditorSliderAfterViewSelection {
+            b.setAttribute(ambiguousEditorSlider, kAXRoleAttribute as String, kAXSliderRole as String)
+            b.setAttribute(ambiguousEditorSlider, kAXDescriptionAttribute as String, thresholdDescription)
+            b.setAttribute(ambiguousEditorSlider, kAXValueAttribute as String, beforeValue)
+        }
+        var pluginWindowChildren = [pluginBypass, pluginLink, slider]
+            + (ambiguousEditorSliderAfterViewSelection ? [ambiguousEditorSlider] : [])
+            + staticTexts
         b.setRole(controlsViewSwitcher, kAXMenuButtonRole as String)
         b.setAttribute(
             controlsViewSwitcher,
@@ -261,7 +279,7 @@ private final class LiveFixture: @unchecked Sendable {
             + staticTexts
             + [controlsViewSwitcher]
         // Controls view itself is identified by a parameter row whose label
-        // and control occupy sibling AXCells. Keep that measured shape even
+        // and control occupy one AXCell as siblings. Keep that measured shape even
         // when this fixture is exercising an editor-slider write rather than
         // a Controls-view checkbox write.
         b.setRole(controlsTable, kAXTableRole as String)
@@ -276,7 +294,6 @@ private final class LiveFixture: @unchecked Sendable {
         b.setAttribute(controlsTable, kAXRowsAttribute as String, [controlsHeadingRow, controlsRow])
         controlsViewWindowChildren += [controlsTable]
         b.setRole(controlsLabelCell, kAXCellRole as String)
-        b.setRole(controlsControlCell, kAXCellRole as String)
         b.setRole(controlsLabel, kAXStaticTextRole as String)
         b.setAttribute(
             controlsLabel,
@@ -285,9 +302,8 @@ private final class LiveFixture: @unchecked Sendable {
         )
         b.setRole(controlsCheckbox, controlsViewControlRole)
         b.setAttribute(controlsCheckbox, kAXValueAttribute as String, controlsCheckboxBefore)
-        b.setChildren(controlsLabelCell, [controlsLabel])
-        b.setChildren(controlsControlCell, [controlsCheckbox])
-        b.setChildren(controlsRow, [controlsLabelCell, controlsControlCell])
+        b.setChildren(controlsLabelCell, [controlsLabel, controlsCheckbox])
+        b.setChildren(controlsRow, [controlsLabelCell])
         // Controls view has rows, but no editor-view slider descriptions.
         // Keep its shape distinct from the native editor so a test cannot
         // accidentally keep relying on Threshold after the view changes.
@@ -306,6 +322,7 @@ private final class LiveFixture: @unchecked Sendable {
         // sticky parameter (readback != requested).
         let sliderKey = b.elementID(slider)
         let targetSlotKey = targetSlot.map { b.elementID($0) }
+        let targetSlotForViewMutation = targetSlot
         let targetOpenButtonKey = targetOpenButton.map { b.elementID($0) }
         let pluginCloseKey = b.elementID(pluginClose)
         let controlsCheckboxKey = b.elementID(controlsCheckbox)
@@ -336,6 +353,10 @@ private final class LiveFixture: @unchecked Sendable {
             },
             childrenResultHandler: { element in
                 guard CFEqual(element, controlsViewSwitcher), menuOpen.value else { return nil }
+                if viewMenuReadFailsAfterFirstSelection,
+                   controlsViewMenuPressCount.value + editorViewMenuPressCount.value > 0 {
+                    return .failure(AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue))
+                }
                 guard let revealAfterPolls = viewMenuRevealAfterPolls else {
                     return .success([])
                 }
@@ -363,6 +384,9 @@ private final class LiveFixture: @unchecked Sendable {
                     ?? 0
                 let writeIndex = sliderWriteCount.value
                 sliderWriteCount.value += 1
+                if rejectSliderWrites {
+                    return false
+                }
                 let landed: Double?
                 switch writeBehavior {
                 case .direct:
@@ -410,7 +434,18 @@ private final class LiveFixture: @unchecked Sendable {
                     menuVisible.value = false
                     if key == controlsViewMenuItemKey {
                         controlsViewMenuPressCount.value += 1
-                        if viewMenuPressChangesStructure {
+                        if invalidateTargetSlotAfterViewSelection, let targetSlotForViewMutation {
+                            b.setAttribute(targetSlotForViewMutation, kAXDescriptionAttribute as String, "Noise Gate")
+                        }
+                        if mutatePluginHeaderAfterViewSelection, staticTexts.indices.contains(1) {
+                            b.setAttribute(staticTexts[1], kAXValueAttribute as String, "Noise Gate")
+                        }
+                        if viewMenuSelectionSetsUnconfirmedStructure {
+                            pendingPluginWindowChildren.value = (
+                                children: [controlsViewSwitcher],
+                                settlesAt: Date().addingTimeInterval(max(0, viewSettleDelay))
+                            )
+                        } else if viewMenuPressChangesStructure {
                             pendingPluginWindowChildren.value = (
                                 children: controlsWindowChildren,
                                 settlesAt: Date().addingTimeInterval(max(0, viewSettleDelay))
@@ -422,7 +457,18 @@ private final class LiveFixture: @unchecked Sendable {
                         return true
                     }
                     editorViewMenuPressCount.value += 1
-                    if viewMenuPressChangesStructure {
+                    if invalidateTargetSlotAfterViewSelection, let targetSlotForViewMutation {
+                        b.setAttribute(targetSlotForViewMutation, kAXDescriptionAttribute as String, "Noise Gate")
+                    }
+                    if mutatePluginHeaderAfterViewSelection, staticTexts.indices.contains(1) {
+                        b.setAttribute(staticTexts[1], kAXValueAttribute as String, "Noise Gate")
+                    }
+                    if viewMenuSelectionSetsUnconfirmedStructure {
+                        pendingPluginWindowChildren.value = (
+                            children: [controlsViewSwitcher],
+                            settlesAt: Date().addingTimeInterval(max(0, viewSettleDelay))
+                        )
+                    } else if viewMenuPressChangesStructure {
                         pendingPluginWindowChildren.value = (
                             children: editorWindowChildren,
                             settlesAt: Date().addingTimeInterval(max(0, viewSettleDelay))
@@ -549,6 +595,15 @@ private func runLive(
     ) as! [String: Any]
 }
 
+private func reportsFailedPluginViewRestoration(_ envelope: [String: Any]) -> Bool {
+    guard let attempted = envelope["plugin_view_restore_attempted"] as? Bool,
+          let observed = envelope["plugin_view_restore_observed"] as? Bool,
+          let leftChanged = envelope["plugin_view_left_changed"] as? Bool else {
+        return false
+    }
+    return attempted && !observed && leftChanged
+}
+
 /// A second same-track Compressor editor for the duplicate-insert post-count
 /// case. Its distinct AX elements intentionally share every non-geometry
 /// identity attribute the live editors share.
@@ -599,7 +654,6 @@ private func controlsViewCompressorEditorWindow(
     let table = b.element(baseID + 5)
     let row = b.element(baseID + 6)
     let labelCell = b.element(baseID + 7)
-    let controlCell = b.element(baseID + 8)
     let label = b.element(baseID + 9)
     let checkbox = b.element(baseID + 10)
 
@@ -613,14 +667,12 @@ private func controlsViewCompressorEditorWindow(
     b.setRole(table, kAXTableRole as String)
     b.setRole(row, kAXRowRole as String)
     b.setRole(labelCell, kAXCellRole as String)
-    b.setRole(controlCell, kAXCellRole as String)
     b.setRole(label, kAXStaticTextRole as String)
     b.setAttribute(label, kAXValueAttribute as String, "Limiter On")
     b.setRole(checkbox, kAXCheckBoxRole as String)
     b.setAttribute(checkbox, kAXValueAttribute as String, false)
-    b.setChildren(labelCell, [label])
-    b.setChildren(controlCell, [checkbox])
-    b.setChildren(row, [labelCell, controlCell])
+    b.setChildren(labelCell, [label, checkbox])
+    b.setChildren(row, [labelCell])
     b.setChildren(table, [row])
     b.setAttribute(table, kAXRowsAttribute as String, [row])
     b.setRole(window, kAXWindowRole as String)
@@ -1211,6 +1263,202 @@ private func namedEQBandParams(
     #expect(restorationFailureWasVisible)
     #expect(observedStructure == "controls")
     #expect(fixtureWasLeftInControls)
+}
+
+@Test func testInitialViewConfirmationFailureReportsItsFailedCompensatingRestore() async throws {
+    let fixture = LiveFixture(
+        controlsViewInitiallySelected: true,
+        viewMenuSelectionSetsUnconfirmedStructure: true,
+        viewMenuReadFailsAfterFirstSelection: true,
+        viewSettleDelay: 0
+    )
+    let result = await runLive(fixture: fixture, params: thresholdParams())
+
+    let error = try #require(result["error"] as? String)
+    let restorationFailureWasVisible = reportsFailedPluginViewRestoration(result)
+    let noSliderWrite = fixture.sliderWriteCount.value == 0
+    let reportedPluginViewNotConfirmed = error == "plugin_view_not_confirmed"
+    #expect(reportedPluginViewNotConfirmed)
+    #expect(restorationFailureWasVisible)
+    #expect(noSliderWrite)
+}
+
+@Test func testTargetRevalidationStateCReportsFailedViewRestore() async throws {
+    let fixture = LiveFixture(
+        controlsViewRowLabel: "Limiter On",
+        viewMenuReadFailsAfterFirstSelection: true,
+        invalidateTargetSlotAfterViewSelection: true
+    )
+    let result = await runLive(fixture: fixture, params: controlsBooleanParams())
+
+    let error = try #require(result["error"] as? String)
+    let restorationFailureWasVisible = reportsFailedPluginViewRestoration(result)
+    let noCheckboxPress = fixture.controlsCheckboxPressCount.value == 0
+    let reportedUnresolvedIdentity = error == "window_identity_unresolved"
+    #expect(reportedUnresolvedIdentity)
+    #expect(restorationFailureWasVisible)
+    #expect(noCheckboxPress)
+}
+
+@Test func testPluginIdentityFailureStateCReportsFailedViewRestore() async throws {
+    let fixture = LiveFixture(
+        controlsViewRowLabel: "Limiter On",
+        viewMenuReadFailsAfterFirstSelection: true,
+        mutatePluginHeaderAfterViewSelection: true
+    )
+    let result = await runLive(fixture: fixture, params: controlsBooleanParams())
+
+    let error = try #require(result["error"] as? String)
+    let restorationFailureWasVisible = reportsFailedPluginViewRestoration(result)
+    let noCheckboxPress = fixture.controlsCheckboxPressCount.value == 0
+    let reportedUnresolvedIdentity = error == "window_identity_unresolved"
+    #expect(reportedUnresolvedIdentity)
+    #expect(restorationFailureWasVisible)
+    #expect(noCheckboxPress)
+}
+
+@Test func testSliderAmbiguityStateCReportsFailedViewRestore() async throws {
+    let fixture = LiveFixture(
+        controlsViewInitiallySelected: true,
+        viewMenuReadFailsAfterFirstSelection: true,
+        ambiguousEditorSliderAfterViewSelection: true
+    )
+    let result = await runLive(fixture: fixture, params: thresholdParams())
+
+    let error = try #require(result["error"] as? String)
+    let restorationFailureWasVisible = reportsFailedPluginViewRestoration(result)
+    let noSliderWrite = fixture.sliderWriteCount.value == 0
+    let reportedUnresolvedIdentity = error == "window_identity_unresolved"
+    #expect(reportedUnresolvedIdentity)
+    #expect(restorationFailureWasVisible)
+    #expect(noSliderWrite)
+}
+
+@Test func testDirectWriteRejectionStateCReportsFailedViewRestore() async throws {
+    let fixture = LiveFixture(
+        rejectSliderWrites: true,
+        controlsViewInitiallySelected: true,
+        viewMenuReadFailsAfterFirstSelection: true
+    )
+    let result = await runLive(fixture: fixture, params: thresholdParams())
+
+    let error = try #require(result["error"] as? String)
+    let restorationFailureWasVisible = reportsFailedPluginViewRestoration(result)
+    let rollbackAttempted = try #require(result["rollback_attempted"] as? Bool)
+    let parameterMayBeChanged = try #require(result["parameter_left_changed"] as? Bool)
+    let reportedAXWriteFailure = error == "ax_write_failed"
+    #expect(reportedAXWriteFailure)
+    #expect(restorationFailureWasVisible)
+    #expect(rollbackAttempted)
+    #expect(parameterMayBeChanged)
+}
+
+@Test func testDirectReadbackLossRollsBackAndReportsFailedViewRestore() async throws {
+    let fixture = LiveFixture(
+        sliderWriteBehavior: .scripted([nil, 51]),
+        controlsViewInitiallySelected: true,
+        viewMenuReadFailsAfterFirstSelection: true
+    )
+    let result = await runLive(fixture: fixture, params: thresholdParams())
+
+    let error = try #require(result["error"] as? String)
+    let rollbackAttempted = try #require(result["rollback_attempted"] as? Bool)
+    let rolledBack = try #require(result["rolled_back"] as? Bool)
+    let rollbackObserved = try #require(result["rollback_observed"] as? Double)
+    let safeToRetry = try #require(result["safe_to_retry"] as? Bool)
+    let parameterLeftChanged = try #require(result["parameter_left_changed"] as? Bool)
+    let restorationFailureWasVisible = reportsFailedPluginViewRestoration(result)
+    let rollbackWasWritten = fixture.sliderWriteCount.value == 2
+    let reportedReadbackLoss = error == "readback_lost_after_write"
+    let rollbackObservedOriginalValue = rollbackObserved == 51
+    let parameterWasNotLeftChanged = !parameterLeftChanged
+    #expect(reportedReadbackLoss)
+    #expect(rollbackAttempted)
+    #expect(rolledBack)
+    #expect(rollbackObservedOriginalValue)
+    #expect(safeToRetry)
+    #expect(parameterWasNotLeftChanged)
+    #expect(restorationFailureWasVisible)
+    #expect(rollbackWasWritten)
+}
+
+@Test func testDirectReadbackLossWithFailedRollbackReportsParameterLeftChanged() async throws {
+    let fixture = LiveFixture(
+        sliderWriteBehavior: .scripted([nil, nil]),
+        controlsViewInitiallySelected: true,
+        viewMenuReadFailsAfterFirstSelection: true
+    )
+    let result = await runLive(fixture: fixture, params: thresholdParams())
+
+    let rollbackAttempted = try #require(result["rollback_attempted"] as? Bool)
+    let rolledBack = try #require(result["rolled_back"] as? Bool)
+    let parameterLeftChanged = try #require(result["parameter_left_changed"] as? Bool)
+    let safeToRetry = try #require(result["safe_to_retry"] as? Bool)
+    let restorationFailureWasVisible = reportsFailedPluginViewRestoration(result)
+    let rollbackWasNotObserved = !rolledBack
+    let retryIsNotSafe = !safeToRetry
+    #expect(rollbackAttempted)
+    #expect(rollbackWasNotObserved)
+    #expect(parameterLeftChanged)
+    #expect(retryIsNotSafe)
+    #expect(restorationFailureWasVisible)
+}
+
+@Test func testReadbackMismatchStateCReportsFailedViewRestore() async throws {
+    let fixture = LiveFixture(
+        forcedAfterValue: 40,
+        controlsViewInitiallySelected: true,
+        viewMenuReadFailsAfterFirstSelection: true
+    )
+    let result = await runLive(fixture: fixture, params: thresholdParams())
+
+    let error = try #require(result["error"] as? String)
+    let restorationFailureWasVisible = reportsFailedPluginViewRestoration(result)
+    let reportedReadbackMismatch = error == "readback_mismatch"
+    #expect(reportedReadbackMismatch)
+    #expect(restorationFailureWasVisible)
+}
+
+@Test func testIncrementWalkFailureStateCReportsFailedViewRestore() async throws {
+    let fixture = LiveFixture(
+        thresholdDescription: channelEQFixtureAXDescription,
+        pluginSlotName: "Channel EQ",
+        beforeValue: 0,
+        sliderWriteBehavior: .scripted([0]),
+        controlsViewInitiallySelected: true,
+        viewMenuReadFailsAfterFirstSelection: true
+    )
+    let result = try await runChannelEQFixture(
+        fixture: fixture,
+        params: channelEQFixtureParams(value: "3", unit: "raw_ax_value"),
+        writeMethod: "ax_slider_increment_walk"
+    )
+
+    let error = try #require(result["error"] as? String)
+    let restorationFailureWasVisible = reportsFailedPluginViewRestoration(result)
+    let reportedNoIncrementProgress = error == "increment_walk_no_progress"
+    #expect(reportedNoIncrementProgress)
+    #expect(restorationFailureWasVisible)
+}
+
+@Test func testUnreadableDirectBeforeStateRefusesWithoutWriting() async throws {
+    let fixture = LiveFixture(
+        sliderBeforeReadable: false,
+        controlsViewInitiallySelected: true,
+        viewMenuReadFailsAfterFirstSelection: true
+    )
+    let result = await runLive(fixture: fixture, params: thresholdParams())
+
+    let error = try #require(result["error"] as? String)
+    let writeAttempted = try #require(result["write_attempted"] as? Bool)
+    let restorationFailureWasVisible = reportsFailedPluginViewRestoration(result)
+    let noSliderWrite = fixture.sliderWriteCount.value == 0
+    let reportedReadbackUnavailable = error == "readback_unavailable"
+    let writeWasNotAttempted = !writeAttempted
+    #expect(reportedReadbackUnavailable)
+    #expect(writeWasNotAttempted)
+    #expect(restorationFailureWasVisible)
+    #expect(noSliderWrite)
 }
 
 @Test func testWithinToleranceStillStateA() async {

--- a/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
+++ b/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
@@ -89,6 +89,8 @@ private final class LiveFixture: @unchecked Sendable {
         pluginWindowTitleReadFails: Bool = false,
         pluginWindowsReadStatusBeforeTargetOpen: AXHelpers.AXStatusError? = nil,
         nonPluginWindowSubroleReadStatus: AXHelpers.AXStatusError? = nil,
+        sliderDescriptionReadStatuses: MutableBox<[Int: AXHelpers.AXStatusError]>? = nil,
+        pluginWindowStaticTextValueReadStatuses: MutableBox<[Int: AXHelpers.AXStatusError]>? = nil,
         // An already-visible editor whose title becomes the target track only
         // after the slot press. This models an existing AX element being
         // retargeted by an unrelated UI transition; duplicate acquisition must
@@ -366,6 +368,14 @@ private final class LiveFixture: @unchecked Sendable {
                    CFEqual(element, pluginWindow),
                    attribute == (kAXTitleAttribute as String) {
                     return .failure(AXHelpers.AXStatusError(raw: AXError.failure.rawValue))
+                }
+                if let status = sliderDescriptionReadStatuses?.value[b.elementID(element)],
+                   attribute == (kAXDescriptionAttribute as String) {
+                    return .failure(status)
+                }
+                if let status = pluginWindowStaticTextValueReadStatuses?.value[b.elementID(element)],
+                   attribute == (kAXValueAttribute as String) {
+                    return .failure(status)
                 }
                 return nil
             },
@@ -2758,7 +2768,7 @@ private func namedEQBandParams(
 }
 
 @Test func testAmbiguousRequestedSlidersFailClosed() async throws {
-    let fixture = LiveFixture(beforeValue: 51)
+    let fixture = LiveFixture(beforeValue: 51, pluginWindowPresent: false)
     let b = fixture.builder
     let duplicateSlider = b.element(3200)
     b.setAttribute(duplicateSlider, kAXRoleAttribute as String, kAXSliderRole as String)
@@ -2769,13 +2779,23 @@ private func namedEQBandParams(
         b.element(1011), b.element(1009),
     ])
 
-    let obj = await runLive(fixture: fixture, params: thresholdParams())
+    let openedWindow = AXUIElementSendable(b.element(1004))
+    let obj = await runLive(
+        fixture: fixture,
+        params: thresholdParams(),
+        opener: { _, _, _, _, _ in
+            b.setAttribute(fixture.app, kAXWindowsAttribute as String, [b.element(1001), b.element(1004)])
+            return openedWindow
+        }
+    )
 
-    #expect(obj["state"] as? String == "C")
-    #expect(obj["error"] as? String == "window_identity_unresolved")
-    let v1 = try #require(obj["write_attempted"] as? Bool)
-    #expect(!v1)
-    #expect(fixture.currentSliderValue == 51)
+    let state = try #require(obj["state"] as? String)
+    let error = try #require(obj["error"] as? String)
+    let writeAttempted = try #require(obj["write_attempted"] as? Bool)
+    let refusedAsAmbiguous = state == "C" && error == "window_identity_unresolved"
+    let noSliderWriteWasAttempted = !writeAttempted && fixture.currentSliderValue == 51
+    #expect(refusedAsAmbiguous)
+    #expect(noSliderWriteWasAttempted)
 }
 
 @Test func testOpenerFallbackProducesStateA() async {
@@ -2831,6 +2851,152 @@ private func namedEQBandParams(
 }
 
 // MARK: - State C: slider not found → param_control_not_found
+
+@Test func testMatchingSliderDescriptionWinsOverAnUnrelatedDescriptionReadFailure() async throws {
+    let descriptionStatuses = MutableBox<[Int: AXHelpers.AXStatusError]>([:])
+    let fixture = LiveFixture(
+        beforeValue: 51,
+        sliderDescriptionReadStatuses: descriptionStatuses
+    )
+    let b = fixture.builder
+    let unreadableSlider = b.element(32_101)
+    b.setAttribute(unreadableSlider, kAXRoleAttribute as String, kAXSliderRole as String)
+    descriptionStatuses.value[b.elementID(unreadableSlider)] = AXHelpers.AXStatusError(
+        raw: AXError.failure.rawValue
+    )
+    b.setChildren(b.element(1004), [
+        b.element(1007), b.element(1008), unreadableSlider, b.element(1005),
+        b.element(1011), b.element(1009),
+    ])
+
+    let result = await runLive(fixture: fixture, params: thresholdParams(value: "60"))
+
+    let state = try #require(result["state"] as? String)
+    let reachedVerifiedWrite = state == "A"
+    let writeWasAttempted = fixture.sliderWriteCount.value == 1
+    let matchingSliderWasWritten = fixture.currentSliderValue == 60
+    #expect(reachedVerifiedWrite)
+    #expect(writeWasAttempted)
+    #expect(matchingSliderWasWritten)
+}
+
+@Test func testUnmatchedSliderDescriptionReadFailureRefusesAsUnknown() async throws {
+    let descriptionStatuses = MutableBox<[Int: AXHelpers.AXStatusError]>([:])
+    let fixture = LiveFixture(
+        thresholdDescription: "Output Gain",
+        pluginWindowPresent: false,
+        sliderDescriptionReadStatuses: descriptionStatuses
+    )
+    let b = fixture.builder
+    let unreadableSlider = b.element(32_102)
+    b.setAttribute(unreadableSlider, kAXRoleAttribute as String, kAXSliderRole as String)
+    descriptionStatuses.value[b.elementID(unreadableSlider)] = AXHelpers.AXStatusError(
+        raw: AXError.failure.rawValue
+    )
+    b.setChildren(b.element(1004), [
+        b.element(1007), b.element(1008), unreadableSlider, b.element(1005),
+        b.element(1011), b.element(1009),
+    ])
+    let openedWindow = AXUIElementSendable(b.element(1004))
+
+    let result = await runLive(
+        fixture: fixture,
+        params: thresholdParams(),
+        opener: { _, _, _, _, _ in openedWindow }
+    )
+
+    let error = try #require(result["error"] as? String)
+    let readFailure = try #require(result["slider_description_read_failure"] as? String)
+    let writeAttempted = try #require(result["write_attempted"] as? Bool)
+    let refusedAsUnknown = error == "window_identity_unresolved"
+    let namesTheAXReadFailure = readFailure == "-25200"
+    let didNotClaimControlWasAbsent = error != "param_control_not_found"
+    let noSliderWriteWasAttempted = !writeAttempted && fixture.sliderWriteCount.value == 0
+    #expect(refusedAsUnknown)
+    #expect(namesTheAXReadFailure)
+    #expect(didNotClaimControlWasAbsent)
+    #expect(noSliderWriteWasAttempted)
+}
+
+@Test func testUnmatchedSliderDescriptionsWithOnlyAbsenceAndSuccessAreNotFound() async throws {
+    let descriptionStatuses = MutableBox<[Int: AXHelpers.AXStatusError]>([:])
+    let fixture = LiveFixture(
+        thresholdDescription: "Output Gain",
+        pluginWindowPresent: false,
+        sliderDescriptionReadStatuses: descriptionStatuses
+    )
+    let b = fixture.builder
+    let noValueSlider = b.element(32_103)
+    let unsupportedSlider = b.element(32_104)
+    b.setAttribute(noValueSlider, kAXRoleAttribute as String, kAXSliderRole as String)
+    b.setAttribute(unsupportedSlider, kAXRoleAttribute as String, kAXSliderRole as String)
+    descriptionStatuses.value[b.elementID(noValueSlider)] = AXHelpers.AXStatusError(
+        raw: AXError.noValue.rawValue
+    )
+    descriptionStatuses.value[b.elementID(unsupportedSlider)] = AXHelpers.AXStatusError(
+        raw: AXError.attributeUnsupported.rawValue
+    )
+    b.setChildren(b.element(1004), [
+        b.element(1007), b.element(1008), noValueSlider, unsupportedSlider, b.element(1005),
+        b.element(1011), b.element(1009),
+    ])
+    let openedWindow = AXUIElementSendable(b.element(1004))
+
+    let result = await runLive(
+        fixture: fixture,
+        params: thresholdParams(),
+        opener: { _, _, _, _, _ in openedWindow }
+    )
+
+    let error = try #require(result["error"] as? String)
+    let writeAttempted = try #require(result["write_attempted"] as? Bool)
+    let reportedObservedAbsence = error == "param_control_not_found"
+    let noReadFailureWasInvented = result["slider_description_read_failure"] == nil
+    let noSliderWriteWasAttempted = !writeAttempted && fixture.sliderWriteCount.value == 0
+    #expect(reportedObservedAbsence)
+    #expect(noReadFailureWasInvented)
+    #expect(noSliderWriteWasAttempted)
+}
+
+@Test func testBypassEvidenceWinsOverAnUnrelatedLabelReadFailure() async throws {
+    let descriptionStatuses = MutableBox<[Int: AXHelpers.AXStatusError]>([:])
+    let fixture = LiveFixture(
+        beforeValue: 51,
+        sliderDescriptionReadStatuses: descriptionStatuses
+    )
+    let b = fixture.builder
+    descriptionStatuses.value[b.elementID(b.element(1008))] = AXHelpers.AXStatusError(
+        raw: AXError.failure.rawValue
+    )
+
+    let result = await runLive(fixture: fixture, params: thresholdParams(value: "60"))
+
+    let state = try #require(result["state"] as? String)
+    let reachedVerifiedWrite = state == "A"
+    let matchingSliderWasWritten = fixture.currentSliderValue == 60
+    #expect(reachedVerifiedWrite)
+    #expect(matchingSliderWasWritten)
+}
+
+@Test func testPluginHeaderEvidenceWinsOverAnUnrelatedStaticTextReadFailure() async throws {
+    let staticTextStatuses = MutableBox<[Int: AXHelpers.AXStatusError]>([:])
+    let fixture = LiveFixture(
+        beforeValue: 51,
+        pluginWindowStaticTextValueReadStatuses: staticTextStatuses
+    )
+    let b = fixture.builder
+    staticTextStatuses.value[b.elementID(b.element(1010))] = AXHelpers.AXStatusError(
+        raw: AXError.failure.rawValue
+    )
+
+    let result = await runLive(fixture: fixture, params: thresholdParams(value: "60"))
+
+    let state = try #require(result["state"] as? String)
+    let reachedVerifiedWrite = state == "A"
+    let matchingSliderWasWritten = fixture.currentSliderValue == 60
+    #expect(reachedVerifiedWrite)
+    #expect(matchingSliderWasWritten)
+}
 
 @Test func testWindowWithoutMatchingSliderIsParamControlNotFound() async {
     // The window exists and is titled with the track name, but its only slider

--- a/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
+++ b/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
@@ -103,6 +103,7 @@ private final class LiveFixture: @unchecked Sendable {
         viewMenuSelectionSetsUnconfirmedStructure: Bool = false,
         viewMenuBecomesUnavailableAfterControlsSelection: Bool = false,
         viewMenuReadFailsAfterFirstSelection: Bool = false,
+        controlsTableReadFailsAfterRestoration: Bool = false,
         invalidateTargetSlotAfterViewSelection: Bool = false,
         mutatePluginHeaderAfterViewSelection: Bool = false,
         ambiguousEditorSliderAfterViewSelection: Bool = false,
@@ -361,6 +362,11 @@ private final class LiveFixture: @unchecked Sendable {
                     b.setChildren(pluginWindow, pending.children)
                     pendingPluginWindowChildren.value = nil
                 }
+                if controlsTableReadFailsAfterRestoration,
+                   CFEqual(element, controlsTable),
+                   controlsViewMenuPressCount.value > 0 {
+                    return .failure(AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue))
+                }
                 guard CFEqual(element, controlsViewSwitcher), menuOpen.value else { return nil }
                 if viewMenuReadFailsAfterFirstSelection,
                    controlsViewMenuPressCount.value + editorViewMenuPressCount.value > 0 {
@@ -606,11 +612,14 @@ private func runLive(
 
 private func reportsFailedPluginViewRestoration(_ envelope: [String: Any]) -> Bool {
     guard let attempted = envelope["plugin_view_restore_attempted"] as? Bool,
-          let observed = envelope["plugin_view_restore_observed"] as? Bool,
-          let leftChanged = envelope["plugin_view_left_changed"] as? Bool else {
+          let observed = envelope["plugin_view_restore_observed"] as? Bool else {
         return false
     }
-    return attempted && !observed && leftChanged
+    if let leftChanged = envelope["plugin_view_left_changed"] as? Bool {
+        return attempted && !observed && leftChanged
+    }
+    let restorationWasUnobserved = envelope["plugin_view_restore_unobserved"] as? Bool ?? false
+    return attempted && !observed && restorationWasUnobserved
 }
 
 /// A second same-track Compressor editor for the duplicate-insert post-count
@@ -1277,7 +1286,29 @@ private func namedEQBandParams(
     #expect(fixtureWasLeftInControls)
 }
 
-@Test func testInitialViewConfirmationFailureReportsItsFailedCompensatingRestore() async throws {
+@Test func testUnobservedRestoreDoesNotClaimTheRestoredEntryViewWasLeftChanged() async throws {
+    let fixture = LiveFixture(
+        controlsViewInitiallySelected: true,
+        controlsTableReadFailsAfterRestoration: true
+    )
+    let result = await runLive(fixture: fixture, params: thresholdParams(value: "60"))
+
+    let state = try #require(result["state"] as? String)
+    let restoreAttempted = try #require(result["plugin_view_restore_attempted"] as? Bool)
+    let restoreObserved = try #require(result["plugin_view_restore_observed"] as? Bool)
+    let restorationWasReportedUnobserved = try #require(result["plugin_view_restore_unobserved"] as? Bool)
+    let entryViewWasActuallyReselected = fixture.currentPluginViewTitle == "컨트롤"
+    let leftChangedWasNotAsserted = result["plugin_view_left_changed"] == nil
+    let writeReachedStateA = state == "A"
+    let restoreAttemptWasUnconfirmed = restoreAttempted && !restoreObserved
+    #expect(writeReachedStateA)
+    #expect(restoreAttemptWasUnconfirmed)
+    #expect(restorationWasReportedUnobserved)
+    #expect(entryViewWasActuallyReselected)
+    #expect(leftChangedWasNotAsserted)
+}
+
+@Test func testNoTableConfirmsEditorBeforeTheFailedCompensatingRestore() async throws {
     let fixture = LiveFixture(
         controlsViewInitiallySelected: true,
         viewMenuSelectionSetsUnconfirmedStructure: true,
@@ -1288,8 +1319,8 @@ private func namedEQBandParams(
     let error = try #require(result["error"] as? String)
     let restorationFailureWasVisible = reportsFailedPluginViewRestoration(result)
     let noSliderWrite = fixture.sliderWriteCount.value == 0
-    let reportedPluginViewNotConfirmed = error == "plugin_view_not_confirmed"
-    #expect(reportedPluginViewNotConfirmed)
+    let reportedMissingEditorControl = error == "param_control_not_found"
+    #expect(reportedMissingEditorControl)
     #expect(restorationFailureWasVisible)
     #expect(noSliderWrite)
 }

--- a/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
+++ b/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
@@ -87,6 +87,8 @@ private final class LiveFixture: @unchecked Sendable {
         sliderUsesSignedPositiveDisplay: Bool = false,
         pluginWindowStaticTextValues: [String]? = nil,
         pluginWindowTitleReadFails: Bool = false,
+        pluginWindowsReadStatusBeforeTargetOpen: AXHelpers.AXStatusError? = nil,
+        nonPluginWindowSubroleReadStatus: AXHelpers.AXStatusError? = nil,
         // An already-visible editor whose title becomes the target track only
         // after the slot press. This models an existing AX element being
         // retargeted by an unrelated UI transition; duplicate acquisition must
@@ -340,6 +342,8 @@ private final class LiveFixture: @unchecked Sendable {
         let editorWindowChildren = pluginWindowChildren
         let forced = forcedAfterValue
         let writeBehavior = sliderWriteBehavior
+        let pluginWindowsReadStatusBeforeTargetOpen = pluginWindowsReadStatusBeforeTargetOpen
+        let nonPluginWindowSubroleReadStatus = nonPluginWindowSubroleReadStatus
         let menuOpen = MutableBox(false)
         let menuVisible = MutableBox(false)
         let menuCensusPolls = MutableBox(0)
@@ -347,6 +351,17 @@ private final class LiveFixture: @unchecked Sendable {
         let runtime = b.makeLogicRuntime(
             appElement: app,
             attributeValueResultHandler: { element, attribute in
+                if let status = pluginWindowsReadStatusBeforeTargetOpen,
+                   CFEqual(element, app),
+                   attribute == (kAXWindowsAttribute as String),
+                   targetOpenControlPressCount.value == 0 {
+                    return .failure(status)
+                }
+                if let status = nonPluginWindowSubroleReadStatus,
+                   CFEqual(element, arrangeWindow),
+                   attribute == (kAXSubroleAttribute as String) {
+                    return .failure(status)
+                }
                 if pluginWindowTitleReadFails,
                    CFEqual(element, pluginWindow),
                    attribute == (kAXTitleAttribute as String) {
@@ -1792,6 +1807,119 @@ private func namedEQBandParams(
     #expect(noTargetSlotPress)
 }
 
+@Test func testDuplicatePrecountTreatsNoValueAXWindowsAsEmptyAndWrites() async throws {
+    let fixture = LiveFixture(
+        beforeValue: 51,
+        pluginWindowPresent: false,
+        openWindowOnSlotPress: true,
+        pluginSlotNamesByTrack: [0: [0: "Compressor", 6: "Compressor"]],
+        pluginWindowsReadStatusBeforeTargetOpen: AXHelpers.AXStatusError(
+            raw: AXError.noValue.rawValue
+        )
+    )
+
+    let result = await runLive(fixture: fixture, params: thresholdParams())
+    let absencePrecountReachedTheWrite = result["state"] as? String == "A"
+        && fixture.targetOpenControlPressCount.value == 1
+        && fixture.currentSliderValue == 60
+    #expect(absencePrecountReachedTheWrite)
+}
+
+@Test func testDuplicatePrecountPreservesCannotCompleteAsARefusal() async throws {
+    let fixture = LiveFixture(
+        beforeValue: 51,
+        pluginWindowPresent: false,
+        openWindowOnSlotPress: true,
+        pluginSlotNamesByTrack: [0: [0: "Compressor", 6: "Compressor"]],
+        pluginWindowsReadStatusBeforeTargetOpen: AXHelpers.AXStatusError(
+            raw: AXError.cannotComplete.rawValue
+        )
+    )
+
+    let result = await runLive(fixture: fixture, params: thresholdParams())
+    let unreadablePrecountRefusedBeforeThePress = result["state"] as? String == "C"
+        && result["error"] as? String == "window_identity_unresolved"
+        && result["plugin_window_read_failure"] as? String == "-25204"
+        && fixture.targetOpenControlPressCount.value == 0
+        && fixture.currentSliderValue == 51
+    #expect(unreadablePrecountRefusedBeforeThePress)
+}
+
+@Test func testPluginEditorEnumerationTreatsDefinitiveAXAbsenceAsEmpty() {
+    let absenceStatuses = [AXError.noValue.rawValue, AXError.attributeUnsupported.rawValue]
+    let everyAbsenceWasAnEmptyCensus = absenceStatuses.allSatisfy { rawStatus in
+        let fixture = LiveFixture(
+            pluginWindowsReadStatusBeforeTargetOpen: AXHelpers.AXStatusError(raw: rawStatus)
+        )
+        switch AXLogicProElements.pluginEditorWindows(runtime: fixture.runtime) {
+        case let .success(editors):
+            return editors.isEmpty
+        case .failure:
+            return false
+        }
+    }
+    #expect(everyAbsenceWasAnEmptyCensus)
+}
+
+@Test func testPluginEditorEnumerationPreservesCannotCompleteAsAReadFailure() {
+    let fixture = LiveFixture(
+        pluginWindowsReadStatusBeforeTargetOpen: AXHelpers.AXStatusError(
+            raw: AXError.cannotComplete.rawValue
+        )
+    )
+    let result = AXLogicProElements.pluginEditorWindows(runtime: fixture.runtime)
+    let cannotCompleteWasPreserved: Bool
+    switch result {
+    case let .failure(error):
+        cannotCompleteWasPreserved = error.raw == AXError.cannotComplete.rawValue
+    case .success:
+        cannotCompleteWasPreserved = false
+    }
+    #expect(cannotCompleteWasPreserved)
+}
+
+@Test func testPluginWindowClassificationTreatsDefinitiveAXAbsenceAsANonCandidate() {
+    let absenceStatuses = [AXError.noValue.rawValue, AXError.attributeUnsupported.rawValue]
+    let everyAbsenceLeftTheReadableEditorClassified = absenceStatuses.allSatisfy { rawStatus in
+        let fixture = LiveFixture(
+            nonPluginWindowSubroleReadStatus: AXHelpers.AXStatusError(raw: rawStatus)
+        )
+        let match = AXLogicProElements.pluginWindowMatch(
+            forTrackName: trackName,
+            matchingPluginID: "logic.stock.effect.compressor",
+            matchingSliderDescription: "Threshold",
+            runtime: fixture.runtime
+        )
+        if case .unique = match {
+            return true
+        }
+        return false
+    }
+    #expect(everyAbsenceLeftTheReadableEditorClassified)
+}
+
+@Test func testPluginWindowClassificationPreservesCannotCompleteAsUnreadable() {
+    let fixture = LiveFixture(
+        nonPluginWindowSubroleReadStatus: AXHelpers.AXStatusError(
+            raw: AXError.cannotComplete.rawValue
+        )
+    )
+    let match = AXLogicProElements.pluginWindowMatch(
+        forTrackName: trackName,
+        matchingPluginID: "logic.stock.effect.compressor",
+        matchingSliderDescription: "Threshold",
+        runtime: fixture.runtime
+    )
+    let cannotCompleteWasUnreadable: Bool
+    switch match {
+    case let .unreadable(error):
+        cannotCompleteWasUnreadable = error.raw == AXError.cannotComplete.rawValue
+    case .none, .unique, .ambiguous, .pluginIdentityMismatch:
+        cannotCompleteWasUnreadable = false
+    }
+    #expect(cannotCompleteWasUnreadable)
+}
+
 @Test func testDuplicatePluginWithTwoEditorsAfterOnePressRefuses() async throws {
     let fixture = LiveFixture(
         beforeValue: 51,
@@ -2938,6 +3066,41 @@ private final class Counter: @unchecked Sendable {
 }
 
 // MARK: - #726 the operation closes the editor it opened
+
+@Test func testNormalAcquisitionViewRefusalClosesTheEditorItOpened() async {
+    // This is the normal (non-duplicate) acquisition path: the target-slot
+    // press opens an editor, then View selection refuses before any parameter
+    // write. The operation owns that newly observed editor even on State C.
+    let fixture = LiveFixture(
+        pluginWindowPresent: false,
+        openWindowOnSlotPress: true,
+        controlsViewRowLabel: "Limiter On",
+        viewMenuSelectionSetsUnconfirmedStructure: true,
+        viewSettleDelay: 0
+    )
+
+    let result = await runLive(
+        fixture: fixture,
+        params: controlsBooleanParams()
+    )
+    // Probe AXWindows directly instead of reusing the writer's plugin-editor
+    // classifier: the cleanup proof must still see an editor if that classifier
+    // is ever changed to omit one.
+    let independentAXProbeFoundNoEditor: Bool
+    if let windows = fixture.builder.attributeValue(
+        fixture.app,
+        kAXWindowsAttribute as String
+    ) as? [AXUIElement] {
+        independentAXProbeFoundNoEditor = windows.count == 1
+    } else {
+        independentAXProbeFoundNoEditor = false
+    }
+    let refusalClosedItsNewEditor = result["state"] as? String == "C"
+        && result["error"] as? String == "plugin_view_not_confirmed"
+        && fixture.pluginCloseControlPressCount.value == 1
+        && independentAXProbeFoundNoEditor
+    #expect(refusalClosedItsNewEditor)
+}
 
 @Test func testDuplicateAcquisitionClosesTheEditorItOpened() async throws {
     // Measured live: writing insert 0 then insert 2 on a two-Compressor track

--- a/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
+++ b/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
@@ -36,6 +36,9 @@ private enum SliderWriteBehavior: Sendable {
 
 private enum ControlsCheckboxWriteBehavior: Sendable, Equatable {
     case toggle
+    /// The first requested transition reads back as AX's mixed/indeterminate
+    /// state. `NSNumber.boolValue` would incorrectly call this true.
+    case mixedAfterPress
     /// AXPress reports status 0/accepted but the checkbox AXValue is inert.
     /// This is the exact observation that prevents a status-only success.
     case statusZeroUnchanged
@@ -94,7 +97,8 @@ private final class LiveFixture: @unchecked Sendable {
         controlsViewInitiallySelected: Bool = false,
         pluginWindowViewSwitcherDescription: String = "보기",
         viewMenuPressChangesStructure: Bool = true,
-        viewMenuPressChangesTitle: Bool = true
+        viewMenuPressChangesTitle: Bool = true,
+        viewMenuBecomesUnavailableAfterControlsSelection: Bool = false
     ) {
         let b = builder
         let windowsAddedOnSlotPress = MutableBox<[AXUIElement]>([])
@@ -247,32 +251,35 @@ private final class LiveFixture: @unchecked Sendable {
         b.setRole(editorViewMenuItem, kAXMenuItemRole as String)
         b.setAttribute(editorViewMenuItem, kAXTitleAttribute as String, "편집기")
         b.setChildren(controlsViewMenu, [controlsViewMenuItem, editorViewMenuItem])
-        b.setChildren(controlsViewSwitcher, [controlsViewMenu])
         pluginWindowChildren += [controlsViewSwitcher]
         var controlsViewWindowChildren = [pluginBypass, pluginLink]
             + staticTexts
             + [controlsViewSwitcher]
-        // Controls view itself is identified by its rows, whether or not this
-        // particular test also supplies a writable labelled control.
+        // Controls view itself is identified by a parameter row whose label
+        // and control occupy sibling AXCells. Keep that measured shape even
+        // when this fixture is exercising an editor-slider write rather than
+        // a Controls-view checkbox write.
         b.setRole(controlsTable, kAXTableRole as String)
         b.setRole(controlsRow, kAXRowRole as String)
         b.setChildren(controlsTable, [controlsRow])
         b.setAttribute(controlsTable, kAXRowsAttribute as String, [controlsRow])
         controlsViewWindowChildren += [controlsTable]
-        if let controlsViewRowLabel {
-            b.setRole(controlsLabelCell, kAXCellRole as String)
-            b.setRole(controlsControlCell, kAXCellRole as String)
-            b.setRole(controlsLabel, kAXStaticTextRole as String)
-            b.setAttribute(controlsLabel, kAXValueAttribute as String, controlsViewRowLabel)
-            b.setRole(controlsCheckbox, controlsViewControlRole)
-            b.setAttribute(controlsCheckbox, kAXValueAttribute as String, controlsCheckboxBefore)
-            b.setChildren(controlsLabelCell, [controlsLabel])
-            b.setChildren(controlsControlCell, [controlsCheckbox])
-            b.setChildren(controlsRow, [controlsLabelCell, controlsControlCell])
-            // Controls view has rows, but no editor-view slider descriptions.
-            // Keep its shape distinct from the native editor so a test cannot
-            // accidentally keep relying on Threshold after the view changes.
-        }
+        b.setRole(controlsLabelCell, kAXCellRole as String)
+        b.setRole(controlsControlCell, kAXCellRole as String)
+        b.setRole(controlsLabel, kAXStaticTextRole as String)
+        b.setAttribute(
+            controlsLabel,
+            kAXValueAttribute as String,
+            controlsViewRowLabel ?? "Measured Controls Parameter"
+        )
+        b.setRole(controlsCheckbox, controlsViewControlRole)
+        b.setAttribute(controlsCheckbox, kAXValueAttribute as String, controlsCheckboxBefore)
+        b.setChildren(controlsLabelCell, [controlsLabel])
+        b.setChildren(controlsControlCell, [controlsCheckbox])
+        b.setChildren(controlsRow, [controlsLabelCell, controlsControlCell])
+        // Controls view has rows, but no editor-view slider descriptions.
+        // Keep its shape distinct from the native editor so a test cannot
+        // accidentally keep relying on Threshold after the view changes.
         b.setChildren(
             pluginWindow,
             controlsViewInitiallySelected ? controlsViewWindowChildren : pluginWindowChildren
@@ -293,6 +300,7 @@ private final class LiveFixture: @unchecked Sendable {
         let controlsCheckboxKey = b.elementID(controlsCheckbox)
         let controlsViewMenuItemKey = b.elementID(controlsViewMenuItem)
         let editorViewMenuItemKey = b.elementID(editorViewMenuItem)
+        let controlsViewSwitcherKey = b.elementID(controlsViewSwitcher)
         let controlsWindowChildren = controlsViewWindowChildren
         let editorWindowChildren = pluginWindowChildren
         let forced = forcedAfterValue
@@ -345,34 +353,43 @@ private final class LiveFixture: @unchecked Sendable {
                     b.setAttribute(pluginWindow, kAXFocusedAttribute as String, false)
                     return true
                 }
-                guard action == (kAXPressAction as String) else {
-                    return true
-                }
                 let key = b.elementID(el)
-                if key == pluginCloseKey {
-                    pluginCloseControlPressCount.value += 1
-                    if !pluginCloseControlFailsToClose {
-                        b.setAttribute(app, kAXWindowsAttribute as String, [arrangeWindow])
+                if key == controlsViewSwitcherKey {
+                    guard action == (kAXPressAction as String) else { return false }
+                    guard !(viewMenuBecomesUnavailableAfterControlsSelection
+                        && controlsViewMenuPressCount.value > 0) else {
+                        return true
                     }
+                    b.setChildren(controlsViewSwitcher, [controlsViewMenu])
                     return true
                 }
-                if key == controlsViewMenuItemKey {
-                    controlsViewMenuPressCount.value += 1
-                    if viewMenuPressChangesStructure {
-                        b.setChildren(pluginWindow, controlsWindowChildren)
+                if key == controlsViewMenuItemKey || key == editorViewMenuItemKey {
+                    guard action == (kAXPickAction as String) else { return false }
+                    b.setChildren(controlsViewSwitcher, [])
+                    if key == controlsViewMenuItemKey {
+                        controlsViewMenuPressCount.value += 1
+                        if viewMenuPressChangesStructure {
+                            b.setChildren(pluginWindow, controlsWindowChildren)
+                        }
+                        if viewMenuPressChangesTitle {
+                            b.setAttribute(controlsViewSwitcher, kAXTitleAttribute as String, "컨트롤")
+                        }
+                        return true
                     }
-                    if viewMenuPressChangesTitle {
-                        b.setAttribute(controlsViewSwitcher, kAXTitleAttribute as String, "컨트롤")
-                    }
-                    return true
-                }
-                if key == editorViewMenuItemKey {
                     editorViewMenuPressCount.value += 1
                     if viewMenuPressChangesStructure {
                         b.setChildren(pluginWindow, editorWindowChildren)
                     }
                     if viewMenuPressChangesTitle {
                         b.setAttribute(controlsViewSwitcher, kAXTitleAttribute as String, "편집기")
+                    }
+                    return true
+                }
+                guard action == (kAXPressAction as String) else { return true }
+                if key == pluginCloseKey {
+                    pluginCloseControlPressCount.value += 1
+                    if !pluginCloseControlFailsToClose {
+                        b.setAttribute(app, kAXWindowsAttribute as String, [arrangeWindow])
                     }
                     return true
                 }
@@ -384,6 +401,10 @@ private final class LiveFixture: @unchecked Sendable {
                             ?? (b.attributeValue(controlsCheckbox, kAXValueAttribute as String) as? Bool)
                             ?? false
                         b.setAttribute(controlsCheckbox, kAXValueAttribute as String, !old)
+                        return true
+                    }
+                    if controlsCheckboxWriteBehavior == .mixedAfterPress {
+                        b.setAttribute(controlsCheckbox, kAXValueAttribute as String, NSNumber(value: 2))
                         return true
                     }
                     // Core AX returns status 0 for a successful action. Keep
@@ -1099,6 +1120,49 @@ private func namedEQBandParams(
     #expect(writeAttempted)
     #expect(statusOnlyWasNotSuccess)
     #expect(pressAndRestore)
+}
+
+@Test func testCompressorControlsViewMixedNSNumberReadbackRefusesInsteadOfStateA() async throws {
+    let fixture = LiveFixture(
+        controlsViewRowLabel: "Limiter On",
+        controlsCheckboxBefore: false,
+        controlsCheckboxWriteBehavior: .mixedAfterPress
+    )
+    let result = await runLive(fixture: fixture, params: controlsBooleanParams())
+
+    let state = try #require(result["state"] as? String)
+    let error = try #require(result["error"] as? String)
+    let writeAttempted = try #require(result["write_attempted"] as? Bool)
+    let stateIsC = state == "C"
+    let mixedReadbackWasNotVerified = error == "readback_lost_after_write"
+    let compensatingPressWasAttempted = fixture.controlsCheckboxPressCount.value == 2
+    #expect(stateIsC)
+    #expect(mixedReadbackWasNotVerified)
+    #expect(writeAttempted)
+    #expect(compensatingPressWasAttempted)
+}
+
+@Test func testControlsLookupRefusalReportsFailedRestoreThatLeavesControlsSelected() async throws {
+    let fixture = LiveFixture(
+        controlsViewRowLabel: "A Different Boolean",
+        controlsCheckboxBefore: false,
+        viewMenuBecomesUnavailableAfterControlsSelection: true
+    )
+    let result = await runLive(fixture: fixture, params: controlsBooleanParams())
+
+    let state = try #require(result["state"] as? String)
+    let error = try #require(result["error"] as? String)
+    let restoreAttempted = try #require(result["plugin_view_restore_attempted"] as? Bool)
+    let restoreObserved = try #require(result["plugin_view_restore_observed"] as? Bool)
+    let leftChanged = try #require(result["plugin_view_left_changed"] as? Bool)
+    let observedStructure = try #require(result["plugin_view_restore_observed_structure"] as? String)
+    let lookupRefusalWasStateC = state == "C" && error == "param_control_not_found"
+    let restorationFailureWasVisible = restoreAttempted && !restoreObserved && leftChanged
+    let fixtureWasLeftInControls = fixture.currentPluginViewTitle == "컨트롤"
+    #expect(lookupRefusalWasStateC)
+    #expect(restorationFailureWasVisible)
+    #expect(observedStructure == "controls")
+    #expect(fixtureWasLeftInControls)
 }
 
 @Test func testWithinToleranceStillStateA() async {

--- a/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
+++ b/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
@@ -42,6 +42,9 @@ private enum ControlsCheckboxWriteBehavior: Sendable, Equatable {
     /// AXPress reports status 0/accepted but the checkbox AXValue is inert.
     /// This is the exact observation that prevents a status-only success.
     case statusZeroUnchanged
+    /// The first post-press value is mixed, so compensation is warranted; the
+    /// compensating press lands on `true` rather than the original `false`.
+    case mixedThenChanged
 }
 
 /// A live-path fixture. The slider's AXValueDescription is recomputed from its
@@ -83,6 +86,7 @@ private final class LiveFixture: @unchecked Sendable {
         sliderDisplayUnit: String = "%",
         sliderUsesSignedPositiveDisplay: Bool = false,
         pluginWindowStaticTextValues: [String]? = nil,
+        pluginWindowTitleReadFails: Bool = false,
         // An already-visible editor whose title becomes the target track only
         // after the slot press. This models an existing AX element being
         // retargeted by an unrelated UI transition; duplicate acquisition must
@@ -272,8 +276,10 @@ private final class LiveFixture: @unchecked Sendable {
         b.setRole(controlsViewMenu, kAXMenuRole as String)
         b.setRole(controlsViewMenuItem, kAXMenuItemRole as String)
         b.setAttribute(controlsViewMenuItem, kAXTitleAttribute as String, "컨트롤")
+        b.setAttribute(controlsViewMenuItem, kAXEnabledAttribute as String, true)
         b.setRole(editorViewMenuItem, kAXMenuItemRole as String)
         b.setAttribute(editorViewMenuItem, kAXTitleAttribute as String, "편집기")
+        b.setAttribute(editorViewMenuItem, kAXEnabledAttribute as String, true)
         b.setChildren(controlsViewMenu, [controlsViewMenuItem, editorViewMenuItem])
         pluginWindowChildren += [controlsViewSwitcher]
         var controlsViewWindowChildren = [pluginBypass, pluginLink]
@@ -340,6 +346,14 @@ private final class LiveFixture: @unchecked Sendable {
         let pendingPluginWindowChildren = MutableBox<(children: [AXUIElement], settlesAt: Date)?>(nil)
         let runtime = b.makeLogicRuntime(
             appElement: app,
+            attributeValueResultHandler: { element, attribute in
+                if pluginWindowTitleReadFails,
+                   CFEqual(element, pluginWindow),
+                   attribute == (kAXTitleAttribute as String) {
+                    return .failure(AXHelpers.AXStatusError(raw: AXError.failure.rawValue))
+                }
+                return nil
+            },
             childrenHandler: { element in
                 if CFEqual(element, pluginWindow),
                    let pending = pendingPluginWindowChildren.value,
@@ -514,6 +528,14 @@ private final class LiveFixture: @unchecked Sendable {
                     }
                     if controlsCheckboxWriteBehavior == .mixedAfterPress {
                         b.setAttribute(controlsCheckbox, kAXValueAttribute as String, NSNumber(value: 2))
+                        return true
+                    }
+                    if controlsCheckboxWriteBehavior == .mixedThenChanged {
+                        if controlsCheckboxPressCount.value == 1 {
+                            b.setAttribute(controlsCheckbox, kAXValueAttribute as String, NSNumber(value: 2))
+                        } else {
+                            b.setAttribute(controlsCheckbox, kAXValueAttribute as String, true)
+                        }
                         return true
                     }
                     // Core AX returns status 0 for a successful action. Keep
@@ -1221,7 +1243,7 @@ private func namedEQBandParams(
     #expect(oneVerifiedPress)
 }
 
-@Test func testCompressorControlsViewStatusZeroUnchangedReadbackRefusesAndRestores() async throws {
+@Test func testCompressorControlsViewStatusZeroUnchangedReadbackRefusesWithoutASecondPress() async throws {
     let fixture = LiveFixture(
         controlsViewRowLabel: "Limiter On",
         controlsCheckboxBefore: false,
@@ -1234,13 +1256,54 @@ private func namedEQBandParams(
     let restoreObserved = try #require(result["restore_observed"] as? Bool)
     let writeAttempted = try #require(result["write_attempted"] as? Bool)
     let statusOnlyWasNotSuccess = result["state"] as? String != "A"
-    let pressAndRestore = fixture.controlsCheckboxPressCount.value == 2
+    let noCompensatingPressWasSent = fixture.controlsCheckboxPressCount.value == 1
     #expect(error == "readback_mismatch")
-    #expect(restoreAttempted)
+    #expect(!restoreAttempted)
     #expect(restoreObserved)
     #expect(writeAttempted)
     #expect(statusOnlyWasNotSuccess)
-    #expect(pressAndRestore)
+    #expect(noCompensatingPressWasSent)
+}
+
+@Test func testControlsViewCheckboxAlreadyAtRequestedValueIsVerifiedWithoutActuation() async throws {
+    let fixture = LiveFixture(
+        controlsViewRowLabel: "Limiter On",
+        controlsCheckboxBefore: true
+    )
+    let result = await runLive(fixture: fixture, params: controlsBooleanParams())
+
+    let state = try #require(result["state"] as? String)
+    let verified = try #require(result["verified"] as? Bool)
+    let observed = try #require(result["observed_boolean"] as? Bool)
+    let writeAttempted = try #require(result["write_attempted"] as? Bool)
+    let noCheckboxPress = fixture.controlsCheckboxPressCount.value == 0
+    #expect(state == "A")
+    #expect(verified)
+    #expect(observed)
+    #expect(!writeAttempted)
+    #expect(noCheckboxPress)
+}
+
+@Test func testFailedCompensatingCheckboxPressReportsTheChangedParameter() async throws {
+    let fixture = LiveFixture(
+        controlsViewRowLabel: "Limiter On",
+        controlsCheckboxBefore: false,
+        controlsCheckboxWriteBehavior: .mixedThenChanged
+    )
+    let result = await runLive(fixture: fixture, params: controlsBooleanParams())
+
+    let state = try #require(result["state"] as? String)
+    let leftChanged = try #require(result["parameter_left_changed"] as? Bool)
+    let restorationObserved = try #require(result["restore_observed"] as? Bool)
+    let restoredValue = try #require(result["restore_observed_boolean"] as? Bool)
+    let safeToRetry = try #require(result["safe_to_retry"] as? Bool)
+    let compensationWasAttempted = fixture.controlsCheckboxPressCount.value == 2
+    #expect(state == "C")
+    #expect(leftChanged)
+    #expect(!restorationObserved)
+    #expect(restoredValue)
+    #expect(!safeToRetry)
+    #expect(compensationWasAttempted)
 }
 
 @Test func testCompressorControlsViewMixedNSNumberReadbackRefusesInsteadOfStateA() async throws {
@@ -1682,6 +1745,53 @@ private func namedEQBandParams(
     #expect(fixture.currentSliderValue == 51)
 }
 
+@Test func testUnreadableCompetingEditorMakesWindowUniquenessUndecidable() async throws {
+    let fixture = LiveFixture(
+        beforeValue: 51,
+        pluginWindowTitleReadFails: true
+    )
+    let sibling = matchingCompressorEditorWindow(fixture: fixture, baseID: 9_000)
+    let existingWindows = try #require(
+        fixture.builder.attributeValue(fixture.app, kAXWindowsAttribute as String) as? [AXUIElement]
+    )
+    fixture.builder.setAttribute(
+        fixture.app,
+        kAXWindowsAttribute as String,
+        existingWindows + [sibling.window]
+    )
+    let obj = await runLive(fixture: fixture, params: thresholdParams())
+
+    let state = try #require(obj["state"] as? String)
+    let error = try #require(obj["error"] as? String)
+    let diagnostic = try #require(obj["plugin_window_read_failure"] as? String)
+    let writeAttempted = try #require(obj["write_attempted"] as? Bool)
+    let sliderWasUntouched = fixture.currentSliderValue == 51
+    #expect(state == "C")
+    #expect(error == "window_identity_unresolved")
+    #expect(diagnostic == "-25200")
+    #expect(!writeAttempted)
+    #expect(sliderWasUntouched)
+    #expect(fixture.builder.attributeValue(sibling.slider, kAXValueAttribute as String) as? Double == 51)
+}
+
+@Test func testUnreadableEditorDuringDuplicatePrecountRefusesBeforeTargetSlotPress() async throws {
+    let fixture = LiveFixture(
+        beforeValue: 51,
+        pluginSlotNamesByTrack: [0: [0: "Compressor", 6: "Compressor"]],
+        pluginWindowTitleReadFails: true
+    )
+    let obj = await runLive(fixture: fixture, params: thresholdParams())
+
+    let state = try #require(obj["state"] as? String)
+    let error = try #require(obj["error"] as? String)
+    let diagnostic = try #require(obj["plugin_window_read_failure"] as? String)
+    let noTargetSlotPress = fixture.targetOpenControlPressCount.value == 0
+    #expect(state == "C")
+    #expect(error == "window_identity_unresolved")
+    #expect(diagnostic == "-25200")
+    #expect(noTargetSlotPress)
+}
+
 @Test func testDuplicatePluginWithTwoEditorsAfterOnePressRefuses() async throws {
     let fixture = LiveFixture(
         beforeValue: 51,
@@ -1704,11 +1814,17 @@ private func namedEQBandParams(
     // Count-mismatch is an early return, but both editors were newly observed
     // after this operation's press and must not be stranded for the next call.
     #expect(fixture.pluginCloseControlPressCount.value == 1)
-    #expect(AXLogicProElements.matchingPluginEditorWindows(
+    let remainingCensus = AXLogicProElements.matchingPluginEditorWindows(
         forTrackName: trackName,
         matchingPluginID: "logic.stock.effect.compressor",
         runtime: fixture.runtime
-    ).isEmpty)
+    )
+    guard case let .success(remainingEditors) = remainingCensus else {
+        Issue.record("the post-close editor census was unreadable")
+        return
+    }
+    let allNewEditorsWereClosed = remainingEditors.isEmpty
+    #expect(allNewEditorsWereClosed)
 }
 
 @Test func testDuplicateAcquisitionRejectsAnExistingEditorThatOnlyBecomesAMatchAfterPress() async throws {
@@ -2841,11 +2957,17 @@ private final class Counter: @unchecked Sendable {
     let closeObserved = try #require(obj["editor_close_observed"] as? Bool)
     #expect(closeObserved)
     #expect(fixture.pluginCloseControlPressCount.value == 1)
-    #expect(AXLogicProElements.matchingPluginEditorWindows(
+    let remainingCensus = AXLogicProElements.matchingPluginEditorWindows(
         forTrackName: trackName,
         matchingPluginID: "logic.stock.effect.compressor",
         runtime: fixture.runtime
-    ).isEmpty)
+    )
+    guard case let .success(remainingEditors) = remainingCensus else {
+        Issue.record("the post-close editor census was unreadable")
+        return
+    }
+    let constructedEditorWasClosed = remainingEditors.isEmpty
+    #expect(constructedEditorWasClosed)
 }
 
 @Test func testReusedEditorIsNotClosedByTheOperation() async {
@@ -2857,11 +2979,17 @@ private final class Counter: @unchecked Sendable {
 
     #expect(obj["state"] as? String == "A")
     #expect(fixture.pluginCloseControlPressCount.value == 0)
-    #expect(!AXLogicProElements.matchingPluginEditorWindows(
+    let reusableCensus = AXLogicProElements.matchingPluginEditorWindows(
         forTrackName: trackName,
         matchingPluginID: "logic.stock.effect.compressor",
         runtime: fixture.runtime
-    ).isEmpty)
+    )
+    guard case let .success(reusableEditors) = reusableCensus else {
+        Issue.record("the reused-editor census was unreadable")
+        return
+    }
+    let existingEditorRemainedOpen = !reusableEditors.isEmpty
+    #expect(existingEditorRemainedOpen)
 }
 
 @Test func testAnUnverifiableCloseDoesNotChangeTheWriteVerdict() async throws {

--- a/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
+++ b/Tests/LogicProMCPTests/PluginSetParamVerifiedLiveTests.swift
@@ -106,7 +106,7 @@ private final class LiveFixture: @unchecked Sendable {
         invalidateTargetSlotAfterViewSelection: Bool = false,
         mutatePluginHeaderAfterViewSelection: Bool = false,
         ambiguousEditorSliderAfterViewSelection: Bool = false,
-        viewMenuRevealAfterPolls: Int? = 4,
+        viewMenuRevealAfterPolls: Int? = 3,
         viewSettleDelay: TimeInterval = 0.5
     ) {
         let b = builder
@@ -352,6 +352,15 @@ private final class LiveFixture: @unchecked Sendable {
                 return nil
             },
             childrenResultHandler: { element in
+                // The status-preserving censuses read through this seam rather
+                // than `childrenHandler`; advance the same realistic view-settle
+                // state before serving either read path.
+                if CFEqual(element, pluginWindow),
+                   let pending = pendingPluginWindowChildren.value,
+                   Date() >= pending.settlesAt {
+                    b.setChildren(pluginWindow, pending.children)
+                    pendingPluginWindowChildren.value = nil
+                }
                 guard CFEqual(element, controlsViewSwitcher), menuOpen.value else { return nil }
                 if viewMenuReadFailsAfterFirstSelection,
                    controlsViewMenuPressCount.value + editorViewMenuPressCount.value > 0 {
@@ -716,7 +725,8 @@ private func channelEQFixtureEntryLookup(
     writeMethod: String = "ax_slider_axvalue",
     unit: String = "dB",
     acceptedUnits: [String]? = nil,
-    range: StockPluginValueRange = StockPluginValueRange(min: -24, max: 24, defaultValue: 0)
+    range: StockPluginValueRange = StockPluginValueRange(min: -24, max: 24, defaultValue: 0),
+    tolerance: Double = 0.5
 ) -> VerifiedPluginCatalog.EntryLookup {
     { pluginID in
         guard pluginID == "logic.stock.effect.channel_eq" else {
@@ -755,7 +765,7 @@ private func channelEQFixtureEntryLookup(
                     valueRange: range,
                     writeMethod: writeMethod,
                     readbackMethod: "ax_slider_axvalue",
-                    tolerance: 0.5,
+                    tolerance: tolerance,
                     axDescription: channelEQFixtureAXDescription,
                     availabilityState: .verified,
                     provenance: provenance
@@ -818,7 +828,8 @@ private func runChannelEQFixture(
     fixture: LiveFixture,
     params: [String: String],
     writeMethod: String,
-    incrementWalkBudget: Int = ChannelEQBandCatalog.incrementWalkBudget
+    incrementWalkBudget: Int = ChannelEQBandCatalog.incrementWalkBudget,
+    tolerance: Double = 0.5
 ) async throws -> [String: Any] {
     let result = await AccessibilityChannel.defaultSetParamVerified(
         params: params,
@@ -827,7 +838,8 @@ private func runChannelEQFixture(
         entryLookup: channelEQFixtureEntryLookup(
             writeMethod: writeMethod,
             unit: "raw_ax_value",
-            range: StockPluginValueRange(min: 0, max: 10, defaultValue: 0)
+            range: StockPluginValueRange(min: 0, max: 10, defaultValue: 0),
+            tolerance: tolerance
         ),
         paramAliasLookup: channelEQFixtureParamAlias,
         pluginPopupMenuCleaner: { _ in .noPopupObserved },
@@ -911,7 +923,7 @@ private func namedEQBandParams(
         beforeValue: 51,
         controlsViewInitiallySelected: true
     )
-    // A duplicate-applyback session can leave another Compressor editor open.
+    // A duplicate-applyback run can leave another Compressor editor open.
     // It shares the plug-in header identity but belongs to another track, so
     // only the target editor may be switched, searched, and written.
     let other = matchingCompressorEditorWindow(
@@ -1269,8 +1281,7 @@ private func namedEQBandParams(
     let fixture = LiveFixture(
         controlsViewInitiallySelected: true,
         viewMenuSelectionSetsUnconfirmedStructure: true,
-        viewMenuReadFailsAfterFirstSelection: true,
-        viewSettleDelay: 0
+        viewMenuReadFailsAfterFirstSelection: true
     )
     let result = await runLive(fixture: fixture, params: thresholdParams())
 
@@ -1402,6 +1413,34 @@ private func namedEQBandParams(
     #expect(parameterLeftChanged)
     #expect(retryIsNotSafe)
     #expect(restorationFailureWasVisible)
+}
+
+@Test func testDirectRollbackNearMissUsesTheParametersOwnZeroTolerance() async throws {
+    let fixture = LiveFixture(
+        thresholdDescription: channelEQFixtureAXDescription,
+        pluginSlotName: "Channel EQ",
+        beforeValue: 51,
+        // The write's readback is lost; compensation reaches 51.4 rather than
+        // the pre-write 51. This fixture declares tolerance 0 below.
+        sliderWriteBehavior: .scripted([nil, 51.4])
+    )
+    let result = try await runChannelEQFixture(
+        fixture: fixture,
+        params: channelEQFixtureParams(value: "3", unit: "raw_ax_value"),
+        writeMethod: "ax_slider_axvalue",
+        tolerance: 0
+    )
+
+    let rollbackAttempted = try #require(result["rollback_attempted"] as? Bool)
+    let rolledBack = try #require(result["rolled_back"] as? Bool)
+    let rollbackObserved = try #require(result["rollback_observed"] as? Double)
+    let parameterLeftChanged = try #require(result["parameter_left_changed"] as? Bool)
+    let safeToRetry = try #require(result["safe_to_retry"] as? Bool)
+    let exactRestorationWasNotObserved = !rolledBack && rollbackObserved == 51.4
+    let parameterWasLeftChanged = parameterLeftChanged && !safeToRetry
+    #expect(rollbackAttempted)
+    #expect(exactRestorationWasNotObserved)
+    #expect(parameterWasLeftChanged)
 }
 
 @Test func testReadbackMismatchStateCReportsFailedViewRestore() async throws {

--- a/Tests/LogicProMCPTests/PluginSetParamVerifiedTests.swift
+++ b/Tests/LogicProMCPTests/PluginSetParamVerifiedTests.swift
@@ -152,3 +152,42 @@ private func validGainParams(
                 "value \(edge) should pass schema and reach preflight")
     }
 }
+
+// MARK: - ADR-011 / ADR-018 negative Controls-view evidence
+
+@Test func testControlsViewSliderRefusesWithMeasuredNotActuableReason() async throws {
+    let obj = await runSetParam([
+        "track": "0", "insert": "2", "plugin": "Compressor", "param": "Ratio",
+        "value": "4", "unit": "raw_ax_value", "mode": "duplicate_applyback",
+        "project_expected_path": expectedPath,
+    ])
+    let error = try #require(obj["error"] as? String)
+    let observation = try #require(obj["what_was_observed"] as? String)
+    let writeAttempted = try #require(obj["write_attempted"] as? Bool)
+    let namesMeasurement = observation.contains("AXSlider actuation is refused")
+        && observation.contains("direct AXValue set and AXIncrement")
+        && observation.contains("did not change")
+    let didNotFallBackToGenericAllowlistRefusal = !observation.contains("not in the verified allowlist")
+    let didNotAttemptWrite = !writeAttempted
+    #expect(error == "unsupported_param_readback")
+    #expect(namesMeasurement)
+    #expect(didNotFallBackToGenericAllowlistRefusal)
+    #expect(didNotAttemptWrite)
+}
+
+@Test func testControlsViewPopupRefusesWithUnmeasuredReason() async throws {
+    let obj = await runSetParam([
+        "track": "0", "insert": "2", "plugin": "Compressor", "param": "circuit_type",
+        "value": "0", "unit": "enumerated", "mode": "duplicate_applyback",
+        "project_expected_path": expectedPath,
+    ])
+    let error = try #require(obj["error"] as? String)
+    let observation = try #require(obj["what_was_observed"] as? String)
+    let writeAttempted = try #require(obj["write_attempted"] as? Bool)
+    let namesMissingMeasurement = observation.contains("AXPopUpButton actuation is refused")
+        && observation.contains("selection has not been measured")
+    let didNotAttemptWrite = !writeAttempted
+    #expect(error == "unsupported_param_readback")
+    #expect(namesMissingMeasurement)
+    #expect(didNotAttemptWrite)
+}

--- a/Tests/LogicProMCPTests/SemanticOracleTests.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleTests.swift
@@ -682,6 +682,34 @@ struct SemanticOracleStrengthTests {
 
 @Suite("#373 semantic oracle fixtures and mutation")
 struct SemanticOracleMutationTests {
+    @Test func pluginSetParamVerifiedOracleAcceptsCheckboxStateAWithoutWeakeningSliderStateA() throws {
+        let oracle = try #require(SemanticOracleTable.byOperationID[.pluginsSetParamVerified])
+        let sliderFixture = try #require(SemanticOracleFixtures.byOperationID[.pluginsSetParamVerified])
+        let sliderAccepted = try #require(oracle.evaluate(
+            responseData: sliderFixture.responseData,
+            readbackData: sliderFixture.readbackData
+        ))
+        let checkbox = Data(#"{"success":true,"verified":true,"state":"A","hc_schema":2,"operation":"logic_plugins.set_param_verified","target_identity":{"track":0,"insert":0,"plugin_id":"logic.stock.effect.compressor"},"param":"limiter_on","requested_normalized":1,"observed_normalized":1,"requested_boolean":true,"observed_boolean":true,"write_source":"ax_controls_view_checkbox","verify_source":"ax_controls_view_checkbox"}"#.utf8)
+        let checkboxAccepted = try #require(oracle.evaluate(
+            responseData: checkbox,
+            readbackData: Data("{}".utf8)
+        ))
+        let sliderWithoutToleranceAccepted = try #require(oracle.evaluate(
+            responseData: Data(#"{"success":true,"verified":true,"state":"A","hc_schema":2,"operation":"logic_plugins.set_param_verified","target_identity":{},"param":"threshold","requested_normalized":60,"observed_normalized":60,"display_unit":"%","write_source":"ax_plugin_window","verify_source":"ax_plugin_window"}"#.utf8),
+            readbackData: Data("{}".utf8)
+        ))
+        let checkboxMismatchAccepted = try #require(oracle.evaluate(
+            responseData: Data(#"{"success":true,"verified":true,"state":"A","hc_schema":2,"operation":"logic_plugins.set_param_verified","target_identity":{},"param":"limiter_on","requested_boolean":true,"observed_boolean":false,"write_source":"ax_controls_view_checkbox","verify_source":"ax_controls_view_checkbox"}"#.utf8),
+            readbackData: Data("{}".utf8)
+        ))
+        let sliderStillRequiresTolerance = !sliderWithoutToleranceAccepted
+        let checkboxRequiresMatchingBools = !checkboxMismatchAccepted
+        #expect(sliderAccepted)
+        #expect(checkboxAccepted)
+        #expect(sliderStillRequiresTolerance)
+        #expect(checkboxRequiresMatchingBools)
+    }
+
     @Test func everyOracleHasAFixture() {
         let missing = Set(SemanticOracleTable.byOperationID.keys)
             .subtracting(SemanticOracleFixtures.byOperationID.keys)
@@ -1453,7 +1481,7 @@ enum JSONMutator {
     static func mutants(for constraint: OracleConstraint, in root: Any) -> [Mutant] {
         let key = constraint.key
         var mutants: [Mutant] = []
-        if let dropped = remove(root, keyPath: key) {
+        if !key.isEmpty, let dropped = remove(root, keyPath: key) {
             mutants.append(Mutant(label: "drop \(key)", json: dropped))
         }
         switch constraint {
@@ -1604,6 +1632,12 @@ enum JSONMutator {
                 mutants.append(contentsOf: replacements(root, keyB, [
                     ("keyB moved off delta", a - offset + 1),
                 ]))
+            }
+        case let .anyOf(alternatives):
+            for alternative in alternatives {
+                for branchConstraint in alternative {
+                    mutants.append(contentsOf: Self.mutants(for: branchConstraint, in: root))
+                }
             }
         }
         return mutants

--- a/Tests/LogicProMCPTests/StockPluginCatalogTests.swift
+++ b/Tests/LogicProMCPTests/StockPluginCatalogTests.swift
@@ -220,6 +220,47 @@ struct StockPluginValidatorTests {
         #expect(issues.contains { $0.code == "verified_parameter_missing_readback" })
     }
 
+    @Test("verified parameter evidence rejects a missing reverse observation")
+    func verifiedParameterEvidenceRequiresBidirectionalObservation() {
+        let provenance = StockPluginProvenance.verified(
+            source: "release_binary_live_drive",
+            method: "logic_plugins.set_param_verified.ax_controls_view_checkbox_press",
+            observedAt: "2026-09-02T11:30:17+09:00",
+            logicVersion: nil,
+            locale: "ko-KR",
+            evidence: [
+                "operation=logic_plugins.set_param_verified",
+                "write_method=ax_controls_view_checkbox_press",
+                "observed_transition=0->1",
+            ]
+        )
+        let parameter = StockPluginParameterMetadata(
+            id: "limiter_on",
+            displayName: "Limiter On",
+            unit: "boolean",
+            valueRange: StockPluginValueRange(min: 0, max: 1, defaultValue: nil),
+            writeMethod: "ax_controls_view_checkbox_press",
+            readbackMethod: "ax_controls_view_checkbox_value",
+            tolerance: 0,
+            availabilityState: .verified,
+            provenance: provenance
+        )
+        let entries = [
+            makeStockPluginEntry(
+                id: "logic.stock.effect.gain",
+                state: .verified,
+                provenance: provenance,
+                parameters: [parameter]
+            ),
+        ]
+
+        let issues = StockPluginCatalogValidator.validate(entries).issues
+        let rejectedForMissingReverse = issues.contains {
+            $0.code == "verified_parameter_missing_write_observation"
+        }
+        #expect(rejectedForMissingReverse)
+    }
+
     @Test("parameter value ranges and duplicate parameter IDs are validated")
     func parameterSanityValidated() {
         let provenance = StockPluginProvenance.inferred(reason: "fixture")

--- a/Tests/LogicProMCPTests/VerifiedPluginCatalogTests.swift
+++ b/Tests/LogicProMCPTests/VerifiedPluginCatalogTests.swift
@@ -57,10 +57,10 @@ import Testing
         VerifiedPluginCatalog.paramCapability(pluginID: "logic.stock.effect.gain", paramKey: "nope")
             == .unknownParameter
     )
-    // An unknown compressor param is still unknown; `threshold` itself is now
-    // writeReadback (T5) — see testCompressorThresholdCapabilityIsWriteReadback.
+    // Ratio is deliberately known-but-unsupported in Controls view, so use a
+    // genuinely absent Compressor key for the unknown-parameter assertion.
     #expect(
-        VerifiedPluginCatalog.paramCapability(pluginID: "logic.stock.effect.compressor", paramKey: "ratio")
+        VerifiedPluginCatalog.paramCapability(pluginID: "logic.stock.effect.compressor", paramKey: "not_a_compressor_parameter")
             == .unknownParameter
     )
 }


### PR DESCRIPTION
Verified control of the Compressor's Controls-view boolean parameters, and the addressing work three ADRs were waiting on.

## What it does

Logic renders a stock plug-in's Controls view as a table with one row per parameter. The parameter's NAME is on the row, not on the control, so the existing `set_param_verified` path — which matches an `AXSlider` by its own `AXDescription` — cannot address any of them. This adds a locator that binds a row label to the control beside it, and ships the write for the shape that turned out to be actuable and verifiable.

Measured on the live Compressor, the surface splits three ways:

```
CHECKBOX   AXPress 0 -> 1 and 1 -> 0, each with an observed readback.  Shipped.
SLIDER     direct AXValue set and AXIncrement both report success and the value does not move.
           `settable` reads true and the actions advertise AXIncrement. Both lie.  Refused.
POPUP      AXValue reads back the current selection, so it is readable.
           Actuation unmeasured.  Refused, saying so.
```

## Live proof at this head

Driven against a release binary built from this branch, on a live Logic:

```
limiter_on    1 -> State A verified observed true ;  0 -> State A verified observed false
auto_release  0 -> State A verified observed false ; 1 -> State A verified observed true
threshold=56  -> State A verified observed 56 (the existing slider path, unbroken)
repeat call   -> State A verified, write_attempted FALSE (a target already observed is a no-op)
```

24 consecutive calls, every one State A, zero editors left open, and the plug-in back in the native editor view it was found in. Full suite 4,339 tests; live qualification gate `failed=0 of 112`; `live_726_a_refusal_leaves_no_editor_open` 20 records, 0 failures, bound to this head.

## The measurements that shaped it

Four adversarial review passes found defects that no unit suite could see, and each fix rests on a measurement rather than a guess:

- **The row shape.** Every row has exactly ONE `AXCell`; the label `AXStaticText` and the control are SIBLINGS inside it. Rows with the control in a sibling *cell*: 0 of 29. An earlier note said otherwise and the code enforced it, so nothing could ever bind.
- **The view menu.** `AXPress` reveals it after 28-46 ms, `AXPick` selects, and the structure settles 527-785 ms later (ten switches, 25 ms poll). One census taken immediately after the press finds nothing.
- **Reads that fail routinely.** `AXDescription` answers `kAXErrorFailure` on 1 element in the editor view and 14 in Controls view. "No slider carries a description" therefore cannot be observed, so the view is classified on positive evidence — the parameter table — instead.
- **`kAXErrorInvalidUIElement`.** A view re-render invalidates elements mid-census. That is a re-read, not a refusal, and bounding it removed the last intermittent failure (was 2 of 12 calls, now 0 of 24).

## Contract

- A boolean State A requires an observed exact 0 or 1; an indeterminate `NSNumber(2)` refuses.
- Absence and unreadability stay distinct: `kAXErrorNoValue` and `kAXErrorAttributeUnsupported` are absent and take the documented fallback; every other status refuses and names itself.
- Every State C taken after the view was switched carries the restoration outcome, so a caller can tell "I refused and left everything as I found it" from "I refused and your plug-in is in another view".
- The direct slider path refuses without a readable before-value, and a post-write failure attempts the rollback, reads it back, and reports whether the parameter was left changed.
- The catalogue validator now requires a bidirectional observation before a parameter may claim `verified`; both shipped booleans carry one.

Scope stays narrow: stock Compressor only. Third-party Controls views are unmeasured and the catalogue does not claim otherwise.

Refs #299 #292 #306
