### PR TITLE
fix(#458): a recording that is not there is not a recording

### DIFF
--- a/Scripts/livekit/evidence.py
+++ b/Scripts/livekit/evidence.py
@@ -967,7 +967,44 @@ AX_REGION_LABELS = {
 # A screen recording smaller than this never contained a frame. `screencapture -v`/`avconvert`
 # write a container header even when they capture nothing, so "the file exists" is not enough and
 # "greater than zero bytes" is not either.
+#
+# The number is measured rather than asserted, because a threshold nobody measured is a threshold
+# that rejects real evidence. Across the 581 recordings this project has on disk the SMALLEST is
+# 371,432 bytes, so 32 KiB sits about eleven times below anything a real run has produced. It is a
+# floor against a header-only stub, not a judgement about what is in the frames — and it is
+# deliberately far from the observed minimum so that a short but genuine capture is not refused.
 MIN_RECORDING_BYTES = 32 * 1024
+
+
+def _recording_is_usable(record, statter=os.path.getsize):
+    """Whether one `recording` record stands for a video that is actually there.
+
+    ONE predicate, because there are two counters and De Morgan is not a place to keep a rule: the
+    valid and invalid comprehensions used to spell this separately, so adding a condition meant
+    remembering to invert it in the other one.
+
+    The filesystem is re-read HERE rather than trusted from the record. `recording()` samples
+    `isfile`/`getsize` once at capture time and stores the answers, and a stored answer is the
+    thing this whole gate exists not to believe: a file deleted or truncated afterwards, a document
+    hand-written with `exists: True` and a large `bytes` and no file at all, both passed. So a
+    record must NAME a file, and the file must still be there and still be big enough when the
+    document is read.
+
+    A record with no `file` key is not usable — that is the hand-written case, and there is nothing
+    to go and look at.
+    """
+    if record.get("kind") != "recording":
+        return False
+    path = record.get("file")
+    if not isinstance(path, str) or not path:
+        return False
+    try:
+        if not os.path.isfile(path):
+            return False
+        size = statter(path)
+    except OSError:
+        return False
+    return size >= MIN_RECORDING_BYTES
 
 
 class Evidence:
@@ -1532,14 +1569,10 @@ def summarize(recs, out=None):
         # capture never started satisfied `recordings > 0`, and the video half of the UI gate was
         # met by a record stating the video is missing. The floor is deliberately tiny: it rejects
         # an empty or truncated file without pretending to judge what is IN the frames.
-        "recordings": sum(1 for r in recs
-                          if r["kind"] == "recording"
-                          and r.get("exists")
-                          and (r.get("bytes") or 0) >= MIN_RECORDING_BYTES),
+        "recordings": sum(1 for r in recs if _recording_is_usable(r)),
         "recordings_missing_or_empty": sum(1 for r in recs
                                            if r["kind"] == "recording"
-                                           and (not r.get("exists")
-                                                or (r.get("bytes") or 0) < MIN_RECORDING_BYTES)),
+                                           and not _recording_is_usable(r)),
         "operations_driven": sum(1 for r in recs if r["kind"] == "operation"),
         # A subject must be a non-empty STRING. `not v.get("subject")` alone accepted True, a
         # dict, or any other truthy object as a name.

--- a/Scripts/livekit/evidence.py
+++ b/Scripts/livekit/evidence.py
@@ -1592,6 +1592,19 @@ def _non_vacuity_earned(summary):
     An undeclared document is judged as UI. Silence is not a class.
     """
     if summary.get("declared_surface") == "non_ui":
+        # A document that declares there is nothing to photograph, and then photographs, refutes
+        # itself. This is a CONSISTENCY check, not a judgement of the author's intent: it costs
+        # nothing, and it catches the case where a harness was written against a UI effect and the
+        # declaration was left behind.
+        #
+        # What it does NOT catch, said plainly because the declaration is otherwise taken on trust:
+        # a run that drives an operation with a plainly visible consequence — creating a track, say —
+        # and simply never captures. The product does not report per-call mutability in a form this
+        # file can read (`write_attempted` is absent from those responses, measured 2026-09-09), so
+        # there is nothing here to check the claim against. The declaration remains the author's
+        # word for that case, and this is the half that can be enforced.
+        if summary["captures"] > 0 or summary["visual_assertions"] > 0:
+            return False
         return summary["checks_with_a_counterexample"] > 0
     return (summary["captures"] > 0
             and summary["visual_assertions"] > 0

--- a/Scripts/livekit/evidence.py
+++ b/Scripts/livekit/evidence.py
@@ -964,6 +964,12 @@ AX_REGION_LABELS = {
 }
 
 
+# A screen recording smaller than this never contained a frame. `screencapture -v`/`avconvert`
+# write a container header even when they capture nothing, so "the file exists" is not enough and
+# "greater than zero bytes" is not either.
+MIN_RECORDING_BYTES = 32 * 1024
+
+
 class Evidence:
     """Accumulates records and writes `<root>/<head>/evidence.json`.
 
@@ -1521,7 +1527,19 @@ def summarize(recs, out=None):
         "captures": len(caps),
         "visual_assertions": len(vis),
         "visual_failed": sum(1 for v in vis if not v.get("passed")),
-        "recordings": sum(1 for r in recs if r["kind"] == "recording"),
+        # A RECORDING THAT IS NOT THERE IS NOT A RECORDING. This counted every `recording` record,
+        # including one whose own fields say `exists: False, bytes: 0` — so a run whose screen
+        # capture never started satisfied `recordings > 0`, and the video half of the UI gate was
+        # met by a record stating the video is missing. The floor is deliberately tiny: it rejects
+        # an empty or truncated file without pretending to judge what is IN the frames.
+        "recordings": sum(1 for r in recs
+                          if r["kind"] == "recording"
+                          and r.get("exists")
+                          and (r.get("bytes") or 0) >= MIN_RECORDING_BYTES),
+        "recordings_missing_or_empty": sum(1 for r in recs
+                                           if r["kind"] == "recording"
+                                           and (not r.get("exists")
+                                                or (r.get("bytes") or 0) < MIN_RECORDING_BYTES)),
         "operations_driven": sum(1 for r in recs if r["kind"] == "operation"),
         # A subject must be a non-empty STRING. `not v.get("subject")` alone accepted True, a
         # dict, or any other truthy object as a name.
@@ -1553,6 +1571,7 @@ _REQUIRED_SUMMARY_KEYS = (
     "captures", "captures_unsettled", "captures_straddling_displays",
     "restorations_failed", "cached_reads_used_as_live",
     "visual_assertions", "visual_failed", "visual_assertions_without_a_subject",
+    "recordings_missing_or_empty",
     "recordings", "declared_surface",
 )
 
@@ -1659,6 +1678,10 @@ def is_clean(summary):
         and summary["restorations_failed"] == 0
         and summary["cached_reads_used_as_live"] == 0
         and summary["visual_assertions_without_a_subject"] == 0
+        # A recording record whose own fields say the file is absent or empty. Counted separately
+        # from `recordings` so the document says WHICH failure happened: a run that never started a
+        # recording reports `recordings: 0`, and a run whose recording failed reports the gap.
+        and summary.get("recordings_missing_or_empty", 0) == 0
     )
 
 

--- a/Scripts/livekit/test_evidence.py
+++ b/Scripts/livekit/test_evidence.py
@@ -808,3 +808,23 @@ print(f"{'ok  ' if ok else 'FAIL'} a stub and a missing file both count as missi
       f"recordings={_s['recordings']} missing={_s['recordings_missing_or_empty']}")
 if not ok:
     FAILURES.append("stub/missing recordings were counted as recordings")
+
+
+# A `non_ui` document says there is nothing to photograph. If it then photographs, it refutes itself,
+# and the gate should not have to decide which half to believe.
+for kw, want, why in [
+    ({"declared_surface": "non_ui", "captures": 0, "visual_assertions": 0, "recordings": 0,
+      "checks_with_a_counterexample": 2}, True,
+     "non_ui with a counterexample and no photographs is clean"),
+    ({"declared_surface": "non_ui", "captures": 1, "visual_assertions": 0, "recordings": 0,
+      "checks_with_a_counterexample": 2}, False,
+     "non_ui that captured a screenshot contradicts its own declaration"),
+    ({"declared_surface": "non_ui", "captures": 0, "visual_assertions": 1, "recordings": 0,
+      "checks_with_a_counterexample": 2}, False,
+     "non_ui that made a visual assertion contradicts its own declaration"),
+]:
+    got = E.is_clean(_summary_for(**kw))
+    ok = got is want
+    print(f"{'ok  ' if ok else 'FAIL'} {why} -> is_clean={got}")
+    if not ok:
+        FAILURES.append(why)

--- a/Scripts/livekit/test_evidence.py
+++ b/Scripts/livekit/test_evidence.py
@@ -765,9 +765,6 @@ for why, ok in shapes:
     failed += 0 if ok else 1
     print(f"{'ok  ' if ok else 'FAIL'} shape: {why}")
 
-E.blocking_modal = _headless_blocking_modal
-print(f"\n{'FAILED' if failed else 'all cases behaved'} ({failed} unexpected)")
-sys.exit(1 if failed else 0)
 
 
 # A RECORDING THAT IS NOT THERE IS NOT A RECORDING. `recordings` counted every `recording` record,
@@ -793,7 +790,7 @@ for kw, want, why in [
     ok = got is want
     print(f"{'ok  ' if ok else 'FAIL'} {why} -> is_clean={got}")
     if not ok:
-        FAILURES.append(why)
+        failed += 1
 
 # And the counter itself: a record that exists but is a stub must not be counted as a recording.
 _root = _tempfile.mkdtemp()
@@ -807,7 +804,38 @@ ok = _s["recordings"] == 0 and _s["recordings_missing_or_empty"] == 2
 print(f"{'ok  ' if ok else 'FAIL'} a stub and a missing file both count as missing -> "
       f"recordings={_s['recordings']} missing={_s['recordings_missing_or_empty']}")
 if not ok:
-    FAILURES.append("stub/missing recordings were counted as recordings")
+    failed += 1
+
+# And the stored fields do not get the last word. A record that CLAIMS a present, large file is
+# read against the filesystem, so a hand-written document cannot vouch for a video nobody has.
+_ev.records.append({"kind": "recording", "file": os.path.join(_ev.dir, "claimed.mov"),
+                    "exists": True, "bytes": 99_000_000})
+_s = _ev._summary({})
+ok = _s["recordings"] == 0 and _s["recordings_missing_or_empty"] == 3
+print(f"{'ok  ' if ok else 'FAIL'} a record claiming a file that is not on disk is not a recording"
+      f" -> recordings={_s['recordings']} missing={_s['recordings_missing_or_empty']}")
+if not ok:
+    failed += 1
+
+# A recording record with no `file` at all names nothing to go and look at.
+_ev.records.append({"kind": "recording", "exists": True, "bytes": 99_000_000})
+_s = _ev._summary({})
+ok = _s["recordings"] == 0 and _s["recordings_missing_or_empty"] == 4
+print(f"{'ok  ' if ok else 'FAIL'} a recording record naming no file is not a recording"
+      f" -> recordings={_s['recordings']} missing={_s['recordings_missing_or_empty']}")
+if not ok:
+    failed += 1
+
+# The floor is a floor: one byte under is refused, exactly at it is accepted. Without this pair the
+# threshold could be any number, including one that rejects every real capture.
+for _size, _want, _why in [(E.MIN_RECORDING_BYTES - 1, 0, "one byte under the floor is refused"),
+                           (E.MIN_RECORDING_BYTES, 1, "exactly the floor is accepted")]:
+    _f = os.path.join(_ev.dir, f"floor-{_size}.mov")
+    open(_f, "wb").write(b"0" * _size)
+    ok = E._recording_is_usable({"kind": "recording", "file": _f}) == bool(_want)
+    print(f"{'ok  ' if ok else 'FAIL'} {_why}")
+    if not ok:
+        failed += 1
 
 
 # A `non_ui` document says there is nothing to photograph. If it then photographs, it refutes itself,
@@ -827,4 +855,8 @@ for kw, want, why in [
     ok = got is want
     print(f"{'ok  ' if ok else 'FAIL'} {why} -> is_clean={got}")
     if not ok:
-        FAILURES.append(why)
+        failed += 1
+
+E.blocking_modal = _headless_blocking_modal
+print(f"\n{'FAILED' if failed else 'all cases behaved'} ({failed} unexpected)")
+sys.exit(1 if failed else 0)

--- a/Scripts/livekit/test_evidence.py
+++ b/Scripts/livekit/test_evidence.py
@@ -27,6 +27,9 @@ GOOD = {
     "visual_assertions": 1, "visual_failed": 0, "visual_assertions_without_a_subject": 0,
     "declared_surface": None,
     "recordings": 1,
+    # Added with the rule that a recording whose file is absent or a stub does not count as one.
+    # `is_clean` refuses a summary missing any dimension it reads, so this fixture carries it.
+    "recordings_missing_or_empty": 0,
     # #797. Absent is not False here either: every fixture below inherits this, and a run that
     # never recorded the session state is one that cannot say it read an application it could see.
     "screen_locked": False,
@@ -765,3 +768,43 @@ for why, ok in shapes:
 E.blocking_modal = _headless_blocking_modal
 print(f"\n{'FAILED' if failed else 'all cases behaved'} ({failed} unexpected)")
 sys.exit(1 if failed else 0)
+
+
+# A RECORDING THAT IS NOT THERE IS NOT A RECORDING. `recordings` counted every `recording` record,
+# including one whose own fields said `exists: False, bytes: 0` — so a run whose screen capture never
+# started still satisfied the UI gate's "recordings > 0", and the video requirement was met by a
+# record stating the video was missing.
+def _summary_for(**kw):
+    d = {k: 0 for k in E._REQUIRED_SUMMARY_KEYS}
+    d.update(dict(checks=1, passed=1, screen_locked=False, declared_surface="ui",
+                  captures=1, visual_assertions=1, recordings=1, operations_driven=1,
+                  checks_with_a_counterexample=1, mutation_claimed=1))
+    d.update(kw)
+    return d
+
+for kw, want, why in [
+    ({}, True, "a healthy UI run is clean"),
+    ({"recordings": 0, "recordings_missing_or_empty": 1}, False,
+     "a recording whose file is absent does not satisfy `recordings > 0`"),
+    ({"recordings_missing_or_empty": 1}, False,
+     "an empty recording invalidates the run even beside a good one"),
+]:
+    got = E.is_clean(_summary_for(**kw))
+    ok = got is want
+    print(f"{'ok  ' if ok else 'FAIL'} {why} -> is_clean={got}")
+    if not ok:
+        FAILURES.append(why)
+
+# And the counter itself: a record that exists but is a stub must not be counted as a recording.
+_root = _tempfile.mkdtemp()
+_ev = E.Evidence("d" * 40, _root)
+_stub = os.path.join(_ev.dir, "stub.mov")
+open(_stub, "wb").write(b"0" * 10)          # a container header and nothing else
+_ev.recording(_stub)
+_ev.recording(os.path.join(_ev.dir, "never-written.mov"))
+_s = _ev._summary({})
+ok = _s["recordings"] == 0 and _s["recordings_missing_or_empty"] == 2
+print(f"{'ok  ' if ok else 'FAIL'} a stub and a missing file both count as missing -> "
+      f"recordings={_s['recordings']} missing={_s['recordings_missing_or_empty']}")
+if not ok:
+    FAILURES.append("stub/missing recordings were counted as recordings")

--- a/Scripts/livekit/test_harness_evidence_coverage.py
+++ b/Scripts/livekit/test_harness_evidence_coverage.py
@@ -9,11 +9,31 @@ never looked like an absence.
 """
 import os
 import sys
+import tempfile
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
 import harness_evidence_coverage as C  # noqa: E402
 
 failed = 0
+
+_REAL_RECORDING = None
+
+
+def _a_real_recording():
+    """A file on disk big enough to be a recording, for the fixtures that stand for a clean run.
+
+    These used to claim `exists: True` with a plausible byte count and no file. That is precisely
+    the document `_recording_is_usable` refuses, so a fixture has to put something where it says it
+    is. Written once per process and reused.
+    """
+    global _REAL_RECORDING
+    if _REAL_RECORDING is None:
+        path = os.path.join(tempfile.mkdtemp(prefix="lpm-fixture-recording-"), "run.mov")
+        with open(path, "wb") as fh:
+            fh.write(b"0" * (E.MIN_RECORDING_BYTES + 1))
+        _REAL_RECORDING = path
+    return _REAL_RECORDING
 
 # --- which paths count as a changed harness ----------------------------------------------------
 #
@@ -44,11 +64,11 @@ CLEAN = {"records": [
     {"kind": "check", "passed": True, "mutation_claimed": True, "blocking_modal": None},
     {"kind": "capture", "settled": True, "display": {"wholly_within": True}},
     {"kind": "visual", "passed": True, "subject": "Tracks header", "region": [0, 0, 1, 1]},
-    # A recording record has to say the FILE is there. A bare `{"kind": "recording"}` means
-    # `exists: false, bytes: 0` to the summary, and a run whose screen capture never started does
-    # not satisfy the video half of the UI gate — so a fixture standing for "a clean run" carries a
-    # real one.
-    {"kind": "recording", "exists": True, "bytes": 2_400_000},
+    # A recording record has to NAME A FILE THAT IS THERE. The summary re-reads the filesystem
+    # rather than believing the record's own `exists`/`bytes`, so a fixture standing for "a clean
+    # run" writes a real file above the floor — claiming one would be exactly the forgery the rule
+    # exists to refuse.
+    {"kind": "recording", "file": _a_real_recording()},
     {"kind": "operation"},
     # The run's environment, which a real document carries (#797). Stated here rather than left
     # absent because absent means `cannot_tell`, and a fixture that means "a clean run" has to say
@@ -287,8 +307,8 @@ with tempfile.TemporaryDirectory() as repo, tempfile.TemporaryDirectory() as evr
             {"kind": "capture", "tag": "c", "settled": True,
              "display": {"wholly_within": True}},
             {"kind": "visual", "tag": "v", "passed": True, "subject": "a named thing"},
-            # A recording record has to say the file is there; see the CLEAN fixture above.
-            {"kind": "recording", "tag": "r", "exists": True, "bytes": 2_400_000},
+            # A recording record has to name a file that is there; see the CLEAN fixture above.
+            {"kind": "recording", "tag": "r", "file": _a_real_recording()},
             {"kind": "operation", "tag": "o"},
             # See the CLEAN fixture above: a document states the environment its run saw, because
             # absent means `cannot_tell` and this one is meant to be judgeable anywhere.

--- a/Scripts/livekit/test_harness_evidence_coverage.py
+++ b/Scripts/livekit/test_harness_evidence_coverage.py
@@ -44,7 +44,11 @@ CLEAN = {"records": [
     {"kind": "check", "passed": True, "mutation_claimed": True, "blocking_modal": None},
     {"kind": "capture", "settled": True, "display": {"wholly_within": True}},
     {"kind": "visual", "passed": True, "subject": "Tracks header", "region": [0, 0, 1, 1]},
-    {"kind": "recording"},
+    # A recording record has to say the FILE is there. A bare `{"kind": "recording"}` means
+    # `exists: false, bytes: 0` to the summary, and a run whose screen capture never started does
+    # not satisfy the video half of the UI gate — so a fixture standing for "a clean run" carries a
+    # real one.
+    {"kind": "recording", "exists": True, "bytes": 2_400_000},
     {"kind": "operation"},
     # The run's environment, which a real document carries (#797). Stated here rather than left
     # absent because absent means `cannot_tell`, and a fixture that means "a clean run" has to say
@@ -283,7 +287,8 @@ with tempfile.TemporaryDirectory() as repo, tempfile.TemporaryDirectory() as evr
             {"kind": "capture", "tag": "c", "settled": True,
              "display": {"wholly_within": True}},
             {"kind": "visual", "tag": "v", "passed": True, "subject": "a named thing"},
-            {"kind": "recording", "tag": "r"},
+            # A recording record has to say the file is there; see the CLEAN fixture above.
+            {"kind": "recording", "tag": "r", "exists": True, "bytes": 2_400_000},
             {"kind": "operation", "tag": "o"},
             # See the CLEAN fixture above: a document states the environment its run saw, because
             # absent means `cannot_tell` and this one is meant to be judgeable anywhere.


### PR DESCRIPTION
The live-test gate counted a `recording` record as a recording. It never asked whether the file
existed, or whether it had anything in it — so a run whose screen capture failed to start, or
started and wrote a 0-byte stub, satisfied the video half of the UI surface's non-vacuity rule.
Measured on the harnesses: a record with no `exists` key reads as present.

Three changes, each with its own failing case:

* `MIN_RECORDING_BYTES = 32 KiB`. `recordings` now counts only records that exist AND clear it, and
  the ones that do not land in a new `recordings_missing_or_empty`, gated at zero in `is_clean` and
  added to `_REQUIRED_SUMMARY_KEYS` — so a summary written by an older harness is refused rather
  than silently read as clean.
* A `non_ui` document that reports captures or visual assertions now refuses itself. Declaring
  there is nothing to photograph and then photographing is a contradiction, and the surface
  declaration is the thing that waives the UI evidence requirement.
* The two synthetic fixtures standing for "a clean run" wrote `{"kind": "recording"}` and nothing
  else — exactly the case above. They carry a real file now.

Verification, at this head:

* 143 self-test cases in `test_evidence.py` pass, including the new missing/stub/self-contradiction
  cases.
* `live_458_a_stale_chord_marker_is_cleared_on_start` run live against Logic at `91ae9be4`:
  11 checks, 11 with a counterexample, 4 captures, 1 visual assertion, `recordings: 1`,
  `recordings_missing_or_empty: 0`.
* Ship gate PASS — 4478 tests, all 38 repo guards, public-surface preflight, live evidence bound to
  `91ae9be4`.

https://claude.ai/code/session_01FPpCJgL1EkuBujPkbEEG2A