### PR TITLE
fix(#798): one renderer for ui-labels.json, and a test that compares its bytes

### DIFF
--- a/Scripts/locale_labels.py
+++ b/Scripts/locale_labels.py
@@ -455,6 +455,22 @@ def report_dropped(dropped, stream=sys.stderr):
               f"the new name — a lost `evidence_scope` is a retraction the next campaign silently "
               f"undoes:\n  " + json.dumps(lost, ensure_ascii=False), file=stream)
 
+# The file on disk is indented with ONE space. Three separate `json.dump` calls used to decide that
+# independently — here twice and once in `locale-propose.py --apply` — and all three said `indent=2`
+# while the tree said one, so the command this file documents for regenerating the document
+# rewrote all 2858 of its lines without changing a value (#798). The guard compares PARSED objects,
+# so nothing in CI could see it, and a campaign adding two provenance blocks produced a diff those
+# blocks were not findable in.
+#
+# One renderer, and `test_locale_labels_json.py` compares its output to the file's BYTES. Comparing
+# parsed objects is what let this drift, so a test that compares parsed objects would not catch it.
+INDENT = 1
+
+
+def render(doc):
+    """The document's exact text, including its trailing newline."""
+    return json.dumps(doc, ensure_ascii=False, indent=INDENT) + "\n"
+
 
 def main():
     args = sys.argv[1:]
@@ -464,8 +480,7 @@ def main():
     if "--write" in args:
         os.makedirs(os.path.dirname(JSON_PATH), exist_ok=True)
         with open(JSON_PATH, "w", encoding="utf-8") as fh:
-            json.dump(doc, fh, indent=2, ensure_ascii=False)
-            fh.write("\n")
+            fh.write(render(doc))
         print(f"wrote {len(doc['labels'])} labels to docs/locale/ui-labels.json")
         return 0
     if "--check" in args:
@@ -475,8 +490,7 @@ def main():
             return 1
         print(f"{len(doc['labels'])} labels agree")
         return 0
-    json.dump(doc, sys.stdout, indent=2, ensure_ascii=False)
-    print()
+    sys.stdout.write(render(doc))
     return 0
 
 

--- a/Scripts/observations/locale-propose.py
+++ b/Scripts/observations/locale-propose.py
@@ -389,8 +389,10 @@ def apply(labels_path, census, proposals, records_by_surface):
                         declared.append(h["role"])
                         declared.sort()
                     n_cov += 1
-    json.dump(doc, open(labels_path, "w", encoding="utf-8"), ensure_ascii=False, indent=2)
-    open(labels_path, "a", encoding="utf-8").write("\n")
+    # The generator's renderer, not a second opinion about how this file is formatted. This call
+    # site said `indent=2` while the tree was indented with one space, so every campaign left the
+    # document in a shape `locale_labels.py --write` would immediately rewrite (#798).
+    open(labels_path, "w", encoding="utf-8").write(_GUARD._module().render(doc))
     if skipped:
         print(f"  not written for {len(skipped)} label(s) whose role this tool cannot constrain "
               f"— declare `roles` for them first: {', '.join(sorted(skipped)[:6])}"

--- a/Scripts/test_locale_labels_json.py
+++ b/Scripts/test_locale_labels_json.py
@@ -867,7 +867,6 @@ def main():
          sp({"reason": "r", "surfaces": ["plugin.window"], "path_contains": "AXWindow["}))
     case("a label with no scope is asked nothing",
          guard.scope_problems("x", {}, {"plugin.window"}) == [], "")
-
     # 16g. THE SIX FINDINGS of the 2026-09-07 review, each reproduced through the guard's real
     #      entry points rather than by calling a helper. Five of the six were only reachable there,
     #      and the sixth — the list of fragments — was a case that passed by asking `scope_problems`
@@ -1143,7 +1142,20 @@ def main():
     case("a caller that asks for no report gets none, and nothing is left behind",
          isinstance(labels.build(existing=gone), dict), "")
 
-    # 17. The real document is clean.
+    # 17. The document on disk is BYTE-identical to what the generator writes.
+    #     Not "parses to the same object" — that is what `main()` already checks, and it is what let
+    #     three `json.dump` calls disagree with the tree about indentation until the documented
+    #     regeneration command rewrote all 2858 lines of the file without changing a value (#798).
+    #     A formatting drift is only visible in the bytes, so this case reads the bytes.
+    on_disk_text = (HERE.parent / "docs" / "locale" / "ui-labels.json").read_text(encoding="utf-8")
+    rendered = labels.render(json.loads(on_disk_text))
+    case("the file on disk is exactly what the writer produces",
+         rendered == on_disk_text,
+         f"writer emits {len(rendered)} bytes, the file holds {len(on_disk_text)}; "
+         f"first difference at "
+         + str(next((i for i, (a, b) in enumerate(zip(rendered, on_disk_text)) if a != b), "EOF")))
+
+    # 18. The real document is clean.
     proc = subprocess.run([sys.executable, str(HERE / "check-locale-labels-json.py")], capture_output=True, text=True)
     case("repository is clean", proc.returncode == 0, proc.stdout.strip()[:200])
 


### PR DESCRIPTION
`docs/locale/ui-labels.json` names the command that regenerates it. Running that command rewrote
every line of the file without changing a value.

```
$ python3 Scripts/locale_labels.py --write
$ git diff --numstat docs/locale/ui-labels.json
2858    2858    docs/locale/ui-labels.json
```

`json.load` of both sides compares equal. Only the indentation moved: the committed file is indented
with one space and round-trips through `indent=1` byte for byte, while `locale_labels.py:408`,
`:419` and `locale-propose.py --apply` each independently said `indent=2`.

### Why nothing caught it

`check-locale-labels-json.py` compares **parsed objects**. Formatting is invisible to it, so the
drift could survive indefinitely, and it did.

What it cost was review. A campaign that adds two provenance blocks, followed by the regeneration
the file itself asks for, produces a 2858-line diff those two blocks are not findable in — met on
2026-09-07 while adding an 8-line field to two labels.

### The fix

`render()` is the only place that decides now, and both call sites go through it. `INDENT = 1`
matches the tree, so this lands with **zero churn** and every in-flight branch keeps applying:
`--write` at this commit leaves the file byte-identical.

### The test compares bytes

Comparing parsed objects is what let this drift, so a test that did the same would not have caught
it. Mutating `INDENT` back to 2 turns the case RED and names the offset:

```
FAIL the file on disk is exactly what the writer produces:
     writer emits 81220 bytes, the file holds 71391; first difference at 3
```

### Verification

34/34 repo guards, 111 self-test cases. Ship gate PASS. For #798.

Stacked on #793 — it needs that branch's roadmap rows to pass `roadmap-table-matches-github.py`.
