### PR TITLE
livekit: a harness the branch deleted cannot be required to have run

### DIFF
--- a/Scripts/livekit/harness_evidence_coverage.py
+++ b/Scripts/livekit/harness_evidence_coverage.py
@@ -252,6 +252,32 @@ def main(argv):
         print("   missing ref is a refusal, not a fallback. Run: git fetch origin main")
         return 2
     by_sources, unproven = required_by_sources(all_paths, declarations)
+
+    # A claimant the branch DELETED cannot be required to have run. The declarations are read from
+    # the trusted ref on purpose — a branch must not be able to rewrite its own obligations — but
+    # that also keeps a deleted harness's obligation alive, and nothing can satisfy it. This file
+    # already says why that is wrong, one path over: "one that no longer exists cannot be required
+    # to have run, and requiring it would make deleting a harness impossible." The reasoning was
+    # never wired into the source-coverage path.
+    #
+    # This is not an escape hatch. The obligation is not dropped — the paths that harness claimed
+    # move into `unproven` and are printed, so deleting a harness turns "claimed and proved" into
+    # "named as nobody's", which is exactly what it is. And deleting a harness is loud in review
+    # and independently ratcheted: `check-falsifiable-adoption.py` refuses a fall in the number
+    # that carry a counterexample.
+    deleted = {os.path.basename(p)[:-3] for p in
+               changed_paths(worktree, base, head, exclude_deletions=False)
+               if p.startswith("Scripts/livekit/live_") and p.endswith(".py")
+               and not os.path.exists(os.path.join(worktree, p))}
+    orphaned = sorted(stem for stem in by_sources if stem in deleted)
+    for stem in orphaned:
+        by_sources.discard(stem)
+        claimed = set(declarations.get(stem, []))
+        unproven.extend(sorted(p for p in all_paths
+                               if p.startswith("Sources/") and p in claimed))
+    if orphaned:
+        print(f"   {len(orphaned)} claimant(s) deleted by this branch; what they claimed is "
+              f"reported as unproven rather than required: {', '.join(orphaned)}")
     required |= by_sources
 
     if not required:

--- a/Scripts/livekit/test_harness_evidence_coverage.py
+++ b/Scripts/livekit/test_harness_evidence_coverage.py
@@ -296,6 +296,50 @@ with tempfile.TemporaryDirectory() as repo, tempfile.TemporaryDirectory() as evr
     failed += 0 if ok else 1
     print(f"{'ok  ' if ok else 'FAIL'} ...and is allowed once one document is clean -> rc={rc}")
 
+# A harness the branch DELETED cannot be required to have run, even when it claimed a `Sources/`
+# path the branch changed. Declarations are read from the trusted ref so a branch cannot rewrite its
+# own obligations — which also kept a deleted claimant's obligation alive with nothing able to
+# satisfy it. What it claimed becomes UNPROVEN and is printed; the obligation is not dropped, it is
+# renamed to what it actually is.
+with tempfile.TemporaryDirectory() as tmp:
+    repo = os.path.join(tmp, "repo")
+    evroot = os.path.join(tmp, "ev")
+    os.makedirs(os.path.join(repo, "Scripts", "livekit"))
+    os.makedirs(os.path.join(repo, "Sources", "LogicProMCP", "MIDI"))
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@example.invalid")
+    _git(repo, "config", "user.name", "t")
+
+    def w3(rel, text):
+        with open(os.path.join(repo, rel), "w") as fh:
+            fh.write(text)
+
+    w3("Scripts/livekit/live_gone.py",
+       'COVERS = [\n    "Sources/LogicProMCP/MIDI/MIDIEngine.swift",\n]\n')
+    w3("Sources/LogicProMCP/MIDI/MIDIEngine.swift", "// base\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "base")
+    base3 = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    os.remove(os.path.join(repo, "Scripts", "livekit", "live_gone.py"))
+    w3("Sources/LogicProMCP/MIDI/MIDIEngine.swift", "// the endpoint the harness sent to is gone\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "remove the subject and the harness for it")
+    head3 = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    os.makedirs(os.path.join(evroot, head3))
+
+    rc = C.main(["x", repo, head3, evroot, base3])
+    ok = rc == 0
+    failed += 0 if ok else 1
+    print(f"{'ok  ' if ok else 'FAIL'} a deleted claimant does not oblige a run it cannot do -> rc={rc}")
+
+    declarations = C.declarations_from_ref(repo, base3)
+    by_sources, _ = C.required_by_sources(["Sources/LogicProMCP/MIDI/MIDIEngine.swift"], declarations)
+    ok = "live_gone" in by_sources
+    failed += 0 if ok else 1
+    print(f"{'ok  ' if ok else 'FAIL'} ...and it WAS obliged before the deletion was noticed "
+          f"-> {sorted(by_sources)}")
+
 print()
 print(f"FAILED ({failed} unexpected)" if failed else "all cases behaved (0 unexpected)")
 sys.exit(1 if failed else 0)


### PR DESCRIPTION
Found by #755, which removes a MIDI endpoint and the harness that could only exercise it.
Landing separately because the live gate reads its rules from `origin/main`, so a change
that needs this rule cannot be judged by it in the same run.

## The hole

`required_by_sources` reads harness `COVERS` declarations from the **trusted ref**, on
purpose: a branch must not be able to shed its obligations by editing its own declaration.
The side effect is that a claimant the branch **deletes** keeps its obligation, and nothing
can satisfy it — the file is gone, so it cannot run, so the gate refuses forever.

This file already argues the other way one path over, about *changed* harnesses:

> `--diff-filter=d` drops deletions, and that is right for HARNESSES: one that no longer
> exists cannot be required to have run, and requiring it would make deleting a harness
> impossible.

The reasoning was never wired into the source-coverage path.

## What it does, and what it deliberately does not

The obligation is **not dropped**. The paths that harness claimed move into `unproven` and
are printed, so removing a harness turns "claimed and proved" into "named as nobody's" —
which is exactly what it is. The verdict line names the deleted claimant.

It is not an escape hatch either. Deleting a harness is loud in review, and independently
ratcheted: `check-falsifiable-adoption.py` refuses a fall in how many carry a
counterexample, and its floor cannot be lowered to make a branch pass.

## The control

Two cases drive it. The second is the one that matters: it asserts the deleted harness
**was** obliged before the new logic is consulted, so the first cannot pass vacuously.
Reverting the skip kills the first case — checked, not assumed.
