### PR TITLE
docs(#448): a track colour has no observable consequence, measured on values rather than names

### DIFF
--- a/Scripts/livekit/ax_colour_value_sweep.swift
+++ b/Scripts/livekit/ax_colour_value_sweep.swift
@@ -1,0 +1,58 @@
+// #448 colour half: the 2026-09-08 census swept attribute NAMES. This sweeps VALUES.
+import AppKit
+import ApplicationServices
+
+func raw(_ e: AXUIElement, _ a: String) -> (AXError, CFTypeRef?) {
+    var v: CFTypeRef?; let s = AXUIElementCopyAttributeValue(e, a as CFString, &v); return (s, v)
+}
+func names(_ e: AXUIElement) -> [String] {
+    var n: CFArray?; guard AXUIElementCopyAttributeNames(e, &n) == .success else { return [] }
+    return (n as? [String]) ?? []
+}
+// An element that HAS no children is not a subtree that could not be read. Counting
+// `noValue`/`attributeUnsupported` as unreadable reported 879 refused subtrees out of 1304
+// elements, which would have made the whole sweep look inconclusive. Only a genuine failure counts.
+enum Kids { case some([AXUIElement]); case none; case unreadable }
+func kidsOrNil(_ e: AXUIElement) -> Kids {
+    let (s, v) = raw(e, kAXChildrenAttribute as String)
+    if s == .success { return .some((v as? [AXUIElement]) ?? []) }
+    if s == .noValue || s == .attributeUnsupported { return .none }
+    return .unreadable
+}
+guard let app = NSRunningApplication.runningApplications(withBundleIdentifier: "com.apple.logic10").first
+else { print("no logic"); exit(1) }
+let ax = AXUIElementCreateApplication(app.processIdentifier)
+var wins: CFTypeRef?; AXUIElementCopyAttributeValue(ax, kAXWindowsAttribute as CFString, &wins)
+
+var visited = 0, unreadable = 0, colourValued = 0, axColorTyped = 0
+var samples: [String] = []
+let needles = ["color", "colour", "#", "rgb", "swatch", "palette"]
+
+func walk(_ e: AXUIElement, _ d: Int) {
+    if d > 16 { return }
+    visited += 1
+    for n in names(e) {
+        let (s, v) = raw(e, n)
+        guard s == .success, let v else { continue }
+        // A real AXValue of colour type would be the strongest possible answer.
+        let tid = CFGetTypeID(v)
+        if tid == CGColor.typeID { axColorTyped += 1; samples.append("AXCOLOR \(n) on depth \(d)") }
+        guard let str = v as? String, !str.isEmpty else { continue }
+        let low = str.lowercased()
+        if needles.contains(where: { low.contains($0) }) {
+            colourValued += 1
+            if samples.count < 12 { samples.append("\(n)=\(String(str.prefix(70)))") }
+        }
+    }
+    switch kidsOrNil(e) {
+    case .unreadable: unreadable += 1
+    case .none: break
+    case let .some(ks): for c in ks { walk(c, d + 1) }
+    }
+}
+for w in (wins as? [AXUIElement]) ?? [] { walk(w, 0) }
+print("elements visited        \(visited)")
+print("child lists unreadable  \(unreadable)")
+print("values mentioning colour \(colourValued)")
+print("attributes of CGColor type \(axColorTyped)")
+for s in samples { print("   ", s) }

--- a/Scripts/observations/reverify-colour-has-no-observable.sh
+++ b/Scripts/observations/reverify-colour-has-no-observable.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Reverify 2026-09-09-no-attribute-value-anywhere-carries-a-track-colour.
+#
+# The record's claim is an ABSENCE, so the probe must be able to find something before its silence
+# means anything. It reports the element count too, and this refuses a run that visited implausibly
+# few — a sweep that reached nothing would otherwise report "no colour" and read as a confirmation.
+set -uo pipefail
+cd "$(dirname "$0")/../.." || exit 2
+WORK=$(mktemp -d); trap 'rm -rf "$WORK"' EXIT
+
+swiftc -O Scripts/livekit/ax_colour_value_sweep.swift -o "$WORK/sweep" 2>"$WORK/build.err" || {
+  echo "REVERIFY FAIL: the sweep probe did not compile"; cat "$WORK/build.err"; exit 1; }
+"$WORK/sweep" > "$WORK/out.txt" 2>&1 || {
+  echo "REVERIFY FAIL: the sweep probe did not run"; cat "$WORK/out.txt"; exit 1; }
+
+VISITED=$(awk '/elements visited/ {print $3}' "$WORK/out.txt")
+UNREADABLE=$(awk '/child lists unreadable/ {print $4}' "$WORK/out.txt")
+CGCOLOR=$(awk '/attributes of CGColor type/ {print $5}' "$WORK/out.txt")
+
+[ -n "${VISITED:-}" ] || { echo "REVERIFY INCONCLUSIVE: could not read the element count"; cat "$WORK/out.txt"; exit 1; }
+# The instrument has to have been AIMED. 1304 was measured; anything near zero means Logic was not
+# up, or no window was reachable, and the absence below would then be the silence of an unaimed
+# instrument rather than a reading.
+if [ "$VISITED" -lt 200 ]; then
+  echo "REVERIFY INCONCLUSIVE: only $VISITED element(s) visited — Logic is probably not showing a project"
+  exit 1
+fi
+if [ "${CGCOLOR:-1}" != "0" ]; then
+  echo "REVERIFY FAIL: $CGCOLOR attribute(s) of CGColor type — a colour observable now EXISTS, and"
+  echo "  this record says none does. That is a better world; update the record."
+  exit 1
+fi
+echo "REVERIFY PASS — $VISITED elements, $UNREADABLE unreadable, no attribute of colour type"

--- a/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
+++ b/Sources/LogicProMCP/Channels/AccessibilityChannel+Tracks.swift
@@ -2198,6 +2198,17 @@ extension AccessibilityChannel {
             String(track.isMuted),
             String(track.isSoloed),
             String(track.isArmed),
+            // ALWAYS EMPTY, and kept deliberately. Nothing populates `TrackState.color`, so this
+            // component cannot move and a recoloured track produces an identical fingerprint — a
+            // consumer comparing fingerprints will not see the change. That is not an oversight to
+            // be fixed here: measured 2026-09-09 across 1406 elements to depth 16, including the
+            // colour palette opened through View > Colors, Logic exposes no attribute of colour
+            // type and no value naming one, so there is nothing for a reader to read
+            // (`docs/observations/2026-09-09-no-attribute-value-anywhere-carries-a-track-colour`).
+            //
+            // The component stays rather than being deleted so that a future colour reader lights
+            // it up without changing this string's shape, and the silence is written down here so
+            // the next reader does not have to re-derive it. #448.
             track.color ?? ""
         ].joined(separator: "|")
     }

--- a/Sources/LogicProMCP/State/StateModels.swift
+++ b/Sources/LogicProMCP/State/StateModels.swift
@@ -64,6 +64,14 @@ struct TrackState: Sendable, Codable, Identifiable {
     var volume: Double = 0.0   // dB, 0 = unity
     var pan: Double = 0.0      // -1.0 (L) to 1.0 (R)
     var automationMode: AutomationMode = .off
+    /// Never populated. Logic exposes no colour observable to read it from: measured 2026-09-09
+    /// over 1406 elements to depth 16, including the palette opened via View > Colors, there is no
+    /// attribute of colour type and no value naming a colour
+    /// (`docs/observations/2026-09-09-no-attribute-value-anywhere-carries-a-track-colour`).
+    ///
+    /// Kept rather than removed so a future reader — the project file is the one route that record
+    /// does not close — can populate it without a schema change. Anything comparing tracks must not
+    /// treat this as a colour that happens to be unset. #448.
     var color: String?
     /// v3.1.8 (Issue #7) — true when this row was synthesised from
     /// MetaData.plist's `NumberOfTracks` because the AX walker returned

--- a/docs/observations/2026-09-09-no-attribute-value-anywhere-carries-a-track-colour.json
+++ b/docs/observations/2026-09-09-no-attribute-value-anywhere-carries-a-track-colour.json
@@ -1,0 +1,71 @@
+{
+ "conclusion": "A track colour has no observable consequence in the accessibility tree. Not one of 1406 elements declares an attribute of colour type, and no value names a colour except the palette window's own title. This is stronger than the 2026-09-08 record for the same issue, which swept names rather than values and reported twenty subtrees it could not read: with the absence/failure distinction made correctly, zero subtrees refuse. The verdict is therefore `wall` rather than `partial` FOR THIS SURFACE. `TrackState.color` is consequently never populated by anything, and the track fingerprint that joins it with `|` carries an always-empty component — so a colour change is invisible to every consumer of that fingerprint.",
+ "date": "2026-09-09",
+ "depends": [],
+ "evidence": [
+  "evidence/2026-09-09-colour-value-sweep-en.json"
+ ],
+ "host": {
+  "app": "Logic Pro",
+  "build": "6674",
+  "locale": "en-US",
+  "note": "Logic's UI language is `en`; the fixture is lpm-locale-campaign with 19 tracks.",
+  "os": "macOS 26.6",
+  "version": "12.3"
+ },
+ "id": "2026-09-09-no-attribute-value-anywhere-carries-a-track-colour",
+ "issues": [
+  448
+ ],
+ "limits": [
+  "The project FILE was not read. A colour that Logic persists into the .logicx package would not appear here, and that is the one route the 2026-09-08 record named which this does not close.",
+  "Values only, at depth 16, from the application's windows. A colour carried in a non-string, non-CGColor attribute type would be missed, though no such attribute was seen.",
+  "The palette was opened but not INTERACTED with. Whether selecting a swatch makes some element momentarily expose a value was not measured.",
+  "One project, 19 tracks, none of which had a colour deliberately assigned first. If Logic only exposes something for a track whose colour differs from the default, this sweep would not have seen it."
+ ],
+ "method": "The 2026-09-08 record for this issue swept attribute NAMES. This sweeps VALUES: from every window of the application, to depth 16, it reads EVERY attribute each element declares, and reports (a) any value whose text names a colour and (b) any attribute whose CFTypeID is CGColor — which is what a real colour observable would be. Run twice: with the colour palette closed, and with it open via View > Colors.",
+ "observations": [
+  {
+   "container": "application windows, depth 16",
+   "count": 1304,
+   "what": "elements visited, palette closed"
+  },
+  {
+   "container": "application windows, depth 16",
+   "count": 1406,
+   "what": "elements visited, palette open"
+  },
+  {
+   "container": "both runs",
+   "count": 0,
+   "what": "attributes of CGColor type"
+  },
+  {
+   "container": "both runs",
+   "count": 0,
+   "what": "values naming a colour, palette closed"
+  },
+  {
+   "container": "the palette WINDOW's own AXTitle and AXValue, both the literal `Color`; no swatch exposes a value",
+   "count": 2,
+   "what": "values naming a colour, palette open"
+  },
+  {
+   "container": "counting only a real failure — `noValue` and `attributeUnsupported` mean the element has no children, and conflating them reported 879 refused subtrees out of 1304 on the first run of this probe",
+   "count": 0,
+   "what": "child lists genuinely unreadable"
+  }
+ ],
+ "question": "Does setting a track colour have ANY observable consequence in the accessibility tree?",
+ "reverify": {
+  "command": "bash Scripts/observations/reverify-colour-has-no-observable.sh",
+  "cost": "live; Logic running with a project open; a few seconds",
+  "expected": "REVERIFY PASS — no attribute of colour type and no value naming a colour, outside the palette window's own title",
+  "kind": "script"
+ },
+ "schema": 2,
+ "subject": "every attribute VALUE reachable from Logic's windows, including the colour palette",
+ "supersedes": null,
+ "surface": "arrange.track_headers",
+ "verdict": "wall"
+}

--- a/docs/observations/evidence/2026-09-09-colour-value-sweep-en.json
+++ b/docs/observations/evidence/2026-09-09-colour-value-sweep-en.json
@@ -1,0 +1,14 @@
+{
+ "captured": "2026-09-09",
+ "host": "Logic Pro 12.3 (6674) on macOS 26.6, UI language en, fixture lpm-locale-campaign (19 tracks)",
+ "how": "Scripts/livekit/ax_colour_value_sweep.swift — from every application window, depth 16, reads EVERY attribute each element declares and reports values naming a colour and attributes whose CFTypeID is CGColor. Run twice: palette closed, then open via View > Colors.",
+ "runs": [
+  {"palette": "closed", "elements_visited": 1304, "child_lists_unreadable": 0,
+   "values_naming_a_colour": 0, "attributes_of_cgcolor_type": 0, "samples": []},
+  {"palette": "open", "elements_visited": 1406, "child_lists_unreadable": 0,
+   "values_naming_a_colour": 2, "attributes_of_cgcolor_type": 0,
+   "samples": ["AXTitle=Color", "AXValue=Color"],
+   "note": "both are the palette WINDOW's own title and value; no swatch exposes a value"}
+ ],
+ "first_run_correction": "The probe's first version counted `noValue` and `attributeUnsupported` on AXChildren as unreadable and reported 879 refused subtrees out of 1304. An element that HAS no children is not a subtree that could not be read; with the distinction made, zero subtrees refuse."
+}

--- a/docs/tickets/issue-448-reorder-and-colour/STATUS.md
+++ b/docs/tickets/issue-448-reorder-and-colour/STATUS.md
@@ -1,0 +1,63 @@
+# #448's two remaining halves, and what each of them is actually waiting on
+
+Size: **S for colour** (the measurement is done; what is left is a decision and a two-line change),
+**M-or-refusal for reorder** (the route may not exist, and finding out costs a measurement this
+ticket names).
+
+## 1. Colour — measured, and it is a wall on this surface
+
+`docs/observations/2026-09-09-no-attribute-value-anywhere-carries-a-track-colour.json`:
+
+    attributes of CGColor type            0   of 1406 elements, depth 16, every window
+    values naming a colour                0   palette closed
+                                          2   palette open — both the palette WINDOW's own title
+    child lists genuinely unreadable      0
+
+The colour palette was the route the 2026-09-08 record left unswept; it is swept now and no swatch
+exposes a value.
+
+**The decision this leaves.** `TrackState.color` is populated by nothing, and
+`AccessibilityChannel+Tracks.swift:2171` joins it into the track fingerprint with `|`. So the
+fingerprint carries a component that is always empty, and a colour change cannot move it — a
+consumer comparing fingerprints will not see a recoloured track, and nothing says so.
+
+Two honest options, and the ticket picks the second:
+
+    remove `color` from the fingerprint   smallest, but the field stays in the model, still always
+                                          nil, and the next reader will ask the same question again
+    keep it and say what it means         the fingerprint gains a comment naming the record, and the
+                                          model field gains one — the component stays so that a
+                                          future colour reader lights it up without a schema change,
+                                          and the always-empty state stops being silent
+
+**Not in scope:** reading the `.logicx` package. That is the one route the record does not close,
+and it is a different surface with its own trust question.
+
+## 2. Reorder — the route may not exist, and that is not yet measured
+
+The row says anchor-based reorder is drag-only. Drag means screen coordinates, which this project
+does not do.
+
+**Measured 2026-09-09, en:**
+
+    Track menu           `Sort Tracks by` and nothing else that moves a track
+    Edit > Move          `To Playhead`, `To Recorded Position`, `To Beat`,
+                         `First Transient to Nearest Beat`, `To Focused Track`,
+                         `Shuffle Left`, `Shuffle Right` — all REGION operations, not tracks
+
+**NOT measured, and it is the next step:** whether Logic exposes a *key command* for moving a track
+up or down. Two routes to the Key Commands window were tried and neither opened it — the
+`Logic Pro > Key Commands` item reports `missing value` for its submenu and clicking it does
+nothing through AX, and Option+K produced no window. So the key-command surface is unread, not
+absent, and this ticket must not record it as absent.
+
+**The decision, once that is measured.** If a key command exists, reorder is implementable the way
+everything else here is — drive the command, verify the effect against a caller-supplied order,
+exactly as `sort_verified` already does. If it does not, the honest outcome is an explicit refusal
+that names why: the only route Logic offers is a drag, and a drag is a screen coordinate.
+
+## 3. What this ticket does NOT establish
+
+That colour is unobservable anywhere — only that it is unobservable through the accessibility tree,
+which is what the product reads. And that no key command exists for reorder — only that two ways of
+opening the window to look did not work.

--- a/docs/tickets/issue-448-reorder-and-colour/STATUS.md
+++ b/docs/tickets/issue-448-reorder-and-colour/STATUS.md
@@ -61,3 +61,21 @@ that names why: the only route Logic offers is a drag, and a drag is a screen co
 That colour is unobservable anywhere — only that it is unobservable through the accessibility tree,
 which is what the product reads. And that no key command exists for reorder — only that two ways of
 opening the window to look did not work.
+
+
+## The issue's own harness cannot run on the current fixture
+
+`live_448_track_stack_readback` fails two PRECONDITIONS here, before it tests anything:
+
+    448/precondition-the-project-has-exactly-one-track-stack
+        arrows: 2, value: 0, owner: 'Absolute Zero'
+    448/precondition-logic-offers-a-disclosure-command-that-is-not-a-structural-one
+        accepted={} rejected={} — every Track-menu item classified structural
+
+The `lpm-locale-campaign` fixture has grown a second disclosure arrow, so the harness's "exactly one
+track stack" no longer holds. That is a fixture fact, not a regression in the code under test, and
+it means this issue's own live proof is currently unrunnable — which is worth knowing before anyone
+reads its silence as a pass.
+
+Closing #448 will need either a fixture with exactly one stack, or a harness whose precondition is
+stated in terms it can establish itself.


### PR DESCRIPTION
Refs #448 — this closes the **colour** half by measurement and states precisely what the **reorder**
half is waiting on. It does not close the issue.

## Colour: a wall on this surface, not a design question

The 2026-09-08 record for this issue swept attribute NAMES and returned `partial`, with twenty child
lists it could not read. This sweeps VALUES — every attribute every element declares, from every
window, to depth 16 — and asks the two questions that decide it:

```
attributes whose CFTypeID is CGColor      0    of 1406 elements
values naming a colour                    0    palette closed
                                          2    palette open — both the palette WINDOW's own
                                               AXTitle and AXValue, the literal `Color`
child lists genuinely unreadable          0
```

The colour palette was the route the earlier record named as unswept. It is swept now, opened
through `View > Colors`, and no swatch exposes a value.

**Why zero unreadable, where the earlier record had twenty.** This probe made the same mistake on
its first run: counting `noValue` and `attributeUnsupported` on `AXChildren` as unreadable reported
**879** refused subtrees out of 1304. An element that *has* no children is not a subtree that could
not be read. With the distinction made, none refuse — which is why this record says `wall` for this
surface where the earlier one said `partial`.

## What follows for the product

`TrackState.color` is populated by nothing, and the track fingerprint joins it with `|`. So the
fingerprint carries an always-empty component, a recoloured track produces an identical fingerprint,
and every consumer comparing fingerprints misses the change — silently.

Both sites now say so and name the record. The field and the component stay rather than being
deleted: removing them would make the silence disappear instead of explaining it, and the one route
the measurement does not close — the project file — could populate the field later without a schema
change.

## Reorder: measured where it could be, unread where it could not

```
Track menu      `Sort Tracks by`, and nothing else that moves a track
Edit > Move     To Playhead, To Recorded Position, To Beat, First Transient to Nearest Beat,
                To Focused Track, Shuffle Left, Shuffle Right — all REGION operations
```

Whether a **key command** moves a track up or down is **unread**: two routes to the Key Commands
window both failed — the menu item reports `missing value` for its submenu and clicking it does
nothing through AX, and Option+K produced no window. The ticket records that surface as unread
rather than absent, because an instrument that would not open has measured nothing.

## Also recorded

This issue's own harness, `live_448_track_stack_readback`, currently fails two **preconditions** on
this fixture — it wants exactly one track stack and sees two disclosure arrows. That is a fixture
fact rather than a regression, and it means the issue's live proof is unrunnable until the fixture
or the precondition changes. Worth knowing before anyone reads its silence as a pass.

## Reverify

`Scripts/observations/reverify-colour-has-no-observable.sh` refuses rather than confirms when the
instrument was not aimed: with Logic closed it exits 1 and says the probe did not run. It also fails
if a `CGColor` attribute ever appears — that would be a better world, and the record would be the
thing that is wrong.