### PR TITLE
fix: the Formula pins v3.16.0's published hash

### DIFF
--- a/Formula/logic-pro-mcp.rb
+++ b/Formula/logic-pro-mcp.rb
@@ -21,7 +21,7 @@ class LogicProMcp < Formula
   # file. Bump `version` and this line together, and let CI confirm it.
   on_macos do
     url "https://github.com/MongLong0214/logic-pro-mcp/releases/download/v#{version}/LogicProMCP-macOS-universal.tar.gz"
-    sha256 "0776b0d257606460164b3e197f6542223c9d0657501f97e96f5f9a250b994788"
+    sha256 "30f632d83f70e02e67754e6cfe8e809a4d218b78a4f47bc58ff374fbdd74bf91"
   end
 
   depends_on :macos => :sonoma


### PR DESCRIPTION
The version moved with the release cut and the hash could not, because v3.16.0 did not exist yet.
`ci-verify-formula-sha.sh` said exactly that rather than passing — which is the behaviour #775 was
opened for, after v3.15.0 shipped carrying **v3.14.0's** hash.

Now that the release is published the check can answer, and it names the hash to use:

```
v3.16.0 has 30f632d83f70e02e67754e6cfe8e809a4d218b78a4f47bc58ff374fbdd74bf91
```

Copied verbatim, re-run:

```
Formula sha256 matches v3.16.0's LogicProMCP-macOS-universal.tar.gz
```

Until this lands, `brew install` fails for everyone on the new version.

Ship gate PASS: 4440 tests, 38 repo guards.