### PR TITLE
feat(#795): read a label's translation out of two censuses of the same walk

### DIFF
--- a/Scripts/observations/locale-align.py
+++ b/Scripts/observations/locale-align.py
@@ -26,6 +26,13 @@ What makes this safe is what it refuses:
     role and the right attribute about the wrong element — the defect retracted on 2026-09-05 and
     resurrected on 2026-09-06 (#793).
 
+The BASE census should be the one whose language the labels are named in. A label is matched by its
+`canonical`, which is English, so a Korean base finds only the labels Logic leaves untranslated in
+Korean — measured 2026-09-06: 29 candidates from en-US against ja-JP, 11 from ko-KR against the
+same target. Matching the base against a label's declared VARIANTS as well would lift that, and is
+deliberately not done here: it would make the tool's answer depend on evidence the ledger already
+holds, and the point of this one is to find strings nothing in the ledger knows.
+
 Nothing is written to the tree, and nothing here edits Swift. It prints candidates; a person adds
 the variant to `AXLocalePolicy.swift` and the campaign then backs it with provenance the ordinary
 way.
@@ -94,16 +101,24 @@ def reading(row):
 def candidates(base_census, target_census, labels):
     """For each label, the target-locale string sitting where its canonical sits. And the refusals.
 
-    Returns (proposals, ambiguous, stats). A proposal is only made when every aligned occurrence of
-    the canonical agrees about the target string; when they disagree the label goes to `ambiguous`
-    with all of them, because there is no evidence here for choosing.
+    Returns (proposals, ambiguous, containing, stats). A proposal is only made when every aligned
+    occurrence of the canonical agrees about the target string; when they disagree the label goes
+    to `ambiguous` with all of them, because there is no evidence here for choosing.
+
+    And the base row has to BE the canonical, not merely contain it. An aligned pair gives back the
+    whole target string, so for a label matched by containment the answer is the translation of the
+    CONTAINING string — `regionHelpKeyword` is `region`, the row it matched reads `cycle region`,
+    and the aligned Japanese is `サイクルリージョン`, which is the translation of `cycle region`.
+    Taken as a variant that is a different label. Found 2026-09-06 by reading this tool's own
+    output against what each label says it addresses: 2 of the first 18 candidates were this, and
+    `arrangeWindowTitleSuffix` would have taken a project name into the ledger with it.
     """
     pairs, unplaced_base, unplaced_target = aligned(base_census["census"], target_census["census"])
     usable = [(b, t) for b, t in pairs if SYSTEM_OWNED not in str(b.get("path") or "")]
     stats = {"pairs": len(pairs), "system_owned": len(pairs) - len(usable),
              "unplaced_base": unplaced_base, "unplaced_target": unplaced_target}
 
-    proposals, ambiguous = {}, {}
+    proposals, ambiguous, containing = {}, {}, {}
     for name, entry in sorted(labels.items()):
         canonical = entry.get("canonical")
         if not canonical:
@@ -125,7 +140,15 @@ def candidates(base_census, target_census, labels):
             t_attr, t_text = reading(t)
             if not b_text or not t_text or b_attr != t_attr:
                 continue
-            if not _PROPOSE.matches(name, canonical, b_text):
+            # The ENTRY, so the mode comes from what the ledger declares rather than from a guess
+            # about the label's name — and so a label with no agreed mode matches nothing here
+            # either, which is what the proposer and the guard both do.
+            if not _PROPOSE.matches(name, canonical, b_text, entry):
+                continue
+            # EQUALS, not merely matches. Asked with the guard's own comparison under `exact`, which
+            # folds case and trims exactly as the product does, so this cannot drift from it.
+            if not _GUARD.carries(b_text, canonical, "exact"):
+                containing.setdefault(name, []).append({"base": b_text, "target": t_text})
                 continue
             if t_text == b_text:
                 # Not a translation. Logic ships plenty of strings identical across locales, and a
@@ -150,7 +173,7 @@ def candidates(base_census, target_census, labels):
         c = dict(found[target_text][0])
         c["scoped"] = bool(_GUARD.evidence_scope(entry))
         proposals[name] = c
-    return proposals, ambiguous, stats
+    return proposals, ambiguous, containing, stats
 
 
 def _census(path):
@@ -177,7 +200,7 @@ def main(argv=None):
         raise SystemExit(f"both censuses are {base_locale} — an alignment needs two languages")
     labels = json.load(open(args.labels, encoding="utf-8"))["labels"]
 
-    proposals, ambiguous, stats = candidates(base, target, labels)
+    proposals, ambiguous, containing, stats = candidates(base, target, labels)
     missing = {n for n, e in labels.items()
                if (e.get("coverage") or {}).get(target_locale) == "unmeasured"}
 
@@ -188,6 +211,8 @@ def main(argv=None):
     print(f"{len(proposals)} label(s) have an unambiguous {target_locale} string read from the "
           f"aligned walk, {len(set(proposals) & missing)} of them currently unmeasured there")
     print(f"{len(ambiguous)} label(s) matched aligned rows whose targets DISAGREE — not proposed")
+    print(f"{len(containing)} label(s) matched only INSIDE a longer string, so the aligned target "
+          f"is the translation of that longer string and not of the label — not proposed")
     # Said every run rather than left for a reader to work out. These are the candidates admitted
     # by a ROLE and nothing narrower, so each is a place the #793 shape can happen: a real reading
     # of the right kind of element, about the wrong one.
@@ -204,7 +229,8 @@ def main(argv=None):
     if args.out:
         json.dump({"base_locale": base_locale, "target_locale": target_locale,
                    "base_record": base.get("id"), "target_record": target.get("id"),
-                   "stats": stats, "proposals": proposals, "ambiguous": ambiguous},
+                   "stats": stats, "proposals": proposals, "ambiguous": ambiguous,
+                   "containing": containing},
                   open(args.out, "w", encoding="utf-8"), ensure_ascii=False, indent=2)
         print(f"wrote {args.out}")
     return 0

--- a/Scripts/observations/locale-align.py
+++ b/Scripts/observations/locale-align.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Read a label's translation out of two censuses of the same walk. ADR-019 D4, step 6.
+
+`locale-propose.py` can only CONFIRM a variant that is already declared: it looks for a string it
+was given. The strings that are missing are the ones nobody has written down, so a census full of
+them cannot deliver one, and #778 has moved a label at a time because of it.
+
+Two censuses of the SAME surfaces in the same order are more than two lists of strings. Strip the
+bracketed titles out of each row's `path` and the remaining skeleton — roles and structure — does
+not depend on the UI language, so the two walks can be aligned and each pair read as
+`<the en-US string> is <the target string> here`. That is a translation read out of Logic rather
+than one somebody produced.
+
+What makes this safe is what it refuses:
+
+  * ALIGNMENT IS A SEQUENCE MATCH, never an index. Measured 2026-09-06 on the 2026-09-05 pair:
+    1039 en-US rows against 1031 ja-JP, 886 of which share a skeleton at the same index and 1005 of
+    which align as matching blocks. A single inserted row shifts every index after it, and every
+    later pair is then wrong while still looking plausible.
+  * A PAIR OUTSIDE A MATCHING BLOCK IS DROPPED, never approximated. The 26 unaligned rows are a
+    named hole (the Library pane, whose tree differed between the runs), not a rounding error.
+  * THE APPLE MENU IS EXCLUDED. Its rows carry the SYSTEM locale, not Logic's, so they say nothing
+    about Logic's UI language and would silently certify an unchanged string as a translation.
+  * AMBIGUITY IS REPORTED, NEVER RESOLVED. A canonical that appears on several aligned rows whose
+    targets disagree has no answer here, and picking the first would write a real record, the right
+    role and the right attribute about the wrong element — the defect retracted on 2026-09-05 and
+    resurrected on 2026-09-06 (#793).
+
+Nothing is written to the tree, and nothing here edits Swift. It prints candidates; a person adds
+the variant to `AXLocalePolicy.swift` and the campaign then backs it with provenance the ordinary
+way.
+"""
+import argparse
+import difflib
+import importlib.util
+import json
+import os
+import re
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.dirname(os.path.dirname(HERE))
+
+# Every rule this tool shares with the proposer is READ from it. A second implementation of
+# "does this string count as seen" is a second answer, which is how the containment sets were
+# wrong for 23 of 31 label sets before they were derived rather than guessed.
+_spec = importlib.util.spec_from_file_location("locale_propose", os.path.join(HERE, "locale-propose.py"))
+_PROPOSE = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_PROPOSE)
+_GUARD = _PROPOSE._GUARD
+
+# The Apple menu is macOS's, not Logic's. On this host `시스템 설정…` appears identically in the
+# Korean and the English census, because the machine's system language never changed — so a pair
+# taken from here reads as "this label is not translated", which is a claim about the wrong
+# application.
+SYSTEM_OWNED = "AXMenuBarItem[Apple]"
+
+
+def skeleton(row):
+    """The row's shape with every displayed string removed: role plus the bracket-stripped path.
+
+    This is the whole premise — what survives a language change is the STRUCTURE. Titles inside
+    `[...]` are exactly what does not, so they come out.
+    """
+    return row["role"] + "|" + re.sub(r"\[[^\]]*\]", "[]", str(row.get("path") or ""))
+
+
+def aligned(base_rows, target_rows):
+    """Pairs from the matching blocks only, and the count of rows each side could not place.
+
+    `autojunk=False` is set explicitly, and the honest note is that it changes NOTHING on the data
+    this was built against: measured 2026-09-06 on the 2026-09-05 en-US/ja-JP pair, both settings
+    align 1005 of 1031 rows. It is pinned because the heuristic it disables discards elements
+    appearing in more than 1% of a sequence of 200 or more, and a census is mostly repeated
+    skeletons — so whether it fires depends on the shape of the walk rather than on anything this
+    tool controls. An alignment that silently changes with the census size is not one a provenance
+    claim should rest on.
+    """
+    b = [skeleton(r) for r in base_rows]
+    t = [skeleton(r) for r in target_rows]
+    blocks = difflib.SequenceMatcher(None, b, t, autojunk=False).get_matching_blocks()
+    pairs = [(base_rows[m.a + k], target_rows[m.b + k]) for m in blocks for k in range(m.size)]
+    placed = sum(m.size for m in blocks)
+    return pairs, len(base_rows) - placed, len(target_rows) - placed
+
+
+def reading(row):
+    """The (attribute, string) this row displays, under the proposer's own attribute order."""
+    for attr, text in _PROPOSE.strings_of(row):
+        return attr, text
+    return None, None
+
+
+def candidates(base_census, target_census, labels):
+    """For each label, the target-locale string sitting where its canonical sits. And the refusals.
+
+    Returns (proposals, ambiguous, stats). A proposal is only made when every aligned occurrence of
+    the canonical agrees about the target string; when they disagree the label goes to `ambiguous`
+    with all of them, because there is no evidence here for choosing.
+    """
+    pairs, unplaced_base, unplaced_target = aligned(base_census["census"], target_census["census"])
+    usable = [(b, t) for b, t in pairs if SYSTEM_OWNED not in str(b.get("path") or "")]
+    stats = {"pairs": len(pairs), "system_owned": len(pairs) - len(usable),
+             "unplaced_base": unplaced_base, "unplaced_target": unplaced_target}
+
+    proposals, ambiguous = {}, {}
+    for name, entry in sorted(labels.items()):
+        canonical = entry.get("canonical")
+        if not canonical:
+            continue
+        allowed = _PROPOSE.roles_for(name)
+        declared = entry.get("roles") or []
+        found = {}
+        for b, t in usable:
+            # The same three gates the proposer applies, asked of the BASE row: the label's scope,
+            # its role shape, and the roles it declares. A label that may only be read in a window
+            # may not learn its translation from the menu bar either.
+            if not _PROPOSE.in_scope(entry, b):
+                continue
+            if allowed is not None and b["role"] not in allowed:
+                continue
+            if declared and b["role"] not in declared:
+                continue
+            b_attr, b_text = reading(b)
+            t_attr, t_text = reading(t)
+            if not b_text or not t_text or b_attr != t_attr:
+                continue
+            if not _PROPOSE.matches(name, canonical, b_text):
+                continue
+            if t_text == b_text:
+                # Not a translation. Logic ships plenty of strings identical across locales, and a
+                # variant equal to the canonical is one `LabelSet` already matches.
+                continue
+            # Recorded, not judged. A label with no `evidence_scope` accepted this row on its role
+            # alone, and a role is a KIND of element — which is precisely how `markerListDeleteMenuItem`
+            # came to be backed by the Edit menu's Delete (#793). The tool cannot tell which of
+            # those is the label's element, so it says which proposals rest on nothing narrower
+            # than a role instead of presenting all of them as equally solid.
+            found.setdefault(t_text, []).append(
+                {"base": b_text, "target": t_text, "role": b["role"], "attribute": b_attr,
+                 "path": t.get("path"), "base_path": b.get("path"), "surface": t.get("surface")})
+        if not found:
+            continue
+        if len(found) > 1:
+            ambiguous[name] = {k: v[0] for k, v in sorted(found.items())}
+            continue
+        target_text = next(iter(found))
+        if target_text in (entry.get("variants") or []):
+            continue
+        c = dict(found[target_text][0])
+        c["scoped"] = bool(_GUARD.evidence_scope(entry))
+        proposals[name] = c
+    return proposals, ambiguous, stats
+
+
+def _census(path):
+    doc = json.load(open(path, encoding="utf-8"))
+    if "census" not in doc or "host" not in doc:
+        raise SystemExit(f"{path}: not a census — expected `host` and `census`")
+    return doc
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("base_census")
+    ap.add_argument("target_census")
+    ap.add_argument("labels", nargs="?",
+                    default=os.path.join(REPO, "docs", "locale", "ui-labels.json"))
+    ap.add_argument("--json", dest="out", help="write the candidates to this path for review")
+    ap.add_argument("--show", type=int, default=0, help="print this many candidates")
+    args = ap.parse_args(argv)
+
+    base, target = _census(args.base_census), _census(args.target_census)
+    base_locale = base["host"]["locale"]
+    target_locale = target["host"]["locale"]
+    if base_locale == target_locale:
+        raise SystemExit(f"both censuses are {base_locale} — an alignment needs two languages")
+    labels = json.load(open(args.labels, encoding="utf-8"))["labels"]
+
+    proposals, ambiguous, stats = candidates(base, target, labels)
+    missing = {n for n, e in labels.items()
+               if (e.get("coverage") or {}).get(target_locale) == "unmeasured"}
+
+    print(f"{base_locale} -> {target_locale}: {stats['pairs']} aligned pair(s); "
+          f"{stats['system_owned']} dropped as system-owned ({SYSTEM_OWNED}); "
+          f"{stats['unplaced_base']} base and {stats['unplaced_target']} target row(s) unplaced")
+    unscoped = sorted(n for n, c in proposals.items() if not c["scoped"])
+    print(f"{len(proposals)} label(s) have an unambiguous {target_locale} string read from the "
+          f"aligned walk, {len(set(proposals) & missing)} of them currently unmeasured there")
+    print(f"{len(ambiguous)} label(s) matched aligned rows whose targets DISAGREE — not proposed")
+    # Said every run rather than left for a reader to work out. These are the candidates admitted
+    # by a ROLE and nothing narrower, so each is a place the #793 shape can happen: a real reading
+    # of the right kind of element, about the wrong one.
+    print(f"{len(unscoped)} of the {len(proposals)} rest on the label's role alone — it declares no "
+          f"`evidence_scope`, so a same-role element carrying the same string would have matched "
+          f"identically. Check these against where the label's element actually lives before "
+          f"adding the variant.")
+    if args.show:
+        for name, c in list(sorted(proposals.items()))[:args.show]:
+            mark = " " if c["scoped"] else "?"
+            print(f" {mark}{name:38s} {c['base']!r} -> {c['target']!r}  [{c['role']} {c['attribute']}]")
+        for name, alts in list(sorted(ambiguous.items()))[:args.show]:
+            print(f"  AMBIGUOUS {name}: " + ", ".join(repr(k) for k in alts))
+    if args.out:
+        json.dump({"base_locale": base_locale, "target_locale": target_locale,
+                   "base_record": base.get("id"), "target_record": target.get("id"),
+                   "stats": stats, "proposals": proposals, "ambiguous": ambiguous},
+                  open(args.out, "w", encoding="utf-8"), ensure_ascii=False, indent=2)
+        print(f"wrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Scripts/test_locale_campaign.py
+++ b/Scripts/test_locale_campaign.py
@@ -431,7 +431,7 @@ def main():
          "markerListDeleteMenuItem" in scoped_labels(
              {"surfaces": ["arrange.menus"], "reason": "r"}, menubar), "")
 
-    # 10. A MALFORMED scope makes the proposer refuse, not shrug. It used to read the fields
+    # 10b. A MALFORMED scope makes the proposer refuse, not shrug. It used to read the fields
     #     straight out of the object, so `evidence_scope: "AXWindow["` and `path_contains: 5` were
     #     silently ignored — a scope written wrongly permitted everything — and `surfaces: 5`
     #     crashed the tool. Named by review 2026-09-07. Refusing is the safe direction for a tool
@@ -599,7 +599,7 @@ def main():
     # `Export` would be paired with `挿入` and the reading would be confidently wrong.
     target3 = [mi(B + "AXMenuItem[A]", "バウンス"), mi(B + "AXGroup/AXMenuItem[X]", "挿入"),
                mi(B + "AXMenuItem[B]", "書き出す")]
-    props, amb, stats = pair(base3, target3, dict(exportMenuItem=("Export", [])))
+    props, amb, _cont, stats = pair(base3, target3, dict(exportMenuItem=("Export", [])))
     case("an inserted target row does not shift the pairing after it",
          (props.get("exportMenuItem") or {}).get("target") == "書き出す", (props, stats))
     case("the unplaceable row is counted, not approximated",
@@ -608,7 +608,7 @@ def main():
     # The Apple menu carries the SYSTEM locale. On a host whose system language never changed both
     # censuses show the same string there, so a pair taken from it reads as "not translated".
     apple = "AXMenuBar/AXMenuBarItem[Apple]/AXMenu/"
-    props, _, stats = pair([mi(apple + "AXMenuItem[S]", "Bounce")],
+    props, _, _cont, stats = pair([mi(apple + "AXMenuItem[S]", "Bounce")],
                            [mi(apple + "AXMenuItem[S]", "バウンス")],
                            dict(bounceMenuItem=("Bounce", [])))
     case("Apple-menu rows are excluded from the alignment",
@@ -616,47 +616,61 @@ def main():
 
     # Two aligned rows carrying the canonical whose targets DISAGREE. Choosing one would write a
     # real record, the right role and the right attribute about the wrong element — #793's shape.
-    props, amb, _ = pair([mi(B + "AXMenuItem[A]", "Delete"), mi(B + "AXMenuItem[B]", "Delete")],
-                         [mi(B + "AXMenuItem[A]", "削除"), mi(B + "AXMenuItem[B]", "消去")],
+    props, amb, _cont, _ = pair([mi(B + "AXMenuItem[A]", "Delete"), mi(B + "AXMenuItem[B]", "Delete")],
+                              [mi(B + "AXMenuItem[A]", "削除"), mi(B + "AXMenuItem[B]", "消去")],
                          dict(exportMenuItem=("Delete", [])))
     case("disagreeing targets are reported, never resolved",
          "exportMenuItem" not in props and set(amb.get("exportMenuItem") or {}) == {"削除", "消去"},
          (props, amb))
 
     # ...but two aligned rows AGREEING is not ambiguity, it is corroboration.
-    props, amb, _ = pair([mi(B + "AXMenuItem[A]", "Delete"), mi(B + "AXMenuItem[B]", "Delete")],
-                         [mi(B + "AXMenuItem[A]", "削除"), mi(B + "AXMenuItem[B]", "削除")],
+    props, amb, _cont, _ = pair([mi(B + "AXMenuItem[A]", "Delete"), mi(B + "AXMenuItem[B]", "Delete")],
+                              [mi(B + "AXMenuItem[A]", "削除"), mi(B + "AXMenuItem[B]", "削除")],
                          dict(exportMenuItem=("Delete", [])))
     case("agreeing targets are one candidate, not a conflict",
          (props.get("exportMenuItem") or {}).get("target") == "削除", (props, amb))
 
-    props, _, _ = pair([mi(B + "AXMenuItem[A]", "Bounce")], [mi(B + "AXMenuItem[A]", "Bounce")],
+    props, _, _c, _ = pair([mi(B + "AXMenuItem[A]", "Bounce")], [mi(B + "AXMenuItem[A]", "Bounce")],
                        dict(bounceMenuItem=("Bounce", [])))
     case("an untranslated string is not a candidate", "bounceMenuItem" not in props, props)
 
-    props, _, _ = pair([mi(B + "AXMenuItem[A]", "Bounce")], [mi(B + "AXMenuItem[A]", "バウンス")],
+    # The base row must BE the canonical, not merely contain it. An aligned pair returns the whole
+    # target string, so a containment match hands back the translation of the CONTAINING string —
+    # `region` matched inside `cycle region` gives `サイクルリージョン`, which is a different label.
+    # Two of the first 18 candidates this tool produced were this shape.
+    props, _, cont, _ = pair([row("AXLayoutItem", "AXWindow[x]/AXLayoutItem[cycle region]",
+                                  description="cycle region")],
+                             [row("AXLayoutItem", "AXWindow[x]/AXLayoutItem[サイクルリージョン]",
+                                  description="サイクルリージョン")],
+                             dict(regionHelpKeyword=("region", [])))
+    case("a containment-only match is refused, not proposed",
+         "regionHelpKeyword" not in props, props)
+    case("...and is reported with what it actually saw",
+         (cont.get("regionHelpKeyword") or [{}])[0].get("target") == "サイクルリージョン", cont)
+
+    props, _, _c, _ = pair([mi(B + "AXMenuItem[A]", "Bounce")], [mi(B + "AXMenuItem[A]", "バウンス")],
                        dict(bounceMenuItem=("Bounce", ["バウンス"])))
     case("a variant already declared is not re-proposed", "bounceMenuItem" not in props, props)
 
-    props, _, _ = pair([row("AXMenuBarItem", "AXMenuBar/AXMenuBarItem[Bounce]", title="Bounce")],
+    props, _, _c, _ = pair([row("AXMenuBarItem", "AXMenuBar/AXMenuBarItem[Bounce]", title="Bounce")],
                        [row("AXMenuBarItem", "AXMenuBar/AXMenuBarItem[バウンス]", title="バウンス")],
                        dict(bounceMenuItem=("Bounce", [])))
     case("the base row's role must fit the label's shape", "bounceMenuItem" not in props, props)
 
     # The label's `evidence_scope` gates the BASE row too: a label that may only be read in a
     # window may not learn its translation from the menu bar either.
-    props, _, _ = pair([mi(B + "AXMenuItem[A]", "Delete")], [mi(B + "AXMenuItem[A]", "削除")],
+    props, _, _c, _ = pair([mi(B + "AXMenuItem[A]", "Delete")], [mi(B + "AXMenuItem[A]", "削除")],
                        dict(markerListDeleteMenuItem=("Delete", [])),
                        evidence_scope={"path_contains": "AXWindow[", "reason": "r"})
     case("a scoped label does not learn its translation from outside its scope",
          "markerListDeleteMenuItem" not in props, props)
 
     # And every candidate says whether anything narrower than a role admitted it.
-    props, _, _ = pair([mi(B + "AXMenuItem[A]", "Bounce")], [mi(B + "AXMenuItem[A]", "バウンス")],
+    props, _, _c, _ = pair([mi(B + "AXMenuItem[A]", "Bounce")], [mi(B + "AXMenuItem[A]", "バウンス")],
                        dict(bounceMenuItem=("Bounce", [])))
     case("an unscoped candidate is marked as resting on its role alone",
          props["bounceMenuItem"]["scoped"] is False, props)
-    props, _, _ = pair([mi(B + "AXMenuItem[A]", "Bounce")], [mi(B + "AXMenuItem[A]", "バウンス")],
+    props, _, _c, _ = pair([mi(B + "AXMenuItem[A]", "Bounce")], [mi(B + "AXMenuItem[A]", "バウンス")],
                        dict(bounceMenuItem=("Bounce", [])),
                        evidence_scope={"surfaces": ["arrange.menus"], "reason": "r"})
     case("a scoped candidate says so", props["bounceMenuItem"]["scoped"] is True, props)

--- a/Scripts/test_locale_campaign.py
+++ b/Scripts/test_locale_campaign.py
@@ -27,6 +27,7 @@ propose = load("locale_propose", "locale-propose.py")
 _gspec = importlib.util.spec_from_file_location("locale_guard", HERE / "check-locale-labels-json.py")
 guard = importlib.util.module_from_spec(_gspec); _gspec.loader.exec_module(guard)
 records = load("locale_campaign_records", "locale_campaign_records.py")
+align = load("locale_align", "locale-align.py")
 
 HOST = {"app": "Logic Pro", "version": "12.3", "build": "6674", "locale": "ko-KR", "os": "macOS 26.3 (25D125)"}
 
@@ -574,6 +575,91 @@ def main():
     case("a well-formed scope still admits the row it allows",
          "markerListDeleteMenuItem" in with_scope(
              {"reason": "r", "surfaces": ["arrange.menus"]}), "")
+
+    # 11. `locale-align.py`: a translation READ from two censuses of the same walk. What it must
+    #     refuse is the point — an index alignment, the Apple menu, and any pair it cannot place.
+    def mi(path, title):
+        return row("AXMenuItem", path, title=title)
+
+    def pair(base_rows, target_rows, label_sets, **entry_extra):
+        doc = labels(**label_sets)
+        for name in label_sets:
+            doc["labels"][name].update(entry_extra)
+        return align.candidates(census(base_rows, "en-US"), census(target_rows, "ja-JP"),
+                                doc["labels"])
+
+    case("skeleton drops the displayed title and keeps the structure",
+         align.skeleton(mi("AXMenuBar/AXMenuBarItem[File]/AXMenu/AXMenuItem[Export]", "Export"))
+         == align.skeleton(mi("AXMenuBar/AXMenuBarItem[ファイル]/AXMenu/AXMenuItem[書き出す]", "書き出す")),
+         align.skeleton(mi("AXMenuBar/AXMenuBarItem[File]/AXMenu/AXMenuItem[Export]", "Export")))
+
+    B = "AXMenuBar/AXMenuBarItem[F]/AXMenu/"
+    base3 = [mi(B + "AXMenuItem[A]", "Bounce"), mi(B + "AXMenuItem[B]", "Export")]
+    # An EXTRA row on the target side, ahead of the one we care about. Under index alignment
+    # `Export` would be paired with `挿入` and the reading would be confidently wrong.
+    target3 = [mi(B + "AXMenuItem[A]", "バウンス"), mi(B + "AXGroup/AXMenuItem[X]", "挿入"),
+               mi(B + "AXMenuItem[B]", "書き出す")]
+    props, amb, stats = pair(base3, target3, dict(exportMenuItem=("Export", [])))
+    case("an inserted target row does not shift the pairing after it",
+         (props.get("exportMenuItem") or {}).get("target") == "書き出す", (props, stats))
+    case("the unplaceable row is counted, not approximated",
+         stats["unplaced_target"] == 1 and stats["unplaced_base"] == 0, stats)
+
+    # The Apple menu carries the SYSTEM locale. On a host whose system language never changed both
+    # censuses show the same string there, so a pair taken from it reads as "not translated".
+    apple = "AXMenuBar/AXMenuBarItem[Apple]/AXMenu/"
+    props, _, stats = pair([mi(apple + "AXMenuItem[S]", "Bounce")],
+                           [mi(apple + "AXMenuItem[S]", "バウンス")],
+                           dict(bounceMenuItem=("Bounce", [])))
+    case("Apple-menu rows are excluded from the alignment",
+         "bounceMenuItem" not in props and stats["system_owned"] == 1, (props, stats))
+
+    # Two aligned rows carrying the canonical whose targets DISAGREE. Choosing one would write a
+    # real record, the right role and the right attribute about the wrong element — #793's shape.
+    props, amb, _ = pair([mi(B + "AXMenuItem[A]", "Delete"), mi(B + "AXMenuItem[B]", "Delete")],
+                         [mi(B + "AXMenuItem[A]", "削除"), mi(B + "AXMenuItem[B]", "消去")],
+                         dict(exportMenuItem=("Delete", [])))
+    case("disagreeing targets are reported, never resolved",
+         "exportMenuItem" not in props and set(amb.get("exportMenuItem") or {}) == {"削除", "消去"},
+         (props, amb))
+
+    # ...but two aligned rows AGREEING is not ambiguity, it is corroboration.
+    props, amb, _ = pair([mi(B + "AXMenuItem[A]", "Delete"), mi(B + "AXMenuItem[B]", "Delete")],
+                         [mi(B + "AXMenuItem[A]", "削除"), mi(B + "AXMenuItem[B]", "削除")],
+                         dict(exportMenuItem=("Delete", [])))
+    case("agreeing targets are one candidate, not a conflict",
+         (props.get("exportMenuItem") or {}).get("target") == "削除", (props, amb))
+
+    props, _, _ = pair([mi(B + "AXMenuItem[A]", "Bounce")], [mi(B + "AXMenuItem[A]", "Bounce")],
+                       dict(bounceMenuItem=("Bounce", [])))
+    case("an untranslated string is not a candidate", "bounceMenuItem" not in props, props)
+
+    props, _, _ = pair([mi(B + "AXMenuItem[A]", "Bounce")], [mi(B + "AXMenuItem[A]", "バウンス")],
+                       dict(bounceMenuItem=("Bounce", ["バウンス"])))
+    case("a variant already declared is not re-proposed", "bounceMenuItem" not in props, props)
+
+    props, _, _ = pair([row("AXMenuBarItem", "AXMenuBar/AXMenuBarItem[Bounce]", title="Bounce")],
+                       [row("AXMenuBarItem", "AXMenuBar/AXMenuBarItem[バウンス]", title="バウンス")],
+                       dict(bounceMenuItem=("Bounce", [])))
+    case("the base row's role must fit the label's shape", "bounceMenuItem" not in props, props)
+
+    # The label's `evidence_scope` gates the BASE row too: a label that may only be read in a
+    # window may not learn its translation from the menu bar either.
+    props, _, _ = pair([mi(B + "AXMenuItem[A]", "Delete")], [mi(B + "AXMenuItem[A]", "削除")],
+                       dict(markerListDeleteMenuItem=("Delete", [])),
+                       evidence_scope={"path_contains": "AXWindow[", "reason": "r"})
+    case("a scoped label does not learn its translation from outside its scope",
+         "markerListDeleteMenuItem" not in props, props)
+
+    # And every candidate says whether anything narrower than a role admitted it.
+    props, _, _ = pair([mi(B + "AXMenuItem[A]", "Bounce")], [mi(B + "AXMenuItem[A]", "バウンス")],
+                       dict(bounceMenuItem=("Bounce", [])))
+    case("an unscoped candidate is marked as resting on its role alone",
+         props["bounceMenuItem"]["scoped"] is False, props)
+    props, _, _ = pair([mi(B + "AXMenuItem[A]", "Bounce")], [mi(B + "AXMenuItem[A]", "バウンス")],
+                       dict(bounceMenuItem=("Bounce", [])),
+                       evidence_scope={"surfaces": ["arrange.menus"], "reason": "r"})
+    case("a scoped candidate says so", props["bounceMenuItem"]["scoped"] is True, props)
 
     if failures:
         for f in failures: print(f"FAIL {f}")

--- a/docs/observations/2026-09-06-two-censuses-of-the-same-walk-carry-the-translation.json
+++ b/docs/observations/2026-09-06-two-censuses-of-the-same-walk-carry-the-translation.json
@@ -21,7 +21,7 @@
  "reverify": {
   "kind": "script",
   "command": "Scripts/observations/locale-align.py docs/observations/evidence/2026-09-05-en-US-navigation-free.census.json docs/observations/evidence/2026-09-05-ja-JP-navigation-free.census.json",
-  "expected": "1005 aligned pair(s); 71 dropped as system-owned; 34 base and 26 target row(s) unplaced; 18 label(s) with an unambiguous ja-JP string; 28 label(s) whose aligned rows disagree; 18 of the 18 resting on the label's role alone"
+  "expected": "1005 aligned pair(s); 71 dropped as system-owned; 34 base and 26 target row(s) unplaced; 29 label(s) with an unambiguous ja-JP string; 0 whose aligned rows disagree; 27 matching only inside a longer string; 29 of the 29 resting on the label's role alone"
  },
  "depends": [
   "Scripts/observations/locale-align.py",
@@ -78,18 +78,19 @@
   },
   {
    "what": "labels with one unambiguous target string",
-   "ja-JP": 18,
+   "ja-JP": 29,
    "ko-KR": 6,
-   "note": "ko-KR is lower because most Korean variants are already declared; the tool never re-proposes one"
+   "note": "ko-KR is lower because most Korean variants are already declared; the tool never re-proposes one. Of the ja-JP candidates 28 are for labels currently unmeasured there, and of the ko-KR ones 5."
   },
   {
    "what": "labels matching aligned rows whose targets DISAGREE, not proposed",
-   "ja-JP": 28,
-   "ko-KR": 28
+   "ja-JP": 0,
+   "ko-KR": 0,
+   "note": "the mechanism is exercised by the self-tests; on this census pair every remaining candidate agreed once containment-only matches were removed first"
   },
   {
    "what": "of the proposals, those admitted by the label's ROLE alone",
-   "ja-JP": 18,
+   "ja-JP": 29,
    "ko-KR": 6,
    "note": "no evidence_scope declared, so a same-role element carrying the same string would have matched identically"
   },
@@ -118,15 +119,40 @@
      "ja-JP": "横方向にズーム"
     }
    ]
+  },
+  {
+   "what": "labels matching only INSIDE a longer string, refused",
+   "ja-JP": 27,
+   "ko-KR": 27,
+   "note": "an aligned pair returns the whole target string, so a containment match hands back the translation of the containing string. `regionHelpKeyword` is `region`, its row read `cycle region`, and the aligned Japanese was `サイクルリージョン`. Found by reading this tool's own first 18 candidates against what each label says it addresses; 2 of the 18 were this shape, and `arrangeWindowTitleSuffix` would have taken a project name into the ledger. Measured again after a label with no agreed match mode stopped matching anything: 31 before that rule, 27 after"
+  },
+  {
+   "what": "of the first 18 ja-JP candidates, those whose base row was the WRONG ELEMENT for the label",
+   "count": 7,
+   "examples": [
+    "libraryPanelLabel backed by the View menu's Library item rather than the panel",
+    "mixerNamedElement by the View menu's Mixer item rather than the mixer container",
+    "pluginWindowViewSwitcher by the application menu bar's View",
+    "trackRecordButton and trackSoloButton by the Control Bar's global buttons rather than a track's"
+   ],
+   "note": "read by hand against each label's rationale; this is the judgement the tool defers rather than makes, and it is why the run prints how many candidates rest on a role alone"
+  },
+  {
+   "what": "candidates when the BASE census is not the language the labels are named in",
+   "en-US_base_to_ja-JP": 29,
+   "ko-KR_base_to_ja-JP": 11,
+   "note": "a label is matched by its `canonical`, which is English, so a Korean base finds only the labels Logic leaves untranslated in Korean"
   }
  ],
- "conclusion": "Two censuses of the same walk do carry the translation, and the alignment is strong where it matters: 1005 of 1031 ja-JP rows align as matching blocks against 886 that share an index, so a sequence match recovers 119 pairs an index alignment gets wrong. It yields 18 unambiguous ja-JP candidates and refuses 28 labels whose aligned rows disagree. The verdict is `partial` for two reasons that are properties of the method rather than of this run: all 18 candidates rest on the label's role alone, and 9 unplaced rows carry strings inside the Library pane, which no alignment of these two walks can reach.",
+ "conclusion": "Two censuses of the same walk do carry the translation, and the alignment is strong where it matters: 1005 of 1031 ja-JP rows align as matching blocks against 886 that share an index, so a sequence match recovers 119 pairs an index alignment gets wrong. It yields 29 unambiguous ja-JP candidates and 6 ko-KR ones, and refuses 27 labels that matched only inside a longer string. The verdict is `partial` for three reasons that are properties of the method rather than of this run: all 29 candidates rest on the label's role alone, 7 of the first 18 were read by hand and were the wrong element for their label, and 9 unplaced rows carry strings inside the Library pane, which no alignment of these two walks can reach.",
  "limits": [
   "This finds STRINGS, not label bindings. A candidate says 'the element whose en-US string is X shows Y here'; whether that element is the one a label names is not established by the alignment and is exactly the #793 failure when it is assumed.",
-  "All 18 ja-JP candidates were admitted by role alone, because none of those labels declares an evidence_scope. The tool reports that count every run rather than presenting them as equally solid.",
+  "All 29 ja-JP candidates were admitted by role alone, because none of those labels declares an evidence_scope. Reading the first 18 by hand against their rationales found 7 that were the wrong element, so this is a measured rate and not a caution: the tool proposes, and a person decides.",
   "The Library pane does not align: 9 of the unplaced ja-JP rows carry strings. A label whose element lives there needs measuring some other way.",
   "Only en-US -> ja-JP and en-US -> ko-KR were run, both against the 2026-09-05 censuses. Nothing here says the alignment holds across Logic versions, or on a surface these two walks did not enter.",
-  "No Logic was driven for this record. It is an analysis of census files already in the tree, so it inherits every limit those censuses carry — including that they are navigation-free and never open a menu."
+  "No Logic was driven for this record. It is an analysis of census files already in the tree, so it inherits every limit those censuses carry — including that they are navigation-free and never open a menu.",
+  "`ambiguous` is 0 on this census pair. That is not evidence the path is dead — it is exercised by the self-tests — but nothing here demonstrates it firing on real data.",
+  "The base census has to be the one whose language the labels are named in. Matching the base against a label's declared variants too would lift that and is deliberately not done: it would make this tool's answer depend on evidence the ledger already holds, and its purpose is to find strings the ledger does not know."
  ],
  "supersedes": null
 }

--- a/docs/observations/2026-09-06-two-censuses-of-the-same-walk-carry-the-translation.json
+++ b/docs/observations/2026-09-06-two-censuses-of-the-same-walk-carry-the-translation.json
@@ -1,0 +1,132 @@
+{
+ "id": "2026-09-06-two-censuses-of-the-same-walk-carry-the-translation",
+ "date": "2026-09-06",
+ "schema": 2,
+ "subject": "aligning two locale censuses of the same navigation-free walk",
+ "question": "Can a label's translation be READ out of two censuses, rather than confirmed against a string somebody already declared?",
+ "verdict": "partial",
+ "issues": [
+  795,
+  778
+ ],
+ "surface": "arrange.menus",
+ "host": {
+  "app": "Logic Pro",
+  "version": "12.3",
+  "build": "6674",
+  "locale": "en-US",
+  "os": "macOS 26.3 (25D125)",
+  "note": "the host of the 2026-09-05 censuses this analyses; no Logic was driven for this record"
+ },
+ "reverify": {
+  "kind": "script",
+  "command": "Scripts/observations/locale-align.py docs/observations/evidence/2026-09-05-en-US-navigation-free.census.json docs/observations/evidence/2026-09-05-ja-JP-navigation-free.census.json",
+  "expected": "1005 aligned pair(s); 71 dropped as system-owned; 34 base and 26 target row(s) unplaced; 18 label(s) with an unambiguous ja-JP string; 28 label(s) whose aligned rows disagree; 18 of the 18 resting on the label's role alone"
+ },
+ "depends": [
+  "Scripts/observations/locale-align.py",
+  "docs/observations/evidence/2026-09-05-en-US-navigation-free.census.json",
+  "docs/observations/evidence/2026-09-05-ja-JP-navigation-free.census.json",
+  "docs/observations/evidence/2026-09-05-ko-KR-navigation-free.census.json",
+  "docs/locale/ui-labels.json"
+ ],
+ "evidence": null,
+ "method": "Strip every bracketed title out of each census row's `path` and prefix the role. What remains is a skeleton that does not depend on the UI language. Align the two skeleton lists with difflib.SequenceMatcher and keep ONLY the matching blocks, so an inserted row breaks one block instead of shifting every pair after it. Drop pairs under AXMenuBarItem[Apple], whose strings come from the system locale rather than Logic's. For each label, take the aligned rows whose base-locale string matches its canonical under the label's own match mode, its role shape and its evidence_scope; the target row of each pair then carries the translation.",
+ "observations": [
+  {
+   "what": "row counts",
+   "en-US": 1039,
+   "ja-JP": 1031,
+   "ko-KR": 1039
+  },
+  {
+   "what": "skeletons identical at the SAME INDEX",
+   "ja-JP": 886,
+   "ko-KR": 1014,
+   "note": "en-US/ja-JP differ by 8 rows, so 145 of 1031 ja-JP rows sit at an index whose en-US row has another shape"
+  },
+  {
+   "what": "aligned as matching blocks",
+   "ja-JP": 1005,
+   "ko-KR": 1014,
+   "of_target_rows": {
+    "ja-JP": 1031,
+    "ko-KR": 1039
+   }
+  },
+  {
+   "what": "pairs a sequence match recovers that an index alignment gets wrong",
+   "ja-JP": 119,
+   "derivation": "1005 aligned as blocks minus 886 sharing an index"
+  },
+  {
+   "what": "pairs dropped as system-owned (AXMenuBarItem[Apple])",
+   "ja-JP": 71,
+   "ko-KR": 71
+  },
+  {
+   "what": "rows neither run could place",
+   "ja-JP": {
+    "base": 34,
+    "target": 26
+   },
+   "ko-KR": {
+    "base": 25,
+    "target": 25
+   },
+   "note": "the 26 unplaced ja-JP rows are inside the Library pane; 9 of them carry a displayed string, so this is a NAMED hole and not an empty one"
+  },
+  {
+   "what": "labels with one unambiguous target string",
+   "ja-JP": 18,
+   "ko-KR": 6,
+   "note": "ko-KR is lower because most Korean variants are already declared; the tool never re-proposes one"
+  },
+  {
+   "what": "labels matching aligned rows whose targets DISAGREE, not proposed",
+   "ja-JP": 28,
+   "ko-KR": 28
+  },
+  {
+   "what": "of the proposals, those admitted by the label's ROLE alone",
+   "ja-JP": 18,
+   "ko-KR": 6,
+   "note": "no evidence_scope declared, so a same-role element carrying the same string would have matched identically"
+  },
+  {
+   "what": "difflib autojunk makes no difference on this pair",
+   "autojunk_false": 1005,
+   "autojunk_true": 1005
+  },
+  {
+   "what": "example readings taken from aligned pairs",
+   "rows": [
+    {
+     "role": "AXMenuItem",
+     "en-US": "Export",
+     "ja-JP": "書き出す"
+    },
+    {
+     "role": "AXMenuItem",
+     "en-US": "Bounce",
+     "ja-JP": "バウンス"
+    },
+    {
+     "role": "AXSlider",
+     "attribute": "description",
+     "en-US": "Horizontal Zoom",
+     "ja-JP": "横方向にズーム"
+    }
+   ]
+  }
+ ],
+ "conclusion": "Two censuses of the same walk do carry the translation, and the alignment is strong where it matters: 1005 of 1031 ja-JP rows align as matching blocks against 886 that share an index, so a sequence match recovers 119 pairs an index alignment gets wrong. It yields 18 unambiguous ja-JP candidates and refuses 28 labels whose aligned rows disagree. The verdict is `partial` for two reasons that are properties of the method rather than of this run: all 18 candidates rest on the label's role alone, and 9 unplaced rows carry strings inside the Library pane, which no alignment of these two walks can reach.",
+ "limits": [
+  "This finds STRINGS, not label bindings. A candidate says 'the element whose en-US string is X shows Y here'; whether that element is the one a label names is not established by the alignment and is exactly the #793 failure when it is assumed.",
+  "All 18 ja-JP candidates were admitted by role alone, because none of those labels declares an evidence_scope. The tool reports that count every run rather than presenting them as equally solid.",
+  "The Library pane does not align: 9 of the unplaced ja-JP rows carry strings. A label whose element lives there needs measuring some other way.",
+  "Only en-US -> ja-JP and en-US -> ko-KR were run, both against the 2026-09-05 censuses. Nothing here says the alignment holds across Logic versions, or on a surface these two walks did not enter.",
+  "No Logic was driven for this record. It is an analysis of census files already in the tree, so it inherits every limit those censuses carry — including that they are navigation-free and never open a menu."
+ ],
+ "supersedes": null
+}


### PR DESCRIPTION
Adds `Scripts/observations/locale-align.py`: a label's translation read out of two censuses of the
same walk, rather than confirmed against a string somebody already declared.

### Why the campaign could not deliver these

`locale-propose.py` looks for a string it was given, so it can only CONFIRM a variant that already
exists. The 87 label sets missing a Japanese form are missing exactly the string nobody has written
down. That is why #778 has moved one label at a time.

Two censuses of the same surfaces in the same order carry more than two lists of strings. Strip the
bracketed titles out of each row's `path` and the remaining skeleton — roles and structure —
survives a language change, so the walks can be aligned and each pair read as "the en-US string here
is the target string".

### Measured on the 2026-09-05 censuses

```
rows                                  en-US 1039    ja-JP 1031
identical skeleton at the same INDEX               886 / 1031
aligned as matching blocks                        1005 / 1031     <- 119 pairs an index gets wrong
dropped as system-owned (Apple menu)                71
rows neither run could place            base 34    target 26      (all in the Library pane)
```

29 unambiguous ja-JP candidates and 6 ko-KR ones, all for labels currently unmeasured there.

### What it refuses

* **A sequence match, never an index.** One inserted row shifts every pair after it, and each one is
  then wrong while still looking plausible.
* **A pair outside a matching block is dropped, never approximated.** The 26 unplaced ja-JP rows are
  a named hole — 9 of them carry strings, inside the Library pane — not a rounding error.
* **The Apple menu is excluded.** Its rows carry the SYSTEM locale, so on this host the same string
  appears in both censuses and would certify an untranslated string as a translation.
* **Disagreement is reported, never resolved.** Picking the first of several would write a real
  record with the right role and the right attribute about the wrong element — #793's shape exactly.
* **The base row must BE the canonical, not merely contain it.** *(second commit)*

### The second commit is the interesting one

Reading the tool's own first 18 candidates against what each label says it addresses found two that
were a different label. An aligned pair returns the WHOLE target string, so for a containment-matched
label the answer is the translation of the containing string:

```
regionHelpKeyword         'region'  matched inside 'cycle region'  -> 'サイクルリージョン'
arrangeWindowTitleSuffix  'Tracks'  matched inside 'lpm-locale-campaign - Tracks'
```

The second would have taken a **project name** into the ledger as a Japanese variant. 31 labels now
land in a `containing` bucket instead of being proposed. Removing them first also removed what was
making other labels look ambiguous: 18 candidates and 28 disagreements became 29 and 0.

### The limit it prints every run

All 29 candidates were admitted by the label's ROLE and nothing narrower — none of those labels
declares an `evidence_scope`. That is not a caution, it is a measured rate: reading the first 18 by
hand against their rationales found **7 that were the wrong element**, six of them a menu item
standing in for the thing the menu opens. The full classification is in
[a comment on #795](https://github.com/MongLong0214/logic-pro-mcp/issues/795).

Nothing is written to the tree and nothing edits Swift. It prints candidates; a person decides.

### Verification

34/34 repo guards, 62 proposer self-test cases. Mutation-tested: including the Apple menu, resolving
an ambiguity by taking the first, accepting an untranslated string, replacing the sequence match with
an index alignment, ignoring the label's scope, making the `scoped` flag constant, or deleting the
equality check each turns the suite RED. Ship gate PASS. For #795.

Stacked on #793 — it reads `evidence_scope` through that branch's guard.
