### PR TITLE
feat(#754): a document may declare a non-UI surface, and earn its zeros by a counterexample

### DIFF
--- a/Scripts/livekit/evidence.py
+++ b/Scripts/livekit/evidence.py
@@ -886,7 +886,14 @@ class Evidence:
     # the only sensible reading of "the run".
     current = None
 
-    def __init__(self, head, root, name=None):
+    # The surfaces a document may declare. Declaring one is a claim about the CHANGE under proof,
+    # made by the harness author, and `is_clean` reads it. There is deliberately no third value: a
+    # run that cannot say which it is has not thought about what it is proving.
+    SURFACES = ("ui", "non_ui")
+
+    def __init__(self, head, root, name=None, surface=None):
+        if surface is not None and surface not in self.SURFACES:
+            raise ValueError(f"surface must be one of {self.SURFACES}, not {surface!r}")
         if not re.fullmatch(r"[0-9a-f]{40}", head or ""):
             # Not fatal: exploratory runs use a label. The gate will simply not find it, which is correct.
             pass
@@ -900,6 +907,13 @@ class Evidence:
         self.name = _safe_name(name) if name else _running_harness_name()
         self.records = []
         self._window_points = None
+        # #754. A change with no surface in Logic's UI cannot earn captures, visual assertions or a
+        # recording — there is nothing to photograph — and `is_clean` used to require all three of
+        # every run. A harness that proves such a change says so HERE, up front, as a record the
+        # summary can read; it is not inferred from which counters happen to be zero, because "the
+        # counters are zero" is also what a harness that did nothing looks like.
+        if surface is not None:
+            self.records.append({"kind": "declaration", "surface": surface})
         Evidence.current = self
 
     # -- locating a band ----------------------------------------------------
@@ -1333,6 +1347,14 @@ def summarize(recs, out=None):
         "checks_with_blocking_modal_unknown":
             sum(1 for c in checks if _modal_snapshot_is_unknown(c.get("blocking_modal"))),
         "mutation_claimed": sum(1 for c in checks if c.get("mutation_claimed")),
+        # The LAST declaration wins, and an absent or malformed one reads as None — which
+        # `is_clean` treats as the UI surface, the stricter of the two. A document that never
+        # declared itself is judged the way every document was judged before #754.
+        "declared_surface": next(
+            (r.get("surface") for r in reversed(recs)
+             if isinstance(r, dict) and r.get("kind") == "declaration"
+             and r.get("surface") in Evidence.SURFACES),
+            None),
         "checks_with_a_counterexample": sum(1 for c in checks if c.get("has_counterexample")),
         "counterexamples_not_rejected":
             sum(1 for c in checks if c.get("has_counterexample") and not c.get("counterexample_rejected")),
@@ -1378,8 +1400,30 @@ _REQUIRED_SUMMARY_KEYS = (
     "captures", "captures_unsettled", "captures_straddling_displays",
     "restorations_failed", "cached_reads_used_as_live",
     "visual_assertions", "visual_failed", "visual_assertions_without_a_subject",
-    "recordings",
+    "recordings", "declared_surface",
 )
+
+
+def _non_vacuity_earned(summary):
+    """Whether the run looked at its subject, by an instrument that fits the subject.
+
+    For a change with a surface in Logic's UI that means what it always meant: a capture, a visual
+    assertion, and a recording, each earned. A run that photographed nothing has not looked.
+
+    For a change the document declares `non_ui` there is nothing to photograph — the stream
+    terminates inside the server — so those three counters are not evidence of anything and are
+    not required. In their place the run must carry at least one check with a COUNTEREXAMPLE, so
+    the assertion is shown to be able to fail (`counterexamples_not_rejected == 0` is enforced
+    beside this for every surface). A non_ui run that asserted nothing therefore still fails, which
+    is the property #754 exists to keep: the zeros are unearnable by silence on either surface.
+
+    An undeclared document is judged as UI. Silence is not a class.
+    """
+    if summary.get("declared_surface") == "non_ui":
+        return summary["checks_with_a_counterexample"] > 0
+    return (summary["captures"] > 0
+            and summary["visual_assertions"] > 0
+            and summary["recordings"] > 0)
 
 
 def is_clean(summary):
@@ -1443,10 +1487,9 @@ def is_clean(summary):
         and summary["checks_recorded_under_blocking_modal"] == 0
         and summary["checks_missing_blocking_modal_snapshot"] == 0
         and summary["checks_with_blocking_modal_unknown"] == 0
-        # Non-vacuity: the run has to have looked, driven, and recorded.
-        and summary["captures"] > 0
-        and summary["visual_assertions"] > 0
-        and summary["recordings"] > 0
+        # Non-vacuity: the run has to have looked, driven, and recorded. WHAT counts as having
+        # looked depends on the surface the document declared — see `_non_vacuity_earned`.
+        and _non_vacuity_earned(summary)
         and summary["mutation_claimed"] > 0
         and summary["counterexamples_not_rejected"] == 0
         and summary["operations_driven"] > 0

--- a/Scripts/livekit/test_evidence.py
+++ b/Scripts/livekit/test_evidence.py
@@ -25,6 +25,7 @@ GOOD = {
     "captures": 1, "captures_unsettled": 0, "captures_straddling_displays": 0,
     "restorations_failed": 0, "cached_reads_used_as_live": 0,
     "visual_assertions": 1, "visual_failed": 0, "visual_assertions_without_a_subject": 0,
+    "declared_surface": None,
     "recordings": 1,
 }
 
@@ -61,6 +62,22 @@ CASES = [
     (False, {**GOOD, "visual_assertions_without_a_subject": 1},
      "a visual that names no subject"),
     (False, None, "not a summary at all"),
+    # #754 — a declared non-UI surface earns its zeros by a different instrument, never by silence.
+    (True, {**GOOD, "declared_surface": "non_ui", "captures": 0, "visual_assertions": 0,
+            "recordings": 0, "checks_with_a_counterexample": 3},
+     "non_ui: no captures, visuals or recordings, but a counterexample control"),
+    (False, {**GOOD, "declared_surface": None, "captures": 0, "visual_assertions": 0,
+             "recordings": 0, "checks_with_a_counterexample": 3},
+     "the same zeros with NO declaration are still unclean — silence is not a class"),
+    (False, {**GOOD, "declared_surface": "non_ui", "captures": 0, "visual_assertions": 0,
+             "recordings": 0, "checks_with_a_counterexample": 0},
+     "non_ui that asserted nothing: zeros unearned on this surface too"),
+    (False, {**GOOD, "declared_surface": "non_ui", "captures": 0, "visual_assertions": 0,
+             "recordings": 0, "checks_with_a_counterexample": 3, "counterexamples_not_rejected": 1},
+     "non_ui whose counterexample was not rejected — the shared rule still applies"),
+    (True, {**GOOD, "declared_surface": "ui"}, "an explicitly declared UI document is judged as before"),
+    (False, {**GOOD, "declared_surface": "ui", "captures": 0},
+     "declaring ui does not relax anything"),
 ]
 
 failed = 0
@@ -529,7 +546,12 @@ out = ev.write()
 shapes.append(("write() returns a dict", isinstance(out, dict)))
 shapes.append(("summary carries every required key",
                all(k in out for k in E._REQUIRED_SUMMARY_KEYS)))
-shapes.append(("counters are ints", all(isinstance(out[k], int) for k in E._REQUIRED_SUMMARY_KEYS)))
+# `declared_surface` is the one required key that is not a counter: it is what the harness said
+# about its subject, so it is a surface name or None. Everything else is a count.
+shapes.append(("counters are ints", all(isinstance(out[k], int)
+                                        for k in E._REQUIRED_SUMMARY_KEYS if k != "declared_surface")))
+shapes.append(("the declaration is a surface name or None",
+               out["declared_surface"] is None or out["declared_surface"] in E.Evidence.SURFACES))
 shapes.append(("is_clean() returns a bool", isinstance(E.is_clean(out), bool)))
 shapes.append(("the driven visual named a subject", out["visual_assertions_without_a_subject"] == 0))
 shapes.append(("have_tools() returns a list", isinstance(E.have_tools(), list)))
@@ -572,6 +594,18 @@ shapes.append(("the summary counts them", fsummary["checks_with_a_counterexample
 shapes.append(("and counts only the ones that failed to reject",
                fsummary["counterexamples_not_rejected"] == 3))
 
+# #754 — the declaration is read off the records by summarize, and only a valid one counts.
+decl = E.summarize([{"kind": "declaration", "surface": "non_ui"}, {"kind": "check", "passed": True}])
+shapes.append(("summarize reads a non_ui declaration", decl["declared_surface"] == "non_ui"))
+shapes.append(("summarize reads no declaration as None",
+               E.summarize([{"kind": "check", "passed": True}])["declared_surface"] is None))
+shapes.append(("summarize ignores a declaration naming an unknown surface",
+               E.summarize([{"kind": "declaration", "surface": "maybe"}])["declared_surface"] is None))
+try:
+    E.Evidence("0" * 40, "/tmp/lpm-test-754-unused", surface="maybe")
+    shapes.append(("Evidence refuses an unknown surface", False))
+except ValueError:
+    shapes.append(("Evidence refuses an unknown surface", True))
 for why, ok in shapes:
     failed += 0 if ok else 1
     print(f"{'ok  ' if ok else 'FAIL'} shape: {why}")


### PR DESCRIPTION
## A document may declare a non-UI surface, and earn its zeros by a counterexample

`is_clean` required a capture, a visual assertion and a recording of every run. A change with no
surface in Logic's UI — the CoreMIDI packet path in #735 is the one that surfaced this — has nothing
to photograph, so those three counters were not evidence of anything and could not be earned
honestly. The harness written for that path drove the real destination callback, carried a working
counterexample control, and was rejected for having taken no pictures.

### What changes

A harness may now say what it is proving:

```python
ev = E.Evidence(HEAD, root, surface="non_ui")
```

That writes a `{"kind": "declaration", "surface": "non_ui"}` record. `summarize` reads it back as
`declared_surface`, and `is_clean` requires the three UI counters only of a UI document. A `non_ui`
document must instead carry at least one check with a counterexample — beside the rule every surface
already has, that no counterexample may go unrejected. So a non_ui run that asserted nothing still
fails.

### What does not change, on purpose

- **An undeclared document is judged as UI.** The class is claimed, never inferred from which
  counters happen to be zero, because zero counters is also what a harness that did nothing looks
  like. Silence is not a class. The test for exactly this is
  *"the same zeros with NO declaration are still unclean"*.
- `declared_surface` joins `_REQUIRED_SUMMARY_KEYS`, so a summary lacking it is not clean — the
  polarity rule that file already enforces for every other key.
- A declaration naming an unknown surface is refused at construction (`ValueError`), and one that
  reaches `summarize` malformed reads as `None`, i.e. as UI, the stricter path.
- Every other clause of `is_clean` applies to both surfaces unchanged.

### Why this PR carries no non_ui harness

`lpm-live-gate.sh` judges a branch's evidence with `is_clean` from `origin/main`, deliberately, so a
branch cannot change what passing means and then pass. This PR is therefore judged by the OLD rule
and points at a standard `live_369` document that is clean under it. The first `non_ui` harness —
#735's — is prepared on a branch stacked on this one and lands as its own pull request once this is
on `main`.

### Tests

`Scripts/livekit/test_evidence.py`: seven new `is_clean` cases covering the declared class, the
undeclared regression guard, the still-enforced counterexample rule, and that declaring `ui` relaxes
nothing; three `summarize` shapes (declaration read, absent → `None`, unknown → `None`); and the
constructor refusal. The pre-existing *"counters are ints"* shape now excludes the one required key
that is a declaration rather than a count, and says so.

Repo guards: `all 16 passed`. Ship gate: PASS.

Refs #754 — closes with the harness PR that follows.
