### PR TITLE
fix(#448): an already-sorted project is a no-op, not an unavailable readback

### DIFF
--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
@@ -614,8 +614,11 @@ extension AccessibilityChannel {
             details["detail"] = "after_order_did_not_match_requested_criterion"
             return .success(HonestContract.encodeStateB(reason: .readbackMismatch, extras: details))
         case .alreadySortedCommandUnobservable:
+            // The arrangement was read, four times, and matched the request. What cannot be read is
+            // whether the menu command did anything, because a correct sort of a sorted project is
+            // a no-op. `readbackUnavailable` said the opposite of what happened (#448).
             details["detail"] = "already_sorted_command_unobservable"
-            return .success(HonestContract.encodeStateB(reason: .readbackUnavailable, extras: details))
+            return .success(HonestContract.encodeStateB(reason: .noopUnobservable, extras: details))
         }
     }
 

--- a/Sources/LogicProMCP/Utilities/HonestContract.swift
+++ b/Sources/LogicProMCP/Utilities/HonestContract.swift
@@ -31,6 +31,13 @@ enum HonestContract {
         /// may bounce silent. Downgrades State A → State B so a caller never treats
         /// a count-delta success as an audible arrangement. v3.6.x (#128).
         case importedAsGMDevice
+        /// The read-back succeeded and matched the request, but the target already held the
+        /// requested value before the write, so the read cannot tell "the command ran" from "the
+        /// command did nothing". Distinct from `readbackUnavailable`, which says the attribute could
+        /// not be read at all: here it was read, and the answer is that nothing observable happened.
+        /// Introduced for `tracks.sort_verified` on an already-sorted project (#448), which had been
+        /// answering `readback_unavailable` after four successful reads.
+        case noopUnobservable
         case sendOnlyNoReadback
         case sagaReconciliationRequired
         case sagaCancellationPending
@@ -42,6 +49,7 @@ enum HonestContract {
             case .readbackMismatch: return "readback_mismatch"
             case .retryExhausted: return "retry_exhausted"
             case .importedAsGMDevice: return "imported_as_gm_device"
+            case .noopUnobservable: return "noop_unobservable"
             case .sendOnlyNoReadback: return "send_only_no_readback"
             case .sagaReconciliationRequired: return "saga_reconciliation_required"
             case .sagaCancellationPending: return "saga_cancellation_pending"

--- a/Tests/LogicProMCPTests/Issue448TrackSortVerifiedTests.swift
+++ b/Tests/LogicProMCPTests/Issue448TrackSortVerifiedTests.swift
@@ -491,9 +491,12 @@ struct Issue448TrackSortVerifiedTests {
             runtime: fixture.runtime
         )
         let body = try #require(sharedJSONObject(result.message))
+        // `noop_unobservable`, not `readback_unavailable`: the arrangement WAS read and matched.
+        // What cannot be observed is whether the command did anything, because a correct sort of
+        // a sorted project changes nothing. The old reason said the readback failed.
         let stateBForUnobservableNoOp = result.isSuccess
             && body["state"] as? String == "B"
-            && body["reason"] as? String == HonestContract.UncertainReason.readbackUnavailable.rawValue
+            && body["reason"] as? String == HonestContract.UncertainReason.noopUnobservable.rawValue
             && body["detail"] as? String == "already_sorted_command_unobservable"
 
         #expect(stateBForUnobservableNoOp)


### PR DESCRIPTION
## `readback_unavailable` said the opposite of what happened

`tracks.sort_verified` on a project already in the requested order answered:

```
state:  "B"
reason: "readback_unavailable"
detail: "already_sorted_command_unobservable"
```

The arrangement had just been read four times and matched the request. What could not be observed is
whether the menu command did anything — a correct sort of an already-sorted project changes nothing.
`detail` said that. `reason` said the readback failed, in the one field every operation in this
server puts its machine-readable answer in.

Measured live on 2026-09-03 while verifying #757: three happy-path drives State A, and the
already-sorted drive State B carrying that pair.

## The change

`UncertainReason` gains `noopUnobservable` (`"noop_unobservable"`) for exactly this shape: the read
succeeded, the value matches, and the target already held it before the write. Only the
already-sorted outcome maps to it.

`readbackUnavailable` keeps its meaning at its other 48 sites — this is not a rename of a shared
bucket, it is one outcome moving out of a bucket it never belonged in.

## The existing test was pinning the wrong contract

`Issue448TrackSortVerifiedTests.alreadySortedIsStateB` asserted
`reason == readbackUnavailable.rawValue`, so it encoded the inaccuracy and would have kept
certifying it. Retargeted to `noopUnobservable`; reverting the mapping reddens it:

```
✘ "an already-sorted reference order is State B with an observable reason"
  Expectation failed: stateBForUnobservableNoOp
```

87 tests across `Issue448`, `Issue757` and the HonestContract envelope suites pass. Ship gate: PASS.

Refs #448
