### PR TITLE
fix: CommitLore had permission to record and no trigger, and its prompt was the whole transcript

### DIFF
--- a/Scripts/commitlore-capture.sh
+++ b/Scripts/commitlore-capture.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Drive CommitLore's capture pipeline for the commit that is about to be made, and report the
+# STRUCTURED outcome rather than an exit code.
+#
+# WHY THIS EXISTS. The practice is "record decision context the diff cannot show". Measured
+# 2026-09-08 in this repository: `commitlore stale` reported ONE record in a thousand commits, while
+# a single session had produced about twenty commits carrying exactly that kind of context — a
+# dropped alternative, a measurement that contradicted the plan, a warning for whoever edits next.
+# Permission was never the obstacle: `.commitlore-policy.json` already says
+# {"mode":"auto","unattended":true}. What was missing is a TRIGGER. The installed hooks consume a
+# transaction that something else must start, and nothing started one.
+#
+# TWO THINGS MAKE THE NAIVE VERSION OF THIS WRONG.
+#
+# 1. THE EXIT CODE IS NOT THE OUTCOME. `capture` reports `staged`, `empty` and `rejected`, and all
+#    three exit 0. A wrapper that checks `$?` records a rejected draft as a success — the exact
+#    shape of false green this repository keeps finding elsewhere. So this reads `--json` and
+#    branches on `outcome`.
+#
+# 2. THE PROMPT IS THE WHOLE TRANSCRIPT. Measured the same day: a 67,981,436-byte session produced a
+#    67,468,122-byte prompt, which no model can consume, and `capture` reports that as
+#    `outcome: "empty"` with exit 0. Filed as commitlore#873. Until it is bounded upstream, this
+#    slices the transcript to a tail window and SAYS SO in its output, because a caller who cannot
+#    tell a slice from a session cannot judge the record that comes out of it.
+#
+# Usage:
+#   Scripts/commitlore-capture.sh prompt [<transcript>]   write the bounded prompt to stdout
+#   Scripts/commitlore-capture.sh stage <draft.json> [<transcript>]   verify + stage that draft
+#   Scripts/commitlore-capture.sh outcome [<transcript>]  print just the outcome word
+set -uo pipefail
+
+WINDOW="${LPM_CAPTURE_WINDOW:-400}"
+REPO="$(git rev-parse --show-toplevel 2>/dev/null)" || { echo "not a git repository" >&2; exit 2; }
+cd "$REPO" || exit 2
+
+find_transcript() {
+    [ -n "${1:-}" ] && { printf '%s' "$1"; return; }
+    [ -n "${LPM_TRANSCRIPT:-}" ] && { printf '%s' "$LPM_TRANSCRIPT"; return; }
+    local dir="$HOME/.claude/projects/$(printf '%s' "$REPO" | tr '/.' '--')"
+    ls -t "$dir"/*.jsonl 2>/dev/null | head -1
+}
+
+slice_of() {
+    local src="$1" out
+    [ -f "$src" ] || { echo "no transcript at $src" >&2; return 2; }
+    out=$(mktemp -t commitlore-slice) || return 2
+    tail -n "$WINDOW" "$src" > "$out" || return 2
+    printf '%s' "$out"
+}
+
+command -v commitlore >/dev/null 2>&1 || { echo "commitlore CLI not on PATH" >&2; exit 2; }
+
+CMD="${1:?usage: $0 prompt|stage|outcome [...]}"
+shift
+
+case "$CMD" in
+  prompt|outcome)
+      SRC=$(find_transcript "${1:-}") || exit 2
+      SLICE=$(slice_of "$SRC") || exit 2
+      trap 'rm -f "$SLICE"' EXIT
+      RAW=$(commitlore capture --json --unattended --transcript "$SLICE" 2>/dev/null) || true
+      [ -n "$RAW" ] || { echo "capture produced no JSON" >&2; exit 2; }
+      if [ "$CMD" = "outcome" ]; then
+          printf '%s' "$RAW" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("outcome","<none>"))'
+      else
+          # The window is reported alongside the prompt so a reader knows what it is looking at.
+          printf '%s' "$RAW" | WINDOW="$WINDOW" SRC="$SRC" python3 -c '
+import json, os, sys
+d = json.load(sys.stdin)
+print("# transcript slice: last {} lines of {}".format(os.environ["WINDOW"], os.environ["SRC"]))
+print("# capture outcome without a draft: {}".format(d.get("outcome")))
+print(d.get("prompt") or "")'
+      fi
+      ;;
+  stage)
+      DRAFT="${1:?usage: $0 stage <draft.json> [<transcript>]}"
+      [ -f "$DRAFT" ] || { echo "no draft at $DRAFT" >&2; exit 2; }
+      SRC=$(find_transcript "${2:-}") || exit 2
+      SLICE=$(slice_of "$SRC") || exit 2
+      trap 'rm -f "$SLICE"' EXIT
+      RAW=$(commitlore capture --json --unattended --transcript "$SLICE" --draft "$DRAFT" 2>/dev/null) || true
+      [ -n "$RAW" ] || { echo "capture produced no JSON" >&2; exit 2; }
+      printf '%s' "$RAW" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+outcome = d.get("outcome")
+print("outcome={} staged={} nonce={}".format(outcome, d.get("staged"), d.get("nonce")))
+# staged is a success; empty is an honest "nothing to record"; rejected is a FAILURE that exits 0
+# from the CLI and must not be read as either of the other two.
+sys.exit({"staged": 0, "empty": 0, "rejected": 1}.get(outcome, 2))'
+      ;;
+  *) echo "usage: $0 prompt|stage|outcome [...]" >&2; exit 2 ;;
+esac

--- a/Scripts/test-commitlore-capture.sh
+++ b/Scripts/test-commitlore-capture.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Prove Scripts/commitlore-capture.sh reads the OUTCOME, not the exit code.
+#
+# The case that carries this: `commitlore capture` reports `staged`, `empty` and `rejected` and all
+# three exit 0. A wrapper that checks `$?` records a rejected draft as a success. That is the false
+# green this helper exists to prevent, so it is the first thing tested — with a stub CLI, because
+# provoking a real rejection needs a draft the verifier disbelieves and that is not reproducible.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+HELPER="Scripts/commitlore-capture.sh"
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
+no()  { FAIL=$((FAIL+1)); printf '  FAIL %s\n' "$1"; }
+
+STUB=$(mktemp -d) || { echo "CANNOT-TEST(2): mktemp"; exit 2; }
+trap 'rm -rf "$STUB"' EXIT
+mkdir -p "$STUB/bin"
+make_stub() {   # $1 = outcome word the fake CLI reports, always exiting 0
+    cat > "$STUB/bin/commitlore" <<EOF
+#!/bin/sh
+printf '{"outcome":"%s","staged":%s,"nonce":null,"prompt":"p"}' "$1" "$( [ "$1" = staged ] && echo true || echo false )"
+exit 0
+EOF
+    chmod +x "$STUB/bin/commitlore"
+}
+echo '{"draft":"x"}' > "$STUB/draft.json"
+printf 'line\n' > "$STUB/t.jsonl"
+
+for outcome in staged empty; do
+    make_stub "$outcome"
+    PATH="$STUB/bin:$PATH" bash "$HELPER" stage "$STUB/draft.json" "$STUB/t.jsonl" >/dev/null 2>&1
+    [ $? -eq 0 ] && ok "$outcome is a pass" || no "$outcome should pass"
+done
+
+# THE ONE THAT MATTERS. The CLI exits 0; the helper must not.
+make_stub rejected
+PATH="$STUB/bin:$PATH" bash "$HELPER" stage "$STUB/draft.json" "$STUB/t.jsonl" >/dev/null 2>&1
+[ $? -eq 1 ] && ok "rejected FAILS even though the CLI exits 0" || no "a rejected record was read as success"
+
+# An unknown outcome is not silently a pass either: a new word from a future CLI must stop the
+# caller rather than fall through whichever branch happens to be last.
+make_stub something_new
+PATH="$STUB/bin:$PATH" bash "$HELPER" stage "$STUB/draft.json" "$STUB/t.jsonl" >/dev/null 2>&1
+[ $? -eq 2 ] && ok "an unrecognised outcome is cannot-tell, not a pass" || no "an unknown outcome did not stop the caller"
+
+# No JSON at all is a failure, not an empty success.
+cat > "$STUB/bin/commitlore" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+chmod +x "$STUB/bin/commitlore"
+PATH="$STUB/bin:$PATH" bash "$HELPER" stage "$STUB/draft.json" "$STUB/t.jsonl" >/dev/null 2>&1
+[ $? -eq 2 ] && ok "no JSON is refused rather than treated as empty" || no "silence was read as an outcome"
+
+# The slice must be BOUNDED — the whole point of the wrapper (commitlore#873).
+make_stub empty
+seq 1 5000 > "$STUB/big.jsonl"
+OUT=$(PATH="$STUB/bin:$PATH" LPM_CAPTURE_WINDOW=10 bash "$HELPER" prompt "$STUB/big.jsonl" 2>/dev/null)
+printf '%s' "$OUT" | grep -q "last 10 lines" && ok "the prompt declares the window it used" \
+    || no "the prompt did not say it was a slice"
+
+echo
+if [ "$FAIL" -ne 0 ]; then echo "FAIL: the capture wrapper does not do what it claims ($FAIL of $((PASS+FAIL)))"; exit 1; fi
+echo "OK: $PASS case(s) — the outcome decides, never the exit code"

--- a/docs/observations/2026-09-08-the-region-surface-has-no-ticks.json
+++ b/docs/observations/2026-09-08-the-region-surface-has-no-ticks.json
@@ -114,6 +114,24 @@
       "length_info_value": "0 1 0 0",
       "reading": "Position is bar / beat / division / TICK — four segments, as a string",
       "caveat": "this is an EVENT's position, not the region's. Here the region starts at bar 1 and its first note reads 1 1 1 1, but a region whose first event is not at its start would not yield the region's startTick this way."
+    },
+    {
+      "what": "descriptor collisions, measured after the design call named them the likeliest failure",
+      "regions": 10,
+      "name_collisions": {
+        "MIDI Region": 10
+      },
+      "distinct_4_tuples": 10,
+      "colliding_4_tuples": 0,
+      "tracks_holding_more_than_one_region": 0,
+      "note": "the tuple's uniqueness here is a property of the FIXTURE, not of the surface: record_sequence creates a new track per call by contract, so this project has one region per track"
+    },
+    {
+      "what": "an attempt to force a same-track collision",
+      "route": "logic_edit duplicate on the region record_sequence had just created",
+      "result": "{\"state\":\"B\",\"reason\":\"readback_unavailable\",\"success\":true,\"method\":\"midi_key_command\"}",
+      "region_count_change": 0,
+      "claim": "the collision case was NOT produced by this route; this does not establish that it cannot occur"
     }
   ],
   "conclusion": "A production observer cannot build `ResolvedRegionIdentity` from a live REGION read. The region surface publishes six fields, none of them a tick or an ordinal, and its finest position is a bar offered as localised prose. Ticks do exist one level down: the Event List's Position column reads bar / beat / division / tick at note level. But that is an EVENT's position, so it supplies a region's startTick only when the region's first event sits exactly at its start — which is a coincidence of this fixture rather than a property. So the seam blocking five issues is not merely unwired: the identity its design requires is not obtainable from the region surface, and the surface that does carry ticks answers a different question.",
@@ -121,7 +139,8 @@
     "One project, one call, en-US. A different project cannot add fields, but this does not prove the AX elements carry nothing more than the publisher exposes — only that the published surface has no tick.",
     "It says nothing about whether `ordinal` could be derived. An index within the enumeration would be positional, which this repository refuses elsewhere, but that is a design judgement rather than a measurement.",
     "`rawHelp` was read as published. Whether the underlying AXHelp carries finer granularity that the parser discards was not checked.",
-    "The Event List reading is one region with two notes, both landing on beat boundaries. Whether a region whose first event is offset reports anything about the REGION's start was not measured, and that is the case the caveat above turns on."
+    "The Event List reading is one region with two notes, both landing on beat boundaries. Whether a region whose first event is offset reports anything about the REGION's start was not measured, and that is the case the caveat above turns on.",
+    "Descriptor uniqueness was measured on one project whose every region sits on its own track. A project with several regions on one track was not available and could not be produced through edit.duplicate, so the collision case the design must refuse remains unmeasured."
   ],
   "supersedes": null
 }


### PR DESCRIPTION
An audit of three practices — the observation ledger, CommitLore, and the live tests — found this
one **failing outright**. The other two are doing real work with stated limits; this one produced
nothing.

`commitlore stale` reports **one record in a thousand commits**. The decisive denominator is not the
thousand: a single recent working period produced about **twenty** commits carrying exactly the
context the practice exists for — a dropped alternative, a measurement that contradicted the plan, a
warning for whoever edits next — and recorded **none** of them.

Permission was never the obstacle. `.commitlore-policy.json` already says
`{"mode":"auto","unattended":true}`. The installed hooks **consume** a transaction that something
else has to start, and nothing started one.

## Two measurements shaped the fix

**The exit code is not the outcome.** `capture` reports `staged`, `empty` and `rejected`, and **all
three exit 0**. Anything checking `$?` records a rejected draft as a success.

**The prompt is the whole transcript.** A 67,981,436-byte transcript produced a 67,468,122-byte
prompt — 99.3% of the file, and more than any model can consume. `capture` reports that as
`outcome: "empty"` with exit 0, so whoever tries it once gets nothing and no reason. Filed upstream
as [commitlore#873](https://github.com/MongLong0214/commitlore/issues/873). Bounding to a tail
window gives **549 KB** from the same file.

That second one is very likely why the practice died: permission and pipeline were both fine, and
pulling the trigger produced something unusable, silently.

## What this adds

`Scripts/commitlore-capture.sh` drives the pipeline, reads `--json` and branches on `outcome`, and
slices the transcript to a window it **declares in its own output** — a caller who cannot tell a
slice from the whole cannot judge the record that comes out of it.

Self-test is stub-driven for the case that matters, because provoking a real rejection needs a draft
the verifier disbelieves and that is not reproducible on demand. Six cases:

```
staged                -> pass
empty                 -> pass          (an honest "nothing to record")
rejected              -> FAILS         while the CLI exits 0
an unknown outcome    -> cannot-tell   not a pass
no JSON at all        -> refused       not read as empty
the prompt            -> states the window it used
```

## Deliberately not here

The refusal half — a commit without a capture outcome being rejected in the chained
`prepare-commit-msg` slot. A hook that can block **every** commit should land on its own and be
watched fail before it is trusted.

Ship gate PASS: 4440 tests, 38 repo guards, roadmap agrees with GitHub.