### PR TITLE
fix(#852): the probe sees the Controls-view role the product actuates

### DIFF
--- a/Scripts/check-probe-product-drift.py
+++ b/Scripts/check-probe-product-drift.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""The AX probe restates a matching rule the product owns. This fails when they can drift.
+"""The AX probe restates rules the product owns. This fails when they can drift.
 
 WHY THIS EXISTS
 ---------------
@@ -13,16 +13,34 @@ noticed for as long as nobody ran it in English.
 
 A comment saying "keep these in sync" was not enough, so this is a check instead.
 
+TWO RESTATED RULES, NOT ONE
+---------------------------
+This began as a label-matching check and was widened on 2026-09-11, when a SECOND restated rule was
+found to have drifted the same way: the probe decided what counts as a Controls-view control with a
+three-role literal while the product's `interactiveControlRoles` names eleven. The missing
+`AXCheckBox` is the only Controls-view role this repository has ever actuated, so the census was
+blind to the one working path and reported a checkbox row as having no control at all.
+
+A separate guard file for the role rule was rejected in favour of widening this one: the PROPERTY is
+"the probe restates product rules", and a guard per instance is how the second one went unwatched
+while the first was covered. The file was named `check-probe-label-matching.py` until that day.
+
+Deriving the role set from one shared place was rejected too, and not on taste: the probe runs
+outside the product and cannot import it, which #846's own record already settled. The rule is
+necessarily restated; this is what keeps the two spellings together.
+
 WHAT IT ENFORCES
 ----------------
 1. The probe folds case when comparing against policy vocabulary, and does it in ONE place, so a
    caller cannot normalise one side and forget the other.
 2. No policy label set contains two labels differing only by case. That is the property that makes
    folding safe: it can never merge two distinct members of one set.
-3. User-supplied identifiers are NOT folded. A track called `Bass` must not match one called `bass`,
+3. The probe's Controls-view control-role set is exactly the product's, and the census reads it
+   from one named constant rather than an inline literal.
+4. User-supplied identifiers are NOT folded. A track called `Bass` must not match one called `bass`,
    so the exact comparisons that carry user data are listed here by name and required to stay exact.
 
-    python3 Scripts/check-probe-label-matching.py
+    python3 Scripts/check-probe-product-drift.py
 """
 import os
 import re
@@ -32,6 +50,7 @@ ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 PROBE = os.path.join(ROOT, "Scripts/livekit/ax_plugin_menu_probe.swift")
 POLICY = os.path.join(ROOT, "Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift")
 PRODUCT = os.path.join(ROOT, "Sources/LogicProMCP/Accessibility/AXLogicProElements+Mixer.swift")
+WRITER = os.path.join(ROOT, "Sources/LogicProMCP/HostParameters/ControlsViewBooleanParameterWriter.swift")
 
 # Comparisons that carry the USER's data rather than policy vocabulary. These must stay exact, and
 # they are named so that adding one is a deliberate act rather than a side effect.
@@ -57,6 +76,7 @@ def read(path):
 probe = read(PROBE)
 policy = read(POLICY)
 product = read(PRODUCT)
+writer = read(WRITER)
 
 # 1. The product's rule is what the probe must mirror. If the product stops lowercasing, this check
 #    is describing a rule that no longer exists and must be revisited rather than silently kept.
@@ -123,11 +143,66 @@ if policy:
                 )
             folded[key] = label
 
+
+# 5. The probe's Controls-view control roles are the product's, spelled out in one place.
+#
+# The probe cannot import the product -- that is settled, and it is why the label rule above is
+# restated rather than shared. So this compares the two SPELLINGS and requires them equal. A
+# superset is not accepted either: a probe that recognises a role the product refuses would report a
+# control the product will not touch, which is the same lie pointing the other way.
+def _roles_from_swift_set(text, declaration):
+    """Every role name in a Swift Set<String> literal, whether written as a kAX… constant or a string."""
+    # `declaration` must anchor past the NAME -- callers pass a trailing `\s*:` -- or a renamed set
+    # matches as a prefix and this parses the very declaration the rename removed.
+    match = re.search(declaration + r"[^=]*=\s*\[(.*?)\n\s*\]", text, re.S)
+    if match is None:
+        return None
+    body = match.group(1)
+    # `kAXCheckBoxRole as String` and `"AXCheckBox"` name the same role; compare the role, not the
+    # spelling, or this check would fail on a difference that is only notation.
+    roles = {f"AX{name}" for name in re.findall(r"kAX(\w+)Role", body)}
+    roles |= set(re.findall(r'"(AX\w+)"', body))
+    return roles
+
+product_roles = _roles_from_swift_set(writer, r"interactiveControlRoles\s*:") if writer else None
+probe_roles = _roles_from_swift_set(probe, r"let controlsViewControlRoles\s*:") if probe else None
+
+if writer and product_roles is None:
+    problems.append(
+        "ControlsViewBooleanParameterWriter.interactiveControlRoles could not be parsed — this check "
+        "went blind rather than passing"
+    )
+if probe and probe_roles is None:
+    problems.append(
+        "the probe has no controlsViewControlRoles set: the Controls-view role rule has no single "
+        "home, so a census can inline its own list again"
+    )
+if product_roles and probe_roles is not None and product_roles != probe_roles:
+    missing = sorted(product_roles - probe_roles)
+    extra = sorted(probe_roles - product_roles)
+    detail = []
+    if missing:
+        detail.append(f"the probe cannot see {', '.join(missing)}")
+    if extra:
+        detail.append(f"the probe accepts {', '.join(extra)}, which the product does not")
+    problems.append(
+        "the probe's Controls-view control roles and the product's interactiveControlRoles differ: "
+        + "; ".join(detail)
+    )
+
+# The census must READ that constant. Without this, the set can be correct and unused -- which is
+# exactly the state the role defect was in, with a literal list inline at the call site.
+if probe and not re.search(r"controlsViewControlRoles\.contains\(roleText\(", probe):
+    problems.append(
+        "rowCensus does not filter with controlsViewControlRoles: the named set is not what decides, "
+        "so it can be right and have no effect"
+    )
+
 if problems:
-    print(f"{len(problems)} probe/policy label-matching problem(s):")
+    print(f"{len(problems)} probe/product drift problem(s):")
     for problem in problems:
         print(f"  {problem}")
-    print("\nThe probe restates a rule the product owns. These must not drift.")
+    print("\nThe probe restates rules the product owns. These must not drift.")
     sys.exit(1)
 
-print("probe label matching mirrors the product, in one place, and folding is safe")
+print("probe label matching and Controls-view roles mirror the product, each in one place, and folding is safe")

--- a/Scripts/livekit/ax_plugin_menu_probe.swift
+++ b/Scripts/livekit/ax_plugin_menu_probe.swift
@@ -752,13 +752,38 @@ func sliders(in root: AXUIElement) -> [JSON] {
     descendants(root).filter { roleText($0) == "AXSlider" }.map(snapshot)
 }
 
+/// The roles that count as a Controls-view row's control.
+///
+/// RESTATED from `ControlsViewBooleanParameterWriter.interactiveControlRoles`, because this probe
+/// runs outside the product and cannot import it -- the same reason `normalizedPolicyLabel` restates
+/// the label rule. `check-probe-product-drift.py` is what keeps the two spellings together; a
+/// comment saying "keep these in sync" is what failed last time.
+///
+/// It listed three roles until 2026-09-11 -- AXSlider, AXRadioButton, AXPopUpButton -- and AXCheckBox
+/// was not among them. The checkbox is the ONLY Controls-view role this repository has ever
+/// actuated, so the census was blind to the one path that works, and a checkbox row came back as
+/// `control_roles: []`: not "this probe does not look for checkboxes" but "this row has no control".
+let controlsViewControlRoles: Set<String> = [
+    "AXCheckBox",
+    "AXSlider",
+    "AXPopUpButton",
+    "AXRadioButton",
+    "AXButton",
+    "AXMenuButton",
+    "AXTextField",
+    "AXComboBox",
+    "AXIncrementor",
+    "AXValueIndicator",
+    "AXScrollBar",
+]
+
 func rowCensus(in root: AXUIElement) -> [JSON] {
     descendants(root).filter { roleText($0) == "AXRow" }.map { row in
         let cells = descendants(row, 6).filter { roleText($0) == "AXCell" }
         let cellData: [JSON] = cells.map { cell in
             let staticTexts = descendants(cell, 6).filter { roleText($0) == "AXStaticText" }
             let controls = descendants(cell, 6).filter {
-                ["AXSlider", "AXRadioButton", "AXPopUpButton"].contains(roleText($0))
+                controlsViewControlRoles.contains(roleText($0))
             }
             return [
                 "static_texts": staticTexts.map { textValueText($0).isEmpty ? elementName($0) : textValueText($0) },

--- a/Scripts/test_probe_product_drift.py
+++ b/Scripts/test_probe_product_drift.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python3
-"""Drive check-probe-label-matching.py against the defects it names.
+"""Drive check-probe-product-drift.py against the defects it names.
 
 Each case injects one defect into a COPY of the tree and asserts the guard reports it, then asserts
 the unmodified tree passes. Three of these cases exist because they were holes: the first version of
 the guard missed them, and a mutation run found them rather than a reading did.
 
-    python3 Scripts/test_probe_label_matching.py
+The last five cases arrived with the role clause on 2026-09-11. The defect that clause exists to
+catch -- the probe's three-role literal against the product's eleven -- is the FIRST of them, written
+as the tree actually stood, so the clause is shown catching the real thing and not only a synthetic
+neighbour of it.
+
+    python3 Scripts/test_probe_product_drift.py
 """
 import os
 import shutil
@@ -14,10 +19,11 @@ import sys
 import tempfile
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-GUARD = "Scripts/check-probe-label-matching.py"
+GUARD = "Scripts/check-probe-product-drift.py"
 PROBE = "Scripts/livekit/ax_plugin_menu_probe.swift"
 POLICY = "Sources/LogicProMCP/Accessibility/AXLocalePolicy.swift"
 PRODUCT = "Sources/LogicProMCP/Accessibility/AXLogicProElements+Mixer.swift"
+WRITER = "Sources/LogicProMCP/HostParameters/ControlsViewBooleanParameterWriter.swift"
 
 # (name, file, find, replace, a phrase the report must contain)
 CASES = [
@@ -45,6 +51,23 @@ CASES = [
     ("the product stops folding, so the rule the probe mirrors is gone",
      PRODUCT, ".whitespacesAndNewlines).lowercased()", ".whitespacesAndNewlines)",
      "no longer trims-then-lowercases before comparing"),
+    # --- the role clause, added 2026-09-11 with #852 ---------------------------------------------
+    ("the probe cannot see AXCheckBox — #852 exactly as it stood",
+     PROBE, '    "AXCheckBox",\n    "AXSlider",', '    "AXSlider",',
+     "the probe cannot see AXCheckBox"),
+    ("the probe accepts a role the product refuses",
+     PROBE, '    "AXScrollBar",\n]', '    "AXScrollBar",\n    "AXOutline",\n]',
+     "the probe accepts AXOutline"),
+    ("the product gains a role and the probe is not moved with it",
+     WRITER, '        "AXScrollBar",\n    ]', '        "AXScrollBar",\n        "AXDisclosureTriangle",\n    ]',
+     "the probe cannot see AXDisclosureTriangle"),
+    ("the named set is right but the census inlines its own list",
+     PROBE, "controlsViewControlRoles.contains(roleText($0))",
+     '["AXSlider"].contains(roleText($0))',
+     "the named set is not what decides"),
+    ("the probe's role set is renamed away",
+     PROBE, "let controlsViewControlRoles", "let controlsViewControlRolesRenamed",
+     "no controlsViewControlRoles set"),
 ]
 
 
@@ -59,7 +82,7 @@ def main():
         tree = os.path.join(tmp, "tree")
         # Only the files the guard reads; copying the repository would be slow and would drag in
         # build products the guard never looks at.
-        for relative in (GUARD, PROBE, POLICY, PRODUCT):
+        for relative in (GUARD, PROBE, POLICY, PRODUCT, WRITER):
             destination = os.path.join(tree, relative)
             os.makedirs(os.path.dirname(destination), exist_ok=True)
             shutil.copy(os.path.join(ROOT, relative), destination)


### PR DESCRIPTION
Stacked on #853 — merge that first.

The AX probe's Controls-view census decided what counts as a control with a three-role literal,
`["AXSlider", "AXRadioButton", "AXPopUpButton"]`, while the product owns that rule and spells it with
eleven (`ControlsViewBooleanParameterWriter.interactiveControlRoles`). **`AXCheckBox` was missing**,
and it is the only Controls-view role this repository has ever actuated — sliders are refused
`sliderNotActuable`, popups `popupNotAddressableByName`.

So a checkbox row came back as `control_roles: []`, which does not read as "this probe does not look
for checkboxes" but as "this row has no control": absence published as a reading, in the direction
that makes the surface look more hostile than it is. It blocked a live measurement — counting
Compressor and Gain checkboxes for #292 — with an instrument that could not see the answer.

## This is #846's class on a second attribute

#846 was the probe restating the product's **label** rule until the two spellings diverged, fixed
with `check-probe-label-matching.py`. That guard covers labels only, and the role set was a second
restated rule nothing checked. Fixing this instance and leaving the guard label-shaped would repeat
the mistake at one remove, so the guard is **widened rather than duplicated** and renamed for the
property it enforces: `check-probe-product-drift.py`. A guard still named for labels while silently
also enforcing roles is how the next person misses it.

The set is restated, not derived. #846's own CommitLore record settles why — the probe runs outside
the product and cannot import it — so the fix that matters is the check, not a shared constant that
cannot exist.

## The self-test earned its keep immediately

Five new cases, the first being #852 exactly as the tree stood, so the clause is shown catching the
real defect rather than a synthetic neighbour. One of them failed on arrival: the declaration regex
matched `controlsViewControlRolesRenamed` as a prefix and happily parsed the declaration the rename
had removed. Anchored past the name; 13 cases pass.

## Not done

The Compressor and Gain checkbox counts this fix was written to obtain. With the role set fixed the
probe still returns zero matching strips against a real Mixer window carrying 21 — a separate
question I have not isolated, and the commit says so rather than implying the measurement followed.