### PR TITLE
fix: the MCU health line says feedback is stale, not how long it has been

### DIFF
--- a/Sources/LogicProMCP/Channels/MCUChannel.swift
+++ b/Sources/LogicProMCP/Channels/MCUChannel.swift
@@ -500,8 +500,18 @@ actor MCUChannel: Channel {
         let age = conn.lastFeedbackAt.map { Date().timeIntervalSince($0) } ?? .infinity
         let stale = age > 5.0
         let registered = conn.registeredAsDevice ? "device registration confirmed" : "MIDI feedback active, device registration not confirmed"
+        // The AGE stays out of the prose. `last_feedback_at` already carries it as a machine field,
+        // and rendering it here made the same fact live in two places with only one of them
+        // projected away: `stableHealthData` strips `feedback_stale` and `last_feedback_at`, then
+        // compares a payload whose `detail` is still counting seconds. Measured 2026-09-11 on a warm
+        // server, `channels[].detail` was the only field that kept moving after that projection —
+        // "feedback stale (8s)" then "feedback stale (13s)" four seconds apart.
+        //
+        // The WORD stays. Three call sites read it (`IntegrationTests:170`, `MCUChannelTests:282`
+        // and `:291`) and an operator reading a health line needs to know staleness at all; what
+        // none of them reads is the integer.
         let detail = stale
-            ? "MCU \(registered), feedback stale (\(Int(age))s)"
+            ? "MCU \(registered), feedback stale"
             : "MCU \(registered), feedback active"
         return .healthy(latencyMs: nil, detail: detail + workBudgetDetail)
     }

--- a/Tests/LogicProMCPTests/MCUChannelTests.swift
+++ b/Tests/LogicProMCPTests/MCUChannelTests.swift
@@ -282,6 +282,20 @@ import Testing
     #expect(staleHealth.detail.contains("stale"))
     #expect(staleHealth.detail.contains("device registration confirmed"))
 
+    // The detail says THAT feedback is stale, never HOW LONG. `last_feedback_at` carries the age as
+    // a machine field; rendering it here too put one fact in two places and only one of them is
+    // projected away for byte-stability, so the payload kept moving on its own.
+    //
+    // Asserted as "no digits" rather than "not (6s)": the defect is a clock in prose, and a reworded
+    // "stale for 6 seconds" would pass a check written against the old spelling while being the
+    // same defect.
+    #expect(!staleHealth.detail.contains { $0.isNumber })
+
+    // A second read a moment later must be byte-identical. This is the property the qualification
+    // projection needs and the one the age broke: same connection state, same string.
+    let staleAgain = await channel.healthCheck()
+    #expect(staleAgain.detail == staleHealth.detail)
+
     connected.registeredAsDevice = false
     connected.lastFeedbackAt = Date()
     await cache.updateMCUConnection(connected)


### PR DESCRIPTION
`MCUChannel` rendered a live second count into `channels[].detail`:

```
"MCU device registration confirmed, feedback stale (8s)"
"MCU device registration confirmed, feedback stale (13s)"
```

four seconds apart on a **warm** server. The age is already a machine field — `last_feedback_at` —
so the same fact lived in two places, and only one of them is projected away: `stableHealthData`
strips `feedback_stale` and `last_feedback_at`, then compares a payload whose prose is still
counting. Measured, `channels[].detail` was the only field that kept moving after that projection.

**The word stays.** Three call sites read it (`IntegrationTests:170`, `MCUChannelTests:282`, `:291`)
and an operator reading a health line needs to know staleness at all. What none of them reads is the
integer — checked across the repository before touching it.

## The regression test asserts no digit, not "not (6s)"

A mutant proved why: `"feedback stale for 6 seconds"` is the same defect reworded, and a check
written against the old spelling passes it. Both mutants turn the test red:

| injected | result |
|---|---|
| the original `(\(Int(age))s)` | RED |
| reworded `for \(Int(age)) seconds` | RED |

It also asserts two consecutive reads are byte-identical — the property the qualification projection
needs and the one the age broke.

## Scope

This closes a second-authority defect, **not a release blocker**. `health_read_stable` records the
instability but nothing gates on it: `isFailClosedAndStable` deliberately excludes it, with a comment
saying health warms during a run. I reported it as a blocker first and corrected that on #284.

Ship gate PASS at `3bd1b647` — 4484 tests, all repo guards, live evidence bound to this head.

https://claude.ai/code/session_01FPpCJgL1EkuBujPkbEEG2A