### PR TITLE
feat(#448): verified track sort — the after-read joins by name, and it reaches State A live

### DIFF
--- a/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift
@@ -327,6 +327,63 @@ enum AXLocalePolicy {
         rationale: "Top-level menu titles expose no stable AXIdentifier in Logic."
     )
 
+    /// #448 — Track > Sort Tracks By. Measured on 2026-09-02 on Logic Pro
+    /// 12.3 with a Korean UI as `트랙 › 트랙을 다음으로 정렬`. The menu bar is
+    /// only partly localized, so this policy deliberately has no inferred EN/JA
+    /// form: a locale without this measurement must refuse.
+    static let sortTracksByMenuItem = LabelSet(
+        canonical: "트랙을 다음으로 정렬",
+        variants: [],
+        rationale: "Measured 2026-09-02 on Korean Logic Pro 12.3: Track > Sort Tracks By submenu title. No other locale is measured; never translate this menu label."
+    )
+
+    static let sortTracksMenuPath = MenuPath(
+        bar: trackMenuBar,
+        item: sortTracksByMenuItem
+    )
+
+    static let sortTracksByMIDIChannelMenuItem = LabelSet(
+        canonical: "MIDI 채널",
+        variants: [],
+        rationale: "Measured 2026-09-02 on Korean Logic Pro 12.3 as a Track > Sort Tracks By leaf; no other locale is measured."
+    )
+
+    static let sortTracksByAudioChannelMenuItem = LabelSet(
+        canonical: "오디오 채널",
+        variants: [],
+        rationale: "Measured 2026-09-02 on Korean Logic Pro 12.3 as a Track > Sort Tracks By leaf; no other locale is measured."
+    )
+
+    static let sortTracksByOutputChannelMenuItem = LabelSet(
+        canonical: "출력 채널",
+        variants: [],
+        rationale: "Measured 2026-09-02 on Korean Logic Pro 12.3 as a Track > Sort Tracks By leaf; no other locale is measured."
+    )
+
+    static let sortTracksByInstrumentNameMenuItem = LabelSet(
+        canonical: "악기 이름",
+        variants: [],
+        rationale: "Measured 2026-09-02 on Korean Logic Pro 12.3 as a Track > Sort Tracks By leaf; no other locale is measured."
+    )
+
+    static let sortTracksByTrackNameMenuItem = LabelSet(
+        canonical: "트랙 이름",
+        variants: [],
+        rationale: "Measured 2026-09-02 on Korean Logic Pro 12.3 as a Track > Sort Tracks By leaf; no other locale is measured."
+    )
+
+    static let sortTracksByUsedMenuItem = LabelSet(
+        canonical: "사용 여부",
+        variants: [],
+        rationale: "Measured 2026-09-02 on Korean Logic Pro 12.3 as a Track > Sort Tracks By leaf; no other locale is measured."
+    )
+
+    static let sortTracksByCreationDateMenuItem = LabelSet(
+        canonical: "생성일",
+        variants: [],
+        rationale: "Measured 2026-09-02 on Korean Logic Pro 12.3 as a Track > Sort Tracks By leaf; no other locale is measured."
+    )
+
     /// #519: File > Save As…
     ///
     /// The English label was MEASURED on 2026-08-19 by enumerating the File menu on a live Logic
@@ -1501,6 +1558,14 @@ enum AXLocalePolicy {
         editMenuBar,
         navigateMenuBar,
         trackMenuBar,
+        sortTracksByMenuItem,
+        sortTracksByMIDIChannelMenuItem,
+        sortTracksByAudioChannelMenuItem,
+        sortTracksByOutputChannelMenuItem,
+        sortTracksByInstrumentNameMenuItem,
+        sortTracksByTrackNameMenuItem,
+        sortTracksByUsedMenuItem,
+        sortTracksByCreationDateMenuItem,
         saveAsMenuItem,
         savePanelWindowTitle,
         savePanelPackageRadio,

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+Menu.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+Menu.swift
@@ -1,4 +1,4 @@
-import ApplicationServices
+@preconcurrency import ApplicationServices
 import Foundation
 
 
@@ -7,6 +7,22 @@ extension AXLogicProElements {
 
     private static let englishTopLevelMenuTitles: Set<String> = ["File", "Edit", "Track"]
     private static let koreanTopLevelMenuTitles: Set<String> = ["파일", "편집", "트랙"]
+
+    /// The legacy menu helpers intentionally flatten AX failure to `nil` for
+    /// best-effort callers. A mutation verifier needs the stronger distinction:
+    /// -25205/-25212 say a menu node is absent; every other status means that
+    /// node was not read and must refuse before an action is sent.
+    enum MenuItemRead: Error {
+        case found(AXUIElement)
+        case absent
+        case unreadable(stage: String, status: String)
+    }
+
+    enum LogicUILocaleRead {
+        case locale(String)
+        case absent
+        case unreadable(stage: String, status: String)
+    }
 
     /// Get the menu bar for Logic Pro.
     static func getMenuBar(runtime: Runtime = .production) -> AXUIElement? {
@@ -20,6 +36,49 @@ extension AXLogicProElements {
             AXHelpers.getTitle($0, runtime: runtime.ax)
         }
         return logicUILocaleIdentifier(menuTitles: titles)
+    }
+
+    /// Status-preserving locale read for mutation verification. It is separate
+    /// from `logicUILocaleIdentifier` so historic read-only callers retain their
+    /// best-effort behavior.
+    static func logicUILocaleIdentifierRead(runtime: Runtime = .production) -> LogicUILocaleRead {
+        switch verifiedMenuBarRead(runtime: runtime) {
+        case .absent:
+            return .absent
+        case .unreadable(let stage, let status):
+            return .unreadable(stage: stage, status: status)
+        case .found(let menuBar):
+            switch verifiedMenuChildrenRead(menuBar, stage: "AXMenuBar.AXChildren", runtime: runtime.ax) {
+            case .failure(let result):
+                switch result {
+                case .absent:
+                    return .absent
+                case .unreadable(let stage, let status):
+                    return .unreadable(stage: stage, status: status)
+                case .found:
+                    preconditionFailure("A children read cannot find a menu item")
+                }
+            case .success(let children):
+                var titles: [String] = []
+                for child in children {
+                    switch verifiedMenuTitleRead(child, stage: "AXMenuBarItem.AXTitle", runtime: runtime.ax) {
+                    case .success(let title):
+                        if let title { titles.append(title) }
+                    case .failure(let result):
+                        switch result {
+                        case .absent:
+                            continue
+                        case .unreadable(let stage, let status):
+                            return .unreadable(stage: stage, status: status)
+                        case .found:
+                            preconditionFailure("A title read cannot find a menu item")
+                        }
+                    }
+                }
+                guard let locale = logicUILocaleIdentifier(menuTitles: titles) else { return .absent }
+                return .locale(locale)
+            }
+        }
     }
 
     static func logicUILocaleIdentifier(menuTitles: [String]) -> String? {
@@ -63,6 +122,73 @@ extension AXLogicProElements {
         return current
     }
 
+    /// Status-preserving counterpart to the locale-resolved `menuItem` lookup.
+    /// It is intentionally additive: ordinary callers retain the old
+    /// best-effort result, while a mutation verifier can distinguish a missing
+    /// leaf from the AX failure that prevented it from being examined.
+    static func menuItemRead(
+        labelPath: [AXLocalePolicy.LabelSet],
+        runtime: Runtime = .production
+    ) -> MenuItemRead {
+        switch verifiedMenuBarRead(runtime: runtime) {
+        case .absent:
+            return .absent
+        case .unreadable(let stage, let status):
+            return .unreadable(stage: stage, status: status)
+        case .found(var current):
+            for labels in labelPath {
+                switch verifiedMenuChildrenRead(current, stage: "AXChildren", runtime: runtime.ax) {
+                case .failure(let read):
+                    return read
+                case .success(let children):
+                    var next: AXUIElement?
+                    for child in children {
+                        switch verifiedMenuTitleRead(child, stage: "AXTitle", runtime: runtime.ax) {
+                        case .failure(let read):
+                            if case .absent = read {
+                                break
+                            }
+                            return read
+                        case .success(let title):
+                            if labels.matches(title) {
+                                next = child
+                                break
+                            }
+                        }
+                        if next != nil { break }
+
+                        switch verifiedMenuChildrenRead(child, stage: "AXChildren", runtime: runtime.ax) {
+                        case .failure(let read):
+                            if case .absent = read {
+                                continue
+                            }
+                            return read
+                        case .success(let descendants):
+                            for descendant in descendants {
+                                switch verifiedMenuTitleRead(descendant, stage: "AXTitle", runtime: runtime.ax) {
+                                case .failure(let read):
+                                    if case .absent = read {
+                                        continue
+                                    }
+                                    return read
+                                case .success(let title):
+                                    if labels.matches(title) {
+                                        next = descendant
+                                        break
+                                    }
+                                }
+                            }
+                        }
+                        if next != nil { break }
+                    }
+                    guard let next else { return .absent }
+                    current = next
+                }
+            }
+            return .found(current)
+        }
+    }
+
     static func menuItem(path: [String], runtime: Runtime = .production) -> AXUIElement? {
         guard var current = getMenuBar(runtime: runtime) else { return nil }
         for title in path {
@@ -89,6 +215,56 @@ extension AXLogicProElements {
             if !found { return nil }
         }
         return current
+    }
+
+    private static func verifiedMenuBarRead(runtime: Runtime) -> MenuItemRead {
+        guard let app = appRoot(runtime: runtime) else {
+            return .unreadable(stage: "app_root", status: "unavailable")
+        }
+        switch AXHelpers.getAttributeResult(
+            app, kAXMenuBarAttribute as String, runtime: runtime.ax
+        ) as Result<AXUIElement?, AXHelpers.AXStatusError> {
+        case .success(.some(let menuBar)):
+            return .found(menuBar)
+        case .success(.none):
+            return .absent
+        case .failure(let error) where error.isDefinitiveAbsence:
+            return .absent
+        case .failure(let error):
+            return .unreadable(stage: "AXMenuBar", status: error.diagnosticLabel)
+        }
+    }
+
+    private static func verifiedMenuChildrenRead(
+        _ element: AXUIElement,
+        stage: String,
+        runtime: AXHelpers.Runtime
+    ) -> Result<[AXUIElement], MenuItemRead> {
+        switch AXHelpers.childrenResult(element, runtime: runtime) {
+        case .success(let children):
+            return .success(children)
+        case .failure(let error) where error.isDefinitiveAbsence:
+            return .failure(.absent)
+        case .failure(let error):
+            return .failure(.unreadable(stage: stage, status: error.diagnosticLabel))
+        }
+    }
+
+    private static func verifiedMenuTitleRead(
+        _ element: AXUIElement,
+        stage: String,
+        runtime: AXHelpers.Runtime
+    ) -> Result<String?, MenuItemRead> {
+        switch AXHelpers.getAttributeResult(
+            element, kAXTitleAttribute as String, runtime: runtime
+        ) as Result<String?, AXHelpers.AXStatusError> {
+        case .success(let title):
+            return .success(title)
+        case .failure(let error) where error.isDefinitiveAbsence:
+            return .failure(.absent)
+        case .failure(let error):
+            return .failure(.unreadable(stage: stage, status: error.diagnosticLabel))
+        }
     }
 
 }

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements+Tracks.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements+Tracks.swift
@@ -15,6 +15,14 @@ extension AXLogicProElements {
         case unreadable
     }
 
+    /// Failure-carrying counterpart for a mutation verdict. It is additive so
+    /// callers of `TrackHeaderRead` retain their existing enum contract.
+    enum VerifiedTrackHeaderRead {
+        case read([AXUIElement])
+        case unavailable
+        case unreadable(stage: String, status: String)
+    }
+
     /// Returns true when Logic's main window is the Choose Project picker
     /// (shown when no project is open). Any AXOutline/AXTable inside the picker
     /// describes template choices, NOT tracks — misidentifying them yields
@@ -215,24 +223,54 @@ extension AXLogicProElements {
             return .unavailable
         }
 
-        // Preserve `getTrackHeaders`' established locator order: named list,
-        // named scroll area, structural/labelled group, then trusted
-        // outline/table fallback. Candidate discovery is intentionally tolerant
-        // of an unrelated subtree being mid-load: the question is whether the
-        // Track Headers rail can be read, not whether every descendant of the
-        // arrange window can be read.
+        // Preserve this shared reader's historic tolerance for an unrelated
+        // subtree being mid-load. `allTrackHeadersVerifiedRead` below is the
+        // fail-closed variant used by a mutation verdict.
         let candidates = trackHeaderCandidates(in: window, maxDepth: 32, runtime: runtime.ax)
+        return readTrackHeaderCandidates(candidates, runtime: runtime.ax)
+    }
+
+    /// A verdict-only counterpart to `allTrackHeadersRead`. A generic AX
+    /// failure while finding the rail is not a missing rail; only -25205 and
+    /// -25212 are structural absence. Keeping this variant separate preserves
+    /// the legacy reader's best-effort contract for its existing callers.
+    static func allTrackHeadersVerifiedRead(
+        in window: AXUIElement,
+        runtime: Runtime = .production
+    ) -> VerifiedTrackHeaderRead {
+        guard !isProjectPickerWindow(window, runtime: runtime) else {
+            return .unavailable
+        }
+        switch verifiedTrackHeaderCandidates(in: window, maxDepth: 32, runtime: runtime.ax) {
+        case .complete(let candidates):
+            switch readTrackHeaderCandidates(candidates, runtime: runtime.ax) {
+            case .read(let headers):
+                return .read(headers)
+            case .unavailable:
+                return .unavailable
+            case .unreadable:
+                return .unreadable(stage: "track_header_rows", status: "unreadable")
+            }
+        case .unreadable(let stage, let status):
+            return .unreadable(stage: stage, status: status)
+        }
+    }
+
+    private static func readTrackHeaderCandidates(
+        _ candidates: TrackHeaderCandidates,
+        runtime: AXHelpers.Runtime
+    ) -> TrackHeaderRead {
         for candidate in candidates.lists {
-            return enumerateTrackHeaderRows(in: candidate, runtime: runtime.ax)
+            return enumerateTrackHeaderRows(in: candidate, runtime: runtime)
         }
         for candidate in candidates.scrollAreas {
-            return enumerateTrackHeaderRows(in: candidate, runtime: runtime.ax)
+            return enumerateTrackHeaderRows(in: candidate, runtime: runtime)
         }
         for candidate in candidates.groups {
-            return enumerateTrackHeaderRows(in: candidate, runtime: runtime.ax)
+            return enumerateTrackHeaderRows(in: candidate, runtime: runtime)
         }
         for candidate in candidates.outlinesAndTables {
-            switch AXHelpers.childrenResult(candidate, runtime: runtime.ax) {
+            switch AXHelpers.childrenResult(candidate, runtime: runtime) {
             case .failure:
                 // This candidate was not established as the rail, so an
                 // unrelated outline/table loading underneath the arrange window
@@ -242,7 +280,7 @@ extension AXLogicProElements {
                 var hasLayoutItem = false
                 var childRoleUnreadable = false
                 for child in children {
-                    switch trackStringAttribute(child, kAXRoleAttribute as String, runtime: runtime.ax) {
+                    switch trackStringAttribute(child, kAXRoleAttribute as String, runtime: runtime) {
                     case .success(let role):
                         hasLayoutItem = hasLayoutItem || role == (kAXLayoutItemRole as String)
                     case .failure:
@@ -254,7 +292,7 @@ extension AXLogicProElements {
                 // separately readable rail unavailable.
                 guard !childRoleUnreadable else { continue }
                 if hasLayoutItem {
-                    return enumerateTrackHeaderRows(in: candidate, runtime: runtime.ax)
+                    return enumerateTrackHeaderRows(in: candidate, runtime: runtime)
                 }
             }
         }
@@ -268,12 +306,13 @@ extension AXLogicProElements {
         var outlinesAndTables: [AXUIElement] = []
     }
 
-    /// Discover potential Track Headers rails without making an unrelated AX
-    /// branch part of the rail's read contract. Once a candidate is positively
-    /// identified, `enumerateTrackHeaderRows` resumes strict, status-preserving
-    /// traversal of that candidate itself. A depth cap or AX failure here only
-    /// stops this untrusted branch; it must not turn a separately readable empty
-    /// rail into `.unreadable`.
+    private enum TrackHeaderCandidatesRead {
+        case complete(TrackHeaderCandidates)
+        case unreadable(stage: String, status: String)
+    }
+
+    /// Historic candidate discovery for the shared best-effort read. A verified
+    /// mutation uses `verifiedTrackHeaderCandidates` instead.
     private static func trackHeaderCandidates(
         in root: AXUIElement,
         maxDepth: Int,
@@ -317,6 +356,75 @@ extension AXLogicProElements {
 
         visit(root, remainingDepth: maxDepth)
         return candidates
+    }
+
+    /// Discover potential Track Headers rails while preserving failure status.
+    /// A verified mutation asks whether its complete scope can be enumerated;
+    /// consequently a role or child traversal that cannot be read is not the
+    /// same observation as "no rail exists." The legacy best-effort APIs keep
+    /// their flattening behavior, but this verdict path refuses on every status
+    /// except AX's two definitive-absence answers (-25205/-25212).
+    private static func verifiedTrackHeaderCandidates(
+        in root: AXUIElement,
+        maxDepth: Int,
+        runtime: AXHelpers.Runtime
+    ) -> TrackHeaderCandidatesRead {
+        var candidates = TrackHeaderCandidates()
+        var encounteredUnreadableAX = false
+        var unreadableStage = "track_header_candidate"
+        var unreadableStatus = "unreadable"
+
+        func visit(_ element: AXUIElement, remainingDepth: Int) {
+            guard !encounteredUnreadableAX else { return }
+            switch trackStringAttribute(element, kAXRoleAttribute as String, runtime: runtime) {
+            case .success(.some(let role)):
+                if role == (kAXListRole as String),
+                   case .success(let identifier) = trackStringAttribute(
+                        element, kAXIdentifierAttribute as String, runtime: runtime
+                   ),
+                   identifier == "Track Headers" {
+                    candidates.lists.append(element)
+                } else if role == (kAXScrollAreaRole as String),
+                          case .success(let identifier) = trackStringAttribute(
+                            element, kAXIdentifierAttribute as String, runtime: runtime
+                          ),
+                          identifier == "Tracks" {
+                    candidates.scrollAreas.append(element)
+                } else if role == (kAXGroupRole as String),
+                          isTrackHeadersGroup(element, runtime: runtime) {
+                    candidates.groups.append(element)
+                } else if role == (kAXOutlineRole as String) || role == (kAXTableRole as String) {
+                    candidates.outlinesAndTables.append(element)
+                }
+            case .success(.none):
+                break
+            case .failure(let error):
+                encounteredUnreadableAX = true
+                unreadableStage = "track_header_candidate_role"
+                unreadableStatus = error.diagnosticLabel
+                return
+            }
+
+            guard remainingDepth > 0 else { return }
+            switch AXHelpers.childrenResult(element, runtime: runtime) {
+            case .success(let children):
+                for child in children {
+                    visit(child, remainingDepth: remainingDepth - 1)
+                }
+            case .failure(let error) where error.isDefinitiveAbsence:
+                return
+            case .failure(let error):
+                encounteredUnreadableAX = true
+                unreadableStage = "track_header_candidate_children"
+                unreadableStatus = error.diagnosticLabel
+                return
+            }
+        }
+
+        visit(root, remainingDepth: maxDepth)
+        return encounteredUnreadableAX
+            ? .unreadable(stage: unreadableStage, status: unreadableStatus)
+            : .complete(candidates)
     }
 
     private enum TrackDescendantsRead {

--- a/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
+++ b/Sources/LogicProMCP/Accessibility/AXLogicProElements.swift
@@ -54,6 +54,15 @@ enum AXLogicProElements {
         case unreadable
     }
 
+    /// Status-carrying arrange-window resolution for a mutation verdict. This
+    /// sits beside the established `ArrangeWindowRead` so existing callers do
+    /// not lose their deliberately compact best-effort shape.
+    enum ArrangeWindowVerifiedRead {
+        case found(AXUIElement)
+        case absent
+        case unreadable(stage: String, status: String)
+    }
+
     /// Get the root AX element for Logic Pro. Returns nil if not running.
     static func appRoot(runtime: Runtime = .production) -> AXUIElement? {
         guard let pid = runtime.logicProPID() else { return nil }
@@ -147,6 +156,36 @@ enum AXLogicProElements {
         }
     }
 
+    /// The status-preserving arrange-window variant used when an unreadable
+    /// window list must be reported as a refusal rather than treated like the
+    /// legacy `mainWindow()` empty-list fallback. Only AX's definitive absence
+    /// statuses (-25205/-25212) permit the direct main-window fallback.
+    static func arrangeWindowVerifiedRead(runtime: Runtime = .production) -> ArrangeWindowVerifiedRead {
+        guard let app = appRoot(runtime: runtime) else {
+            return .unreadable(stage: "app_root", status: "unavailable")
+        }
+
+        switch AXHelpers.getAttributeResult(
+            app, kAXWindowsAttribute as String, runtime: runtime.ax
+        ) as Result<[AXUIElement]?, AXHelpers.AXStatusError> {
+        case .success(.some(let windows)) where !windows.isEmpty:
+            let nonDialogs = windows.filter { !isDialogWindow($0, runtime: runtime.ax) }
+            guard !nonDialogs.isEmpty else { return .absent }
+            if let arrange = nonDialogs.first(where: {
+                hasTrackHeadersGroup($0, runtime: runtime.ax)
+            }) {
+                return .found(arrange)
+            }
+            return .found(nonDialogs[0])
+        case .success:
+            return directArrangeWindowVerifiedRead(app: app, runtime: runtime.ax)
+        case .failure(let error) where error.isDefinitiveAbsence:
+            return directArrangeWindowVerifiedRead(app: app, runtime: runtime.ax)
+        case .failure(let error):
+            return .unreadable(stage: "AXWindows", status: error.diagnosticLabel)
+        }
+    }
+
     private static func directArrangeWindowRead(
         app: AXUIElement,
         runtime: AXHelpers.Runtime
@@ -162,6 +201,24 @@ enum AXLogicProElements {
             return .absent
         case .failure:
             return .unreadable
+        }
+    }
+
+    private static func directArrangeWindowVerifiedRead(
+        app: AXUIElement,
+        runtime: AXHelpers.Runtime
+    ) -> ArrangeWindowVerifiedRead {
+        switch AXHelpers.getAttributeResult(
+            app, kAXMainWindowAttribute as String, runtime: runtime
+        ) as Result<AXUIElement?, AXHelpers.AXStatusError> {
+        case .success(.some(let window)):
+            return .found(window)
+        case .success(.none):
+            return .absent
+        case .failure(let error) where error.isDefinitiveAbsence:
+            return .absent
+        case .failure(let error):
+            return .unreadable(stage: "AXMainWindow", status: error.diagnosticLabel)
         }
     }
 

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
@@ -48,12 +48,42 @@ extension AccessibilityChannel {
         var beforeTracks: [TrackState]?
         var afterTracks: [TrackState]?
         var afterReferences: [String]?
-        guard let beforeRead = strictTrackSortStateRead(runtime: runtime) else {
+        var actuatedMenuItem: TrackSortVerifier.ActuatedMenuItem?
+        var menuPressReportedSuccess: Bool?
+        let beforeRead: TrackSortStateRead
+        switch strictTrackSortStateRead(runtime: runtime) {
+        case .read(let read):
+            beforeRead = read
+        case .unavailable:
             return trackSortStateC(
                 .readbackUnavailable,
                 criterion: criterion.rawValue,
                 reason: "before_order_unreadable",
                 hint: "sort_verified refused before the menu action because the full track order could not be read."
+            )
+        case .unreadable(let stage, let status):
+            return trackSortStateC(
+                .readbackUnavailable,
+                criterion: criterion.rawValue,
+                reason: "before_order_read_failed",
+                hint: "sort_verified refused before the menu action because \(stage) could not be read (\(status)).",
+                extras: ["read_failure_stage": stage, "read_failure_status": status]
+            )
+        case .stackStateUnreadable(let index, let name):
+            return trackSortStateC(
+                .readbackUnavailable,
+                criterion: criterion.rawValue,
+                reason: "track_stack_state_unreadable",
+                hint: "sort_verified refused before the menu action because track \(index) ('\(name)') could not prove whether its stack is expanded.",
+                extras: ["unreadable_stack": ["index": index, "name": name]]
+            )
+        case .collapsedStack(let index, let name):
+            return trackSortStateC(
+                .invalidParams,
+                criterion: criterion.rawValue,
+                reason: "collapsed_track_stack",
+                hint: "sort_verified refused before the menu action because track \(index) ('\(name)') is a collapsed stack; expand it and re-read logic://tracks so the complete track order can be checked.",
+                extras: ["collapsed_stack": ["index": index, "name": name]]
             )
         }
         beforeTracks = beforeRead.tracks
@@ -62,14 +92,26 @@ extension AccessibilityChannel {
             expectedOrder: expectedOrder
         )
         guard case .matched(let beforeReferences) = beforeOrder else {
-            let missing = beforeOrder.missingReferences
-            return trackSortStateC(
-                .staleTargetReference,
-                criterion: criterion.rawValue,
-                reason: "expected_order_track_refs_not_in_before_order",
-                hint: "sort_verified expected_order names track references that are not in the current pre-sort order: \(missing.joined(separator: ", ")). Re-read logic://tracks and retry with its current track_ref values.",
-                extras: ["missing_track_refs": missing]
-            )
+            switch beforeOrder {
+            case .missing(let missing):
+                return trackSortStateC(
+                    .staleTargetReference,
+                    criterion: criterion.rawValue,
+                    reason: "expected_order_track_refs_not_in_before_order",
+                    hint: "sort_verified expected_order names track references that are not in the current pre-sort order: \(missing.joined(separator: ", ")). Re-read logic://tracks and retry with its current track_ref values.",
+                    extras: ["missing_track_refs": missing]
+                )
+            case .ambiguous(let references):
+                return trackSortStateC(
+                    .staleTargetReference,
+                    criterion: criterion.rawValue,
+                    reason: "duplicate_name_reference_identity_unprovable",
+                    hint: "sort_verified refused before the menu action because duplicate track names have no issued per-track identity beyond index and name. Rename duplicates and re-read logic://tracks before sorting.",
+                    extras: ["ambiguous_track_refs": references]
+                )
+            case .matched:
+                preconditionFailure("The matched case is handled by the guard")
+            }
         }
         let outcome = TrackSortVerifier.execute(
             criterion: criterion,
@@ -78,51 +120,112 @@ extension AccessibilityChannel {
                 .read(beforeReferences)
             },
             actuate: {
-                let observedLocale = AXLogicProElements.logicUILocaleIdentifier(runtime: runtime)
-                guard let locale = observedLocale,
-                      let measuredLabel = criterion.measuredLabel(for: locale) else {
-                    return .unmeasuredLocale(observedLocale ?? "unknown")
+                let locale: String
+                switch AXLogicProElements.logicUILocaleIdentifierRead(runtime: runtime) {
+                case .locale(let observed):
+                    locale = observed
+                case .absent:
+                    return .unmeasuredLocale("unknown")
+                case .unreadable(let stage, let status):
+                    return .menuReadFailed(stage: stage, status: status)
                 }
-                guard let item = AXLogicProElements.menuItem(
+                guard let measuredLabel = criterion.measuredLabel(for: locale) else {
+                    return .unmeasuredLocale(locale)
+                }
+                let item: AXUIElement
+                switch AXLogicProElements.menuItemRead(
                     labelPath: [
                         AXLocalePolicy.sortTracksMenuPath.bar,
                         AXLocalePolicy.sortTracksMenuPath.item,
                         criterion.label,
                     ],
                     runtime: runtime
-                ) else {
+                ) {
+                case .found(let found):
+                    item = found
+                case .absent:
                     return .criterionLabelMissing(measuredLabel)
+                case .unreadable(let stage, let status):
+                    return .menuReadFailed(stage: stage, status: status)
                 }
-                let enabled: Bool? = AXHelpers.getAttribute(
-                    item,
-                    kAXEnabledAttribute as String,
-                    runtime: runtime.ax
+                let observedLabel: String
+                switch AXHelpers.getAttributeResult(
+                    item, kAXTitleAttribute as String, runtime: runtime.ax
+                ) as Result<String?, AXHelpers.AXStatusError> {
+                case .success(.some(let title)) where !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty:
+                    observedLabel = title
+                case .success(.some), .success(.none):
+                    return .criterionUnverified("unknown")
+                case .failure(let error) where error.isDefinitiveAbsence:
+                    return .criterionUnverified("unknown")
+                case .failure(let error):
+                    return .menuReadFailed(stage: "AXMenuItem.AXTitle", status: error.diagnosticLabel)
+                }
+                guard let observedCriterion = TrackSortCriterion.measuredCriterion(
+                    forObservedMenuItemLabel: observedLabel,
+                    localeIdentifier: locale
+                ) else {
+                    return .criterionUnverified(observedLabel)
+                }
+                let observedItem = TrackSortVerifier.ActuatedMenuItem(
+                    localizedLabel: observedLabel,
+                    criterion: observedCriterion
                 )
-                guard enabled == true else {
-                    return .disabledMenuItem(measuredLabel)
+                guard observedCriterion == criterion else {
+                    return .criterionMismatch(observedItem)
                 }
-                guard AXHelpers.performAction(item, kAXPressAction as String, runtime: runtime.ax) else {
-                    return .pressFailed(measuredLabel)
+                switch AXHelpers.getAttributeResult(
+                    item, kAXEnabledAttribute as String, runtime: runtime.ax
+                ) as Result<Bool?, AXHelpers.AXStatusError> {
+                case .success(.some(true)):
+                    break
+                case .success(.some(false)):
+                    return .disabledMenuItem(observedLabel)
+                case .success(.none):
+                    return .enabledStateUnavailable(observedLabel)
+                case .failure(let error) where error.isDefinitiveAbsence:
+                    return .enabledStateUnavailable(observedLabel)
+                case .failure(let error):
+                    return .menuReadFailed(stage: "AXMenuItem.AXEnabled", status: error.diagnosticLabel)
                 }
-                // The menu action is asynchronous on some Logic builds. The
-                // bounded settle is not proof; the second strict rail read is.
-                usleep(150_000)
-                return .actuated
+                // The menu leaf does not expose a persistent "selected sort"
+                // attribute. Its own title is therefore the only trustworthy
+                // criterion witness: we record the title and its measured mapping
+                // from this exact element before sending AXPress.
+                actuatedMenuItem = observedItem
+                let pressSucceeded = AXHelpers.performAction(
+                    item, kAXPressAction as String, runtime: runtime.ax
+                )
+                menuPressReportedSuccess = pressSucceeded
+                return pressSucceeded ? .actuated(observedItem) : .pressReportedFailure(observedItem)
             },
             after: {
-                guard let afterRead = strictTrackSortStateRead(runtime: runtime) else {
-                    return .unavailable
+                var previousOrder: [String]?
+                // Two equal, independently strict observations are required.
+                // We poll at most four times with 75 ms between later reads
+                // (225 ms after the first read). This bound replaces the old
+                // fixed 150 ms delay, but remains an unmeasured assumption until
+                // a live sort establishes Logic's settling distribution.
+                for attempt in 0..<4 {
+                    if attempt > 0 { usleep(75_000) }
+                    guard case .read(let afterRead) = strictTrackSortStateRead(runtime: runtime) else {
+                        return .unavailable
+                    }
+                    afterTracks = afterRead.tracks
+                    guard let resolvedAfterReferences = trackSortAfterOrder(
+                        headers: afterRead.headers,
+                        beforeHeaders: beforeRead.headers,
+                        beforeReferences: beforeReferences
+                    ) else {
+                        return .unavailable
+                    }
+                    afterReferences = resolvedAfterReferences
+                    if previousOrder == resolvedAfterReferences {
+                        return .read(resolvedAfterReferences)
+                    }
+                    previousOrder = resolvedAfterReferences
                 }
-                afterTracks = afterRead.tracks
-                guard let resolvedAfterReferences = trackSortAfterOrder(
-                    headers: afterRead.headers,
-                    beforeHeaders: beforeRead.headers,
-                    beforeReferences: beforeReferences
-                ) else {
-                    return .unavailable
-                }
-                afterReferences = resolvedAfterReferences
-                return .read(resolvedAfterReferences)
+                return .unavailable
             }
         )
 
@@ -132,7 +235,9 @@ extension AccessibilityChannel {
             beforeOrder: beforeReferences,
             afterOrder: afterReferences,
             before: beforeTracks,
-            after: afterTracks
+            after: afterTracks,
+            actuatedMenuItem: actuatedMenuItem,
+            menuPressReportedSuccess: menuPressReportedSuccess
         )
         switch outcome {
         case .verified:
@@ -153,34 +258,60 @@ extension AccessibilityChannel {
         let tracks: [TrackState]
     }
 
+    private enum StrictTrackSortStateRead {
+        case read(TrackSortStateRead)
+        case unavailable
+        case unreadable(stage: String, status: String)
+        case stackStateUnreadable(index: Int, name: String)
+        case collapsedStack(index: Int, name: String)
+    }
+
     private enum TrackSortBeforeOrder {
         case matched([String])
         case missing([String])
-
-        var missingReferences: [String] {
-            if case .missing(let references) = self { return references }
-            return []
-        }
+        case ambiguous([String])
     }
 
     private static func strictTrackSortStateRead(
         runtime: AXLogicProElements.Runtime
-    ) -> TrackSortStateRead? {
-        guard let window = AXLogicProElements.mainWindow(runtime: runtime),
-              case .read(let headers) = AXLogicProElements.allTrackHeadersRead(in: window, runtime: runtime)
-        else {
-            return nil
+    ) -> StrictTrackSortStateRead {
+        let window: AXUIElement
+        switch AXLogicProElements.arrangeWindowVerifiedRead(runtime: runtime) {
+        case .found(let resolved):
+            window = resolved
+        case .absent:
+            return .unavailable
+        case .unreadable(let stage, let status):
+            return .unreadable(stage: stage, status: status)
+        }
+        let headers: [AXUIElement]
+        switch AXLogicProElements.allTrackHeadersVerifiedRead(in: window, runtime: runtime) {
+        case .read(let read):
+            headers = read
+        case .unavailable:
+            return .unavailable
+        case .unreadable(let stage, let status):
+            return .unreadable(stage: stage, status: status)
         }
         let tracks = headers.enumerated().map { index, header in
             AXValueExtractors.extractTrackState(from: header, index: index, runtime: runtime.ax)
         }
-        guard tracks.allSatisfy({
-            $0.liveIdentityBacked
-                && !$0.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        }) else {
-            return nil
+        for track in tracks {
+            guard track.liveIdentityBacked,
+                  !track.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                return .unreadable(stage: "track_identity", status: "unreadable")
+            }
+            guard let isStackHeader = track.isStackHeader else {
+                return .stackStateUnreadable(index: track.id, name: track.name)
+            }
+            guard !isStackHeader || track.stackCollapsed != nil else {
+                return .stackStateUnreadable(index: track.id, name: track.name)
+            }
+            if isStackHeader, track.stackCollapsed == true {
+                return .collapsedStack(index: track.id, name: track.name)
+            }
         }
-        return TrackSortStateRead(headers: headers, tracks: tracks)
+        return .read(TrackSortStateRead(headers: headers, tracks: tracks))
     }
 
     private static func decodeTrackSortExpectedOrder(_ raw: String?) -> [TrackSortExpectedTrack]? {
@@ -199,14 +330,27 @@ extension AccessibilityChannel {
         return decoded
     }
 
-    /// The reference's pre-sort descriptor can bind each duplicate display name
-    /// to exactly one header. Name matching alone is intentionally absent here.
+    /// TargetDescriptor currently issues only `(index, name)` for a track. That
+    /// is not an identity when any name is duplicated: an out-of-band swap or
+    /// delete/recreate can leave both fields unchanged. Refuse those projects
+    /// rather than silently rebind a reference to whichever same-named header
+    /// now occupies its old index.
     private static func trackSortBeforeOrder(
         tracks: [TrackState],
         expectedOrder: [TrackSortExpectedTrack]
     ) -> TrackSortBeforeOrder {
         guard expectedOrder.count == tracks.count else {
             return .missing(expectedOrder.map(\.reference))
+        }
+        let duplicateNames = Set(
+            Dictionary(grouping: tracks, by: \.name)
+                .filter { $0.value.count > 1 }
+                .keys
+        )
+        if !duplicateNames.isEmpty {
+            return .ambiguous(expectedOrder.compactMap {
+                duplicateNames.contains($0.beforeName) ? $0.reference : nil
+            })
         }
         var order = Array(repeating: "", count: tracks.count)
         var missing: [String] = []
@@ -226,10 +370,11 @@ extension AccessibilityChannel {
         return .matched(order)
     }
 
-    /// Header equality is the measured transaction-local continuity witness:
-    /// the strict reads retain the same AX header objects across the menu press.
-    /// If Logic replaces a header object, we cannot prove which duplicate track
-    /// moved, so the caller receives State B rather than a guessed identity.
+    /// Header equality is an unmeasured transaction-local continuity assumption:
+    /// the #448 fixture reuses fake header objects, but no live sort has yet
+    /// established that Logic retains them across the menu action. If Logic
+    /// replaces a header object, we cannot prove which track moved, so the
+    /// caller receives State B rather than a guessed identity.
     private static func trackSortAfterOrder(
         headers: [AXUIElement],
         beforeHeaders: [AXUIElement],
@@ -258,11 +403,17 @@ extension AccessibilityChannel {
         beforeOrder: [String]?,
         afterOrder: [String]?,
         before: [TrackState]?,
-        after: [TrackState]?
+        after: [TrackState]?,
+        actuatedMenuItem: TrackSortVerifier.ActuatedMenuItem?,
+        menuPressReportedSuccess: Bool?
     ) -> [String: Any] {
         [
             "operation": "track.sort_verified",
             "criterion": criterion.rawValue,
+            "actuated_criterion": actuatedMenuItem?.criterion.rawValue ?? NSNull(),
+            "actuated_menu_item_label": actuatedMenuItem?.localizedLabel ?? NSNull(),
+            "menu_press_reported_success": menuPressReportedSuccess ?? NSNull(),
+            "write_attempted": actuatedMenuItem != nil,
             "expected_order": expectedOrder,
             "before_order": beforeOrder ?? NSNull(),
             "after_order": afterOrder ?? NSNull(),
@@ -341,6 +492,22 @@ extension AccessibilityChannel {
                 hint: "sort_verified expected the measured criterion label '\(label)' in the current Track > Sort Tracks By menu, but it was absent.",
                 extras: extras
             )
+        case .criterionUnverified(let label):
+            return trackSortStateC(
+                .elementNotFound,
+                criterion: criterion.rawValue,
+                reason: "actuated_criterion_unverified",
+                hint: "sort_verified refused because the menu leaf title '\(label)' could not be mapped to a measured sort criterion.",
+                extras: extras
+            )
+        case .criterionMismatch(let actual, let label):
+            return trackSortStateC(
+                .elementNotFound,
+                criterion: criterion.rawValue,
+                reason: "actuated_criterion_did_not_match_requested_criterion",
+                hint: "sort_verified refused because menu leaf '\(label)' maps to '\(actual.rawValue)', not requested criterion '\(criterion.rawValue)'.",
+                extras: extras
+            )
         case .disabledMenuItem(let label):
             return trackSortStateC(
                 .axWriteFailed,
@@ -349,12 +516,20 @@ extension AccessibilityChannel {
                 hint: "sort_verified refused because the measured menu item '\(label)' was disabled; AXPress on a disabled item is not an action.",
                 extras: extras
             )
-        case .menuPressFailed(let label):
+        case .enabledStateUnavailable(let label):
             return trackSortStateC(
-                .axWriteFailed,
+                .readbackUnavailable,
                 criterion: criterion.rawValue,
-                reason: "sort_menu_press_failed",
-                hint: "sort_verified could not press the measured menu item '\(label)'.",
+                reason: "sort_menu_item_enabled_state_unreadable",
+                hint: "sort_verified refused because the enabled state of menu item '\(label)' was unavailable; no AXPress was sent.",
+                extras: extras
+            )
+        case .menuReadFailed(let stage, let status):
+            return trackSortStateC(
+                .readbackUnavailable,
+                criterion: criterion.rawValue,
+                reason: "sort_menu_read_failed",
+                hint: "sort_verified refused because \(stage) could not be read (\(status)); no AXPress was sent.",
                 extras: extras
             )
         }
@@ -366,9 +541,11 @@ extension AccessibilityChannel {
     ) -> ChannelResult {
         var details = extras
         details["write_attempted"] = true
+        details["safe_to_retry"] = false
         switch uncertainty {
         case .afterOrderUnreadable:
             details["detail"] = "after_order_unreadable"
+            details["project_state"] = "unknown"
             return .success(HonestContract.encodeStateB(reason: .readbackUnavailable, extras: details))
         case .afterOrderMismatch:
             details["detail"] = "after_order_did_not_match_requested_criterion"

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
@@ -17,6 +17,264 @@ extension AccessibilityChannel {
         }
     }
 
+    // MARK: - Verified track sort (#448)
+
+    /// Drives the measured Track > Sort Tracks By leaf and verifies the complete
+    /// post-write arrangement order. This path must not reuse the cache: the
+    /// poller can legitimately still hold the pre-sort rail while this mutation
+    /// needs the two reads that bracket its own menu press.
+    static func defaultSortTracks(
+        params: [String: String],
+        runtime: AXLogicProElements.Runtime = .production
+    ) -> ChannelResult {
+        guard let criterionRaw = params["criterion"],
+              let criterion = TrackSortCriterion(rawValue: criterionRaw) else {
+            return trackSortStateC(
+                .invalidParams,
+                criterion: params["criterion"],
+                reason: "unknown_sort_criterion",
+                hint: "sort_verified requires one of: \(TrackSortCriterion.allCases.map(\.rawValue).joined(separator: ", "))"
+            )
+        }
+        guard let expectedOrder = decodeTrackSortExpectedOrder(params["expected_order_json"]) else {
+            return trackSortStateC(
+                .invalidParams,
+                criterion: criterion.rawValue,
+                reason: "expected_order_invalid",
+                hint: "sort_verified requires expected_order as a non-empty array of unique track names."
+            )
+        }
+
+        var beforeTracks: [TrackState]?
+        var afterTracks: [TrackState]?
+        let outcome = TrackSortVerifier.execute(
+            criterion: criterion,
+            expectedOrder: expectedOrder,
+            before: {
+                guard let tracks = strictTrackSortStateRead(runtime: runtime) else {
+                    return .unavailable
+                }
+                beforeTracks = tracks
+                return .read(tracks.map(\.name))
+            },
+            actuate: {
+                let observedLocale = AXLogicProElements.logicUILocaleIdentifier(runtime: runtime)
+                guard let locale = observedLocale,
+                      let measuredLabel = criterion.measuredLabel(for: locale) else {
+                    return .unmeasuredLocale(observedLocale ?? "unknown")
+                }
+                guard let item = AXLogicProElements.menuItem(
+                    labelPath: [
+                        AXLocalePolicy.sortTracksMenuPath.bar,
+                        AXLocalePolicy.sortTracksMenuPath.item,
+                        criterion.label,
+                    ],
+                    runtime: runtime
+                ) else {
+                    return .criterionLabelMissing(measuredLabel)
+                }
+                let enabled: Bool? = AXHelpers.getAttribute(
+                    item,
+                    kAXEnabledAttribute as String,
+                    runtime: runtime.ax
+                )
+                guard enabled == true else {
+                    return .disabledMenuItem(measuredLabel)
+                }
+                guard AXHelpers.performAction(item, kAXPressAction as String, runtime: runtime.ax) else {
+                    return .pressFailed(measuredLabel)
+                }
+                // The menu action is asynchronous on some Logic builds. The
+                // bounded settle is not proof; the second strict rail read is.
+                usleep(150_000)
+                return .actuated
+            },
+            after: {
+                guard let tracks = strictTrackSortStateRead(runtime: runtime) else {
+                    return .unavailable
+                }
+                afterTracks = tracks
+                return .read(tracks.map(\.name))
+            }
+        )
+
+        let evidence = trackSortEvidence(
+            criterion: criterion,
+            expectedOrder: expectedOrder,
+            before: beforeTracks,
+            after: afterTracks
+        )
+        switch outcome {
+        case .verified:
+            return .success(HonestContract.encodeStateA(extras: evidence))
+        case .refused(let refusal):
+            return trackSortRefusal(refusal, criterion: criterion, extras: evidence)
+        case .uncertain(let uncertainty):
+            return trackSortUncertain(uncertainty, extras: evidence)
+        }
+    }
+
+    /// `allTrackHeaders()` intentionally returns an empty array for historic
+    /// best-effort readers. A verified mutation cannot collapse unavailable or
+    /// unreadable into that same empty value, so it uses the status-preserving
+    /// rail reader and requires every row's identity to be readable.
+    private static func strictTrackSortStateRead(
+        runtime: AXLogicProElements.Runtime
+    ) -> [TrackState]? {
+        guard let window = AXLogicProElements.mainWindow(runtime: runtime),
+              case .read(let headers) = AXLogicProElements.allTrackHeadersRead(in: window, runtime: runtime)
+        else {
+            return nil
+        }
+        let tracks = headers.enumerated().map { index, header in
+            AXValueExtractors.extractTrackState(from: header, index: index, runtime: runtime.ax)
+        }
+        guard tracks.allSatisfy({
+            $0.liveIdentityBacked
+                && !$0.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }) else {
+            return nil
+        }
+        return tracks
+    }
+
+    private static func decodeTrackSortExpectedOrder(_ raw: String?) -> [String]? {
+        guard let raw,
+              let data = raw.data(using: .utf8),
+              let decoded = try? JSONDecoder().decode([String].self, from: data),
+              !decoded.isEmpty,
+              decoded.allSatisfy({ !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }),
+              Set(decoded).count == decoded.count else {
+            return nil
+        }
+        return decoded
+    }
+
+    private static func trackSortEvidence(
+        criterion: TrackSortCriterion,
+        expectedOrder: [String],
+        before: [TrackState]?,
+        after: [TrackState]?
+    ) -> [String: Any] {
+        [
+            "operation": "track.sort_verified",
+            "criterion": criterion.rawValue,
+            "expected_order": expectedOrder,
+            "before_order": before?.map(\.name) ?? NSNull(),
+            "after_order": after?.map(\.name) ?? NSNull(),
+            // Preserve the full public order read, not just its name projection.
+            // `id` is the observed arrangement index, and the remaining fields
+            // are the stable `logic://tracks` row shape that accompanied it.
+            "before_tracks": before.map(trackSortTrackList) ?? NSNull(),
+            "after_tracks": after.map(trackSortTrackList) ?? NSNull(),
+            "before_track_count": before?.count ?? NSNull(),
+            "after_track_count": after?.count ?? NSNull(),
+        ]
+    }
+
+    private static func trackSortTrackList(_ tracks: [TrackState]) -> [[String: Any]] {
+        tracks.map { track in
+            [
+                "id": track.id,
+                "name": track.name,
+                "type": track.type.rawValue,
+                "is_stack_header": track.isStackHeader ?? NSNull(),
+                "stack_collapsed": track.stackCollapsed ?? NSNull(),
+            ]
+        }
+    }
+
+    private static func trackSortStateC(
+        _ error: HonestContract.FailureError,
+        criterion: String?,
+        reason: String,
+        hint: String,
+        extras: [String: Any] = [:]
+    ) -> ChannelResult {
+        var details = extras
+        details["operation"] = "track.sort_verified"
+        details["criterion"] = criterion ?? NSNull()
+        details["reason"] = reason
+        details["write_attempted"] = false
+        return .error(HonestContract.encodeStateC(error: error, hint: hint, extras: details))
+    }
+
+    private static func trackSortRefusal(
+        _ refusal: TrackSortVerifier.Refusal,
+        criterion: TrackSortCriterion,
+        extras: [String: Any]
+    ) -> ChannelResult {
+        switch refusal {
+        case .beforeOrderUnreadable:
+            return trackSortStateC(
+                .readbackUnavailable,
+                criterion: criterion.rawValue,
+                reason: "before_order_unreadable",
+                hint: "sort_verified refused before the menu action because the full track order could not be read.",
+                extras: extras
+            )
+        case .expectedOrderIsNotBeforeOrder:
+            return trackSortStateC(
+                .invalidParams,
+                criterion: criterion.rawValue,
+                reason: "expected_order_not_full_before_order",
+                hint: "sort_verified expected_order must name each current track exactly once, so an unrelated order cannot certify a wrong sort.",
+                extras: extras
+            )
+        case .unmeasuredLocale(let locale):
+            return trackSortStateC(
+                .elementNotFound,
+                criterion: criterion.rawValue,
+                reason: "unmeasured_locale_missing_sort_menu_measurement",
+                hint: "sort_verified has no measured Track > Sort Tracks By labels for Logic UI locale '\(locale)'; measure that locale before enabling this command.",
+                extras: extras
+            )
+        case .criterionLabelMissing(let label):
+            return trackSortStateC(
+                .elementNotFound,
+                criterion: criterion.rawValue,
+                reason: "measured_criterion_label_absent",
+                hint: "sort_verified expected the measured criterion label '\(label)' in the current Track > Sort Tracks By menu, but it was absent.",
+                extras: extras
+            )
+        case .disabledMenuItem(let label):
+            return trackSortStateC(
+                .axWriteFailed,
+                criterion: criterion.rawValue,
+                reason: "sort_menu_item_disabled",
+                hint: "sort_verified refused because the measured menu item '\(label)' was disabled; AXPress on a disabled item is not an action.",
+                extras: extras
+            )
+        case .menuPressFailed(let label):
+            return trackSortStateC(
+                .axWriteFailed,
+                criterion: criterion.rawValue,
+                reason: "sort_menu_press_failed",
+                hint: "sort_verified could not press the measured menu item '\(label)'.",
+                extras: extras
+            )
+        }
+    }
+
+    private static func trackSortUncertain(
+        _ uncertainty: TrackSortVerifier.Uncertainty,
+        extras: [String: Any]
+    ) -> ChannelResult {
+        var details = extras
+        details["write_attempted"] = true
+        switch uncertainty {
+        case .afterOrderUnreadable:
+            details["detail"] = "after_order_unreadable"
+            return .success(HonestContract.encodeStateB(reason: .readbackUnavailable, extras: details))
+        case .afterOrderMismatch:
+            details["detail"] = "after_order_did_not_match_requested_criterion"
+            return .success(HonestContract.encodeStateB(reason: .readbackMismatch, extras: details))
+        case .alreadySortedCommandUnobservable:
+            details["detail"] = "already_sorted_command_unobservable"
+            return .success(HonestContract.encodeStateB(reason: .readbackUnavailable, extras: details))
+        }
+    }
+
     static func defaultGetSelectedTrack(runtime: AXLogicProElements.Runtime = .production) -> ChannelResult {
         let headers = AXLogicProElements.allTrackHeaders(runtime: runtime)
         for (index, header) in headers.enumerated() {

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
@@ -41,21 +41,41 @@ extension AccessibilityChannel {
                 .invalidParams,
                 criterion: criterion.rawValue,
                 reason: "expected_order_invalid",
-                hint: "sort_verified requires expected_order as a non-empty array of unique track names."
+                hint: "sort_verified requires expected_order as a non-empty array of unique track_ref values."
             )
         }
 
         var beforeTracks: [TrackState]?
         var afterTracks: [TrackState]?
+        var afterReferences: [String]?
+        guard let beforeRead = strictTrackSortStateRead(runtime: runtime) else {
+            return trackSortStateC(
+                .readbackUnavailable,
+                criterion: criterion.rawValue,
+                reason: "before_order_unreadable",
+                hint: "sort_verified refused before the menu action because the full track order could not be read."
+            )
+        }
+        beforeTracks = beforeRead.tracks
+        let beforeOrder = trackSortBeforeOrder(
+            tracks: beforeRead.tracks,
+            expectedOrder: expectedOrder
+        )
+        guard case .matched(let beforeReferences) = beforeOrder else {
+            let missing = beforeOrder.missingReferences
+            return trackSortStateC(
+                .staleTargetReference,
+                criterion: criterion.rawValue,
+                reason: "expected_order_track_refs_not_in_before_order",
+                hint: "sort_verified expected_order names track references that are not in the current pre-sort order: \(missing.joined(separator: ", ")). Re-read logic://tracks and retry with its current track_ref values.",
+                extras: ["missing_track_refs": missing]
+            )
+        }
         let outcome = TrackSortVerifier.execute(
             criterion: criterion,
-            expectedOrder: expectedOrder,
+            expectedOrder: expectedOrder.map(\.reference),
             before: {
-                guard let tracks = strictTrackSortStateRead(runtime: runtime) else {
-                    return .unavailable
-                }
-                beforeTracks = tracks
-                return .read(tracks.map(\.name))
+                .read(beforeReferences)
             },
             actuate: {
                 let observedLocale = AXLogicProElements.logicUILocaleIdentifier(runtime: runtime)
@@ -90,17 +110,27 @@ extension AccessibilityChannel {
                 return .actuated
             },
             after: {
-                guard let tracks = strictTrackSortStateRead(runtime: runtime) else {
+                guard let afterRead = strictTrackSortStateRead(runtime: runtime) else {
                     return .unavailable
                 }
-                afterTracks = tracks
-                return .read(tracks.map(\.name))
+                afterTracks = afterRead.tracks
+                guard let resolvedAfterReferences = trackSortAfterOrder(
+                    headers: afterRead.headers,
+                    beforeHeaders: beforeRead.headers,
+                    beforeReferences: beforeReferences
+                ) else {
+                    return .unavailable
+                }
+                afterReferences = resolvedAfterReferences
+                return .read(resolvedAfterReferences)
             }
         )
 
         let evidence = trackSortEvidence(
             criterion: criterion,
-            expectedOrder: expectedOrder,
+            expectedOrder: expectedOrder.map(\.reference),
+            beforeOrder: beforeReferences,
+            afterOrder: afterReferences,
             before: beforeTracks,
             after: afterTracks
         )
@@ -118,9 +148,24 @@ extension AccessibilityChannel {
     /// best-effort readers. A verified mutation cannot collapse unavailable or
     /// unreadable into that same empty value, so it uses the status-preserving
     /// rail reader and requires every row's identity to be readable.
+    private struct TrackSortStateRead {
+        let headers: [AXUIElement]
+        let tracks: [TrackState]
+    }
+
+    private enum TrackSortBeforeOrder {
+        case matched([String])
+        case missing([String])
+
+        var missingReferences: [String] {
+            if case .missing(let references) = self { return references }
+            return []
+        }
+    }
+
     private static func strictTrackSortStateRead(
         runtime: AXLogicProElements.Runtime
-    ) -> [TrackState]? {
+    ) -> TrackSortStateRead? {
         guard let window = AXLogicProElements.mainWindow(runtime: runtime),
               case .read(let headers) = AXLogicProElements.allTrackHeadersRead(in: window, runtime: runtime)
         else {
@@ -135,24 +180,83 @@ extension AccessibilityChannel {
         }) else {
             return nil
         }
-        return tracks
+        return TrackSortStateRead(headers: headers, tracks: tracks)
     }
 
-    private static func decodeTrackSortExpectedOrder(_ raw: String?) -> [String]? {
+    private static func decodeTrackSortExpectedOrder(_ raw: String?) -> [TrackSortExpectedTrack]? {
         guard let raw,
               let data = raw.data(using: .utf8),
-              let decoded = try? JSONDecoder().decode([String].self, from: data),
+              let decoded = try? JSONDecoder().decode([TrackSortExpectedTrack].self, from: data),
               !decoded.isEmpty,
-              decoded.allSatisfy({ !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }),
-              Set(decoded).count == decoded.count else {
+              decoded.allSatisfy({
+                  !$0.reference.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                      && $0.beforeIndex >= 0
+                      && !$0.beforeName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+              }),
+              Set(decoded.map(\.reference)).count == decoded.count else {
             return nil
         }
         return decoded
     }
 
+    /// The reference's pre-sort descriptor can bind each duplicate display name
+    /// to exactly one header. Name matching alone is intentionally absent here.
+    private static func trackSortBeforeOrder(
+        tracks: [TrackState],
+        expectedOrder: [TrackSortExpectedTrack]
+    ) -> TrackSortBeforeOrder {
+        guard expectedOrder.count == tracks.count else {
+            return .missing(expectedOrder.map(\.reference))
+        }
+        var order = Array(repeating: "", count: tracks.count)
+        var missing: [String] = []
+        for expected in expectedOrder {
+            guard expected.beforeIndex < tracks.count,
+                  tracks[expected.beforeIndex].name == expected.beforeName,
+                  order[expected.beforeIndex].isEmpty else {
+                missing.append(expected.reference)
+                continue
+            }
+            order[expected.beforeIndex] = expected.reference
+        }
+        let unmatched = order.filter(\.isEmpty)
+        guard missing.isEmpty, unmatched.isEmpty else {
+            return .missing(missing.isEmpty ? expectedOrder.map(\.reference) : missing)
+        }
+        return .matched(order)
+    }
+
+    /// Header equality is the measured transaction-local continuity witness:
+    /// the strict reads retain the same AX header objects across the menu press.
+    /// If Logic replaces a header object, we cannot prove which duplicate track
+    /// moved, so the caller receives State B rather than a guessed identity.
+    private static func trackSortAfterOrder(
+        headers: [AXUIElement],
+        beforeHeaders: [AXUIElement],
+        beforeReferences: [String]
+    ) -> [String]? {
+        guard headers.count == beforeHeaders.count,
+              beforeReferences.count == beforeHeaders.count else {
+            return nil
+        }
+        var matchedBeforeIndexes = Set<Int>()
+        var order: [String] = []
+        order.reserveCapacity(headers.count)
+        for header in headers {
+            guard let beforeIndex = beforeHeaders.firstIndex(where: { CFEqual($0, header) }),
+                  matchedBeforeIndexes.insert(beforeIndex).inserted else {
+                return nil
+            }
+            order.append(beforeReferences[beforeIndex])
+        }
+        return order
+    }
+
     private static func trackSortEvidence(
         criterion: TrackSortCriterion,
         expectedOrder: [String],
+        beforeOrder: [String]?,
+        afterOrder: [String]?,
         before: [TrackState]?,
         after: [TrackState]?
     ) -> [String: Any] {
@@ -160,8 +264,8 @@ extension AccessibilityChannel {
             "operation": "track.sort_verified",
             "criterion": criterion.rawValue,
             "expected_order": expectedOrder,
-            "before_order": before?.map(\.name) ?? NSNull(),
-            "after_order": after?.map(\.name) ?? NSNull(),
+            "before_order": beforeOrder ?? NSNull(),
+            "after_order": afterOrder ?? NSNull(),
             // Preserve the full public order read, not just its name projection.
             // `id` is the observed arrangement index, and the remaining fields
             // are the stable `logic://tracks` row shape that accompanied it.
@@ -218,7 +322,7 @@ extension AccessibilityChannel {
                 .invalidParams,
                 criterion: criterion.rawValue,
                 reason: "expected_order_not_full_before_order",
-                hint: "sort_verified expected_order must name each current track exactly once, so an unrelated order cannot certify a wrong sort.",
+                hint: "sort_verified expected_order must name each current track reference exactly once, so an unrelated order cannot certify a wrong sort.",
                 extras: extras
             )
         case .unmeasuredLocale(let locale):

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
@@ -213,8 +213,8 @@ extension AccessibilityChannel {
                     }
                     afterTracks = afterRead.tracks
                     guard let resolvedAfterReferences = trackSortAfterOrder(
-                        headers: afterRead.headers,
-                        beforeHeaders: beforeRead.headers,
+                        afterNames: afterRead.tracks.map(\.name),
+                        beforeNames: beforeRead.tracks.map(\.name),
                         beforeReferences: beforeReferences
                     ) else {
                         return .unavailable
@@ -370,29 +370,49 @@ extension AccessibilityChannel {
         return .matched(order)
     }
 
-    /// Header equality is an unmeasured transaction-local continuity assumption:
-    /// the #448 fixture reuses fake header objects, but no live sort has yet
-    /// established that Logic retains them across the menu action. If Logic
-    /// replaces a header object, we cannot prove which track moved, so the
-    /// caller receives State B rather than a guessed identity.
-    private static func trackSortAfterOrder(
-        headers: [AXUIElement],
-        beforeHeaders: [AXUIElement],
+    /// Recovers which reference each row holds AFTER the sort, by track name.
+    ///
+    /// This used to join on `AXUIElement` identity, guarded by a comment that called that an
+    /// unmeasured assumption and predicted the failure would be Logic REPLACING a header object,
+    /// costing us the identity and yielding State B. Driven live on Logic Pro 12.3 on 2026-09-03,
+    /// the assumption fails the other way, which is worse: across a sort that demonstrably moved
+    /// the rows, every after-element was `CFEqual` to the before-element at the SAME index while
+    /// the names moved between them. Logic keeps the objects in place and swaps their content.
+    ///
+    /// An identity join therefore returns the identity permutation for every sort, `after_order`
+    /// always equals `before_order`, and the comparison against the caller's expected order can
+    /// only fail — so `sort_verified` could never award State A for any criterion.
+    ///
+    /// Names carry the join instead. That is sound here and only here: this operation has already
+    /// refused a project whose track names are not unique, before any AX work. A duplicate name
+    /// reaching this point means that guard did not hold, and is answered with `nil` (the caller's
+    /// "unreadable") rather than an arbitrary pick.
+    /// `internal`, not `private`: joining on names rather than element handles is what makes this
+    /// decidable from values, and a rule that decides the verdict with no test is how the identity
+    /// join survived to a live drive. See `Issue448TrackSortAfterOrderTests`.
+    static func trackSortAfterOrder(
+        afterNames: [String],
+        beforeNames: [String],
         beforeReferences: [String]
     ) -> [String]? {
-        guard headers.count == beforeHeaders.count,
-              beforeReferences.count == beforeHeaders.count else {
+        guard afterNames.count == beforeNames.count,
+              beforeReferences.count == beforeNames.count else {
             return nil
         }
-        var matchedBeforeIndexes = Set<Int>()
-        var order: [String] = []
-        order.reserveCapacity(headers.count)
-        for header in headers {
-            guard let beforeIndex = beforeHeaders.firstIndex(where: { CFEqual($0, header) }),
-                  matchedBeforeIndexes.insert(beforeIndex).inserted else {
+        var referenceByName: [String: String] = [:]
+        referenceByName.reserveCapacity(beforeNames.count)
+        for (name, reference) in zip(beforeNames, beforeReferences) {
+            guard referenceByName.updateValue(reference, forKey: name) == nil else {
                 return nil
             }
-            order.append(beforeReferences[beforeIndex])
+        }
+        var order: [String] = []
+        order.reserveCapacity(afterNames.count)
+        for name in afterNames {
+            guard let reference = referenceByName[name] else {
+                return nil
+            }
+            order.append(reference)
         }
         return order
     }

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel.swift
@@ -97,6 +97,7 @@ actor AccessibilityChannel: Channel {
         let selectTrack: @Sendable ([String: String]) async -> ChannelResult
         let setTrackToggle: @Sendable ([String: String], String) -> ChannelResult
         let renameTrack: @Sendable ([String: String]) -> ChannelResult
+        let sortTracks: @Sendable ([String: String]) -> ChannelResult
         let mixerState: @Sendable () -> ChannelResult
         let channelStrip: @Sendable ([String: String]) -> ChannelResult
         let setMixerValue: @Sendable ([String: String], MixerTarget) -> ChannelResult
@@ -132,6 +133,7 @@ actor AccessibilityChannel: Channel {
             selectTrack: @escaping @Sendable ([String: String]) async -> ChannelResult,
             setTrackToggle: @escaping @Sendable ([String: String], String) -> ChannelResult,
             renameTrack: @escaping @Sendable ([String: String]) -> ChannelResult,
+            sortTracks: @escaping @Sendable ([String: String]) -> ChannelResult = { _ in .error("sortTracks not wired") },
             mixerState: @escaping @Sendable () -> ChannelResult,
             channelStrip: @escaping @Sendable ([String: String]) -> ChannelResult,
             setMixerValue: @escaping @Sendable ([String: String], MixerTarget) -> ChannelResult,
@@ -165,6 +167,7 @@ actor AccessibilityChannel: Channel {
             self.selectTrack = selectTrack
             self.setTrackToggle = setTrackToggle
             self.renameTrack = renameTrack
+            self.sortTracks = sortTracks
             self.mixerState = mixerState
             self.channelStrip = channelStrip
             self.setMixerValue = setMixerValue
@@ -245,6 +248,7 @@ actor AccessibilityChannel: Channel {
                         processRuntime: processRuntime
                     )
                 },
+                sortTracks: { AccessibilityChannel.defaultSortTracks(params: $0, runtime: logicRuntime) },
                 mixerState: { AccessibilityChannel.defaultGetMixerState(runtime: logicRuntime) },
                 channelStrip: { AccessibilityChannel.defaultGetChannelStrip(params: $0, runtime: logicRuntime) },
                 setMixerValue: { AccessibilityChannel.defaultSetMixerValue(params: $0, target: $1, runtime: logicRuntime) },
@@ -398,6 +402,8 @@ actor AccessibilityChannel: Channel {
             return runtime.setTrackToggle(params, "Record")
         case "track.rename":
             return runtime.renameTrack(params)
+        case "track.sort_verified":
+            return runtime.sortTracks(params)
         case "track.set_color":
             // v3.1.2 P2-1 — explicit State C `not_implemented` so callers
             // (and the router's terminal-error gate) can distinguish a

--- a/Sources/LogicProMCP/Channels/RoutingTable.swift
+++ b/Sources/LogicProMCP/Channels/RoutingTable.swift
@@ -62,6 +62,10 @@ extension ChannelRouter {
         // the menu path AX query fails.
         "track.delete":               [.accessibility, .midiKeyCommands, .cgEvent],
         "track.rename":               [.accessibility],
+        // #448: menu-only structural reorder. The Accessibility channel reads
+        // the full order before and after the measured menu action; no fallback
+        // may substitute a different reorder semantics.
+        "track.sort_verified":        [.accessibility],
         // AX first: reads current checkbox state and only presses when it
         // differs from desired — idempotent. MCU fallback is last-resort because
         // its buttons are press-only (release is ignored by Logic), so

--- a/Sources/LogicProMCP/Channels/TrackSortVerification.swift
+++ b/Sources/LogicProMCP/Channels/TrackSortVerification.swift
@@ -37,6 +37,18 @@ enum TrackSortCriterion: String, CaseIterable, Sendable, Hashable {
         guard localeIdentifier == "ko_KR" || localeIdentifier == "ko-KR" else { return nil }
         return label.canonical
     }
+
+    /// Maps the title read from the menu leaf itself back to its stable API
+    /// identity. The sort transaction uses this after locating the leaf: the
+    /// request tells us what to look for, while this value tells us what was
+    /// actually about to be pressed.
+    static func measuredCriterion(
+        forObservedMenuItemLabel label: String,
+        localeIdentifier: String?
+    ) -> TrackSortCriterion? {
+        let matches = allCases.filter { $0.measuredLabel(for: localeIdentifier) == label }
+        return matches.count == 1 ? matches[0] : nil
+    }
 }
 
 /// An issued track reference together with the pre-sort rail location it named.
@@ -70,12 +82,25 @@ enum TrackSortVerifier {
         case unavailable
     }
 
+    struct ActuatedMenuItem: Equatable, Sendable {
+        /// These are read from the exact AX menu leaf that will receive
+        /// `AXPress`, not copied from the request or from the lookup path.
+        let localizedLabel: String
+        let criterion: TrackSortCriterion
+    }
+
     enum Actuation: Equatable, Sendable {
-        case actuated
+        /// The action call was sent. AX's Boolean return is not used as an
+        /// effect witness; both cases require post-write order readback.
+        case actuated(ActuatedMenuItem)
+        case pressReportedFailure(ActuatedMenuItem)
         case unmeasuredLocale(String)
         case criterionLabelMissing(String)
+        case criterionUnverified(String)
+        case criterionMismatch(ActuatedMenuItem)
         case disabledMenuItem(String)
-        case pressFailed(String)
+        case enabledStateUnavailable(String)
+        case menuReadFailed(stage: String, status: String)
     }
 
     enum Refusal: Equatable, Sendable {
@@ -83,8 +108,11 @@ enum TrackSortVerifier {
         case expectedOrderIsNotBeforeOrder
         case unmeasuredLocale(String)
         case criterionLabelMissing(String)
+        case criterionUnverified(String)
+        case criterionMismatch(actual: TrackSortCriterion, label: String)
         case disabledMenuItem(String)
-        case menuPressFailed(String)
+        case enabledStateUnavailable(String)
+        case menuReadFailed(stage: String, status: String)
     }
 
     enum Uncertainty: Equatable, Sendable {
@@ -102,8 +130,8 @@ enum TrackSortVerifier {
     /// A changed order is not a verifier: another criterion could produce it.
     /// The caller supplies the complete expected *track-reference* order
     /// derived from the requested criterion, and it must be a permutation of
-    /// the pre-write order. State A therefore requires an exact post-write
-    /// match.
+    /// the pre-write order. State A therefore requires both an exact post-write
+    /// match and the criterion mapped from the exact menu leaf that was pressed.
     ///
     /// A correct sort of an already-sorted project is observationally identical
     /// to a menu press that did nothing. We do not inspect Undo text or infer an
@@ -115,8 +143,6 @@ enum TrackSortVerifier {
         actuate: () -> Actuation,
         after: () -> OrderRead
     ) -> Outcome {
-        _ = criterion // Keeps the API explicit at this transaction boundary.
-
         guard case .read(let beforeOrder) = before() else {
             return .refused(.beforeOrderUnreadable)
         }
@@ -125,16 +151,30 @@ enum TrackSortVerifier {
         }
 
         switch actuate() {
-        case .actuated:
-            break
+        case .actuated(let item), .pressReportedFailure(let item):
+            guard item.criterion == criterion else {
+                return .refused(.criterionMismatch(
+                    actual: item.criterion,
+                    label: item.localizedLabel
+                ))
+            }
         case .unmeasuredLocale(let locale):
             return .refused(.unmeasuredLocale(locale))
         case .criterionLabelMissing(let label):
             return .refused(.criterionLabelMissing(label))
+        case .criterionUnverified(let label):
+            return .refused(.criterionUnverified(label))
+        case .criterionMismatch(let item):
+            return .refused(.criterionMismatch(
+                actual: item.criterion,
+                label: item.localizedLabel
+            ))
         case .disabledMenuItem(let label):
             return .refused(.disabledMenuItem(label))
-        case .pressFailed(let label):
-            return .refused(.menuPressFailed(label))
+        case .enabledStateUnavailable(let label):
+            return .refused(.enabledStateUnavailable(label))
+        case .menuReadFailed(let stage, let status):
+            return .refused(.menuReadFailed(stage: stage, status: status))
         }
 
         guard case .read(let afterOrder) = after() else {

--- a/Sources/LogicProMCP/Channels/TrackSortVerification.swift
+++ b/Sources/LogicProMCP/Channels/TrackSortVerification.swift
@@ -1,0 +1,133 @@
+import Foundation
+
+/// The seven *observed* leaves of Logic's Track > Sort Tracks By menu.
+///
+/// These are stable API identities, not translated UI text. `label` remains in
+/// `AXLocalePolicy`, and `measuredLabel(for:)` deliberately returns nil outside
+/// a locale with an explicit menu measurement.
+enum TrackSortCriterion: String, CaseIterable, Sendable, Hashable {
+    case midiChannel = "midi_channel"
+    case audioChannel = "audio_channel"
+    case outputChannel = "output_channel"
+    case instrumentName = "instrument_name"
+    case trackName = "track_name"
+    case used
+    case creationDate = "creation_date"
+
+    var label: AXLocalePolicy.LabelSet {
+        switch self {
+        case .midiChannel: AXLocalePolicy.sortTracksByMIDIChannelMenuItem
+        case .audioChannel: AXLocalePolicy.sortTracksByAudioChannelMenuItem
+        case .outputChannel: AXLocalePolicy.sortTracksByOutputChannelMenuItem
+        case .instrumentName: AXLocalePolicy.sortTracksByInstrumentNameMenuItem
+        case .trackName: AXLocalePolicy.sortTracksByTrackNameMenuItem
+        case .used: AXLocalePolicy.sortTracksByUsedMenuItem
+        case .creationDate: AXLocalePolicy.sortTracksByCreationDateMenuItem
+        }
+    }
+
+    /// The #448 menu measurement is Korean-only. Logic's partially localized
+    /// menu bar is not a translation oracle: an English or unknown UI locale is
+    /// a missing measurement, even if a human could guess a plausible label.
+    func measuredLabel(for localeIdentifier: String?) -> String? {
+        guard localeIdentifier == "ko_KR" else { return nil }
+        return label.canonical
+    }
+}
+
+/// Pure decision core for the track-sort transaction. The AX layer supplies
+/// the two independently read arrangement orders and the menu actuation result;
+/// keeping those seams here makes every no-live-project safety branch testable.
+enum TrackSortVerifier {
+    enum OrderRead: Equatable, Sendable {
+        case read([String])
+        case unavailable
+    }
+
+    enum Actuation: Equatable, Sendable {
+        case actuated
+        case unmeasuredLocale(String)
+        case criterionLabelMissing(String)
+        case disabledMenuItem(String)
+        case pressFailed(String)
+    }
+
+    enum Refusal: Equatable, Sendable {
+        case beforeOrderUnreadable
+        case expectedOrderIsNotBeforeOrder
+        case unmeasuredLocale(String)
+        case criterionLabelMissing(String)
+        case disabledMenuItem(String)
+        case menuPressFailed(String)
+    }
+
+    enum Uncertainty: Equatable, Sendable {
+        case afterOrderUnreadable
+        case afterOrderMismatch
+        case alreadySortedCommandUnobservable
+    }
+
+    enum Outcome: Equatable, Sendable {
+        case verified
+        case refused(Refusal)
+        case uncertain(Uncertainty)
+    }
+
+    /// A changed order is not a verifier: another criterion could produce it.
+    /// The caller supplies the complete expected name order derived from the
+    /// requested criterion, and it must be a permutation of the pre-write
+    /// order. State A therefore requires an exact post-write match.
+    ///
+    /// A correct sort of an already-sorted project is observationally identical
+    /// to a menu press that did nothing. We do not inspect Undo text or infer an
+    /// action from AX's return code, so that case intentionally remains State B.
+    static func execute(
+        criterion: TrackSortCriterion,
+        expectedOrder: [String],
+        before: () -> OrderRead,
+        actuate: () -> Actuation,
+        after: () -> OrderRead
+    ) -> Outcome {
+        _ = criterion // Keeps the API explicit at this transaction boundary.
+
+        guard case .read(let beforeOrder) = before() else {
+            return .refused(.beforeOrderUnreadable)
+        }
+        guard ordersContainSameUniqueNames(beforeOrder, expectedOrder) else {
+            return .refused(.expectedOrderIsNotBeforeOrder)
+        }
+
+        switch actuate() {
+        case .actuated:
+            break
+        case .unmeasuredLocale(let locale):
+            return .refused(.unmeasuredLocale(locale))
+        case .criterionLabelMissing(let label):
+            return .refused(.criterionLabelMissing(label))
+        case .disabledMenuItem(let label):
+            return .refused(.disabledMenuItem(label))
+        case .pressFailed(let label):
+            return .refused(.menuPressFailed(label))
+        }
+
+        guard case .read(let afterOrder) = after() else {
+            return .uncertain(.afterOrderUnreadable)
+        }
+        guard afterOrder == expectedOrder else {
+            return .uncertain(.afterOrderMismatch)
+        }
+        guard beforeOrder != expectedOrder else {
+            return .uncertain(.alreadySortedCommandUnobservable)
+        }
+        return .verified
+    }
+
+    private static func ordersContainSameUniqueNames(_ before: [String], _ expected: [String]) -> Bool {
+        guard before.count == expected.count,
+              Set(before).count == before.count,
+              Set(expected).count == expected.count else {
+            return false
+        }
+        return Set(before) == Set(expected)
+    }
+}

--- a/Sources/LogicProMCP/Channels/TrackSortVerification.swift
+++ b/Sources/LogicProMCP/Channels/TrackSortVerification.swift
@@ -30,8 +30,34 @@ enum TrackSortCriterion: String, CaseIterable, Sendable, Hashable {
     /// menu bar is not a translation oracle: an English or unknown UI locale is
     /// a missing measurement, even if a human could guess a plausible label.
     func measuredLabel(for localeIdentifier: String?) -> String? {
-        guard localeIdentifier == "ko_KR" else { return nil }
+        // `logicUILocaleIdentifier` publishes BCP-47 (`ko-KR`), while the
+        // original #448 fixture used the underscore spelling (`ko_KR`). Both
+        // identify the one measured Korean UI; accepting this formatting
+        // difference does not infer a label for another locale.
+        guard localeIdentifier == "ko_KR" || localeIdentifier == "ko-KR" else { return nil }
         return label.canonical
+    }
+}
+
+/// An issued track reference together with the pre-sort rail location it named.
+///
+/// `expected_order` is a caller-facing list of the `trk_…` values emitted by
+/// `logic://tracks`; this value is only the dispatcher-to-channel witness that
+/// lets the channel bind those references to one strict pre-sort AX read. We
+/// deliberately do not use arrangement indexes as the public identity: sorting
+/// changes them. We also do not manufacture `(name, ordinal)` identities: no
+/// measurement establishes that Logic preserves an equal-name ordinal through a
+/// sort. If a reference no longer resolves, or its bound pre-sort row is gone,
+/// the operation refuses before pressing the menu and names that reference.
+struct TrackSortExpectedTrack: Codable, Equatable, Sendable {
+    let reference: String
+    let beforeIndex: Int
+    let beforeName: String
+
+    enum CodingKeys: String, CodingKey {
+        case reference = "track_ref"
+        case beforeIndex = "before_index"
+        case beforeName = "before_name"
     }
 }
 
@@ -74,9 +100,10 @@ enum TrackSortVerifier {
     }
 
     /// A changed order is not a verifier: another criterion could produce it.
-    /// The caller supplies the complete expected name order derived from the
-    /// requested criterion, and it must be a permutation of the pre-write
-    /// order. State A therefore requires an exact post-write match.
+    /// The caller supplies the complete expected *track-reference* order
+    /// derived from the requested criterion, and it must be a permutation of
+    /// the pre-write order. State A therefore requires an exact post-write
+    /// match.
     ///
     /// A correct sort of an already-sorted project is observationally identical
     /// to a menu press that did nothing. We do not inspect Undo text or infer an
@@ -93,7 +120,7 @@ enum TrackSortVerifier {
         guard case .read(let beforeOrder) = before() else {
             return .refused(.beforeOrderUnreadable)
         }
-        guard ordersContainSameUniqueNames(beforeOrder, expectedOrder) else {
+        guard ordersContainSameUniqueTrackReferences(beforeOrder, expectedOrder) else {
             return .refused(.expectedOrderIsNotBeforeOrder)
         }
 
@@ -122,7 +149,7 @@ enum TrackSortVerifier {
         return .verified
     }
 
-    private static func ordersContainSameUniqueNames(_ before: [String], _ expected: [String]) -> Bool {
+    private static func ordersContainSameUniqueTrackReferences(_ before: [String], _ expected: [String]) -> Bool {
         guard before.count == expected.count,
               Set(before).count == before.count,
               Set(expected).count == expected.count else {

--- a/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
@@ -12,7 +12,7 @@ struct TrackDispatcher: OperationTraceDispatching {
 
     static let tool = Tool(
         name: "logic_tracks",
-        description: "Track actions in Logic Pro. Commands: select, create_audio, create_instrument, create_drummer, create_external_midi, delete, duplicate, rename, mute, solo, arm, arm_only, record_sequence, set_automation, set_instrument, list_library, scan_library, resolve_path, scan_plugin_presets. Params: select -> { index: Int } or { name: String }; rename -> { name: String, index: Int (≥0) } or, by default (disable with LOGIC_MCP_ADR002_TARGET_REF=0), { name: String, target_ref: String, index?: Int }; when the kill-switch is set, supplying target_ref fails closed with target_ref_unavailable; omit it to use index; mute/solo/arm/arm_only/set_automation/set_instrument ALL require explicit { index: Int (≥0) }; mute/solo/arm -> also { enabled: Bool }; arm_only disarms all others + arms target, returns error on partial disarm failure; record_sequence -> { bar?: Int (default 1), notes: \"pitch,offsetMs,durMs[,vel[,ch]];...\" (BREAKING since v3.1.6: optional `ch` field is 1-based, range 1..16 — pre-v3.1.6 was 0-based; whole-parse-fail on any invalid segment; SMF end <= 3,600,000 ms), tempo?: Float } SMF-import path: generates a Standard MIDI File server-side, forces playhead to bar 1, imports via AX menu — byte-exact timing, creates a new track each call, then verifies the imported region by AX readback. Successful responses include `created_track`, `target_track_index`, `target_track_name`, `region_name`, `start_bar`, `end_bar`, `note_count`, and `verify_source`; structured error JSON distinguishes `import_failure`, `audibility_unverified`, `import_unverified`, `wrong_track_import`, `timing_mismatch`, and `unreadable_readback`. If Logic imports GM Device / External MIDI lanes, record_sequence fails closed instead of promoting region readback to audible success. v3.0.8 REMOVED the internal instrument auto-load: response always carries `\"instrument\":\"not-attempted\"`; callers that want a specific patch must follow up with explicit `set_instrument` on a Software Instrument track. The legacy `instrument_path` param is accepted for wire compat but ignored (surfaces as `\"ignored:<path>\"` in the response) — see CHANGELOG v3.0.8 for why the inline auto-load was unsafe (could load the wrong track's patch, corrupting a pre-existing track); create_* -> {}; delete/duplicate -> { index: Int, expected_name: String } (PRD-007 index binding: delete, duplicate and set_instrument are `corroborated` — a bare index is REFUSED with index_binding_corroboration_required; supply expected_name (the track name you expect at that index, corroborated against the live header and required to be unique) or a target_ref instead; expected_name + target_ref together is invalid_params; every binding failure is pre-write with write_attempted:false); set_automation -> { mode: read|write|touch|latch|trim } (independent readback required for State A); set_instrument -> { path: String, expected_name: String } or { category: String, preset: String, expected_name: String } — path mode preferred and only `resolve_path` results with kind=`leaf` and loadable=true are valid apply candidates; scan_library -> { mode?: \"ax\"|\"disk\"|\"both\" } (default disk — dedupes user and app-bundle Instrument `.patch` candidates with Panel-taxonomy remap; ax is the legacy live Library Panel scan; both returns diff summary); resolve_path -> { path: String } cache-backed read-only classifier returning kind/source/loadable; scan_plugin_presets -> { submenuOpenDelayMs?: Int }. ADR-002 (on by default; disable with LOGIC_MCP_ADR002_TARGET_REF=0): select, delete, duplicate, mute, solo, arm, arm_only, set_automation, and set_instrument ALSO accept a session-stable { target_ref: String } (a trk_… value from the logic://tracks resource) in place of the explicit index; when both target_ref and index are supplied they must agree or the op fails closed (stale_target_reference); when the kill-switch is set, any supplied target_ref fails closed with target_ref_unavailable; omit target_ref to use the explicit index path.",
+        description: "Track actions in Logic Pro. Commands: select, create_audio, create_instrument, create_drummer, create_external_midi, delete, duplicate, rename, mute, solo, arm, arm_only, record_sequence, sort_verified, set_automation, set_instrument, list_library, scan_library, resolve_path, scan_plugin_presets. Params: select -> { index: Int } or { name: String }; rename -> { name: String, index: Int (≥0) } or, by default (disable with LOGIC_MCP_ADR002_TARGET_REF=0), { name: String, target_ref: String, index?: Int }; when the kill-switch is set, supplying target_ref fails closed with target_ref_unavailable; omit it to use index; mute/solo/arm/arm_only/set_automation/set_instrument ALL require explicit { index: Int (≥0) }; mute/solo/arm -> also { enabled: Bool }; arm_only disarms all others + arms target, returns error on partial disarm failure; record_sequence -> { bar?: Int (default 1), notes: \"pitch,offsetMs,durMs[,vel[,ch]];...\" (BREAKING since v3.1.6: optional `ch` field is 1-based, range 1..16 — pre-v3.1.6 was 0-based; whole-parse-fail on any invalid segment; SMF end <= 3,600,000 ms), tempo?: Float } SMF-import path: generates a Standard MIDI File server-side, forces playhead to bar 1, imports via AX menu — byte-exact timing, creates a new track each call, then verifies the imported region by AX readback. Successful responses include `created_track`, `target_track_index`, `target_track_name`, `region_name`, `start_bar`, `end_bar`, `note_count`, and `verify_source`; structured error JSON distinguishes `import_failure`, `audibility_unverified`, `import_unverified`, `wrong_track_import`, `timing_mismatch`, and `unreadable_readback`. sort_verified -> { criterion: midi_channel|audio_channel|output_channel|instrument_name|track_name|used|creation_date, expected_order: [unique track names], confirmed: true }; the caller supplies the complete order implied by the requested criterion so the after-read can reject a wrong sort rather than treating any order change as success. A correctly already-sorted project remains State B because a no-op cannot prove the menu command ran. If Logic imports GM Device / External MIDI lanes, record_sequence fails closed instead of promoting region readback to audible success. v3.0.8 REMOVED the internal instrument auto-load: response always carries `\"instrument\":\"not-attempted\"`; callers that want a specific patch must follow up with explicit `set_instrument` on a Software Instrument track. The legacy `instrument_path` param is accepted for wire compat but ignored (surfaces as `\"ignored:<path>\"` in the response) — see CHANGELOG v3.0.8 for why the inline auto-load was unsafe (could load the wrong track's patch, corrupting a pre-existing track); create_* -> {}; delete/duplicate -> { index: Int, expected_name: String } (PRD-007 index binding: delete, duplicate and set_instrument are `corroborated` — a bare index is REFUSED with index_binding_corroboration_required; supply expected_name (the track name you expect at that index, corroborated against the live header and required to be unique) or a target_ref instead; expected_name + target_ref together is invalid_params; every binding failure is pre-write with write_attempted:false); set_automation -> { mode: read|write|touch|latch|trim } (independent readback required for State A); set_instrument -> { path: String, expected_name: String } or { category: String, preset: String, expected_name: String } — path mode preferred and only `resolve_path` results with kind=`leaf` and loadable=true are valid apply candidates; scan_library -> { mode?: \"ax\"|\"disk\"|\"both\" } (default disk — dedupes user and app-bundle Instrument `.patch` candidates with Panel-taxonomy remap; ax is the legacy live Library Panel scan; both returns diff summary); resolve_path -> { path: String } cache-backed read-only classifier returning kind/source/loadable; scan_plugin_presets -> { submenuOpenDelayMs?: Int }. ADR-002 (on by default; disable with LOGIC_MCP_ADR002_TARGET_REF=0): select, delete, duplicate, mute, solo, arm, arm_only, set_automation, and set_instrument ALSO accept a session-stable { target_ref: String } (a trk_… value from the logic://tracks resource) in place of the explicit index; when both target_ref and index are supplied they must agree or the op fails closed (stale_target_reference); when the kill-switch is set, any supplied target_ref fails closed with target_ref_unavailable; omit target_ref to use the explicit index path.",
         inputSchema: commandParamsToolSchema(commandDescription: "Track command to execute")
     )
 
@@ -652,6 +652,80 @@ struct TrackDispatcher: OperationTraceDispatching {
         case "set_color":
             return notExposedCommandResult(operation: "track.set_color")
 
+        case "sort_verified":
+            guard let criterion = TrackSortCriterion(rawValue: stringParam(params, "criterion")) else {
+                return toolInvalidParamsResult(
+                    "sort_verified 'criterion' must be one of \(TrackSortCriterion.allCases.map(\.rawValue).joined(separator: ", "))",
+                    extras: [
+                        "operation": "track.sort_verified",
+                        "reason": "unknown_sort_criterion",
+                        "write_attempted": false,
+                    ]
+                )
+            }
+            guard let expectedOrder = trackSortExpectedOrder(params) else {
+                return toolInvalidParamsResult(
+                    "sort_verified requires expected_order as a non-empty array of unique track names",
+                    extras: [
+                        "operation": "track.sort_verified",
+                        "reason": "expected_order_invalid",
+                        "write_attempted": false,
+                    ]
+                )
+            }
+            switch strictBoolParam(params, "confirmed") {
+            case .value(true):
+                break
+            case .missing, .value(false):
+                let level = DestructivePolicy.promptLabel(
+                    of: OperationRegistry.spec(
+                        tool: ToolID.logicTracks.rawValue,
+                        command: "sort_verified"
+                    )?.confirmation ?? .l2
+                ) ?? "L2"
+                let confirmedParams = HonestContract.jsonString([
+                    "criterion": criterion.rawValue,
+                    "expected_order": expectedOrder,
+                    "confirmed": true,
+                ])
+                return toolTextResult(HonestContract.jsonString([
+                    "status": "confirmation_required",
+                    "command": "sort_verified",
+                    "level": level,
+                    "message": "sort_verified reorders the project's track layout. Re-call with confirmed:true after reviewing the expected order.",
+                    "confirm_command": "logic_tracks(\"sort_verified\", \(confirmedParams))",
+                ]))
+            case .invalid(let hint):
+                return toolInvalidParamsResult(
+                    "sort_verified \(hint)",
+                    extras: ["operation": "track.sort_verified", "write_attempted": false]
+                )
+            }
+            guard let encodedExpectedOrder = encodeTrackSortExpectedOrder(expectedOrder) else {
+                return toolInvalidParamsResult(
+                    "sort_verified could not encode expected_order",
+                    extras: ["operation": "track.sort_verified", "write_attempted": false]
+                )
+            }
+            let traceID = await startTraceIfEnabled(command: command)
+            let result = await withWriteBoundaryArmed(traceID) {
+                await router.route(
+                    operation: "track.sort_verified",
+                    params: [
+                        "criterion": criterion.rawValue,
+                        "expected_order_json": encodedExpectedOrder,
+                    ]
+                )
+            }
+            // State B (after-order unavailable, mismatch, or already-sorted
+            // no-op) is an error to callers of this verified surface. The menu
+            // may have changed project state, so it is not retroactively turned
+            // into a pre-write State C refusal.
+            return await finalizeTrace(
+                toolTextResultTreatingUnverifiedAsError(result),
+                traceID: traceID
+            )
+
         case "set_automation":
             let index: Int
             let resolvedReference: TargetReference?
@@ -874,6 +948,25 @@ struct TrackDispatcher: OperationTraceDispatching {
         OperationRegistry.spec(tool: ToolID.logicTracks.rawValue, command: command)?.indexBinding
     }
 
+    private static func trackSortExpectedOrder(_ params: [String: Value]) -> [String]? {
+        guard let values = params["expected_order"]?.arrayValue,
+              !values.isEmpty,
+              values.allSatisfy({ $0.stringValue != nil }) else {
+            return nil
+        }
+        let names = values.compactMap(\.stringValue)
+        guard names.allSatisfy({ !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }),
+              Set(names).count == names.count else {
+            return nil
+        }
+        return names
+    }
+
+    private static func encodeTrackSortExpectedOrder(_ names: [String]) -> String? {
+        guard let data = try? JSONEncoder().encode(names) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
     private static func handleToggle(
         command: String,
         operation: String,
@@ -952,6 +1045,7 @@ struct TrackDispatcher: OperationTraceDispatching {
         case "arm": return "track.set_arm"
         case "arm_only": return "track.arm_only"
         case "record_sequence": return "track.record_sequence"
+        case "sort_verified": return "track.sort_verified"
         case "set_automation": return "track.set_automation"
         default: return nil
         }

--- a/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
@@ -741,9 +741,9 @@ struct TrackDispatcher: OperationTraceDispatching {
                     ]
                 )
             }
-            // A successful press may reorder the rail even when the following
-            // read is State B. Existing index/name target bindings must never
-            // survive that possible topology change.
+            // A sent press may reorder the rail even when AX reports the press
+            // as failed or the following read is State B. Existing index/name
+            // target bindings must never survive that possible topology change.
             if FeatureFlags.adr002TargetRef,
                channelResultIsVerified(result) || channelResultIsUnverified(result) {
                 await targetRegistry?.bumpTopologyGeneration()
@@ -1016,6 +1016,10 @@ struct TrackDispatcher: OperationTraceDispatching {
                 missing.append(rawReference)
                 continue
             }
+            // TargetDescriptor has no per-track identity beyond this index/name
+            // pair. The channel therefore rejects a duplicate-name live rail
+            // before pressing: preserving the pair here must not be mistaken for
+            // evidence that a same-named replacement is the issued track.
             tracks.append(TrackSortExpectedTrack(
                 reference: rawReference,
                 beforeIndex: binding.descriptor.trackIndex,

--- a/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/TrackDispatcher.swift
@@ -12,7 +12,7 @@ struct TrackDispatcher: OperationTraceDispatching {
 
     static let tool = Tool(
         name: "logic_tracks",
-        description: "Track actions in Logic Pro. Commands: select, create_audio, create_instrument, create_drummer, create_external_midi, delete, duplicate, rename, mute, solo, arm, arm_only, record_sequence, sort_verified, set_automation, set_instrument, list_library, scan_library, resolve_path, scan_plugin_presets. Params: select -> { index: Int } or { name: String }; rename -> { name: String, index: Int (≥0) } or, by default (disable with LOGIC_MCP_ADR002_TARGET_REF=0), { name: String, target_ref: String, index?: Int }; when the kill-switch is set, supplying target_ref fails closed with target_ref_unavailable; omit it to use index; mute/solo/arm/arm_only/set_automation/set_instrument ALL require explicit { index: Int (≥0) }; mute/solo/arm -> also { enabled: Bool }; arm_only disarms all others + arms target, returns error on partial disarm failure; record_sequence -> { bar?: Int (default 1), notes: \"pitch,offsetMs,durMs[,vel[,ch]];...\" (BREAKING since v3.1.6: optional `ch` field is 1-based, range 1..16 — pre-v3.1.6 was 0-based; whole-parse-fail on any invalid segment; SMF end <= 3,600,000 ms), tempo?: Float } SMF-import path: generates a Standard MIDI File server-side, forces playhead to bar 1, imports via AX menu — byte-exact timing, creates a new track each call, then verifies the imported region by AX readback. Successful responses include `created_track`, `target_track_index`, `target_track_name`, `region_name`, `start_bar`, `end_bar`, `note_count`, and `verify_source`; structured error JSON distinguishes `import_failure`, `audibility_unverified`, `import_unverified`, `wrong_track_import`, `timing_mismatch`, and `unreadable_readback`. sort_verified -> { criterion: midi_channel|audio_channel|output_channel|instrument_name|track_name|used|creation_date, expected_order: [unique track names], confirmed: true }; the caller supplies the complete order implied by the requested criterion so the after-read can reject a wrong sort rather than treating any order change as success. A correctly already-sorted project remains State B because a no-op cannot prove the menu command ran. If Logic imports GM Device / External MIDI lanes, record_sequence fails closed instead of promoting region readback to audible success. v3.0.8 REMOVED the internal instrument auto-load: response always carries `\"instrument\":\"not-attempted\"`; callers that want a specific patch must follow up with explicit `set_instrument` on a Software Instrument track. The legacy `instrument_path` param is accepted for wire compat but ignored (surfaces as `\"ignored:<path>\"` in the response) — see CHANGELOG v3.0.8 for why the inline auto-load was unsafe (could load the wrong track's patch, corrupting a pre-existing track); create_* -> {}; delete/duplicate -> { index: Int, expected_name: String } (PRD-007 index binding: delete, duplicate and set_instrument are `corroborated` — a bare index is REFUSED with index_binding_corroboration_required; supply expected_name (the track name you expect at that index, corroborated against the live header and required to be unique) or a target_ref instead; expected_name + target_ref together is invalid_params; every binding failure is pre-write with write_attempted:false); set_automation -> { mode: read|write|touch|latch|trim } (independent readback required for State A); set_instrument -> { path: String, expected_name: String } or { category: String, preset: String, expected_name: String } — path mode preferred and only `resolve_path` results with kind=`leaf` and loadable=true are valid apply candidates; scan_library -> { mode?: \"ax\"|\"disk\"|\"both\" } (default disk — dedupes user and app-bundle Instrument `.patch` candidates with Panel-taxonomy remap; ax is the legacy live Library Panel scan; both returns diff summary); resolve_path -> { path: String } cache-backed read-only classifier returning kind/source/loadable; scan_plugin_presets -> { submenuOpenDelayMs?: Int }. ADR-002 (on by default; disable with LOGIC_MCP_ADR002_TARGET_REF=0): select, delete, duplicate, mute, solo, arm, arm_only, set_automation, and set_instrument ALSO accept a session-stable { target_ref: String } (a trk_… value from the logic://tracks resource) in place of the explicit index; when both target_ref and index are supplied they must agree or the op fails closed (stale_target_reference); when the kill-switch is set, any supplied target_ref fails closed with target_ref_unavailable; omit target_ref to use the explicit index path.",
+        description: "Track actions in Logic Pro. Commands: select, create_audio, create_instrument, create_drummer, create_external_midi, delete, duplicate, rename, mute, solo, arm, arm_only, record_sequence, sort_verified, set_automation, set_instrument, list_library, scan_library, resolve_path, scan_plugin_presets. Params: select -> { index: Int } or { name: String }; rename -> { name: String, index: Int (≥0) } or, by default (disable with LOGIC_MCP_ADR002_TARGET_REF=0), { name: String, target_ref: String, index?: Int }; when the kill-switch is set, supplying target_ref fails closed with target_ref_unavailable; omit it to use index; mute/solo/arm/arm_only/set_automation/set_instrument ALL require explicit { index: Int (≥0) }; mute/solo/arm -> also { enabled: Bool }; arm_only disarms all others + arms target, returns error on partial disarm failure; record_sequence -> { bar?: Int (default 1), notes: \"pitch,offsetMs,durMs[,vel[,ch]];...\" (BREAKING since v3.1.6: optional `ch` field is 1-based, range 1..16 — pre-v3.1.6 was 0-based; whole-parse-fail on any invalid segment; SMF end <= 3,600,000 ms), tempo?: Float } SMF-import path: generates a Standard MIDI File server-side, forces playhead to bar 1, imports via AX menu — byte-exact timing, creates a new track each call, then verifies the imported region by AX readback. Successful responses include `created_track`, `target_track_index`, `target_track_name`, `region_name`, `start_bar`, `end_bar`, `note_count`, and `verify_source`; structured error JSON distinguishes `import_failure`, `audibility_unverified`, `import_unverified`, `wrong_track_import`, `timing_mismatch`, and `unreadable_readback`. sort_verified -> { criterion: midi_channel|audio_channel|output_channel|instrument_name|track_name|used|creation_date, expected_order: [unique track_ref values from logic://tracks], confirmed: true }; the caller supplies the complete reference order implied by the requested criterion so the after-read can reject a wrong sort rather than treating any order change as success. A correctly already-sorted project remains State B because a no-op cannot prove the menu command ran. If Logic imports GM Device / External MIDI lanes, record_sequence fails closed instead of promoting region readback to audible success. v3.0.8 REMOVED the internal instrument auto-load: response always carries `\"instrument\":\"not-attempted\"`; callers that want a specific patch must follow up with explicit `set_instrument` on a Software Instrument track. The legacy `instrument_path` param is accepted for wire compat but ignored (surfaces as `\"ignored:<path>\"` in the response) — see CHANGELOG v3.0.8 for why the inline auto-load was unsafe (could load the wrong track's patch, corrupting a pre-existing track); create_* -> {}; delete/duplicate -> { index: Int, expected_name: String } (PRD-007 index binding: delete, duplicate and set_instrument are `corroborated` — a bare index is REFUSED with index_binding_corroboration_required; supply expected_name (the track name you expect at that index, corroborated against the live header and required to be unique) or a target_ref instead; expected_name + target_ref together is invalid_params; every binding failure is pre-write with write_attempted:false); set_automation -> { mode: read|write|touch|latch|trim } (independent readback required for State A); set_instrument -> { path: String, expected_name: String } or { category: String, preset: String, expected_name: String } — path mode preferred and only `resolve_path` results with kind=`leaf` and loadable=true are valid apply candidates; scan_library -> { mode?: \"ax\"|\"disk\"|\"both\" } (default disk — dedupes user and app-bundle Instrument `.patch` candidates with Panel-taxonomy remap; ax is the legacy live Library Panel scan; both returns diff summary); resolve_path -> { path: String } cache-backed read-only classifier returning kind/source/loadable; scan_plugin_presets -> { submenuOpenDelayMs?: Int }. ADR-002 (on by default; disable with LOGIC_MCP_ADR002_TARGET_REF=0): select, delete, duplicate, mute, solo, arm, arm_only, set_automation, and set_instrument ALSO accept a session-stable { target_ref: String } (a trk_… value from the logic://tracks resource) in place of the explicit index; when both target_ref and index are supplied they must agree or the op fails closed (stale_target_reference); when the kill-switch is set, any supplied target_ref fails closed with target_ref_unavailable; omit target_ref to use the explicit index path.",
         inputSchema: commandParamsToolSchema(commandDescription: "Track command to execute")
     )
 
@@ -665,10 +665,34 @@ struct TrackDispatcher: OperationTraceDispatching {
             }
             guard let expectedOrder = trackSortExpectedOrder(params) else {
                 return toolInvalidParamsResult(
-                    "sort_verified requires expected_order as a non-empty array of unique track names",
+                    "sort_verified requires expected_order as a non-empty array of unique track_ref values",
                     extras: [
                         "operation": "track.sort_verified",
                         "reason": "expected_order_invalid",
+                        "write_attempted": false,
+                    ]
+                )
+            }
+            let expectedTracks: [TrackSortExpectedTrack]
+            switch await trackSortExpectedTracks(
+                expectedOrder,
+                targetRegistry: targetRegistry
+            ) {
+            case .resolved(let tracks):
+                expectedTracks = tracks
+            case .unavailable:
+                return TargetRefResolver.targetReferenceUnavailableResult(
+                    expectedOrder.first,
+                    operation: "track.sort_verified"
+                )
+            case .missing(let references):
+                return toolStateCResult(
+                    .staleTargetReference,
+                    hint: "sort_verified expected_order names track references that are unavailable or stale: \(references.joined(separator: ", ")). Re-read logic://tracks and retry with its current track_ref values.",
+                    extras: [
+                        "operation": "track.sort_verified",
+                        "reason": "expected_order_unknown_track_refs",
+                        "missing_track_refs": references,
                         "write_attempted": false,
                     ]
                 )
@@ -701,7 +725,7 @@ struct TrackDispatcher: OperationTraceDispatching {
                     extras: ["operation": "track.sort_verified", "write_attempted": false]
                 )
             }
-            guard let encodedExpectedOrder = encodeTrackSortExpectedOrder(expectedOrder) else {
+            guard let encodedExpectedOrder = encodeTrackSortExpectedOrder(expectedTracks) else {
                 return toolInvalidParamsResult(
                     "sort_verified could not encode expected_order",
                     extras: ["operation": "track.sort_verified", "write_attempted": false]
@@ -716,6 +740,13 @@ struct TrackDispatcher: OperationTraceDispatching {
                         "expected_order_json": encodedExpectedOrder,
                     ]
                 )
+            }
+            // A successful press may reorder the rail even when the following
+            // read is State B. Existing index/name target bindings must never
+            // survive that possible topology change.
+            if FeatureFlags.adr002TargetRef,
+               channelResultIsVerified(result) || channelResultIsUnverified(result) {
+                await targetRegistry?.bumpTopologyGeneration()
             }
             // State B (after-order unavailable, mismatch, or already-sorted
             // no-op) is an error to callers of this verified surface. The menu
@@ -948,22 +979,54 @@ struct TrackDispatcher: OperationTraceDispatching {
         OperationRegistry.spec(tool: ToolID.logicTracks.rawValue, command: command)?.indexBinding
     }
 
+    private enum TrackSortExpectedTrackResolution {
+        case resolved([TrackSortExpectedTrack])
+        case unavailable
+        case missing([String])
+    }
+
     private static func trackSortExpectedOrder(_ params: [String: Value]) -> [String]? {
         guard let values = params["expected_order"]?.arrayValue,
               !values.isEmpty,
               values.allSatisfy({ $0.stringValue != nil }) else {
             return nil
         }
-        let names = values.compactMap(\.stringValue)
-        guard names.allSatisfy({ !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }),
-              Set(names).count == names.count else {
+        let references = values.compactMap(\.stringValue)
+        guard references.allSatisfy({ !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }),
+              Set(references).count == references.count else {
             return nil
         }
-        return names
+        return references
     }
 
-    private static func encodeTrackSortExpectedOrder(_ names: [String]) -> String? {
-        guard let data = try? JSONEncoder().encode(names) else { return nil }
+    private static func trackSortExpectedTracks(
+        _ references: [String],
+        targetRegistry: TargetRegistry?
+    ) async -> TrackSortExpectedTrackResolution {
+        guard FeatureFlags.adr002TargetRef, let targetRegistry else {
+            return .unavailable
+        }
+        var tracks: [TrackSortExpectedTrack] = []
+        var missing: [String] = []
+        for rawReference in references {
+            let reference = TargetReference(rawValue: rawReference)
+            guard let binding = await targetRegistry.resolve(reference),
+                  binding.kind == .track,
+                  binding.observedFingerprint == binding.descriptor.fingerprint else {
+                missing.append(rawReference)
+                continue
+            }
+            tracks.append(TrackSortExpectedTrack(
+                reference: rawReference,
+                beforeIndex: binding.descriptor.trackIndex,
+                beforeName: binding.descriptor.trackName
+            ))
+        }
+        return missing.isEmpty ? .resolved(tracks) : .missing(missing)
+    }
+
+    private static func encodeTrackSortExpectedOrder(_ tracks: [TrackSortExpectedTrack]) -> String? {
+        guard let data = try? JSONEncoder().encode(tracks) else { return nil }
         return String(data: data, encoding: .utf8)
     }
 

--- a/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
+++ b/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
@@ -1306,8 +1306,8 @@ enum SemanticOracleTable {
 
     // #448: `defaultSortTracks` publishes State A only after a fresh complete
     // arrangement-rail read matches the caller's complete criterion-implied
-    // order. A changed order is intentionally insufficient, so this exact array
-    // equality is the load-bearing response invariant.
+    // `trk_` reference order. A changed order is intentionally insufficient, so
+    // this exact array equality is the load-bearing response invariant.
     static let tracksSortVerified = SafeMutationOracle.oracle(
         .tracksSortVerified,
         semantics: [

--- a/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
+++ b/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
@@ -1306,13 +1306,17 @@ enum SemanticOracleTable {
 
     // #448: `defaultSortTracks` publishes State A only after a fresh complete
     // arrangement-rail read matches the caller's complete criterion-implied
-    // `trk_` reference order. A changed order is intentionally insufficient, so
-    // this exact array equality is the load-bearing response invariant.
+    // `trk_` reference order AND the title read from the pressed menu leaf maps
+    // back to that same criterion. A changed order is intentionally insufficient,
+    // so these two equalities are the load-bearing response invariants.
     static let tracksSortVerified = SafeMutationOracle.oracle(
         .tracksSortVerified,
         semantics: [
             .valueEquals(key: "operation", expected: .string("track.sort_verified")),
             .enumMember(key: "criterion", allowed: TrackSortCriterion.allCases.map(\.rawValue)),
+            .enumMember(key: "actuated_criterion", allowed: TrackSortCriterion.allCases.map(\.rawValue)),
+            .fieldsEqual(keyA: "criterion", keyB: "actuated_criterion"),
+            .typedField(key: "actuated_menu_item_label", type: .string),
             .fieldsEqual(keyA: "expected_order", keyB: "after_order"),
             .nonEmptyArray(key: "before_order"),
             .nonEmptyArray(key: "after_order"),

--- a/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
+++ b/Sources/LogicProMCP/Qualification/SemanticOracleTable.swift
@@ -243,9 +243,12 @@ enum SemanticOracleTable {
     /// a later operation into them would falsify that record.
     ///
     /// `edit.move_to_playhead` belongs on the covered side: the handler re-reads the selected region
-    /// and the playhead after the menu click and reaches a genuine State A.
+    /// and the playhead after the menu click and reaches a genuine State A. `tracks.sort_verified`
+    /// joins it in #448: it admits State A only when the independently re-read complete order equals
+    /// the caller's requested criterion order.
     static let postClosureMutatingOperationIDs: Set<OperationID> = [
         .editMoveToPlayhead,
+        .tracksSortVerified,
     ]
 
     /// Every mutating operation the table covers: the B1 verified-write increment
@@ -489,6 +492,7 @@ enum SemanticOracleTable {
         mixerSetMasterVolume,
         tracksSelect,
         tracksRename,
+        tracksSortVerified,
         tracksMute,
         tracksSolo,
         tracksArm,
@@ -1297,6 +1301,21 @@ enum SemanticOracleTable {
             .fieldsEqual(keyA: "requested", keyB: "observed"),
             .typedField(key: "track", type: .number),
             .typedField(key: "via", type: .string),
+        ]
+    )
+
+    // #448: `defaultSortTracks` publishes State A only after a fresh complete
+    // arrangement-rail read matches the caller's complete criterion-implied
+    // order. A changed order is intentionally insufficient, so this exact array
+    // equality is the load-bearing response invariant.
+    static let tracksSortVerified = SafeMutationOracle.oracle(
+        .tracksSortVerified,
+        semantics: [
+            .valueEquals(key: "operation", expected: .string("track.sort_verified")),
+            .enumMember(key: "criterion", allowed: TrackSortCriterion.allCases.map(\.rawValue)),
+            .fieldsEqual(keyA: "expected_order", keyB: "after_order"),
+            .nonEmptyArray(key: "before_order"),
+            .nonEmptyArray(key: "after_order"),
         ]
     )
 

--- a/Sources/LogicProMCP/Server/OperationRegistry.swift
+++ b/Sources/LogicProMCP/Server/OperationRegistry.swift
@@ -105,6 +105,7 @@ enum OperationID: String, CaseIterable, Codable, Sendable, Hashable {
     case tracksArm = "tracks.arm"
     case tracksArmOnly = "tracks.arm_only"
     case tracksRecordSequence = "tracks.record_sequence"
+    case tracksSortVerified = "tracks.sort_verified"
     case tracksSetAutomation = "tracks.set_automation"
     case tracksSetInstrument = "tracks.set_instrument"
     case tracksListLibrary = "tracks.list_library"
@@ -336,7 +337,7 @@ enum OperationRegistry {
             "tracks.select", "tracks.create_audio", "tracks.create_instrument",
             "tracks.create_drummer", "tracks.create_external_midi", "tracks.delete",
             "tracks.duplicate", "tracks.rename", "tracks.mute", "tracks.solo", "tracks.arm",
-            "tracks.arm_only", "tracks.record_sequence", "tracks.set_automation",
+            "tracks.arm_only", "tracks.record_sequence", "tracks.sort_verified", "tracks.set_automation",
             "tracks.set_instrument", "tracks.list_library", "tracks.scan_library",
             "tracks.resolve_path", "tracks.scan_plugin_presets",
         ],
@@ -388,7 +389,7 @@ enum OperationRegistry {
         ToolID.logicTracks.rawValue: [
             "select", "create_audio", "create_instrument", "create_drummer",
             "create_external_midi", "delete", "duplicate", "rename", "mute", "solo", "arm",
-            "arm_only", "record_sequence", "set_automation", "set_instrument", "list_library",
+            "arm_only", "record_sequence", "sort_verified", "set_automation", "set_instrument", "list_library",
             "scan_library", "resolve_path", "scan_plugin_presets",
         ],
     ]
@@ -905,6 +906,10 @@ enum OperationRegistry {
         (.tracksArm, "arm", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired, TargetPolicy.acceptsStableTarget, ["enabled", "index", "track"]),
         (.tracksArmOnly, "arm_only", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired, TargetPolicy.acceptsStableTarget, ["index", "track"]),
         (.tracksRecordSequence, "record_sequence", Mutability.`mutating`, DeadlineClass.long, VerificationPolicy.readbackRequired, TargetPolicy.none, ["bar", "notes", "tempo"]),
+        // #448: the menu action globally reorders the arrange rail. It is
+        // structural rather than target-indexed, so it needs explicit L2
+        // confirmation but accepts no track target reference.
+        (.tracksSortVerified, "sort_verified", Mutability.`mutating`, DeadlineClass.medium, VerificationPolicy.readbackRequired, TargetPolicy.none, ["confirmed", "criterion", "expected_order"]),
         (.tracksSetAutomation, "set_automation", Mutability.`mutating`, DeadlineClass.short, VerificationPolicy.readbackRequired, TargetPolicy.acceptsStableTarget, ["index", "mode", "track"]),
         (.tracksSetInstrument, "set_instrument", Mutability.`mutating`, DeadlineClass.medium, VerificationPolicy.readbackRequired, TargetPolicy.acceptsStableTarget, ["category", "index", "path", "preset"]),
         (.tracksListLibrary, "list_library", Mutability.readOnly, DeadlineClass.long, VerificationPolicy.none, TargetPolicy.none, []),
@@ -917,7 +922,7 @@ enum OperationRegistry {
             tool: .logicTracks,
             command: entry.1,
             mutability: entry.2,
-            confirmation: .none,
+            confirmation: entry.0 == .tracksSortVerified ? .l2 : .none,
             target: entry.5,
             verification: entry.4,
             retry: .neverAutomatic,

--- a/Sources/LogicProMCP/Workflows/WorkflowSkillCatalog.swift
+++ b/Sources/LogicProMCP/Workflows/WorkflowSkillCatalog.swift
@@ -513,7 +513,7 @@ enum WorkflowSkillCatalog {
         "logic_tracks": [
             "select", "create_audio", "create_instrument", "create_drummer",
             "create_external_midi", "delete", "duplicate", "rename",
-            "mute", "solo", "arm", "arm_only", "record_sequence",
+            "mute", "solo", "arm", "arm_only", "record_sequence", "sort_verified",
             "set_automation", "set_instrument",
             "resolve_path", "list_library", "scan_library", "scan_plugin_presets",
         ],

--- a/Tests/LogicProMCPTests/HCGlobalInvariantTests.swift
+++ b/Tests/LogicProMCPTests/HCGlobalInvariantTests.swift
@@ -90,7 +90,7 @@ struct HCGlobalInvariantTests {
             RouteCase(tool: "logic_tracks", command: "arm_only", params: ["index": .int(1)], operation: "track.arm_only", destinations: [], invariant: .minimumV1),
             RouteCase(tool: "logic_tracks", command: "set_automation", params: ["index": .int(0), "mode": .string("read")], operation: "track.set_automation", destinations: [], invariant: .minimumV1),
             RouteCase(tool: "logic_tracks", command: "set_instrument", params: ["index": .int(2), "path": .string("/Library/Application Support/Logic/Patches/Instrument/HC.patch"), "expected_name": .string("Bass")], operation: "track.set_instrument", destinations: [], invariant: .minimumV1),
-            RouteCase(tool: "logic_tracks", command: "sort_verified", params: ["criterion": .string("track_name"), "expected_order": .array([.string("Bass"), .string("Kick")]), "confirmed": .bool(true)], operation: "track.sort_verified", destinations: [], invariant: .minimumV1),
+            RouteCase(tool: "logic_tracks", command: "sort_verified", params: ["criterion": .string("track_name"), "expected_order": .array([.string("trk_hc_bass"), .string("trk_hc_kick")]), "confirmed": .bool(true)], operation: "track.sort_verified", destinations: [], invariant: .minimumV1),
 
             RouteCase(tool: "logic_mixer", command: "set_volume", params: ["track": .int(0), "value": .double(0.5)], operation: "mixer.set_volume", destinations: [], invariant: .minimumV1),
             RouteCase(tool: "logic_mixer", command: "set_pan", params: ["track": .int(0), "value": .double(0)], operation: "mixer.set_pan", destinations: [], invariant: .minimumV1),
@@ -462,7 +462,32 @@ struct HCGlobalInvariantTests {
                 sleep: { _ in }
             )
         case "logic_tracks":
-            return await TrackDispatcher.handle(command: routeCase.command, params: routeCase.params, router: router, cache: cache, liveTrackNames: hcLiveTrackHeaders)
+            var trackParams = routeCase.params
+            let targetRegistry = TargetRegistry()
+            if routeCase.command == "sort_verified" {
+                let descriptors = [
+                    TargetDescriptor(trackIndex: 2, trackName: "Bass"),
+                    TargetDescriptor(trackIndex: 0, trackName: "Kick"),
+                    TargetDescriptor(trackIndex: 1, trackName: "Kick"),
+                ]
+                var references: [TargetReference] = []
+                for descriptor in descriptors {
+                    references.append(await targetRegistry.bind(
+                        kind: .track,
+                        descriptor: descriptor,
+                        fingerprint: descriptor.fingerprint
+                    ))
+                }
+                trackParams["expected_order"] = .array(references.map { .string($0.rawValue) })
+            }
+            return await TrackDispatcher.handle(
+                command: routeCase.command,
+                params: trackParams,
+                router: router,
+                cache: cache,
+                targetRegistry: targetRegistry,
+                liveTrackNames: hcLiveTrackHeaders
+            )
         case "logic_mixer":
             return await MixerDispatcher.handle(command: routeCase.command, params: routeCase.params, router: router, cache: cache)
         case "logic_midi":

--- a/Tests/LogicProMCPTests/HCGlobalInvariantTests.swift
+++ b/Tests/LogicProMCPTests/HCGlobalInvariantTests.swift
@@ -90,6 +90,7 @@ struct HCGlobalInvariantTests {
             RouteCase(tool: "logic_tracks", command: "arm_only", params: ["index": .int(1)], operation: "track.arm_only", destinations: [], invariant: .minimumV1),
             RouteCase(tool: "logic_tracks", command: "set_automation", params: ["index": .int(0), "mode": .string("read")], operation: "track.set_automation", destinations: [], invariant: .minimumV1),
             RouteCase(tool: "logic_tracks", command: "set_instrument", params: ["index": .int(2), "path": .string("/Library/Application Support/Logic/Patches/Instrument/HC.patch"), "expected_name": .string("Bass")], operation: "track.set_instrument", destinations: [], invariant: .minimumV1),
+            RouteCase(tool: "logic_tracks", command: "sort_verified", params: ["criterion": .string("track_name"), "expected_order": .array([.string("Bass"), .string("Kick")]), "confirmed": .bool(true)], operation: "track.sort_verified", destinations: [], invariant: .minimumV1),
 
             RouteCase(tool: "logic_mixer", command: "set_volume", params: ["track": .int(0), "value": .double(0.5)], operation: "mixer.set_volume", destinations: [], invariant: .minimumV1),
             RouteCase(tool: "logic_mixer", command: "set_pan", params: ["track": .int(0), "value": .double(0)], operation: "mixer.set_pan", destinations: [], invariant: .minimumV1),

--- a/Tests/LogicProMCPTests/Issue448TrackSortAfterOrderTests.swift
+++ b/Tests/LogicProMCPTests/Issue448TrackSortAfterOrderTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Testing
+@testable import LogicProMCP
+
+/// The rule that decides `sort_verified`'s verdict, and the one thing about it that had no test.
+///
+/// `trackSortAfterOrder` used to join the after-read to the before-read on `AXUIElement` identity.
+/// It was `private` and took `[AXUIElement]`, so nothing in the deterministic suite could reach it;
+/// every test above it passed while the join underneath returned the identity permutation for every
+/// sort. Driven live on Logic Pro 12.3 (2026-09-03), that is exactly what live Logic produces: the
+/// header objects stay at their rail positions and their CONTENT moves, so `CFEqual` matched
+/// after[i] to before[i] on a sort that had visibly reordered the tracks.
+///
+/// These tests exist against values rather than element handles, which is the point of the change.
+@Suite struct Issue448TrackSortAfterOrderTests {
+    /// The live shape: the rows moved, so the references must move with them.
+    @Test("a permuted after-read carries each reference to the row that now holds that track")
+    func permutationCarriesReferences() throws {
+        let order = AccessibilityChannel.trackSortAfterOrder(
+            afterNames: ["Yankee", "Bravo", "Zulu"],
+            beforeNames: ["Bravo", "Yankee", "Zulu"],
+            beforeReferences: ["trk_bravo", "trk_yankee", "trk_zulu"]
+        )
+        let resolved = try #require(order)
+        #expect(resolved == ["trk_yankee", "trk_bravo", "trk_zulu"])
+    }
+
+    /// The regression this file is named after. Under the old identity join this input produced
+    /// `["trk_bravo", "trk_yankee", "trk_zulu"]` — the before-order, unchanged — because the element
+    /// at each index was the same object before and after. Anything that returns the before-order
+    /// for a moved list has reintroduced the defect.
+    @Test("a sort that moved the rows does not answer with the before-order")
+    func movedRowsDoNotAnswerWithBeforeOrder() throws {
+        let before = ["trk_bravo", "trk_yankee", "trk_zulu"]
+        let order = AccessibilityChannel.trackSortAfterOrder(
+            afterNames: ["Yankee", "Bravo", "Zulu"],
+            beforeNames: ["Bravo", "Yankee", "Zulu"],
+            beforeReferences: before
+        )
+        let resolved = try #require(order)
+        #expect(resolved != before)
+    }
+
+    /// An unmoved list is still an answer, and it is the before-order — the case the old join got
+    /// right by accident and the new one has to keep getting right on purpose.
+    @Test("an unmoved after-read answers with the same order")
+    func unmovedListIsUnchanged() throws {
+        let order = AccessibilityChannel.trackSortAfterOrder(
+            afterNames: ["Alpha", "Bravo"],
+            beforeNames: ["Alpha", "Bravo"],
+            beforeReferences: ["trk_a", "trk_b"]
+        )
+        let resolved = try #require(order)
+        #expect(resolved == ["trk_a", "trk_b"])
+    }
+
+    /// Names carry the join only because the operation has already refused a project whose names
+    /// are not unique. If one reaches here that guard did not hold, and picking either reference
+    /// would be a guess — so there is no order at all.
+    @Test("duplicate names in the before-read produce no order rather than an arbitrary one")
+    func duplicateBeforeNamesRefuse() {
+        let order = AccessibilityChannel.trackSortAfterOrder(
+            afterNames: ["Same", "Same"],
+            beforeNames: ["Same", "Same"],
+            beforeReferences: ["trk_1", "trk_2"]
+        )
+        #expect(order == nil)
+    }
+
+    @Test("a name that was not present before produces no order")
+    func unknownAfterNameRefuses() {
+        let order = AccessibilityChannel.trackSortAfterOrder(
+            afterNames: ["Alpha", "Renamed"],
+            beforeNames: ["Alpha", "Bravo"],
+            beforeReferences: ["trk_a", "trk_b"]
+        )
+        #expect(order == nil)
+    }
+
+    @Test("a length disagreement between the two reads produces no order")
+    func lengthMismatchRefuses() {
+        #expect(AccessibilityChannel.trackSortAfterOrder(
+            afterNames: ["Alpha"],
+            beforeNames: ["Alpha", "Bravo"],
+            beforeReferences: ["trk_a", "trk_b"]
+        ) == nil)
+        #expect(AccessibilityChannel.trackSortAfterOrder(
+            afterNames: ["Alpha", "Bravo"],
+            beforeNames: ["Alpha", "Bravo"],
+            beforeReferences: ["trk_a"]
+        ) == nil)
+    }
+}

--- a/Tests/LogicProMCPTests/Issue448TrackSortVerifiedTests.swift
+++ b/Tests/LogicProMCPTests/Issue448TrackSortVerifiedTests.swift
@@ -1,9 +1,99 @@
+@preconcurrency import ApplicationServices
+import Foundation
 import Testing
 @testable import LogicProMCP
 
 /// #448 — a sort is only State A when the post-write arrangement order is the
 /// requested criterion's expected order. A changed order alone proves nothing:
 /// another sort criterion also changes track order.
+
+private actor TrackSortStateBChannel: Channel {
+    nonisolated let id: ChannelID = .accessibility
+    private(set) var calls: [(operation: String, params: [String: String])] = []
+
+    func start() async throws {}
+    func stop() async {}
+
+    func execute(operation: String, params: [String: String]) async -> ChannelResult {
+        calls.append((operation, params))
+        return .success(HonestContract.encodeStateB(
+            reason: .readbackMismatch,
+            extras: ["operation": operation]
+        ))
+    }
+
+    func healthCheck() async -> ChannelHealth {
+        .healthy(detail: "#448 track-sort State-B probe")
+    }
+}
+
+private struct TrackSortAXFixture {
+    let runtime: AXLogicProElements.Runtime
+    let expectedOrderJSON: String
+
+    init(orderAfterPress: [Int], expectedReferenceOrder: [Int]? = nil) {
+        let builder = FakeAXRuntimeBuilder()
+        let app = builder.element(448_000)
+        let arrange = builder.element(448_001)
+        let rail = builder.element(448_002)
+        let menuBar = builder.element(448_003)
+        let file = builder.element(448_004)
+        let edit = builder.element(448_005)
+        let track = builder.element(448_006)
+        let sortBy = builder.element(448_007)
+        let sortByName = builder.element(448_008)
+
+        builder.setAttribute(app, kAXMainWindowAttribute as String, arrange)
+        builder.setAttribute(app, kAXMenuBarAttribute as String, menuBar)
+        builder.setChildren(arrange, [rail])
+        builder.setAttribute(rail, kAXRoleAttribute as String, kAXGroupRole as String)
+        builder.setAttribute(rail, kAXDescriptionAttribute as String, "Track Headers")
+
+        let headers = (0..<3).map { offset -> AXUIElement in
+            let header = builder.element(448_100 + offset)
+            builder.setAttribute(header, kAXRoleAttribute as String, kAXLayoutItemRole as String)
+            builder.setAttribute(header, kAXTitleAttribute as String, "Studio Grand")
+            builder.setChildren(header, [])
+            return header
+        }
+        builder.setChildren(rail, headers)
+
+        builder.setAttribute(file, kAXTitleAttribute as String, "파일")
+        builder.setAttribute(edit, kAXTitleAttribute as String, "편집")
+        builder.setAttribute(track, kAXTitleAttribute as String, "트랙")
+        builder.setAttribute(sortBy, kAXTitleAttribute as String, "트랙을 다음으로 정렬")
+        builder.setAttribute(sortByName, kAXTitleAttribute as String, "트랙 이름")
+        builder.setAttribute(sortByName, kAXEnabledAttribute as String, true)
+        builder.setChildren(menuBar, [file, edit, track])
+        builder.setChildren(track, [sortBy])
+        builder.setChildren(sortBy, [sortByName])
+
+        runtime = builder.makeLogicRuntime(
+            appElement: app,
+            setAttributeHandler: nil,
+            performActionHandler: { element, action in
+                guard action == kAXPressAction as String,
+                      builder.elementID(element) == builder.elementID(sortByName) else {
+                    return false
+                }
+                builder.setChildren(rail, orderAfterPress.map { headers[$0] })
+                return true
+            }
+        )
+        let expected = (expectedReferenceOrder ?? orderAfterPress).map {
+            TrackSortExpectedTrack(
+                reference: "trk_studio_grand_\($0)",
+                beforeIndex: $0,
+                beforeName: "Studio Grand"
+            )
+        }
+        expectedOrderJSON = String(
+            data: try! JSONEncoder().encode(expected),
+            encoding: .utf8
+        )!
+    }
+}
+
 @Suite("#448 verified track sort")
 struct Issue448TrackSortVerifiedTests {
     @Test("an unknown sort criterion is rejected before any AX work")
@@ -29,8 +119,11 @@ struct Issue448TrackSortVerifiedTests {
         let resolved = Dictionary(uniqueKeysWithValues: TrackSortCriterion.allCases.map {
             ($0, $0.measuredLabel(for: "ko_KR"))
         })
+        let runtimeResolved = Dictionary(uniqueKeysWithValues: TrackSortCriterion.allCases.map {
+            ($0, $0.measuredLabel(for: "ko-KR"))
+        })
         let allResolved = expected.allSatisfy { criterion, label in
-            resolved[criterion] == label
+            resolved[criterion] == label && runtimeResolved[criterion] == label
         }
 
         #expect(allResolved)
@@ -41,10 +134,10 @@ struct Issue448TrackSortVerifiedTests {
         let policyRefusesEnglish = TrackSortCriterion.trackName.measuredLabel(for: "en_US") == nil
         let outcome = TrackSortVerifier.execute(
             criterion: .trackName,
-            expectedOrder: ["Bass", "Kick"],
-            before: { .read(["Kick", "Bass"]) },
+            expectedOrder: ["trk_bass", "trk_kick"],
+            before: { .read(["trk_kick", "trk_bass"]) },
             actuate: { .unmeasuredLocale("en_US") },
-            after: { .read(["Bass", "Kick"]) }
+            after: { .read(["trk_bass", "trk_kick"]) }
         )
 
         let refusedForMissingMeasurement: Bool
@@ -61,10 +154,10 @@ struct Issue448TrackSortVerifiedTests {
     func measuredCriterionLabelAbsentRefuses() {
         let outcome = TrackSortVerifier.execute(
             criterion: .trackName,
-            expectedOrder: ["Bass", "Kick"],
-            before: { .read(["Kick", "Bass"]) },
+            expectedOrder: ["trk_bass", "trk_kick"],
+            before: { .read(["trk_kick", "trk_bass"]) },
             actuate: { .criterionLabelMissing("트랙 이름") },
-            after: { .read(["Bass", "Kick"]) }
+            after: { .read(["trk_bass", "trk_kick"]) }
         )
 
         let refusedForAbsentMeasuredLabel: Bool
@@ -80,10 +173,10 @@ struct Issue448TrackSortVerifiedTests {
     func postSortMismatchRefuses() {
         let outcome = TrackSortVerifier.execute(
             criterion: .trackName,
-            expectedOrder: ["Bass", "Kick"],
-            before: { .read(["Kick", "Bass"]) },
+            expectedOrder: ["trk_bass", "trk_kick"],
+            before: { .read(["trk_kick", "trk_bass"]) },
             actuate: { .actuated },
-            after: { .read(["Kick", "Bass"]) }
+            after: { .read(["trk_kick", "trk_bass"]) }
         )
 
         let rejectedMismatch: Bool
@@ -99,15 +192,15 @@ struct Issue448TrackSortVerifiedTests {
     func unreadableOrdersRefuseOrRemainUncertain() {
         let beforeUnreadable = TrackSortVerifier.execute(
             criterion: .trackName,
-            expectedOrder: ["Bass", "Kick"],
+            expectedOrder: ["trk_bass", "trk_kick"],
             before: { .unavailable },
             actuate: { .actuated },
-            after: { .read(["Bass", "Kick"]) }
+            after: { .read(["trk_bass", "trk_kick"]) }
         )
         let afterUnreadable = TrackSortVerifier.execute(
             criterion: .trackName,
-            expectedOrder: ["Bass", "Kick"],
-            before: { .read(["Kick", "Bass"]) },
+            expectedOrder: ["trk_bass", "trk_kick"],
+            before: { .read(["trk_kick", "trk_bass"]) },
             actuate: { .actuated },
             after: { .unavailable }
         )
@@ -129,33 +222,149 @@ struct Issue448TrackSortVerifiedTests {
         #expect(afterUncertain)
     }
 
-    @Test("an already-sorted project is State B because a no-op is not observable")
-    func alreadySortedIsUncertain() {
-        let outcome = TrackSortVerifier.execute(
-            criterion: .trackName,
-            expectedOrder: ["Bass", "Kick"],
-            before: { .read(["Bass", "Kick"]) },
-            actuate: { .actuated },
-            after: { .read(["Bass", "Kick"]) }
+    @Test("three same-named tracks sort and verify by their issued references")
+    func duplicateNamesSortAndVerify() throws {
+        let fixture = TrackSortAXFixture(orderAfterPress: [2, 1, 0])
+        let result = AccessibilityChannel.defaultSortTracks(
+            params: [
+                "criterion": "track_name",
+                "expected_order_json": fixture.expectedOrderJSON,
+            ],
+            runtime: fixture.runtime
         )
+        let body = try #require(sharedJSONObject(result.message))
+        let expected = ["trk_studio_grand_2", "trk_studio_grand_1", "trk_studio_grand_0"]
+        let allDisplayNamesAreDuplicates = Set(["Studio Grand", "Studio Grand", "Studio Grand"]).count == 1
+        let verifiedUnambiguously = result.isSuccess
+            && body["state"] as? String == "A"
+            && body["expected_order"] as? [String] == expected
+            && body["after_order"] as? [String] == expected
 
-        let isUnobservableNoOp: Bool
-        if case .uncertain(.alreadySortedCommandUnobservable) = outcome {
-            isUnobservableNoOp = true
-        } else {
-            isUnobservableNoOp = false
+        #expect(allDisplayNamesAreDuplicates)
+        #expect(verifiedUnambiguously)
+    }
+
+    @Test("an already-sorted reference order is State B with an observable reason")
+    func alreadySortedIsStateB() throws {
+        let fixture = TrackSortAXFixture(orderAfterPress: [0, 1, 2])
+        let result = AccessibilityChannel.defaultSortTracks(
+            params: [
+                "criterion": "track_name",
+                "expected_order_json": fixture.expectedOrderJSON,
+            ],
+            runtime: fixture.runtime
+        )
+        let body = try #require(sharedJSONObject(result.message))
+        let stateBForUnobservableNoOp = result.isSuccess
+            && body["state"] as? String == "B"
+            && body["reason"] as? String == HonestContract.UncertainReason.readbackUnavailable.rawValue
+            && body["detail"] as? String == "already_sorted_command_unobservable"
+
+        #expect(stateBForUnobservableNoOp)
+    }
+
+    @Test("a wrong post-sort reference order reaches State B and the tool surface refuses it")
+    func postSortMismatchIsRefusedByToolSurface() async throws {
+        let fixture = TrackSortAXFixture(
+            orderAfterPress: [1, 0, 2],
+            expectedReferenceOrder: [2, 1, 0]
+        )
+        let channelResult = AccessibilityChannel.defaultSortTracks(
+            params: [
+                "criterion": "track_name",
+                "expected_order_json": fixture.expectedOrderJSON,
+            ],
+            runtime: fixture.runtime
+        )
+        let channelBody = try #require(sharedJSONObject(channelResult.message))
+
+        let registry = TargetRegistry()
+        let references = await FeatureFlags.withAdr002TargetRefForTests(true) {
+            var references: [TargetReference] = []
+            for index in 0..<3 {
+                let descriptor = TargetDescriptor(trackIndex: index, trackName: "Studio Grand")
+                references.append(await registry.bind(
+                    kind: .track,
+                    descriptor: descriptor,
+                    fingerprint: descriptor.fingerprint
+                ))
+            }
+            return references
         }
-        #expect(isUnobservableNoOp)
+        let router = ChannelRouter()
+        let stateBChannel = TrackSortStateBChannel()
+        await router.register(stateBChannel)
+        let toolResult = await FeatureFlags.withAdr002TargetRefForTests(true) {
+            await TrackDispatcher.handle(
+                command: "sort_verified",
+                params: [
+                    "criterion": .string("track_name"),
+                    "expected_order": .array(references.reversed().map { .string($0.rawValue) }),
+                    "confirmed": .bool(true),
+                ],
+                router: router,
+                cache: StateCache(),
+                targetRegistry: registry
+            )
+        }
+        let toolBody = try #require(sharedJSONObject(sharedToolText(toolResult)))
+        let mismatchWasStateB = channelResult.isSuccess
+            && channelBody["state"] as? String == "B"
+            && channelBody["reason"] as? String == HonestContract.UncertainReason.readbackMismatch.rawValue
+        let toolRefusedMismatch = toolResult.isError == true
+            && toolBody["state"] as? String == "B"
+            && toolBody["reason"] as? String == HonestContract.UncertainReason.readbackMismatch.rawValue
+
+        #expect(mismatchWasStateB)
+        #expect(toolRefusedMismatch)
+    }
+
+    @Test("an expected order names an unavailable track reference before any write")
+    func unavailableExpectedReferenceRefusesAndNamesIt() async throws {
+        let registry = TargetRegistry()
+        let descriptor = TargetDescriptor(trackIndex: 0, trackName: "Studio Grand")
+        let liveReference = await registry.bind(
+            kind: .track,
+            descriptor: descriptor,
+            fingerprint: descriptor.fingerprint
+        )
+        let absentReference = "trk_\(UUID().uuidString)"
+        let router = ChannelRouter()
+        let stateBChannel = TrackSortStateBChannel()
+        await router.register(stateBChannel)
+
+        let result = await FeatureFlags.withAdr002TargetRefForTests(true) {
+            await TrackDispatcher.handle(
+                command: "sort_verified",
+                params: [
+                    "criterion": .string("track_name"),
+                    "expected_order": .array([.string(liveReference.rawValue), .string(absentReference)]),
+                    "confirmed": .bool(true),
+                ],
+                router: router,
+                cache: StateCache(),
+                targetRegistry: registry
+            )
+        }
+        let body = try #require(sharedJSONObject(sharedToolText(result)))
+        let missingReferences = try #require(body["missing_track_refs"] as? [String])
+        let noWriteWasRouted = await stateBChannel.calls.isEmpty
+        let namedAbsentReference = result.isError == true
+            && body["reason"] as? String == "expected_order_unknown_track_refs"
+            && missingReferences == [absentReference]
+            && noWriteWasRouted
+
+        #expect(namedAbsentReference)
     }
 
     @Test("a disabled measured menu item is refused before it is pressed")
     func disabledMenuItemRefuses() {
         let outcome = TrackSortVerifier.execute(
             criterion: .trackName,
-            expectedOrder: ["Bass", "Kick"],
-            before: { .read(["Kick", "Bass"]) },
+            expectedOrder: ["trk_bass", "trk_kick"],
+            before: { .read(["trk_kick", "trk_bass"]) },
             actuate: { .disabledMenuItem("트랙 이름") },
-            after: { .read(["Bass", "Kick"]) }
+            after: { .read(["trk_bass", "trk_kick"]) }
         )
 
         let disabledWasRefused: Bool

--- a/Tests/LogicProMCPTests/Issue448TrackSortVerifiedTests.swift
+++ b/Tests/LogicProMCPTests/Issue448TrackSortVerifiedTests.swift
@@ -1,0 +1,169 @@
+import Testing
+@testable import LogicProMCP
+
+/// #448 — a sort is only State A when the post-write arrangement order is the
+/// requested criterion's expected order. A changed order alone proves nothing:
+/// another sort criterion also changes track order.
+@Suite("#448 verified track sort")
+struct Issue448TrackSortVerifiedTests {
+    @Test("an unknown sort criterion is rejected before any AX work")
+    func unknownCriterionRefuses() {
+        let criterion = TrackSortCriterion(rawValue: "not_a_sort_criterion")
+        let isUnknown = criterion == nil
+
+        #expect(isUnknown)
+    }
+
+    @Test("every measured Korean criterion resolves to its observed menu label")
+    func everyCriterionResolvesMeasuredLabel() {
+        let expected: [TrackSortCriterion: String] = [
+            .midiChannel: "MIDI 채널",
+            .audioChannel: "오디오 채널",
+            .outputChannel: "출력 채널",
+            .instrumentName: "악기 이름",
+            .trackName: "트랙 이름",
+            .used: "사용 여부",
+            .creationDate: "생성일",
+        ]
+
+        let resolved = Dictionary(uniqueKeysWithValues: TrackSortCriterion.allCases.map {
+            ($0, $0.measuredLabel(for: "ko_KR"))
+        })
+        let allResolved = expected.allSatisfy { criterion, label in
+            resolved[criterion] == label
+        }
+
+        #expect(allResolved)
+    }
+
+    @Test("an unmeasured locale names the missing sort-menu measurement")
+    func unmeasuredLocaleRefuses() {
+        let policyRefusesEnglish = TrackSortCriterion.trackName.measuredLabel(for: "en_US") == nil
+        let outcome = TrackSortVerifier.execute(
+            criterion: .trackName,
+            expectedOrder: ["Bass", "Kick"],
+            before: { .read(["Kick", "Bass"]) },
+            actuate: { .unmeasuredLocale("en_US") },
+            after: { .read(["Bass", "Kick"]) }
+        )
+
+        let refusedForMissingMeasurement: Bool
+        if case .refused(.unmeasuredLocale(let locale)) = outcome {
+            refusedForMissingMeasurement = locale == "en_US"
+        } else {
+            refusedForMissingMeasurement = false
+        }
+        let bothLocaleGuardsHeld = policyRefusesEnglish && refusedForMissingMeasurement
+        #expect(bothLocaleGuardsHeld)
+    }
+
+    @Test("a missing leaf in the measured locale has its own refusal")
+    func measuredCriterionLabelAbsentRefuses() {
+        let outcome = TrackSortVerifier.execute(
+            criterion: .trackName,
+            expectedOrder: ["Bass", "Kick"],
+            before: { .read(["Kick", "Bass"]) },
+            actuate: { .criterionLabelMissing("트랙 이름") },
+            after: { .read(["Bass", "Kick"]) }
+        )
+
+        let refusedForAbsentMeasuredLabel: Bool
+        if case .refused(.criterionLabelMissing(let label)) = outcome {
+            refusedForAbsentMeasuredLabel = label == "트랙 이름"
+        } else {
+            refusedForAbsentMeasuredLabel = false
+        }
+        #expect(refusedForAbsentMeasuredLabel)
+    }
+
+    @Test("an order changed by the wrong criterion is refused, not reported verified")
+    func postSortMismatchRefuses() {
+        let outcome = TrackSortVerifier.execute(
+            criterion: .trackName,
+            expectedOrder: ["Bass", "Kick"],
+            before: { .read(["Kick", "Bass"]) },
+            actuate: { .actuated },
+            after: { .read(["Kick", "Bass"]) }
+        )
+
+        let rejectedMismatch: Bool
+        if case .uncertain(.afterOrderMismatch) = outcome {
+            rejectedMismatch = true
+        } else {
+            rejectedMismatch = false
+        }
+        #expect(rejectedMismatch)
+    }
+
+    @Test("an unreadable before or after order is never assumed")
+    func unreadableOrdersRefuseOrRemainUncertain() {
+        let beforeUnreadable = TrackSortVerifier.execute(
+            criterion: .trackName,
+            expectedOrder: ["Bass", "Kick"],
+            before: { .unavailable },
+            actuate: { .actuated },
+            after: { .read(["Bass", "Kick"]) }
+        )
+        let afterUnreadable = TrackSortVerifier.execute(
+            criterion: .trackName,
+            expectedOrder: ["Bass", "Kick"],
+            before: { .read(["Kick", "Bass"]) },
+            actuate: { .actuated },
+            after: { .unavailable }
+        )
+
+        let beforeRefused: Bool
+        if case .refused(.beforeOrderUnreadable) = beforeUnreadable {
+            beforeRefused = true
+        } else {
+            beforeRefused = false
+        }
+        let afterUncertain: Bool
+        if case .uncertain(.afterOrderUnreadable) = afterUnreadable {
+            afterUncertain = true
+        } else {
+            afterUncertain = false
+        }
+
+        #expect(beforeRefused)
+        #expect(afterUncertain)
+    }
+
+    @Test("an already-sorted project is State B because a no-op is not observable")
+    func alreadySortedIsUncertain() {
+        let outcome = TrackSortVerifier.execute(
+            criterion: .trackName,
+            expectedOrder: ["Bass", "Kick"],
+            before: { .read(["Bass", "Kick"]) },
+            actuate: { .actuated },
+            after: { .read(["Bass", "Kick"]) }
+        )
+
+        let isUnobservableNoOp: Bool
+        if case .uncertain(.alreadySortedCommandUnobservable) = outcome {
+            isUnobservableNoOp = true
+        } else {
+            isUnobservableNoOp = false
+        }
+        #expect(isUnobservableNoOp)
+    }
+
+    @Test("a disabled measured menu item is refused before it is pressed")
+    func disabledMenuItemRefuses() {
+        let outcome = TrackSortVerifier.execute(
+            criterion: .trackName,
+            expectedOrder: ["Bass", "Kick"],
+            before: { .read(["Kick", "Bass"]) },
+            actuate: { .disabledMenuItem("트랙 이름") },
+            after: { .read(["Bass", "Kick"]) }
+        )
+
+        let disabledWasRefused: Bool
+        if case .refused(.disabledMenuItem(let label)) = outcome {
+            disabledWasRefused = label == "트랙 이름"
+        } else {
+            disabledWasRefused = false
+        }
+        #expect(disabledWasRefused)
+    }
+}

--- a/Tests/LogicProMCPTests/Issue448TrackSortVerifiedTests.swift
+++ b/Tests/LogicProMCPTests/Issue448TrackSortVerifiedTests.swift
@@ -10,16 +10,21 @@ import Testing
 private actor TrackSortStateBChannel: Channel {
     nonisolated let id: ChannelID = .accessibility
     private(set) var calls: [(operation: String, params: [String: String])] = []
+    private let result: ChannelResult
+
+    init(result: ChannelResult = .success(HonestContract.encodeStateB(
+        reason: .readbackMismatch,
+        extras: ["operation": "track.sort_verified"]
+    ))) {
+        self.result = result
+    }
 
     func start() async throws {}
     func stop() async {}
 
     func execute(operation: String, params: [String: String]) async -> ChannelResult {
         calls.append((operation, params))
-        return .success(HonestContract.encodeStateB(
-            reason: .readbackMismatch,
-            extras: ["operation": operation]
-        ))
+        return result
     }
 
     func healthCheck() async -> ChannelHealth {
@@ -27,12 +32,58 @@ private actor TrackSortStateBChannel: Channel {
     }
 }
 
+private final class TrackSortActionProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+    private var postPressRailReadCount = 0
+
+    func recordPress() {
+        lock.lock()
+        count += 1
+        lock.unlock()
+    }
+
+    var pressCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+
+    func nextPostPressRailRead() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        let current = postPressRailReadCount
+        postPressRailReadCount += 1
+        return current
+    }
+}
+
+private let trackNameActuation = TrackSortVerifier.ActuatedMenuItem(
+    localizedLabel: "트랙 이름",
+    criterion: .trackName
+)
+
 private struct TrackSortAXFixture {
     let runtime: AXLogicProElements.Runtime
     let expectedOrderJSON: String
+    let actionProbe: TrackSortActionProbe
 
-    init(orderAfterPress: [Int], expectedReferenceOrder: [Int]? = nil) {
+    init(
+        orderAfterPress: [Int],
+        expectedReferenceOrder: [Int]? = nil,
+        names: [String] = ["Kick", "Bass", "Piano"],
+        pressReturnsSuccess: Bool = true,
+        collapsedStackAt: Int? = nil,
+        railUnreadableAfterPress: Bool = false,
+        postPressOrders: [[Int]]? = nil,
+        windowsReadStatus: AXHelpers.AXStatusError? = nil,
+        railRoleReadStatus: AXHelpers.AXStatusError? = nil,
+        menuEnabledReadStatus: AXHelpers.AXStatusError? = nil
+    ) {
+        precondition(names.count == 3)
         let builder = FakeAXRuntimeBuilder()
+        let probe = TrackSortActionProbe()
+        actionProbe = probe
         let app = builder.element(448_000)
         let arrange = builder.element(448_001)
         let rail = builder.element(448_002)
@@ -52,8 +103,15 @@ private struct TrackSortAXFixture {
         let headers = (0..<3).map { offset -> AXUIElement in
             let header = builder.element(448_100 + offset)
             builder.setAttribute(header, kAXRoleAttribute as String, kAXLayoutItemRole as String)
-            builder.setAttribute(header, kAXTitleAttribute as String, "Studio Grand")
-            builder.setChildren(header, [])
+            builder.setAttribute(header, kAXTitleAttribute as String, names[offset])
+            if collapsedStackAt == offset {
+                let disclosure = builder.element(448_200 + offset)
+                builder.setAttribute(disclosure, kAXRoleAttribute as String, kAXDisclosureTriangleRole as String)
+                builder.setAttribute(disclosure, kAXValueAttribute as String, 0)
+                builder.setChildren(header, [disclosure])
+            } else {
+                builder.setChildren(header, [])
+            }
             return header
         }
         builder.setChildren(rail, headers)
@@ -70,21 +128,59 @@ private struct TrackSortAXFixture {
 
         runtime = builder.makeLogicRuntime(
             appElement: app,
+            attributeValueResultHandler: { element, attribute in
+                if let windowsReadStatus,
+                   builder.elementID(element) == builder.elementID(app),
+                   attribute == (kAXWindowsAttribute as String) {
+                    return .failure(windowsReadStatus)
+                }
+                if let railRoleReadStatus,
+                   builder.elementID(element) == builder.elementID(rail),
+                   attribute == (kAXRoleAttribute as String) {
+                    return .failure(railRoleReadStatus)
+                }
+                if let menuEnabledReadStatus,
+                   builder.elementID(element) == builder.elementID(sortByName),
+                   attribute == (kAXEnabledAttribute as String) {
+                    return .failure(menuEnabledReadStatus)
+                }
+                return nil
+            },
+            childrenResultHandler: { element in
+                guard builder.elementID(element) == builder.elementID(rail),
+                      probe.pressCount > 0 else {
+                    return nil
+                }
+                if railUnreadableAfterPress {
+                    return .failure(AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue))
+                }
+                if let postPressOrders, !postPressOrders.isEmpty {
+                    // The strict rail scan reads the candidate and then its rows,
+                    // so each observation consumes two rail-children reads.
+                    let observation = min(
+                        probe.nextPostPressRailRead() / 2,
+                        postPressOrders.count - 1
+                    )
+                    return .success(postPressOrders[observation].map { headers[$0] })
+                }
+                return nil
+            },
             setAttributeHandler: nil,
             performActionHandler: { element, action in
                 guard action == kAXPressAction as String,
                       builder.elementID(element) == builder.elementID(sortByName) else {
                     return false
                 }
+                probe.recordPress()
                 builder.setChildren(rail, orderAfterPress.map { headers[$0] })
-                return true
+                return pressReturnsSuccess
             }
         )
         let expected = (expectedReferenceOrder ?? orderAfterPress).map {
             TrackSortExpectedTrack(
-                reference: "trk_studio_grand_\($0)",
+                reference: "trk_\($0)",
                 beforeIndex: $0,
-                beforeName: "Studio Grand"
+                beforeName: names[$0]
             )
         }
         expectedOrderJSON = String(
@@ -169,23 +265,29 @@ struct Issue448TrackSortVerifiedTests {
         #expect(refusedForAbsentMeasuredLabel)
     }
 
-    @Test("an order changed by the wrong criterion is refused, not reported verified")
-    func postSortMismatchRefuses() {
+    @Test("an order matching expectation under the wrong actuated criterion is refused")
+    func wrongActuatedCriterionRefuses() {
+        let instrumentNameActuation = TrackSortVerifier.ActuatedMenuItem(
+            localizedLabel: "악기 이름",
+            criterion: .instrumentName
+        )
         let outcome = TrackSortVerifier.execute(
             criterion: .trackName,
             expectedOrder: ["trk_bass", "trk_kick"],
             before: { .read(["trk_kick", "trk_bass"]) },
-            actuate: { .actuated },
-            after: { .read(["trk_kick", "trk_bass"]) }
+            actuate: { .actuated(instrumentNameActuation) },
+            // The wrong sort happens to produce the requested permutation. This
+            // test fails if the production criterion-binding guard is removed.
+            after: { .read(["trk_bass", "trk_kick"]) }
         )
 
-        let rejectedMismatch: Bool
-        if case .uncertain(.afterOrderMismatch) = outcome {
-            rejectedMismatch = true
+        let rejectedWrongActuatedCriterion: Bool
+        if case .refused(.criterionMismatch(let actual, let label)) = outcome {
+            rejectedWrongActuatedCriterion = actual == .instrumentName && label == "악기 이름"
         } else {
-            rejectedMismatch = false
+            rejectedWrongActuatedCriterion = false
         }
-        #expect(rejectedMismatch)
+        #expect(rejectedWrongActuatedCriterion)
     }
 
     @Test("an unreadable before or after order is never assumed")
@@ -194,14 +296,14 @@ struct Issue448TrackSortVerifiedTests {
             criterion: .trackName,
             expectedOrder: ["trk_bass", "trk_kick"],
             before: { .unavailable },
-            actuate: { .actuated },
+            actuate: { .actuated(trackNameActuation) },
             after: { .read(["trk_bass", "trk_kick"]) }
         )
         let afterUnreadable = TrackSortVerifier.execute(
             criterion: .trackName,
             expectedOrder: ["trk_bass", "trk_kick"],
             before: { .read(["trk_kick", "trk_bass"]) },
-            actuate: { .actuated },
+            actuate: { .actuated(trackNameActuation) },
             after: { .unavailable }
         )
 
@@ -222,8 +324,31 @@ struct Issue448TrackSortVerifiedTests {
         #expect(afterUncertain)
     }
 
-    @Test("three same-named tracks sort and verify by their issued references")
-    func duplicateNamesSortAndVerify() throws {
+    @Test("duplicate names refuse before AX work because no per-track identity was issued")
+    func duplicateNamesRefuseBeforePress() throws {
+        let fixture = TrackSortAXFixture(
+            orderAfterPress: [2, 1, 0],
+            names: ["Studio Grand", "Studio Grand", "Studio Grand"]
+        )
+        let result = AccessibilityChannel.defaultSortTracks(
+            params: [
+                "criterion": "track_name",
+                "expected_order_json": fixture.expectedOrderJSON,
+            ],
+            runtime: fixture.runtime
+        )
+        let body = try #require(sharedJSONObject(result.message))
+        let duplicateNamesWerePresent = Set(["Studio Grand", "Studio Grand", "Studio Grand"]).count == 1
+        let refusedWithoutAXPress = result.isSuccess == false
+            && body["reason"] as? String == "duplicate_name_reference_identity_unprovable"
+            && fixture.actionProbe.pressCount == 0
+
+        #expect(duplicateNamesWerePresent)
+        #expect(refusedWithoutAXPress)
+    }
+
+    @Test("State A carries the exact pressed leaf and its measured criterion")
+    func verifiedSortCarriesActuatedCriterionEvidence() throws {
         let fixture = TrackSortAXFixture(orderAfterPress: [2, 1, 0])
         let result = AccessibilityChannel.defaultSortTracks(
             params: [
@@ -233,15 +358,126 @@ struct Issue448TrackSortVerifiedTests {
             runtime: fixture.runtime
         )
         let body = try #require(sharedJSONObject(result.message))
-        let expected = ["trk_studio_grand_2", "trk_studio_grand_1", "trk_studio_grand_0"]
-        let allDisplayNamesAreDuplicates = Set(["Studio Grand", "Studio Grand", "Studio Grand"]).count == 1
-        let verifiedUnambiguously = result.isSuccess
+        let includesActualLeafEvidence = result.isSuccess
             && body["state"] as? String == "A"
-            && body["expected_order"] as? [String] == expected
-            && body["after_order"] as? [String] == expected
+            && body["criterion"] as? String == "track_name"
+            && body["actuated_criterion"] as? String == "track_name"
+            && body["actuated_menu_item_label"] as? String == "트랙 이름"
+            && fixture.actionProbe.pressCount == 1
 
-        #expect(allDisplayNamesAreDuplicates)
-        #expect(verifiedUnambiguously)
+        #expect(includesActualLeafEvidence)
+    }
+
+    @Test("a collapsed stack refuses before its hidden tracks can be sorted")
+    func collapsedStackRefusesBeforePress() throws {
+        let fixture = TrackSortAXFixture(orderAfterPress: [2, 1, 0], collapsedStackAt: 1)
+        let result = AccessibilityChannel.defaultSortTracks(
+            params: [
+                "criterion": "track_name",
+                "expected_order_json": fixture.expectedOrderJSON,
+            ],
+            runtime: fixture.runtime
+        )
+        let body = try #require(sharedJSONObject(result.message))
+        let collapsedScopeWasRejected = result.isSuccess == false
+            && body["reason"] as? String == "collapsed_track_stack"
+            && (body["collapsed_stack"] as? [String: Any])?["index"] as? Int == 1
+            && fixture.actionProbe.pressCount == 0
+
+        #expect(collapsedScopeWasRejected)
+    }
+
+    @Test("a failed AXPress still reads back and reports a verified observed order")
+    func failedPressStillReadsBack() throws {
+        let fixture = TrackSortAXFixture(orderAfterPress: [2, 1, 0], pressReturnsSuccess: false)
+        let result = AccessibilityChannel.defaultSortTracks(
+            params: [
+                "criterion": "track_name",
+                "expected_order_json": fixture.expectedOrderJSON,
+            ],
+            runtime: fixture.runtime
+        )
+        let body = try #require(sharedJSONObject(result.message))
+        let failedReceiptDidNotEraseTheWrite = result.isSuccess
+            && body["state"] as? String == "A"
+            && body["menu_press_reported_success"] as? Bool == false
+            && body["write_attempted"] as? Bool == true
+            && body["after_order"] as? [String] == ["trk_2", "trk_1", "trk_0"]
+            && fixture.actionProbe.pressCount == 1
+
+        #expect(failedReceiptDidNotEraseTheWrite)
+    }
+
+    @Test("a failed AXPress with unreadable order marks project state unknown and invalidates refs")
+    func failedPressUnreadableOrderInvalidatesReferences() async throws {
+        let fixture = TrackSortAXFixture(
+            orderAfterPress: [2, 1, 0],
+            pressReturnsSuccess: false,
+            railUnreadableAfterPress: true
+        )
+        let channelResult = AccessibilityChannel.defaultSortTracks(
+            params: [
+                "criterion": "track_name",
+                "expected_order_json": fixture.expectedOrderJSON,
+            ],
+            runtime: fixture.runtime
+        )
+        let channelBody = try #require(sharedJSONObject(channelResult.message))
+
+        let registry = TargetRegistry()
+        let descriptor = TargetDescriptor(trackIndex: 0, trackName: "Kick")
+        let reference = await registry.bind(
+            kind: .track,
+            descriptor: descriptor,
+            fingerprint: descriptor.fingerprint
+        )
+        let router = ChannelRouter()
+        await router.register(TrackSortStateBChannel(result: channelResult))
+        _ = await FeatureFlags.withAdr002TargetRefForTests(true) {
+            await TrackDispatcher.handle(
+                command: "sort_verified",
+                params: [
+                    "criterion": .string("track_name"),
+                    "expected_order": .array([.string(reference.rawValue)]),
+                    "confirmed": .bool(true),
+                ],
+                router: router,
+                cache: StateCache(),
+                targetRegistry: registry
+            )
+        }
+        let referenceWasInvalidated = await registry.resolve(reference) == nil
+        let unknownStateWasHonest = channelResult.isSuccess
+            && channelBody["state"] as? String == "B"
+            && channelBody["write_attempted"] as? Bool == true
+            && channelBody["project_state"] as? String == "unknown"
+            && channelBody["safe_to_retry"] as? Bool == false
+            && fixture.actionProbe.pressCount == 1
+
+        #expect(unknownStateWasHonest)
+        #expect(referenceWasInvalidated)
+    }
+
+    @Test("a transient matching order cannot reach State A before the second matching observation")
+    func transientOrderDoesNotPassSettleWitness() throws {
+        let fixture = TrackSortAXFixture(
+            orderAfterPress: [2, 1, 0],
+            postPressOrders: [[2, 1, 0], [1, 0, 2]]
+        )
+        let result = AccessibilityChannel.defaultSortTracks(
+            params: [
+                "criterion": "track_name",
+                "expected_order_json": fixture.expectedOrderJSON,
+            ],
+            runtime: fixture.runtime
+        )
+        let body = try #require(sharedJSONObject(result.message))
+        let transientWasNotPromoted = result.isSuccess
+            && body["state"] as? String == "B"
+            && body["reason"] as? String == HonestContract.UncertainReason.readbackMismatch.rawValue
+            && body["after_order"] as? [String] == ["trk_1", "trk_0", "trk_2"]
+
+        #expect(transientWasNotPromoted)
     }
 
     @Test("an already-sorted reference order is State B with an observable reason")
@@ -355,6 +591,94 @@ struct Issue448TrackSortVerifiedTests {
             && noWriteWasRouted
 
         #expect(namedAbsentReference)
+    }
+
+    @Test("an AXWindows read failure refuses instead of falling through a legacy empty list")
+    func windowsReadFailureRefusesBeforePress() throws {
+        let fixture = TrackSortAXFixture(
+            orderAfterPress: [2, 1, 0],
+            windowsReadStatus: AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue)
+        )
+        let result = AccessibilityChannel.defaultSortTracks(
+            params: [
+                "criterion": "track_name",
+                "expected_order_json": fixture.expectedOrderJSON,
+            ],
+            runtime: fixture.runtime
+        )
+        let body = try #require(sharedJSONObject(result.message))
+        let failedWindowReadWasNotAnEmptyWindowList = result.isSuccess == false
+            && body["reason"] as? String == "before_order_read_failed"
+            && body["read_failure_stage"] as? String == "AXWindows"
+            && body["read_failure_status"] as? String == String(AXError.cannotComplete.rawValue)
+            && fixture.actionProbe.pressCount == 0
+
+        #expect(failedWindowReadWasNotAnEmptyWindowList)
+    }
+
+    @Test("the two definitive-absence AX statuses still permit the direct arrange-window read")
+    func windowsDefinitiveAbsenceIsNotAReadFailure() throws {
+        let fixture = TrackSortAXFixture(
+            orderAfterPress: [2, 1, 0],
+            windowsReadStatus: AXHelpers.AXStatusError(raw: AXError.noValue.rawValue)
+        )
+        let result = AccessibilityChannel.defaultSortTracks(
+            params: [
+                "criterion": "track_name",
+                "expected_order_json": fixture.expectedOrderJSON,
+            ],
+            runtime: fixture.runtime
+        )
+        let body = try #require(sharedJSONObject(result.message))
+        let definitiveAbsenceWasHandledAsAbsence = result.isSuccess
+            && body["state"] as? String == "A"
+            && fixture.actionProbe.pressCount == 1
+
+        #expect(definitiveAbsenceWasHandledAsAbsence)
+    }
+
+    @Test("an unreadable rail role refuses instead of being flattened to no rail")
+    func railRoleReadFailureRefusesBeforePress() throws {
+        let fixture = TrackSortAXFixture(
+            orderAfterPress: [2, 1, 0],
+            railRoleReadStatus: AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue)
+        )
+        let result = AccessibilityChannel.defaultSortTracks(
+            params: [
+                "criterion": "track_name",
+                "expected_order_json": fixture.expectedOrderJSON,
+            ],
+            runtime: fixture.runtime
+        )
+        let body = try #require(sharedJSONObject(result.message))
+        let unreadableRoleWasNotReportedAsAbsentRail = result.isSuccess == false
+            && body["reason"] as? String == "before_order_read_failed"
+            && body["read_failure_stage"] as? String == "track_header_candidate_role"
+            && body["read_failure_status"] as? String == String(AXError.cannotComplete.rawValue)
+            && fixture.actionProbe.pressCount == 0
+
+        #expect(unreadableRoleWasNotReportedAsAbsentRail)
+    }
+
+    @Test("an unreadable AXEnabled status is not misreported as a disabled menu item")
+    func menuEnabledReadFailureRefusesBeforePress() throws {
+        let fixture = TrackSortAXFixture(
+            orderAfterPress: [2, 1, 0],
+            menuEnabledReadStatus: AXHelpers.AXStatusError(raw: AXError.cannotComplete.rawValue)
+        )
+        let result = AccessibilityChannel.defaultSortTracks(
+            params: [
+                "criterion": "track_name",
+                "expected_order_json": fixture.expectedOrderJSON,
+            ],
+            runtime: fixture.runtime
+        )
+        let body = try #require(sharedJSONObject(result.message))
+        let enabledReadFailureWasNamed = result.isSuccess == false
+            && body["reason"] as? String == "sort_menu_read_failed"
+            && fixture.actionProbe.pressCount == 0
+
+        #expect(enabledReadFailureWasNamed)
     }
 
     @Test("a disabled measured menu item is refused before it is pressed")

--- a/Tests/LogicProMCPTests/OperationCatalogTests.swift
+++ b/Tests/LogicProMCPTests/OperationCatalogTests.swift
@@ -195,6 +195,7 @@ struct OperationCatalogTests {
         .tracksSolo: ["enabled"],
         .tracksArm: ["enabled"],
         .tracksRecordSequence: ["bar", "notes", "tempo"],
+        .tracksSortVerified: ["confirmed", "criterion", "expected_order"],
         .tracksSetAutomation: ["mode"],
         .tracksSetInstrument: ["category", "path", "preset"],
         .tracksScanLibrary: ["mode"],
@@ -399,7 +400,7 @@ struct OperationCatalogTests {
                     ("get_trace", "system.get_trace", ["trace_id"], .none),
                     ("clear_traces", "system.clear_traces", ["confirmed"], .l2),
                 ]
-                #expect(OperationRegistry.specs.count == 112)
+                #expect(OperationRegistry.specs.count == 113)
                 for (command, operationID, allowedParams, confirmation) in expectedSpecs {
                     let spec = OperationRegistry.spec(tool: "logic_system", command: command)
                     #expect(spec?.id.rawValue == operationID, "\(command) must have one public spec")
@@ -726,7 +727,7 @@ struct OperationCatalogTests {
 
     @Test("strict: every registered operation rejects unknown keys and accepts its pinned keys")
     func strictRegistryWideInvariant() throws {
-        #expect(OperationRegistry.specs.count == 112)
+        #expect(OperationRegistry.specs.count == 113)
         #expect(Set(OperationRegistry.specs.map(\.id)) == Set(OperationID.allCases))
 
         for spec in OperationRegistry.specs {
@@ -893,7 +894,7 @@ struct OperationCatalogTests {
         #expect(sharedToolText(trackRejected).contains("port parameter not supported for record_sequence"))
     }
 
-    @Test("catalog: exact URI reads the generated 112-operation catalog")
+    @Test("catalog: exact URI reads the generated 113-operation catalog")
     func catalogReadsRegistryProjection() async throws {
         let result = try await ResourceHandlers.read(
             uri: Self.uri,
@@ -906,7 +907,7 @@ struct OperationCatalogTests {
         #expect(body["generated_at"] as? String != nil)
         #expect(body["operation_count"] as? Int == OperationRegistry.specs.count)
         let operations = try #require(body["operations"] as? [[String: Any]])
-        #expect(operations.count == 112)
+        #expect(operations.count == 113)
         #expect(!text.contains("\n"))
 
         let ids = operations.compactMap { $0["id"] as? String }

--- a/Tests/LogicProMCPTests/OperationHandlerBindingTests.swift
+++ b/Tests/LogicProMCPTests/OperationHandlerBindingTests.swift
@@ -142,7 +142,7 @@ struct OperationHandlerBindingTests {
         let specKeys = Set(specs.map { "\($0.tool.rawValue):\($0.command)" })
         let bindingKeys = bindings.map { "\($0.tool):\($0.command)" }
 
-        #expect(specs.count == 112)   // #575 registered edit.move_to_playhead
+        #expect(specs.count == 113)   // #448 registered tracks.sort_verified
         #expect(bindings.count == specs.count)
         #expect(Set(bindingIDs).count == bindings.count, "duplicate handler IDs")
         #expect(Set(bindingKeys).count == bindings.count, "duplicate handler keys")

--- a/Tests/LogicProMCPTests/OperationRegistryCoverageTests.swift
+++ b/Tests/LogicProMCPTests/OperationRegistryCoverageTests.swift
@@ -24,7 +24,7 @@ struct OperationRegistryCoverageTests {
         let missing = Self.publicOperations.subtracting(Self.registeredOperations).sorted()
         let orphans = Self.registeredOperations.subtracting(Self.publicOperations).sorted()
 
-        #expect(OperationRegistry.specs.count == 112)   // #575 registered edit.move_to_playhead
+        #expect(OperationRegistry.specs.count == 113)   // #448 registered tracks.sort_verified
         #expect(OperationRegistry.registeredToolRawValues == Set(WorkflowSkillCatalog.publicCommands.keys))
         #expect(Self.registeredOperations.count == OperationRegistry.specs.count)
         #expect(missing.isEmpty, "missing specs: \(missing)")
@@ -86,12 +86,12 @@ struct OperationRegistryCoverageTests {
             .tracksSetInstrument,
         ]
 
-        #expect(mutating.count == 89)   // #575: move_to_playhead is a mutating edit verb;
+        #expect(mutating.count == 90)   // #448: sort_verified is a mutating structural verb;
                                         // #301 added plugins.set_eq_band_verified, which is
                                         // target-bearing, so `targetless` is unchanged
         #expect(readOnly.count == 23)
         #expect(targetBearingIDs == expectedTargetBearingIDs)
-        #expect(targetless.count == 74)   // #575: it acts on the selection, so it bears no target
+        #expect(targetless.count == 75)   // #448: it reorders the arrangement, so it bears no target
         #expect(targetBearingIDs.count + targetless.count == mutating.count)
         #expect(readOnly.allSatisfy { $0.target == .none })
     }

--- a/Tests/LogicProMCPTests/OperationRegistryTests.swift
+++ b/Tests/LogicProMCPTests/OperationRegistryTests.swift
@@ -607,6 +607,7 @@ struct OperationRegistryTests {
         ("logic_project", "export_resume", .l2),
         ("logic_mixer", "insert_plugin", .l2),
         ("logic_system", "clear_traces", .l2),
+        ("logic_tracks", "sort_verified", .l2),
         ("logic_project", "close", .l3),
         ("logic_project", "quit", .l3),
     ]
@@ -967,6 +968,7 @@ struct OperationRegistryTests {
         ("tracks.arm", "arm", .mutating, .short, .readbackRequired),
         ("tracks.arm_only", "arm_only", .mutating, .short, .readbackRequired),
         ("tracks.record_sequence", "record_sequence", .mutating, .long, .readbackRequired),
+        ("tracks.sort_verified", "sort_verified", .mutating, .medium, .readbackRequired),
         ("tracks.set_automation", "set_automation", .mutating, .short, .readbackRequired),
         ("tracks.set_instrument", "set_instrument", .mutating, .medium, .readbackRequired),
         ("tracks.list_library", "list_library", .readOnly, .long, .none),
@@ -1011,7 +1013,8 @@ struct OperationRegistryTests {
             #expect(spec.tool == tool)
             #expect(spec.command == entry.command)
             #expect(spec.mutability == entry.mutability)
-            #expect(spec.confirmation == .none)
+            let expectedConfirmation: ConfirmationPolicy = entry.command == "sort_verified" ? .l2 : .none
+            #expect(spec.confirmation == expectedConfirmation)
             #expect(spec.target == (targetBearingCommands.contains(entry.command) ? .acceptsStableTarget : .none))
             #expect(spec.verification == entry.verification)
             #expect(spec.retry == .neverAutomatic)
@@ -1038,7 +1041,7 @@ struct OperationRegistryTests {
             .map(\.command))
         #expect(expected == Set([
             "select", "create_audio", "create_instrument", "create_drummer", "create_external_midi",
-            "delete", "duplicate", "rename", "mute", "solo", "arm", "arm_only", "record_sequence",
+            "delete", "duplicate", "rename", "mute", "solo", "arm", "arm_only", "record_sequence", "sort_verified",
             "set_automation", "set_instrument",
         ]))
         #expect(OperationRegistry.mutatingCommands(tool: tool) == expected)
@@ -1054,7 +1057,7 @@ struct OperationRegistryTests {
     @Test("tracks deadlines preserve short medium long and read-only long tiers")
     func tracksDeadlineParity() {
         #expect(Self.trackCommands.filter { $0.deadline == .short }.count == 14)
-        #expect(Self.trackCommands.filter { $0.deadline == .medium }.map(\.command) == ["set_instrument"])
+        #expect(Self.trackCommands.filter { $0.deadline == .medium }.map(\.command) == ["sort_verified", "set_instrument"])
         #expect(Set(Self.trackCommands.filter { $0.deadline == .long }.map(\.command)) == Set([
             "record_sequence", "list_library", "scan_library", "scan_plugin_presets",
         ]))

--- a/Tests/LogicProMCPTests/OperationTraceCoverageTests.swift
+++ b/Tests/LogicProMCPTests/OperationTraceCoverageTests.swift
@@ -186,8 +186,8 @@ extension OperationTraceTests {
         let mutatingSpecs = OperationRegistry.specs.filter {
             $0.mutability == Mutability.`mutating`
         }
-        #expect(OperationRegistry.specs.count == 112)
-        #expect(mutatingSpecs.count == 89)   // #575 registered edit.move_to_playhead
+        #expect(OperationRegistry.specs.count == 113)
+        #expect(mutatingSpecs.count == 90)   // #448 registered tracks.sort_verified
 
         // A mutating op that refuses BEFORE dispatch starts its trace (the
         // consent-first setup_arm_key, #413) starts no trace with the coverage
@@ -297,7 +297,7 @@ extension OperationTraceTests {
 
         let readOnlySpecs = OperationRegistry.specs.filter { $0.mutability == .readOnly }
         let mutatingSpecs = OperationRegistry.specs.filter { $0.mutability == Mutability.`mutating` }
-        #expect(OperationRegistry.specs.count == 112)
+        #expect(OperationRegistry.specs.count == 113)
         #expect(readOnlySpecs.count == 23)
         // Mutability is total: the mutating census (87) and this inverse gate
         // (23) together account for every registered spec, so a new operation
@@ -755,6 +755,12 @@ private func operationTraceCoverageParams(
         ]
     case .tracksRename:
         return ["index": .int(0), "name": .string("Trace Coverage")]
+    case .tracksSortVerified:
+        return [
+            "criterion": .string("track_name"),
+            "expected_order": .array([.string("Track 1")]),
+            "confirmed": .bool(true),
+        ]
     case .tracksMute, .tracksSolo, .tracksArm:
         return ["index": .int(0), "enabled": .bool(true)]
     case .tracksRecordSequence:

--- a/Tests/LogicProMCPTests/OperationTraceCoverageTests.swift
+++ b/Tests/LogicProMCPTests/OperationTraceCoverageTests.swift
@@ -80,6 +80,7 @@ private struct OperationTraceCoverageFixtures {
     let projectPath: String
     let outputRoot: String
     let midiPath: String
+    let sortExpectedOrder: [String]
 }
 
 /// Shared fixture for the #389 store-wide censuses: the same temp project /
@@ -89,6 +90,7 @@ private struct OperationTraceCensusContext {
     let fixtures: OperationTraceCoverageFixtures
     let router: ChannelRouter
     let cache: StateCache
+    let targetRegistry: TargetRegistry
     let mutatingSpecs: [OperationSpec]
     let cleanup: @Sendable () -> Void
 }
@@ -111,6 +113,16 @@ private func makeOperationTraceCensusContext() async throws -> OperationTraceCen
         await router.register(OperationTraceCoverageChannel(id: channelID))
     }
     let cache = StateCache()
+    let targetRegistry = TargetRegistry()
+    let trackDescriptor = TargetDescriptor(
+        trackIndex: 0,
+        trackName: operationTraceCoverageTrackName
+    )
+    let trackReference = await targetRegistry.bind(
+        kind: .track,
+        descriptor: trackDescriptor,
+        fingerprint: trackDescriptor.fingerprint
+    )
     await cache.updateMarkers([
         MarkerState(id: 0, name: "Coverage Marker", position: "1.1.1.1", positionSource: .parser),
     ])
@@ -118,10 +130,12 @@ private func makeOperationTraceCensusContext() async throws -> OperationTraceCen
         fixtures: OperationTraceCoverageFixtures(
             projectPath: project.path,
             outputRoot: outputRoot.path,
-            midiPath: midiFile.fileURL.path
+            midiPath: midiFile.fileURL.path,
+            sortExpectedOrder: [trackReference.rawValue]
         ),
         router: router,
         cache: cache,
+        targetRegistry: targetRegistry,
         mutatingSpecs: OperationRegistry.specs.filter { $0.mutability == Mutability.`mutating` },
         cleanup: {
             try? FileManager.default.removeItem(at: projectRoot)
@@ -169,10 +183,21 @@ extension OperationTraceTests {
         try Data([0x4D, 0x54, 0x68, 0x64]).write(to: midiFile.fileURL)
         defer { SMFWriter.cleanupTemporaryMIDIFile(midiFile) }
 
+        let targetRegistry = TargetRegistry()
+        let trackDescriptor = TargetDescriptor(
+            trackIndex: 0,
+            trackName: operationTraceCoverageTrackName
+        )
+        let trackReference = await targetRegistry.bind(
+            kind: .track,
+            descriptor: trackDescriptor,
+            fingerprint: trackDescriptor.fingerprint
+        )
         let fixtures = OperationTraceCoverageFixtures(
             projectPath: project.path,
             outputRoot: outputRoot.path,
-            midiPath: midiFile.fileURL.path
+            midiPath: midiFile.fileURL.path,
+            sortExpectedOrder: [trackReference.rawValue]
         )
         let router = ChannelRouter()
         for channelID in ChannelID.allCases {
@@ -201,7 +226,8 @@ extension OperationTraceTests {
                 spec,
                 params: operationTraceCoverageParams(for: spec.id, fixtures: fixtures),
                 router: router,
-                cache: cache
+                cache: cache,
+                targetRegistry: targetRegistry
             )
 
             let matchingTrace = await OperationTraceStore.shared.recent(limit: 128)
@@ -265,7 +291,8 @@ extension OperationTraceTests {
         let fixtures = OperationTraceCoverageFixtures(
             projectPath: project.path,
             outputRoot: outputRoot.path,
-            midiPath: midiFile.fileURL.path
+            midiPath: midiFile.fileURL.path,
+            sortExpectedOrder: []
         )
         let router = ChannelRouter()
         for channelID in ChannelID.allCases {
@@ -370,7 +397,8 @@ extension OperationTraceTests {
                     spec,
                     params: operationTraceCoverageParams(for: spec.id, fixtures: context.fixtures),
                     router: context.router,
-                    cache: context.cache
+                    cache: context.cache,
+                    targetRegistry: context.targetRegistry
                 )
             }
             for trace in await OperationTraceStore.shared.recent(limit: 128) {
@@ -432,7 +460,8 @@ extension OperationTraceTests {
                         spec,
                         params: operationTraceCoverageParams(for: spec.id, fixtures: context.fixtures),
                         router: context.router,
-                        cache: context.cache
+                        cache: context.cache,
+                        targetRegistry: context.targetRegistry
                     )
                 }
             }
@@ -540,7 +569,8 @@ private func dispatchOperationTraceCoverageSpec(
     _ spec: OperationSpec,
     params: [String: Value],
     router: ChannelRouter,
-    cache: StateCache
+    cache: StateCache,
+    targetRegistry: TargetRegistry? = nil
 ) async -> CallTool.Result {
     switch spec.tool {
     case .logicTransport:
@@ -627,6 +657,7 @@ private func dispatchOperationTraceCoverageSpec(
             params: params,
             router: router,
             cache: cache,
+            targetRegistry: targetRegistry,
             liveTrackNames: operationTraceCoverageLiveTrackNames
         )
     }
@@ -758,7 +789,7 @@ private func operationTraceCoverageParams(
     case .tracksSortVerified:
         return [
             "criterion": .string("track_name"),
-            "expected_order": .array([.string("Track 1")]),
+            "expected_order": .array(fixtures.sortExpectedOrder.map { .string($0) }),
             "confirmed": .bool(true),
         ]
     case .tracksMute, .tracksSolo, .tracksArm:

--- a/Tests/LogicProMCPTests/QualificationRunnerTests.swift
+++ b/Tests/LogicProMCPTests/QualificationRunnerTests.swift
@@ -109,12 +109,12 @@ struct QualificationRunnerTests {
         // recorded protocolSmoke ("transport worked, nobody checked meaning").
         // Now every read-only spec has an oracle, so a read that returns its
         // real payload qualifies: passed == 23 (22 oracles + health's bespoke
-        // validator), protocolSmoke == 0. The 87 mutating ops are unchanged —
+        // validator), protocolSmoke == 0. The 90 mutating ops are all
         // they still defer to ADR-001-c for live mutation.
-        #expect(operationCases.count == 112)
+        #expect(operationCases.count == 113)
         #expect(operationCases.filter { $0.status == .passed }.count == 23)
         #expect(operationCases.filter { $0.status == .protocolSmoke }.isEmpty)
-        #expect(operationCases.filter { $0.status == .notQualified }.count == 89)
+        #expect(operationCases.filter { $0.status == .notQualified }.count == 90)
         #expect(operationCases.filter { $0.status == .failed }.isEmpty)
         #expect(operationCases.filter { $0.status == .passed }.allSatisfy {
             $0.verificationKind == .semanticReadback
@@ -307,7 +307,7 @@ struct QualificationRunnerTests {
         let specs = OperationRegistry.specs
         let driveResult = Self.driveResult(specs: specs, qualifiedReadOperationCount: 0)
         #expect(driveResult.operationResults.values.filter { $0.status == .passed }.isEmpty)
-        #expect(driveResult.operationResults.values.filter { $0.status == .notQualified }.count == 112)
+        #expect(driveResult.operationResults.values.filter { $0.status == .notQualified }.count == 113)
         let fixture = try Fixture(specs: specs, drive: { _ in driveResult })
         defer { fixture.remove() }
 
@@ -1580,7 +1580,7 @@ struct QualificationRunnerTests {
         ))
 
         #expect(result.handshakeOK)
-        #expect(result.catalog?.operationCount == 112)   // #575 registered edit.move_to_playhead
+        #expect(result.catalog?.operationCount == 113)   // #448 registered tracks.sort_verified
         #expect(result.catalogCountMatch)
         #expect(result.traceOK)
 
@@ -1590,7 +1590,7 @@ struct QualificationRunnerTests {
         let liveGate = QualificationLiveGateSummary(operationResults: operationResults)
 
         #expect(operationResults.count == OperationRegistry.specs.count)
-        #expect(mutating.count == 89)
+        #expect(mutating.count == 90)
         #expect(readOnly.count == 23)
         #expect(operationResults.allSatisfy { $0.status != .failed })
         #expect(liveGate.accounted == operationResults.count)
@@ -2113,7 +2113,7 @@ struct QualificationRunnerTests {
         // #373 Phase A: the read-only surface now qualifies semantically.
         #expect(operationCases.filter { $0.status == .passed }.count == 23)
         #expect(operationCases.filter { $0.status == .protocolSmoke }.isEmpty)
-        #expect(operationCases.filter { $0.status == .notQualified }.count == 89)
+        #expect(operationCases.filter { $0.status == .notQualified }.count == 90)
         // #373 Phase A: 22 oracled read-only ops + system.health's bespoke
         // validator. The aggregate axes contribute no passes here.
         #expect(attestation.passed == 23)

--- a/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
@@ -634,8 +634,8 @@ enum SemanticOracleFixtures {
             response: """
                 {"success":true,"verified":true,"state":"A",\
                 "operation":"track.sort_verified","criterion":"track_name",\
-                "expected_order":["Bass","Kick"],"before_order":["Kick","Bass"],\
-                "after_order":["Bass","Kick"],"before_track_count":2,"after_track_count":2}
+                "expected_order":["trk_bass","trk_kick"],"before_order":["trk_kick","trk_bass"],\
+                "after_order":["trk_bass","trk_kick"],"before_track_count":2,"after_track_count":2}
                 """,
             readback: "{}"
         ),

--- a/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
@@ -634,6 +634,7 @@ enum SemanticOracleFixtures {
             response: """
                 {"success":true,"verified":true,"state":"A",\
                 "operation":"track.sort_verified","criterion":"track_name",\
+                "actuated_criterion":"track_name","actuated_menu_item_label":"트랙 이름",\
                 "expected_order":["trk_bass","trk_kick"],"before_order":["trk_kick","trk_bass"],\
                 "after_order":["trk_bass","trk_kick"],"before_track_count":2,"after_track_count":2}
                 """,

--- a/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleFixtures.swift
@@ -628,6 +628,17 @@ enum SemanticOracleFixtures {
                 """,
             readback: "{}"
         ),
+        // #448 AccessibilityChannel+Tracks.defaultSortTracks: State A contains
+        // the complete independently re-read order, exactly matching expected.
+        .tracksSortVerified: SemanticOracleFixture(
+            response: """
+                {"success":true,"verified":true,"state":"A",\
+                "operation":"track.sort_verified","criterion":"track_name",\
+                "expected_order":["Bass","Kick"],"before_order":["Kick","Bass"],\
+                "after_order":["Bass","Kick"],"before_track_count":2,"after_track_count":2}
+                """,
+            readback: "{}"
+        ),
         // AccessibilityChannel+Tracks.defaultSetTrackToggle (Mute): requested==observed bool.
         // Mute's coordinate-free primary is exclusive-select + key 'm' (#106).
         .tracksMute: SemanticOracleFixture(

--- a/Tests/LogicProMCPTests/SemanticOracleTests.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleTests.swift
@@ -682,6 +682,20 @@ struct SemanticOracleStrengthTests {
 
 @Suite("#373 semantic oracle fixtures and mutation")
 struct SemanticOracleMutationTests {
+    @Test("#448 sort State A rejects a response whose actuated criterion differs from the request")
+    func trackSortOracleRejectsWrongActuatedCriterion() throws {
+        let oracle = try #require(SemanticOracleTable.byOperationID[.tracksSortVerified])
+        let wrongCriterionStateA = Data(
+            #"{"success":true,"verified":true,"state":"A","operation":"track.sort_verified","criterion":"track_name","actuated_criterion":"instrument_name","actuated_menu_item_label":"악기 이름","expected_order":["trk_bass","trk_kick"],"before_order":["trk_kick","trk_bass"],"after_order":["trk_bass","trk_kick"]}"#.utf8
+        )
+        let wrongCriterionWasAccepted: Bool = oracle.evaluate(
+            responseData: wrongCriterionStateA,
+            readbackData: Data("{}".utf8)
+        ) == true
+
+        #expect(!wrongCriterionWasAccepted)
+    }
+
     @Test func pluginSetParamVerifiedOracleAcceptsCheckboxStateAWithoutWeakeningSliderStateA() throws {
         let oracle = try #require(SemanticOracleTable.byOperationID[.pluginsSetParamVerified])
         let sliderFixture = try #require(SemanticOracleFixtures.byOperationID[.pluginsSetParamVerified])

--- a/Tests/LogicProMCPTests/SemanticOracleTests.swift
+++ b/Tests/LogicProMCPTests/SemanticOracleTests.swift
@@ -468,8 +468,8 @@ struct SemanticOracleCensusTests {
                 )
             }
         }
-        // 49 through B4, plus the one registered after the inventory closed (#575).
-        #expect(SemanticOracleTable.coveredMutatingOperationIDs.count == 50)
+        // 49 through B4, plus two registered after the inventory closed (#575, #448).
+        #expect(SemanticOracleTable.coveredMutatingOperationIDs.count == 51)
     }
 
     /// #373 B4 — the mutating oracle inventory is CLOSED. Every supported


### PR DESCRIPTION
## Do not merge until this has been driven live

This operation reorders the tracks of a real project and its happy path has never run against Logic. What blocks the drive on this machine is recorded below, not hand-waved. Everything else here is done: the design, the fixes from an adversarial review, and a live check of the fail-closed path.

## What it adds

`tracks.sort_verified` drives `Track > Sort Tracks by` and checks the effect by re-reading the arrangement order. The caller supplies `criterion`, `expected_order` (a complete list of already-issued `trk_` references) and `confirmed: true`.

The design decisions worth naming:

- **"The order changed" is not proof.** A sort by the wrong criterion also changes the order, so the after-order must equal the caller's complete expected order exactly.
- **An already-sorted project is State B, not State A.** A correct sort changes nothing there, and "nothing changed" cannot be distinguished from "the command did nothing".
- **`expected_order` takes references, not names.** Duplicating a track in Logic produces identically named tracks; an identity that cannot name two of the things it orders is not an identity.
- Criterion labels live in `AXLocalePolicy` with what was measured and when. An unmeasured locale refuses by name rather than guessing a translation.

Anchor-based reorder ("move track A before track B") stays out: it is drag-only as recorded, and a sort is not a substitute.

## What an adversarial review found, and what changed

Four ways State A could be awarded for something unproven, all closed:

- **A wrong criterion could pass.** The verifier discarded the requested criterion. The verdict is now bound to the menu leaf actually pressed: its title is read from that element, mapped to a criterion, compared with the request, and emitted as `actuated_menu_item_label` / `actuated_criterion`. The menu exposes no persistent selected-sort attribute and the comment says so.
- **A stale reference to a same-named track was silently rebound** to whichever header sat at its old index. `TargetDescriptor` carries only index and name, so a duplicate-name project now refuses before any AX work.
- **"Complete order" was not complete.** A collapsed stack takes the header rail from 44 rows to 21 by this repository's own measurement, so hidden tracks could go unrepresented and be reordered anyway. A sort whose scope cannot be enumerated is refused.
- **A failed press claimed nothing was written.** The action had already been sent. The order is now read back even on a failed press; when it cannot be read the response says the state is unknown, invalidates the affected references, and is not safe to retry.

With them: four verdict-driving read sites now keep `kAXErrorNoValue` and `kAXErrorAttributeUnsupported` as absence and name every other status as a read failure; the single read taken 150 ms after the press became a settle witness requiring two consecutive identical observations; a comment that claimed a live measurement was corrected; and three tests that could not fail were rewritten.

## What was driven live

The fail-closed path, against a release binary built from this head:

```
sort_verified criterion=track_name expected_order=[trk_0…trk_4] confirmed=true
  -> State C stale_target_reference, write_attempted: false
     "expected_order names track references that are unavailable or stale: trk_0, trk_1, …
      Re-read logic://tracks and retry with its current track_ref values."
```

Nothing was mutated. That is the behaviour the contract promises for unknown references, observed rather than asserted.

## Why the happy path is still unproven, precisely

Two conditions on this machine, both measured:

1. `logic://tracks` currently answers `readable: false`, `reason: track_names_synthesised_from_project_file`, with placeholder names, after an explicit `system.refresh_cache`. A caller therefore cannot obtain the real `trk_` references the operation requires.
2. The available fixture project has three tracks named `Studio Grand`, and duplicate names are exactly what this change now refuses before touching AX.

A first live drive needs a project whose track resource reads live and whose track names are unique. It has to check what the unit tests cannot: that the menu leaf title read back after the press really identifies the criterion, that the settle witness sees a stable order rather than a transient one, and that Logic does not recreate header objects in a way that turns every real sort into State B.

Full suite and repository guards pass; live evidence for this head is the export-menu harness, which proves the artifact answers a live Logic and is not about the sort.

Refs #448
