### PR TITLE
fix(#792): a harness may not define a check it never calls

### DIFF
--- a/Scripts/check-dead-harness-helpers.py
+++ b/Scripts/check-dead-harness-helpers.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""A live harness may not define a check it never calls.
+
+Discovered automatically by `run-repo-guards.py` (top-level `Scripts/check-*.py`), so it runs in
+both CI jobs that gate a merge.
+
+THE FAILURE THIS REFUSES, three times over. A helper is added to a harness, described in a commit
+message as closing a review finding, and never wired in. A function that runs zero times is a check
+that cannot fail — the exact defect these harnesses exist to catch — and until now it was invisible
+to everything: the ship gate runs the suite and the harness, and both are happy with a function
+nobody calls. The third instance is what prompted this: `same_region` was added to
+`live_575_move_to_playhead_reachable.py` to close a finding about a band that could be built from
+two different regions, documented as the fix, and called from nowhere. A blind review of that commit
+approved it.
+
+WHY `live_*.py` AND NOT THE WHOLE DIRECTORY. These files are entry points: they are run, never
+imported. So a module-level name referenced only by its own `def` is unreachable, full stop.
+`evidence.py` is the opposite — every harness imports it, and its `label_set`, `artifact_answered`,
+`is_clean` and `have_tools` are its public surface. `test_*.py` there are unit tests of the rules
+and are run by the discoverer, not imported either, but their `def`s are collected by a test runner
+rather than called by name.
+
+That assumption is CHECKED rather than trusted: if a `live_*.py` ever does get imported somewhere,
+this says so instead of quietly continuing to treat it as an entry point.
+
+A RATCHET WOULD BE THE WRONG INSTRUMENT and this deliberately does not offer one. A dead helper is
+not a debt to hold a line on, it is a deletion; a guard that lets one be registered instead of
+removed re-creates the thing it detects.
+"""
+import ast
+import glob
+import os
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+LIVEKIT = os.path.join(REPO, "Scripts", "livekit")
+
+
+def harnesses(root=LIVEKIT):
+    """The entry-point harnesses: `live_*.py`, which are run and never imported."""
+    return sorted(glob.glob(os.path.join(root, "live_*.py")))
+
+
+def dead_defs(source):
+    """Module-level function names that appear nowhere else in their own file.
+
+    Counts NAME references, so a dictionary key that happens to spell the same word — `recorded
+    .get("start_bar")` — is not a reference and does not keep a dead `start_bar` alive. Decorated
+    functions are excluded: a decorator is a call site this file cannot see through, and refusing
+    one would be a guess about a framework rather than a reading of the code.
+    """
+    tree = ast.parse(source)
+    defined = {}
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and not node.decorator_list:
+            defined.setdefault(node.name, node.lineno)
+    used = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
+            used.add(node.id)
+        elif isinstance(node, ast.Attribute):
+            used.add(node.attr)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for dec in node.decorator_list:
+                for sub in ast.walk(dec):
+                    if isinstance(sub, ast.Name):
+                        used.add(sub.id)
+    return sorted((name, line) for name, line in defined.items() if name not in used)
+
+
+def importers(paths, root=REPO):
+    """Any file that imports one of these harnesses as a module, by stem.
+
+    The premise of this guard is that a `live_*.py` is an entry point. If that ever stops being
+    true the premise is wrong, and saying so is better than continuing to reason from it.
+    """
+    stems = {os.path.splitext(os.path.basename(p))[0] for p in paths}
+    found = {}
+    for path in glob.glob(os.path.join(root, "Scripts", "**", "*.py"), recursive=True):
+        if os.path.basename(path).startswith("live_"):
+            continue
+        try:
+            tree = ast.parse(open(path, encoding="utf-8").read())
+        except (OSError, SyntaxError):
+            continue
+        for node in ast.walk(tree):
+            names = []
+            if isinstance(node, ast.Import):
+                names = [a.name for a in node.names]
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                names = [node.module]
+            for n in names:
+                stem = n.split(".")[-1]
+                if stem in stems:
+                    found.setdefault(stem, set()).add(os.path.relpath(path, root))
+    return found
+
+
+def main():
+    paths = harnesses()
+    problems = []
+    for stem, where in sorted(importers(paths).items()):
+        problems.append(f"{stem} is IMPORTED by {sorted(where)} — this guard assumes `live_*.py` "
+                        f"files are entry points and reasons about them on that basis. Reading a "
+                        f"name as unreachable is only sound while nothing imports it")
+    for path in paths:
+        rel = os.path.relpath(path, REPO)
+        try:
+            source = open(path, encoding="utf-8").read()
+        except OSError as exc:
+            problems.append(f"{rel}: cannot be read ({exc})")
+            continue
+        try:
+            dead = dead_defs(source)
+        except SyntaxError as exc:
+            problems.append(f"{rel}: does not parse ({exc})")
+            continue
+        for name, line in dead:
+            problems.append(f"{rel}:{line}: `{name}` is defined and referenced nowhere in this "
+                            f"file. A harness is run, never imported, so this cannot be called — "
+                            f"and a check that runs zero times cannot fail. Delete it, or wire it "
+                            f"in")
+    if problems:
+        print("dead helpers in live harnesses:")
+        for line in problems:
+            print(f"  {line}")
+        print("\n  There is no ratchet for this on purpose: a dead helper is a deletion, not a "
+              "debt.")
+        return 1
+    print(f"{len(paths)} live harness(es): every module-level def is referenced in its own file")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Scripts/livekit/live_519_region_op_on_a_localized_logic.py
+++ b/Scripts/livekit/live_519_region_op_on_a_localized_logic.py
@@ -183,16 +183,6 @@ def current_language_setting():
     return [c for c in codes if c not in ("", )] or ["en"]
 
 
-def start_bar(help_text):
-    """The bar Logic's help string says a region starts at — the two languages differ in order."""
-    text = help_text or ""
-    korean = re.search(r"(\d+)\s*마디[^0-9]*시작", text)
-    if korean:
-        return int(korean.group(1))
-    english = re.search(r"starts at\D*(\d+)", text)
-    return int(english.group(1)) if english else None
-
-
 original_languages = current_language_setting()
 ev.note("519/original-language", {"AppleLanguages": original_languages})
 

--- a/Scripts/livekit/live_534_goto_position.py
+++ b/Scripts/livekit/live_534_goto_position.py
@@ -44,12 +44,6 @@ rec = ev.record_screen(seconds=45)
 d = E.Driver()
 
 
-def playhead():
-    """The transport readout, read live rather than from cache."""
-    body = d.tool("logic_transport", "goto_position", {"position": PARK}) if False else None
-    return d.resource("logic://transport")
-
-
 win = E.logic_window()
 if not win:
     ev.check("534/precondition-logic-window", False,

--- a/Scripts/test_dead_harness_helpers.py
+++ b/Scripts/test_dead_harness_helpers.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Prove `Scripts/check-dead-harness-helpers.py` can fail, and on the right things.
+
+The two cases that matter are the last two: a name that appears only as a STRING must not keep a
+dead function alive, and a `live_*.py` that somebody imports must break the guard's premise loudly
+rather than silently.
+"""
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+spec = importlib.util.spec_from_file_location("dead_helpers", HERE / "check-dead-harness-helpers.py")
+guard = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(guard)
+
+
+def main():
+    failures = []
+    ran = [0]
+
+    def case(name, cond, detail):
+        ran[0] += 1
+        if not cond:
+            failures.append(f"{name}: {detail}")
+
+    def dead(src):
+        return [n for n, _ in guard.dead_defs(src)]
+
+    case("a def nobody calls is dead",
+         dead("def helper():\n    return 1\n") == ["helper"], dead("def helper():\n    return 1\n"))
+    case("a def that is called is not dead",
+         dead("def helper():\n    return 1\n\nhelper()\n") == [],
+         dead("def helper():\n    return 1\n\nhelper()\n"))
+    case("a def referenced without calling is not dead",
+         dead("def helper():\n    return 1\n\nf = helper\n") == [],
+         dead("def helper():\n    return 1\n\nf = helper\n"))
+    case("a def called from inside another function is not dead",
+         dead("def a():\n    return 1\n\ndef b():\n    return a()\n\nb()\n") == [],
+         dead("def a():\n    return 1\n\ndef b():\n    return a()\n\nb()\n"))
+
+    # THE STRING CASE. `live_519` carried a dead `start_bar` while `recorded.get("start_bar")`
+    # appeared three times — as a dictionary KEY. Counting text rather than names would have read
+    # those as references and left the dead helper in place.
+    src = 'def start_bar(t):\n    return 1\n\nx = {"start_bar": 2}\ny = x.get("start_bar")\n'
+    case("a name that appears only as a string does not keep a def alive",
+         dead(src) == ["start_bar"], dead(src))
+
+    # A decorated function has a call site this guard cannot see through. Refusing it would be a
+    # guess about a framework rather than a reading of the code.
+    src = "import functools\n\n@functools.cache\ndef helper():\n    return 1\n"
+    case("a decorated def is not called dead", dead(src) == [], dead(src))
+    # ...but the decorator's own name still counts as a use of whatever it names.
+    src = "def deco(f):\n    return f\n\n@deco\ndef helper():\n    return 1\n\nhelper()\n"
+    case("a decorator counts as a reference to the function it names", dead(src) == [], dead(src))
+
+    # Nested defs are not module-level and are not this guard's business.
+    src = "def outer():\n    def inner():\n        return 1\n    return 2\n\nouter()\n"
+    case("a nested def is out of scope", dead(src) == [], dead(src))
+
+    # THE PREMISE CHECK. `live_*.py` is treated as unreachable-if-unreferenced only because nothing
+    # imports it. If that stops being true the guard must say so, not keep reasoning from it.
+    root = Path(tempfile.mkdtemp())
+    (root / "Scripts" / "livekit").mkdir(parents=True)
+    (root / "Scripts" / "livekit" / "live_x.py").write_text("def helper():\n    return 1\n",
+                                                            encoding="utf-8")
+    case("with nothing importing it, no premise complaint",
+         guard.importers(guard.harnesses(str(root / "Scripts" / "livekit")), str(root)) == {},
+         "")
+    (root / "Scripts" / "importer.py").write_text("import live_x\n", encoding="utf-8")
+    found = guard.importers(guard.harnesses(str(root / "Scripts" / "livekit")), str(root))
+    case("an imported harness is reported, not assumed away",
+         set(found) == {"live_x"}, found)
+
+    # And the guard as a whole is green on the real tree.
+    proc = subprocess.run([sys.executable, str(HERE / "check-dead-harness-helpers.py")],
+                          capture_output=True, text=True)
+    case("repository has no dead harness helpers", proc.returncode == 0, proc.stdout.strip()[:200])
+
+    if failures:
+        for f in failures:
+            print(f"FAIL {f}")
+        return 1
+    print(f"{ran[0]} case(s) pass: a helper nobody calls is a check that cannot fail")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Three times a helper was added to a live harness, described in a commit message as closing a review
finding, and never wired in. A function that runs zero times is a check that cannot fail — the exact
defect these harnesses exist to catch — and it was invisible to everything the repository has: the
suite is happy, the harness is happy, and the ship gate runs both.

### The two that were live are deleted

`start_bar` in `live_519` parsed a bar number out of Logic's help string. `playhead` in `live_534`
is worse, because its body is

```python
body = d.tool("logic_transport", "goto_position", {"position": PARK}) if False else None
return d.resource("logic://transport")
```

under a docstring saying it reads live. The operation it names is not sent and `body` is unused, so
a reader looking for where this harness parks the playhead finds this and believes it.

### The guard counts names, not text

`live_519` used `recorded.get("start_bar")` three times as a dictionary KEY. A textual search would
have read those as uses and left the dead helper in place, so the guard walks the AST and counts
NAME references. Decorated functions are exempt — a decorator is a call site it cannot see through,
and refusing one would be a guess about a framework rather than a reading of the code.

The premise is CHECKED rather than assumed: `live_*.py` is treated as unreachable-if-unreferenced
only because nothing imports it, so if one ever is imported the guard says so instead of continuing
to reason from a premise that has stopped holding.

**No ratchet, deliberately,** as the issue asks. A dead helper is a deletion, not a debt, and a
guard that lets one be registered instead of removed re-creates what it detects.

### Verification

Eleven self-test cases, including the two that carry the weight: a name appearing only as a string
does not keep a def alive, and an imported harness is reported. Injecting a dead helper into
`live_534` names it by file, line and symbol.

```
== live gate for 11f10c23f183a1274b05a4b8e1bae6f6d64f467e ==
   harnesses this branch must prove: 2 (0 obliged by a Sources/ change)
        ok  live_519_region_op_on_a_localized_logic
        ok  live_534_goto_position
LIVE GATE PASS
```

36 repo guards pass. Ship gate PASS. For #792.