### PR TITLE
fix(#846): the probe folds case where the product does, in one place, with a guard

### DIFF
--- a/Scripts/check-probe-label-matching.py
+++ b/Scripts/check-probe-label-matching.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""The AX probe restates a matching rule the product owns. This fails when they can drift.
+
+WHY THIS EXISTS
+---------------
+`Scripts/livekit/ax_plugin_menu_probe.swift` runs outside the product and cannot import it, so it
+restates `AXLocalePolicy` matching. On 2026-09-10 the two had already drifted: the product lowercases
+before comparing (`AXLogicProElements+Mixer.swift`), the probe trimmed whitespace only. The label set
+spells the mixer `"mixer"`; Logic answers `AXDescription` with `"Mixer"`. The probe's mixer match
+could therefore never succeed on an English Logic, and only a locale without case distinction
+(`믹서`) passed — which is why the harness driving it was written against a Korean fixture and nobody
+noticed for as long as nobody ran it in English.
+
+A comment saying "keep these in sync" was not enough, so this is a check instead.
+
+WHAT IT ENFORCES
+----------------
+1. The probe folds case when comparing against policy vocabulary, and does it in ONE place, so a
+   caller cannot normalise one side and forget the other.
+2. No policy label set contains two labels differing only by case. That is the property that makes
+   folding safe: it can never merge two distinct members of one set.
+3. User-supplied identifiers are NOT folded. A track called `Bass` must not match one called `bass`,
+   so the exact comparisons that carry user data are listed here by name and required to stay exact.
+
+    python3 Scripts/check-probe-label-matching.py
+"""
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PROBE = os.path.join(ROOT, "Scripts/livekit/ax_plugin_menu_probe.swift")
+POLICY = os.path.join(ROOT, "Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift")
+PRODUCT = os.path.join(ROOT, "Sources/LogicProMCP/Accessibility/AXLogicProElements+Mixer.swift")
+
+# Comparisons that carry the USER's data rather than policy vocabulary. These must stay exact, and
+# they are named so that adding one is a deliberate act rather than a side effect.
+EXACT_BY_DESIGN = [
+    "titleText($0) == expectedTitle",          # a window the caller named
+    'descriptionText($0) == name',             # a group the caller named
+    "descriptionText(strip)) == target",       # a track the caller named
+    'descriptionText($0) == "EQ"',             # a literal role marker, not vocabulary
+]
+
+problems = []
+
+
+def read(path):
+    try:
+        with open(path, encoding="utf-8") as handle:
+            return handle.read()
+    except OSError as exc:
+        problems.append(f"cannot read {os.path.relpath(path, ROOT)}: {exc}")
+        return ""
+
+
+probe = read(PROBE)
+policy = read(POLICY)
+product = read(PRODUCT)
+
+# 1. The product's rule is what the probe must mirror. If the product stops lowercasing, this check
+#    is describing a rule that no longer exists and must be revisited rather than silently kept.
+# Anchored on the SPECIFIC comparison, not on any occurrence of `.lowercased()` in the file. A
+# mutation test showed the loose form: the file has several, so deleting the load-bearing one left
+# the check green.
+PRODUCT_RULE = re.compile(
+    r"trimmingCharacters\(in:\s*\.whitespacesAndNewlines\)\.lowercased\(\)[\s\S]{0,200}?"
+    r"AXLocalePolicy\.mixerNamedElement\.labels\.contains"
+)
+if product and not PRODUCT_RULE.search(product):
+    problems.append(
+        "AXLogicProElements+Mixer.swift no longer trims-then-lowercases before comparing against "
+        "AXLocalePolicy.mixerNamedElement — the rule this probe mirrors has changed, so update both "
+        "and this check together"
+    )
+
+# 2. The probe folds, in one place.
+if probe:
+    if not re.search(r"func normalizedPolicyLabel\s*\(", probe):
+        problems.append("the probe has no normalizedPolicyLabel(): the folding rule has no single home")
+    elif not re.search(r"func normalizedPolicyLabel\([^)]*\)\s*->\s*String\s*\{\s*\n\s*trimmed\([^)]*\)\.lowercased\(\)",
+                       probe):
+        problems.append(
+            "normalizedPolicyLabel() no longer trims-then-lowercases; it must mirror the product's rule"
+        )
+    if not re.search(r"func matchesPolicyLabel\s*\(", probe):
+        problems.append("the probe has no matchesPolicyLabel(): callers can fold one side and not the other")
+
+    # 3. No bare == against a policy label, except the user-data comparisons named above.
+    for line_number, line in enumerate(probe.splitlines(), 1):
+        stripped = line.strip()
+        if stripped.startswith("//") or stripped.startswith("///"):
+            continue
+        # Two spellings of the same mistake: `label == observed`, and `labels.contains(observed)`.
+        # A mutation test caught the second slipping through when only the first was checked.
+        bare_equality = re.search(r"(descriptionText|titleText|elementName)\([^)]*\)\s*==", line)
+        bare_contains = re.search(r"\.contains\(\s*(descriptionText|titleText|elementName)\(", line)
+        if not bare_equality and not bare_contains:
+            continue
+        if any(allowed in line for allowed in EXACT_BY_DESIGN):
+            continue
+        problems.append(
+            f"ax_plugin_menu_probe.swift:{line_number}: a policy label compared without folding (bare `==` or `.contains`). "
+            f"Use matchesPolicyLabel(), or add it to EXACT_BY_DESIGN if it carries user data: {stripped[:90]}"
+        )
+
+# 4. Folding is only safe while no set has case-only duplicates.
+if policy:
+    sets = re.findall(
+        r'static let (\w+)\s*=\s*LabelSet\(\s*canonical:\s*"([^"]*)"\s*,\s*variants:\s*\[([^\]]*)\]',
+        policy, re.S)
+    if not sets:
+        problems.append("no LabelSet declarations parsed from AXLocalePolicy.swift — this check went blind")
+    for name, canonical, variants in sets:
+        labels = [canonical] + re.findall(r'"((?:[^"\\]|\\.)*)"', variants)
+        folded = {}
+        for label in labels:
+            key = label.strip().lower()
+            if key in folded and folded[key] != label:
+                problems.append(
+                    f"AXLocalePolicy.{name}: {folded[key]!r} and {label!r} differ only by case, so "
+                    f"case-folded matching would merge two distinct members"
+                )
+            folded[key] = label
+
+if problems:
+    print(f"{len(problems)} probe/policy label-matching problem(s):")
+    for problem in problems:
+        print(f"  {problem}")
+    print("\nThe probe restates a rule the product owns. These must not drift.")
+    sys.exit(1)
+
+print("probe label matching mirrors the product, in one place, and folding is safe")

--- a/Scripts/livekit/ax_plugin_menu_probe.swift
+++ b/Scripts/livekit/ax_plugin_menu_probe.swift
@@ -397,7 +397,7 @@ func press(_ element: AXUIElement, _ action: String = kAXPressAction as String) 
 
 func closeWindow(_ window: AXUIElement, closeLabel: String) -> JSON {
     let buttons = descendants(window).filter {
-        roleText($0) == "AXButton" && descriptionText($0) == closeLabel
+        roleText($0) == "AXButton" && matchesPolicyLabel(descriptionText($0), anyOf: [closeLabel])
     }
     var result: JSON = [
         "close_button_candidates": buttons.map(snapshot),
@@ -427,6 +427,37 @@ func trimmed(_ text: String) -> String {
     text.trimmingCharacters(in: .whitespacesAndNewlines)
 }
 
+// MARK: - Policy-label matching
+
+/// Compare an OBSERVED accessibility string against a policy label set the way the PRODUCT does.
+///
+/// `AXLogicProElements+Mixer.swift` lowercases before comparing against `AXLocalePolicy`; this probe
+/// runs outside the product and cannot import it, so the rule is restated here — and restating a
+/// rule is exactly how the two drifted. Measured 2026-09-10 on an en-US Logic: the label set spells
+/// the mixer `"mixer"`, Logic answers `AXDescription` with `"Mixer"`, and the probe's whitespace-only
+/// comparison could never match. Only a locale without case distinction (`믹서`) passed, which is why
+/// the harness driving this was written against a Korean fixture.
+///
+/// Both sides are folded HERE, in one place, so no caller can normalise one side and forget the
+/// other — the shape that produced the bug. `Scripts/check-probe-label-matching.py` fails if a
+/// policy label is compared with a bare `==` anywhere in this file.
+///
+/// Folding is safe because no label set contains two labels differing only by case (asserted by that
+/// same guard), so it can never merge two distinct members of one set.
+///
+/// NOT for user-supplied identifiers. Track names, window titles and plug-in names are the user's
+/// data, not policy vocabulary, and stay exact — a track called `Bass` must not match one called
+/// `bass`.
+func normalizedPolicyLabel(_ text: String) -> String {
+    trimmed(text).lowercased()
+}
+
+/// Whether an observed string is one of a policy label set's members.
+func matchesPolicyLabel(_ observed: String, anyOf labels: [String]) -> Bool {
+    let folded = normalizedPolicyLabel(observed)
+    return labels.contains { normalizedPolicyLabel($0) == folded }
+}
+
 struct AncestorGroupSearch {
     let found: Bool
     let matchingDescription: String?
@@ -451,7 +482,7 @@ func matchingGroupAncestor(
             return AncestorGroupSearch(found: false, matchingDescription: nil, boundHit: false)
         }
         if roleText(parent) == (kAXGroupRole as String) {
-            let parentDescription = trimmed(descriptionText(parent))
+            let parentDescription = normalizedPolicyLabel(descriptionText(parent))
             if expectedDescriptions.contains(parentDescription) {
                 return AncestorGroupSearch(
                     found: true,
@@ -483,7 +514,7 @@ struct MixerContainerSearch {
 }
 
 func mixerContainers(named mixerLabels: [String]) -> MixerContainerSearch {
-    let targets = Set(mixerLabels.map(trimmed))
+    let targets = Set(mixerLabels.map(normalizedPolicyLabel))
     guard !targets.isEmpty else {
         return MixerContainerSearch(
             layoutAreasSeen: [],
@@ -514,7 +545,7 @@ func mixerContainers(named mixerLabels: [String]) -> MixerContainerSearch {
         // Only a layout area inside a labelled mixer group is a description candidate. Require
         // the same exact label so one configured synonym cannot admit another by coincidence.
         // Keep a failed read observable: descriptionText records it in ax_read_failures.
-        let layoutAreaDescription = trimmed(descriptionText(container))
+        let layoutAreaDescription = normalizedPolicyLabel(descriptionText(container))
         if layoutAreaDescription == ancestorDescription {
             containers.append(container)
             continue
@@ -691,7 +722,7 @@ func openPlugin(
     // toggled it and toggled it back before the witness looked.
     beforePress?(slot)
     let buttons = childElements(slot).filter {
-        roleText($0) == "AXButton" && descriptionText($0) == openLabel
+        roleText($0) == "AXButton" && matchesPolicyLabel(descriptionText($0), anyOf: [openLabel])
     }
     result["slot_children"] = childElements(slot).map(snapshot)
     result["open_button_candidates"] = buttons.map(snapshot)
@@ -747,7 +778,7 @@ func menuItems(for button: AXUIElement) -> [AXUIElement] {
 
 func selectView(in window: AXUIElement, viewLabels: [String], wanted: String) -> JSON {
     let buttons = descendants(window).filter {
-        roleText($0) == "AXMenuButton" && viewLabels.contains(descriptionText($0))
+        roleText($0) == "AXMenuButton" && matchesPolicyLabel(descriptionText($0), anyOf: viewLabels)
     }
     var result: JSON = [
         "button_candidates": buttons.map(snapshot),
@@ -763,7 +794,7 @@ func selectView(in window: AXUIElement, viewLabels: [String], wanted: String) ->
     result["show_menu_status"] = press(buttons[0], kAXShowMenuAction as String)
     usleep(700_000)
     let items = menuItems(for: buttons[0])
-    let selected = items.filter { elementName($0) == wanted }
+    let selected = items.filter { matchesPolicyLabel(elementName($0), anyOf: [wanted]) }
     result["items"] = items.map(snapshot)
     result["item_candidates"] = selected.map(snapshot)
     result["outcome"] = candidateOutcome(selected.count)
@@ -799,7 +830,7 @@ func runChannelEQ() {
         mixerLabels: mixerLabels.isEmpty ? nil : mixerLabels
     ) { slot in
         bypasses = childElements(slot).filter {
-            roleText($0) == "AXCheckBox" && bypassLabels.contains(descriptionText($0))
+            roleText($0) == "AXCheckBox" && matchesPolicyLabel(descriptionText($0), anyOf: bypassLabels)
         }
         if bypasses.count == 1 {
             bypassBefore = scalarValue(bypasses[0], kAXValueAttribute as String)
@@ -948,7 +979,7 @@ func runExportMenu() {
         return
     }
     let fileItems = childElements(menuBar).filter {
-        roleText($0) == "AXMenuBarItem" && fileLabels.contains(elementName($0))
+        roleText($0) == "AXMenuBarItem" && matchesPolicyLabel(elementName($0), anyOf: fileLabels)
     }
     result["file_candidates"] = fileItems.map(snapshot)
     guard fileItems.count == 1 else {
@@ -967,10 +998,10 @@ func runExportMenu() {
 
     let fileMenu = menus[0]
     let exportItems = childElements(fileMenu).filter {
-        roleText($0) == "AXMenuItem" && elementName($0) == exportLabel
+        roleText($0) == "AXMenuItem" && matchesPolicyLabel(elementName($0), anyOf: [exportLabel])
     }
     let openItems = childElements(fileMenu).filter {
-        roleText($0) == "AXMenuItem" && elementName($0) == openLabel
+        roleText($0) == "AXMenuItem" && matchesPolicyLabel(elementName($0), anyOf: [openLabel])
     }
     result["export_candidates"] = exportItems.map(snapshot)
     result["open_candidates"] = openItems.map(snapshot)
@@ -990,8 +1021,8 @@ func runExportMenu() {
     }
 
     let leaves = childElements(exportMenus[0]).filter { roleText($0) == "AXMenuItem" }
-    let allTracks = leaves.filter { elementName($0) == allTracksLabel }
-    let oneTrack = leaves.filter { elementName($0) == oneTrackLabel }
+    let allTracks = leaves.filter { matchesPolicyLabel(elementName($0), anyOf: [allTracksLabel]) }
+    let oneTrack = leaves.filter { matchesPolicyLabel(elementName($0), anyOf: [oneTrackLabel]) }
     result["all_tracks_candidates"] = allTracks.map(snapshot)
     result["one_track_candidates"] = oneTrack.map(snapshot)
     result["all_tracks_path"] = allTracks.count == 1

--- a/Scripts/test_probe_label_matching.py
+++ b/Scripts/test_probe_label_matching.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Drive check-probe-label-matching.py against the defects it names.
+
+Each case injects one defect into a COPY of the tree and asserts the guard reports it, then asserts
+the unmodified tree passes. Three of these cases exist because they were holes: the first version of
+the guard missed them, and a mutation run found them rather than a reading did.
+
+    python3 Scripts/test_probe_label_matching.py
+"""
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+GUARD = "Scripts/check-probe-label-matching.py"
+PROBE = "Scripts/livekit/ax_plugin_menu_probe.swift"
+POLICY = "Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift"
+PRODUCT = "Sources/LogicProMCP/Accessibility/AXLogicProElements+Mixer.swift"
+
+# (name, file, find, replace, a phrase the report must contain)
+CASES = [
+    ("the fold is dropped — the original defect, restored",
+     PROBE, "trimmed(text).lowercased()", "trimmed(text)",
+     "no longer trims-then-lowercases"),
+    ("a caller compares a label set with .contains instead of folding",
+     PROBE,
+     "matchesPolicyLabel(descriptionText($0), anyOf: viewLabels)",
+     "viewLabels.contains(descriptionText($0))",
+     "without folding"),
+    ("a caller compares a single label with a bare ==",
+     PROBE,
+     "matchesPolicyLabel(descriptionText($0), anyOf: [openLabel])",
+     "descriptionText($0) == openLabel",
+     "without folding"),
+    ("the shared helper is renamed away",
+     PROBE, "func matchesPolicyLabel", "func matchesPolicyLabelRenamed",
+     "no matchesPolicyLabel"),
+    ("a label set gains a member differing only by case",
+     POLICY,
+     'canonical: "mixer",\n        variants: ["믹서"]',
+     'canonical: "mixer",\n        variants: ["믹서", "Mixer"]',
+     "differ only by case"),
+    ("the product stops folding, so the rule the probe mirrors is gone",
+     PRODUCT, ".whitespacesAndNewlines).lowercased()", ".whitespacesAndNewlines)",
+     "no longer trims-then-lowercases before comparing"),
+]
+
+
+def run_guard(tree):
+    return subprocess.run([sys.executable, os.path.join(tree, GUARD)],
+                          capture_output=True, text=True, cwd=tree)
+
+
+def main():
+    failed = 0
+    with tempfile.TemporaryDirectory() as tmp:
+        tree = os.path.join(tmp, "tree")
+        # Only the files the guard reads; copying the repository would be slow and would drag in
+        # build products the guard never looks at.
+        for relative in (GUARD, PROBE, POLICY, PRODUCT):
+            destination = os.path.join(tree, relative)
+            os.makedirs(os.path.dirname(destination), exist_ok=True)
+            shutil.copy(os.path.join(ROOT, relative), destination)
+
+        clean = run_guard(tree)
+        ok = clean.returncode == 0
+        failed += 0 if ok else 1
+        print(f"{'ok  ' if ok else 'FAIL'} the unmodified tree passes"
+              + ("" if ok else f" -> {clean.stdout.strip()[:200]}"))
+
+        for name, relative, find, replace, expected in CASES:
+            path = os.path.join(tree, relative)
+            original = open(path, encoding="utf-8").read()
+            if original.count(find) < 1:
+                failed += 1
+                print(f"FAIL {name} -> anchor absent, the defect was NEVER INJECTED")
+                continue
+            open(path, "w", encoding="utf-8").write(original.replace(find, replace, 1))
+            result = run_guard(tree)
+            open(path, "w", encoding="utf-8").write(original)
+
+            caught = result.returncode != 0 and expected in result.stdout
+            failed += 0 if caught else 1
+            if caught:
+                print(f"ok   {name}")
+            else:
+                print(f"FAIL {name} -> rc={result.returncode}, expected {expected!r} in the report")
+
+        restored = run_guard(tree)
+        ok = restored.returncode == 0
+        failed += 0 if ok else 1
+        print(f"{'ok  ' if ok else 'FAIL'} the tree passes again after every restore")
+
+    print(f"\n{'FAILED' if failed else 'all cases behaved'} ({failed} unexpected)")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The AX probe restates a matching rule the product owns, and the two had drifted.

| | comparison | against Logic's `"Mixer"` |
|---|---|---|
| product — `AXLogicProElements+Mixer.swift` | trims **then lowercases** | matches `"mixer"` ✅ |
| probe — `ax_plugin_menu_probe.swift` | trimmed whitespace only | never matched ❌ |

`AXLocalePolicy.mixerNamedElement` spells the English form `"mixer"`; Logic answers `AXDescription`
with `"Mixer"`. So the probe's mixer match could not succeed on an English Logic, and only a locale
without case distinction (`믹서`) passed — which is why the harness driving it was written against a
Korean fixture, and why the gap survived as long as nobody ran it in English.

## Why this is not a one-line fix

Folding inside each comparison would have fixed the instance and left the shape. All **thirteen**
policy-label comparisons now go through one `matchesPolicyLabel`, which folds **both sides**, so a
caller cannot normalise one and forget the other — the shape that produced the bug.

**The boundary is in the name.** User-supplied identifiers stay exact: a track called `Bass` must not
match one called `bass`. The four comparisons carrying user data are listed in the guard by name, so
adding one is a deliberate act.

**Folding is safe because no label set contains two labels differing only by case.** That is not an
assumption — the guard asserts it, and it is what stops a fold from merging two distinct members of
one set.

## A comment did not hold, so this is a guard

`Scripts/check-probe-label-matching.py` fails when the probe and the product can drift. It is in the
set CI discovers, and `Scripts/test_probe_label_matching.py` drives it.

**Its first version had three holes**, and a mutation run found all three rather than a reading did:

| injected | why it slipped through |
|---|---|
| `matchesPolicyLabel(…)` → `labels.contains(observed)` | the regex looked for `==` only — **the same defect in another spelling** |
| `func matchesPolicyLabel` → `…Renamed` | a substring test, which `…Renamed` contains |
| one `.lowercased()` deleted from the product | the file has several, so an `in` test never noticed the load-bearing one |

The self-test now injects **six** defects and requires each to be reported by name, then requires the
restored tree to pass.

## Verified

- Live end to end after hardening: `mixer 1 → strip 1 → slot 1 → open_press 0 → 7 Controls sliders`,
  and the probe closes the window it opened.
- The Korean fixture `live_306` targets is unchanged **by construction**: every observed string there
  is Hangul, where folding is the identity.
- Ship gate PASS at `5aa8bba0` — 4484 tests, all repo guards, public-surface preflight.

https://claude.ai/code/session_01FPpCJgL1EkuBujPkbEEG2A