### PR TITLE
fix(#736): an endpoint this process created can never be foreign to it

### DIFF
--- a/Sources/LogicProMCP/Channels/ChannelRouter.swift
+++ b/Sources/LogicProMCP/Channels/ChannelRouter.swift
@@ -21,6 +21,7 @@ actor ChannelRouter {
     }
 
     private var channels: [ChannelID: any Channel] = [:]
+    private var channelStartOrder: [ChannelID] = []
 
     // Operations for which an Accessibility `element_not_found` is provably a
     // PRE-WRITE miss, so a later channel may still run. Three conditions must all
@@ -81,7 +82,11 @@ actor ChannelRouter {
     // MARK: - Lifecycle
 
     func register(_ channel: any Channel) {
-        channels[channel.id] = channel
+        // Re-registering the same id replaces the channel but keeps its original
+        // position, so a caller cannot reorder startup by registering twice.
+        if channels.updateValue(channel, forKey: channel.id) == nil {
+            channelStartOrder.append(channel.id)
+        }
     }
 
     func startAll() async -> StartReport {
@@ -89,7 +94,8 @@ actor ChannelRouter {
         var failures: [ChannelID: String] = [:]
         var degraded: [ChannelID: String] = [:]
 
-        for (id, channel) in channels {
+        for id in channelStartOrder {
+            guard let channel = channels[id] else { continue }
             do {
                 try await channel.start()
                 Log.info("Channel \(id.rawValue) started", subsystem: "router")

--- a/Sources/LogicProMCP/Channels/MCUChannel.swift
+++ b/Sources/LogicProMCP/Channels/MCUChannel.swift
@@ -475,14 +475,14 @@ actor MCUChannel: Channel {
             let portName = conn.portName.isEmpty ? "LogicProMCP-MCU-Internal" : conn.portName
             guard census.isObserved,
                   let endpointCount = census.endpointCount,
-                  let hasForeignEndpoint = census.hasForeignEndpoint else {
+                  census.hasForeignEndpoint != nil else {
                 return .unavailable(
                     "MCU feedback not detected: CoreMIDI endpoint census for '\(portName)' is unknown; "
                         + "this server refused to infer port ownership or publish a duplicate (\(census.reason ?? "no reason supplied"))."
                         + workBudgetDetail
                 )
             }
-            if hasForeignEndpoint {
+            if census.hasForeignConflict {
                 return .unavailable(
                     "MCU feedback not detected: \(endpointCount) endpoint(s) named "
                         + "'\(portName)' include one this server did not create. Another server instance "

--- a/Sources/LogicProMCP/MIDI/MIDIEngine.swift
+++ b/Sources/LogicProMCP/MIDI/MIDIEngine.swift
@@ -197,7 +197,7 @@ actor MIDIEngine: CoreMIDIEngineProtocol {
             runtime.disposeClient(createdClient)
             throw MIDIEngineError.sourceCreationFailed(sourceStatus)
         }
-        VirtualMIDIEndpointProcessOwnership.shared.claim(createdSource)
+        runtime.endpointRuntime.claimProcessOwnership(of: createdSource)
         do {
             try assignStableUniqueID(
                 to: createdSource,
@@ -232,7 +232,7 @@ actor MIDIEngine: CoreMIDIEngineProtocol {
             runtime.disposeClient(createdClient)
             throw MIDIEngineError.destinationCreationFailed(destinationStatus)
         }
-        VirtualMIDIEndpointProcessOwnership.shared.claim(createdDestination)
+        runtime.endpointRuntime.claimProcessOwnership(of: createdDestination)
         do {
             try assignStableUniqueID(
                 to: createdDestination,
@@ -366,14 +366,14 @@ actor MIDIEngine: CoreMIDIEngineProtocol {
         let census = runtime.endpointRuntime.census(named: name)
         guard census.isObserved,
               let endpointCount = census.endpointCount,
-              let hasForeignEndpoint = census.hasForeignEndpoint else {
+              census.hasForeignEndpoint != nil else {
             Log.warn(
                 "Virtual MIDI endpoint '\(name)' census is unknown; skipping creation (\(census.reason ?? "no reason supplied"))",
                 subsystem: "midi"
             )
             throw MIDIEngineError.censusUnknown(name: name, census: census)
         }
-        guard !hasForeignEndpoint else {
+        guard !census.hasForeignConflict else {
             Log.warn(
                 "Virtual MIDI endpoint '\(name)' is owned by another instance or is stale; skipping creation "
                     + "(\(endpointCount) matching endpoint(s))",
@@ -412,7 +412,7 @@ actor MIDIEngine: CoreMIDIEngineProtocol {
             )
             return false
         }
-        VirtualMIDIEndpointProcessOwnership.shared.release(endpoint)
+        runtime.endpointRuntime.releaseProcessOwnership(of: endpoint)
         return true
     }
 

--- a/Sources/LogicProMCP/MIDI/MIDIPortManager.swift
+++ b/Sources/LogicProMCP/MIDI/MIDIPortManager.swift
@@ -149,7 +149,7 @@ actor MIDIPortManager: VirtualPortManaging {
         guard status == noErr else {
             throw MIDIPortError.sourceCreationFailed(name, status)
         }
-        VirtualMIDIEndpointProcessOwnership.shared.claim(source)
+        runtime.endpointRuntime.claimProcessOwnership(of: source)
         do {
             try assignStableUniqueID(to: source, name: name, kind: .source)
         } catch {
@@ -163,7 +163,7 @@ actor MIDIPortManager: VirtualPortManaging {
             _ = disposeOwnedEndpoint(source)
             throw MIDIPortError.destinationCreationFailed(name, status)
         }
-        VirtualMIDIEndpointProcessOwnership.shared.claim(dest)
+        runtime.endpointRuntime.claimProcessOwnership(of: dest)
         do {
             try assignStableUniqueID(to: dest, name: name, kind: .destination)
         } catch {
@@ -195,7 +195,7 @@ actor MIDIPortManager: VirtualPortManaging {
         guard status == noErr else {
             throw MIDIPortError.sourceCreationFailed(name, status)
         }
-        VirtualMIDIEndpointProcessOwnership.shared.claim(source)
+        runtime.endpointRuntime.claimProcessOwnership(of: source)
         do {
             try assignStableUniqueID(to: source, name: name, kind: .source)
         } catch {
@@ -264,14 +264,14 @@ actor MIDIPortManager: VirtualPortManaging {
         let census = currentCensus(named: name)
         guard census.isObserved,
               let endpointCount = census.endpointCount,
-              let hasForeignEndpoint = census.hasForeignEndpoint else {
+              census.hasForeignEndpoint != nil else {
             Log.warn(
                 "Virtual MIDI port '\(name)' census is unknown; skipping creation (\(census.reason ?? "no reason supplied"))",
                 subsystem: "midi"
             )
             throw MIDIPortError.censusUnknown(name: name, census: census)
         }
-        guard !hasForeignEndpoint else {
+        guard !census.hasForeignConflict else {
             // The first instance to start owns the ports. A later instance runs
             // degraded and cannot use this MIDI port; if the owner exits, this
             // process does not take over because it created nothing. Restart it.
@@ -313,7 +313,7 @@ actor MIDIPortManager: VirtualPortManaging {
             )
             return false
         }
-        VirtualMIDIEndpointProcessOwnership.shared.release(endpoint)
+        runtime.endpointRuntime.releaseProcessOwnership(of: endpoint)
         return true
     }
 

--- a/Sources/LogicProMCP/MIDI/VirtualMIDIEndpointIdentity.swift
+++ b/Sources/LogicProMCP/MIDI/VirtualMIDIEndpointIdentity.swift
@@ -51,6 +51,14 @@ struct VirtualMIDIEndpointCensus: Sendable, Equatable, Codable {
         state == .observed
     }
 
+    /// A foreign-endpoint conflict requires a concrete, non-empty observation.
+    /// Keep this invariant here instead of asking each creator to reconcile a
+    /// count with a separate Boolean. In particular, an observed empty catalog
+    /// can never be promoted into an ownership conflict.
+    var hasForeignConflict: Bool {
+        isObserved && (endpointCount ?? 0) > 0 && hasForeignEndpoint == true
+    }
+
     enum CodingKeys: String, CodingKey {
         case state
         case endpointCount = "endpoint_count"
@@ -113,6 +121,19 @@ struct VirtualMIDIEndpointRuntime: Sendable {
     let allEndpoints: @Sendable () -> VirtualMIDIEndpointCatalogRead
     let endpointName: @Sendable (_ endpoint: MIDIEndpointRef) -> VirtualMIDIEndpointNameRead
     let setUniqueID: @Sendable (_ endpoint: MIDIEndpointRef, _ uniqueID: Int32) -> OSStatus
+    private let processOwnership: VirtualMIDIEndpointProcessOwnership
+
+    init(
+        allEndpoints: @escaping @Sendable () -> VirtualMIDIEndpointCatalogRead,
+        endpointName: @escaping @Sendable (_ endpoint: MIDIEndpointRef) -> VirtualMIDIEndpointNameRead,
+        setUniqueID: @escaping @Sendable (_ endpoint: MIDIEndpointRef, _ uniqueID: Int32) -> OSStatus,
+        processOwnership: VirtualMIDIEndpointProcessOwnership = .shared
+    ) {
+        self.allEndpoints = allEndpoints
+        self.endpointName = endpointName
+        self.setUniqueID = setUniqueID
+        self.processOwnership = processOwnership
+    }
 
     static let production = Self(
         allEndpoints: { readAllEndpoints() },
@@ -141,10 +162,18 @@ struct VirtualMIDIEndpointRuntime: Sendable {
             return .init(
                 endpointCount: matchingEndpoints.count,
                 hasForeignEndpoint: matchingEndpoints.contains {
-                    !VirtualMIDIEndpointProcessOwnership.shared.contains($0)
+                    !processOwnership.contains($0)
                 }
             )
         }
+    }
+
+    func claimProcessOwnership(of endpoint: MIDIEndpointRef) {
+        processOwnership.claim(endpoint)
+    }
+
+    func releaseProcessOwnership(of endpoint: MIDIEndpointRef) {
+        processOwnership.release(endpoint)
     }
 
     /// `MIDIGetNumberOfSources` and `MIDIGetNumberOfDestinations` return zero

--- a/Tests/LogicProMCPTests/ChannelRouterTests.swift
+++ b/Tests/LogicProMCPTests/ChannelRouterTests.swift
@@ -114,6 +114,42 @@ private actor StopAllCompletionProbe {
     }
 }
 
+private actor StartOrderRecorder {
+    private var started: [ChannelID] = []
+
+    func record(_ id: ChannelID) {
+        started.append(id)
+    }
+
+    func snapshot() -> [ChannelID] {
+        started
+    }
+}
+
+private actor OrderedStartChannel: Channel {
+    nonisolated let id: ChannelID
+    private let recorder: StartOrderRecorder
+
+    init(id: ChannelID, recorder: StartOrderRecorder) {
+        self.id = id
+        self.recorder = recorder
+    }
+
+    func start() async throws {
+        await recorder.record(id)
+    }
+
+    func stop() async {}
+
+    func execute(operation: String, params: [String: String]) async -> ChannelResult {
+        .success("ordered start channel")
+    }
+
+    func healthCheck() async -> ChannelHealth {
+        .healthy(detail: "ordered start channel")
+    }
+}
+
 private func waitUntil(
     timeoutNanoseconds: UInt64 = 1_000_000_000,
     pollIntervalNanoseconds: UInt64 = 5_000_000,
@@ -645,6 +681,21 @@ private func verifiedReadbackMismatchEnvelope() -> String {
     #expect(report.started.contains(.coreMIDI))
     #expect(report.failures[.appleScript] != nil)
     #expect(report.hasFailures)
+}
+
+@Test func issue736RouterStartsChannelsInRegistrationOrder() async {
+    let router = ChannelRouter()
+    let recorder = StartOrderRecorder()
+    let registeredOrder: [ChannelID] = [.mcu, .midiKeyCommands, .scripter, .coreMIDI]
+
+    for id in registeredOrder {
+        await router.register(OrderedStartChannel(id: id, recorder: recorder))
+    }
+    _ = await router.startAll()
+
+    let observedOrder = await recorder.snapshot()
+    let preservesRegistrationOrder = observedOrder == registeredOrder
+    #expect(preservesRegistrationOrder)
 }
 
 @Test func testRouterStartAllTreatsOptionalStartupFailureAsDegraded() async {

--- a/Tests/LogicProMCPTests/MCUChannelTests.swift
+++ b/Tests/LogicProMCPTests/MCUChannelTests.swift
@@ -76,6 +76,18 @@ import Testing
     #expect(health.detail.count > 0)
 }
 
+@Test func issue736ObservedEmptyForeignCensusDoesNotClaimAnotherMCUOwner() async {
+    let emptyForeignCensus = VirtualMIDIEndpointCensus(endpointCount: 0, hasForeignEndpoint: true)
+    let transport = MockMCUTransport(endpointCensus: emptyForeignCensus)
+    let channel = MCUChannel(transport: transport, cache: StateCache())
+
+    let health = await channel.healthCheck()
+
+    let doesNotClaimAnotherOwner = !health.detail.contains("did not create")
+        && !health.detail.contains("Another server instance")
+    #expect(doesNotClaimAnotherOwner)
+}
+
 @Test func testMCUStartRequiresFeedbackBeforeHealthy() async throws {
     let transport = MockMCUTransport()
     let cache = StateCache()
@@ -538,7 +550,12 @@ actor MockMCUTransport: MCUTransportProtocol {
     var sentBytes: [[UInt8]] = []
     var startCount = 0
     var stopCount = 0
+    private let endpointCensusValue: VirtualMIDIEndpointCensus
     private var onReceive: (@Sendable (MIDIFeedback.Event) -> Void)?
+
+    init(endpointCensus: VirtualMIDIEndpointCensus = .none) {
+        endpointCensusValue = endpointCensus
+    }
 
     func send(_ bytes: [UInt8]) {
         sentBytes.append(bytes)
@@ -547,6 +564,10 @@ actor MockMCUTransport: MCUTransportProtocol {
     func start(onReceive: @escaping @Sendable (MIDIFeedback.Event) -> Void) async throws {
         startCount += 1
         self.onReceive = onReceive
+    }
+
+    func endpointCensus() -> VirtualMIDIEndpointCensus {
+        endpointCensusValue
     }
 
     func stop() {

--- a/Tests/LogicProMCPTests/MIDIEngineTests.swift
+++ b/Tests/LogicProMCPTests/MIDIEngineTests.swift
@@ -57,7 +57,9 @@ private final class MIDIEngineRuntimeHarness: @unchecked Sendable {
     private var notificationHandler: (@Sendable (Int32) -> Void)?
     private var lifecycleEvents: [String] = []
 
-    func makeRuntime() -> MIDIEngine.Runtime {
+    func makeRuntime(
+        processOwnership: VirtualMIDIEndpointProcessOwnership = .shared
+    ) -> MIDIEngine.Runtime {
         MIDIEngine.Runtime(
             createClient: { [self] name, onNotification in
                 withLock {
@@ -114,7 +116,8 @@ private final class MIDIEngineRuntimeHarness: @unchecked Sendable {
             endpointRuntime: .init(
                 allEndpoints: { [self] in self.allEndpoints() },
                 endpointName: { [self] endpoint in self.endpointName(endpoint) },
-                setUniqueID: { [self] endpoint, uniqueID in self.setUniqueID(endpoint, uniqueID: uniqueID) }
+                setUniqueID: { [self] endpoint, uniqueID in self.setUniqueID(endpoint, uniqueID: uniqueID) },
+                processOwnership: processOwnership
             ),
             acquireOwnershipLock: { [self] in acquireOwnershipLock() }
         )
@@ -402,34 +405,75 @@ private final class MIDIEngineRuntimeHarness: @unchecked Sendable {
     #expect(snapshot.createDestinationCalls == 0)
 }
 
+@Test func issue736ObservedEmptyCensusCannotReportAnOwnershipConflict() {
+    let emptyCensus = VirtualMIDIEndpointCensus(endpointCount: 0, hasForeignEndpoint: true)
+
+    let reportsConflict = emptyCensus.hasForeignConflict
+    let doesNotReportConflict = !reportsConflict
+
+    #expect(doesNotReportConflict)
+}
+
 @Test func issue736MIDIEngineOwnershipIsSharedWithPortManager() async throws {
+    let processOwnership = VirtualMIDIEndpointProcessOwnership()
     let engineHarness = MIDIEngineRuntimeHarness()
-    let engine = MIDIEngine(runtime: engineHarness.makeRuntime())
+    let engine = MIDIEngine(runtime: engineHarness.makeRuntime(processOwnership: processOwnership))
     try await engine.start()
 
     let managerHarness = MIDIPortRuntimeHarness()
     managerHarness.foreignEndpointsByName[ServerConfig.virtualMIDISourceName] = [engineHarness.createdSource]
-    let manager = MIDIPortManager(runtime: managerHarness.runtime())
+    let manager = MIDIPortManager(runtime: managerHarness.runtime(processOwnership: processOwnership))
     try await manager.start()
 
-    let channel = CoreMIDIChannel(engine: engine, portManager: manager)
-    let router = ChannelRouter()
-    await router.register(channel)
-    let response = await MIDIDispatcher.handle(
-        command: "create_virtual_port",
-        params: ["name": .string(ServerConfig.virtualMIDISourceName)],
-        router: router,
-        cache: StateCache()
-    )
-
-    #expect(!(response.isError!), "our MIDIEngine endpoint must not be reported as foreign: \(sharedToolText(response))")
-    let envelope = try #require(sharedJSONObject(sharedToolText(response)))
-    #expect(envelope["port_name"] as? String == ServerConfig.virtualMIDISourceName)
-    let createdSources = managerHarness.createdSources
-    #expect(createdSources == [ServerConfig.virtualMIDISourceName])
+    let census = await manager.endpointCensus(name: ServerConfig.virtualMIDISourceName)
+    let hasForeignEndpoint = try #require(census.hasForeignEndpoint as Bool?)
+    let treatsEngineEndpointAsLocal = !hasForeignEndpoint
+    #expect(treatsEngineEndpointAsLocal)
 
     await manager.stop()
     await engine.stop()
+}
+
+@Test func issue736EndpointClaimedByAnotherProcessStillConflicts() async throws {
+    let otherProcessOwnership = VirtualMIDIEndpointProcessOwnership()
+    let thisProcessOwnership = VirtualMIDIEndpointProcessOwnership()
+    let portName = ServerConfig.virtualMIDISourceName
+    let otherProcessHarness = MIDIEngineRuntimeHarness()
+    let otherProcessEngine = MIDIEngine(
+        runtime: otherProcessHarness.makeRuntime(processOwnership: otherProcessOwnership)
+    )
+    try await otherProcessEngine.start()
+    // This testing process also has a claim for the same integer reference.
+    // A census must use *its configured process registry*, not whichever
+    // process-wide singleton happens to contain the reference.
+    VirtualMIDIEndpointProcessOwnership.shared.claim(otherProcessHarness.createdSource)
+
+    let harness = MIDIPortRuntimeHarness()
+    harness.foreignEndpointsByName[portName] = [otherProcessHarness.createdSource]
+    let manager = MIDIPortManager(runtime: harness.runtime(processOwnership: thisProcessOwnership))
+    try await manager.start()
+
+    var conflict: MIDIPortError?
+    do {
+        _ = try await manager.createSendOnlyPort(name: portName)
+        Issue.record("Expected the other process endpoint to be refused")
+    } catch let error as MIDIPortError {
+        conflict = error
+    }
+
+    guard case .foreignEndpointConflict(name: let rejectedName, census: let census)? = conflict else {
+        Issue.record("Expected foreign endpoint conflict, got: \(String(describing: conflict))")
+        await manager.stop()
+        VirtualMIDIEndpointProcessOwnership.shared.release(otherProcessHarness.createdSource)
+        await otherProcessEngine.stop()
+        return
+    }
+    let isOtherProcessEndpoint = rejectedName == portName && census.hasForeignConflict
+    #expect(isOtherProcessEndpoint)
+
+    await manager.stop()
+    VirtualMIDIEndpointProcessOwnership.shared.release(otherProcessHarness.createdSource)
+    await otherProcessEngine.stop()
 }
 
 @Test func issue736OwnershipConflictSurvivesToCoreMIDIOperationResponse() async throws {

--- a/Tests/LogicProMCPTests/MIDIPortTests.swift
+++ b/Tests/LogicProMCPTests/MIDIPortTests.swift
@@ -33,7 +33,9 @@ final class MIDIPortRuntimeHarness: @unchecked Sendable {
     private var claimedUniqueIDs: [Int32: MIDIEndpointRef] = [:]
     private var lifecycleEvents: [String] = []
 
-    func runtime() -> MIDIPortManager.Runtime {
+    func runtime(
+        processOwnership: VirtualMIDIEndpointProcessOwnership = .shared
+    ) -> MIDIPortManager.Runtime {
         MIDIPortManager.Runtime(
             createClient: { name, client in
                 self.createClient(name: name, client: &client)
@@ -53,7 +55,8 @@ final class MIDIPortRuntimeHarness: @unchecked Sendable {
             endpointRuntime: .init(
                 allEndpoints: { self.allEndpoints() },
                 endpointName: { endpoint in self.endpointName(endpoint) },
-                setUniqueID: { endpoint, uniqueID in self.setUniqueID(endpoint, uniqueID: uniqueID) }
+                setUniqueID: { endpoint, uniqueID in self.setUniqueID(endpoint, uniqueID: uniqueID) },
+                processOwnership: processOwnership
             ),
             acquireOwnershipLock: { self.acquireOwnershipLock() }
         )


### PR DESCRIPTION
Hardening for the virtual MIDI endpoint ownership check, plus a deterministic channel startup order.

## What it changes

Ownership was decided from a reference set reached through a global registry rather than from the runtime the actor was given. In production both actors already consulted the same process-wide registry, so this is not a defect anyone could have hit there. What it fixes is that an injected runtime could disagree with the process it belongs to — the configuration the tests exercise, and the one a future caller would trip over.

- The claim and release go through the endpoint runtime, so a process has one ownership view whichever actor created the endpoint.
- A conflict requires a concrete non-empty observation: `hasForeignConflict` is `isObserved && endpointCount > 0 && hasForeignEndpoint`. A census that saw nothing can no longer become a conflict — the earlier message could say "1 matching endpoint(s)" while the machine had none. Health reporting uses the same invariant, so an observed-empty census cannot diagnose another owner there either.
- Channel startup keeps registration order instead of iterating a dictionary, and re-registering an id replaces the channel without moving its position.

## What is measured, and what is not

This is hardening, not a fix for a proven regression. The `midi.list_ports` ownership refusal seen during earlier work is still unexplained as a single-server event: every census taken then was after the run had finished and cleaned up, which cannot describe the moment of the failure, and a clean single run passes.

What is now established is that the refusal reproduces exactly when a SECOND server is up — which is what the qualification suite, or a stray test process, creates. Measured with this build, two servers started 2 s apart, repeated runs, identical every time:

```
baseline           0 LogicProMCP endpoints
after server A     6 entries, 5 distinct names (MCU appears as a source and a destination)
after server B     6 entries, 5 distinct names -- B created NOTHING
A midi.list_ports  answers: 4 LogicProMCP sources, 2 destinations
B midi.list_ports  refuses: channels_exhausted / "MIDI endpoint 'LogicProMCP-MIDI-Internal' ownership conflict"
after both exit    0 LogicProMCP endpoints
```

So two genuinely separate processes still produce the conflict, the second creates no twin, and neither leaks an endpoint on exit. Which instance wins is a startup race: in one run the order reversed and the first server was the one that refused.

## Review

An adversarial review pass found three things, all addressed: the commit message overclaimed what production could have hit (reworded above and in the commit), a test asserted a successful creation using a fake that cannot reproduce CoreMIDI's unique-ID rejection (that assertion is dropped; the census assertion the test exists for is kept), and MCU health bypassed the new non-empty-conflict invariant (it now uses it).

Live qualification gate at this head: `failed=0 of 112`.

Refs #736
