### PR TITLE
fix: the MCU staleness rule is one predicate, not a comparison each caller rewrites

### DIFF
--- a/Scripts/check-falsifiable-adoption.py
+++ b/Scripts/check-falsifiable-adoption.py
@@ -55,7 +55,7 @@ REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # Three raises in two days is not churn: each names the harness that made the number true. This one
 # was a MERGE conflict, both sides having raised the same constant for different harnesses, and the
 # resolution is the union rather than either side.
-FLOOR = 14
+FLOOR = 15
 _FALSIFIABLE_PARAMETERS = (
     "tag", "predicate", "observation", "counterexample", "expected", "mutation", "modal_snapshot",
 )

--- a/Scripts/livekit/live_849_one_staleness_answer_reaches_both_surfaces.py
+++ b/Scripts/livekit/live_849_one_staleness_answer_reaches_both_surfaces.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Live proof that the published MCU staleness bit follows the rule its own snapshot states.
+
+Usage:  LPM_EVIDENCE_ROOT=/abs/path/outside/repo \
+        python3 live_849_one_staleness_answer_reaches_both_surfaces.py <worktree> <full-40-char-head-sha>
+
+WHAT WAS WRONG
+--------------
+`age > 5.0` was written twice. `MCUChannel.health` compared it after an early return on
+`!conn.isConnected`; `SystemDispatcher` compared `mcu.isConnected && (age ?? .infinity) > 5.0`
+inline for `mcu.feedback_stale`. `MCUConnectionState.isFeedbackStale(now:)` is now the one spelling.
+
+WHAT THIS DOES NOT MEASURE, SAID FIRST
+--------------------------------------
+The two former spellings AGREED. This harness would have passed before the change, and nothing here
+claims otherwise -- `MCUFeedbackStalenessRuleTests` carries that load, with four mutants killed.
+
+Rejected, after being this harness's first shape: comparing `mcu.feedback_stale` against the word in
+`channels[].detail`. Those two fields ship in one payload but come from two reads of the cache --
+`router.healthReport()` at `SystemDispatcher.swift:371` and `cache.getMCUConnection()` at `:386`. Feedback arriving between them can separate the two fields legitimately, so a check that
+required them to match would have been green by luck and red on a race -- a flake wearing the shape
+of a proof. That gap is a defect in its own right and is filed separately; it is not this change's,
+and folding a fix for it into a refactor would have widened the very definition this change narrowed.
+
+WHAT IT DOES MEASURE
+--------------------
+Every field the check reads comes from the SAME `getMCUConnection()` read: `connected`,
+`feedback_stale` and `last_feedback_at` are one snapshot. So the question it can answer is whether
+the published bit follows the published rule -- `connected && age > 5s`, recomputed here from the
+timestamp on the wire.
+
+The threshold is written out in this file rather than imported. An oracle that read the product's
+own constant would agree with any value the product chose, including a wrong one.
+
+THE COUNTEREXAMPLE, AND WHY THE SWEEP HAS TO SEE BOTH STATES
+------------------------------------------------------------
+"The bit matches the timestamp" is satisfied by a surface where the bit is permanently true and the
+timestamp permanently ancient -- a server whose MCU never connects agrees with itself forever. So
+the sweep must contain BOTH readings: a fresh one and a stale one. The server's own startup device
+query supplies them without touching the project -- Logic answers it, which makes feedback fresh,
+and five seconds of silence afterwards makes it stale. A sweep that saw one state is recorded as a
+failure, not as a weaker pass: it cannot tell a rule from a constant.
+
+This is a `non_ui` run: there is no rectangle to photograph.
+"""
+import datetime
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import evidence as E  # noqa: E402
+
+
+COVERS = [
+    "Sources/LogicProMCP/State/StateModels.swift",
+    "Sources/LogicProMCP/Channels/MCUChannel.swift",
+    "Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift",
+]
+
+# Deliberately not imported from the product. See the docstring.
+STALE_AFTER_SEC = 5.0
+
+WT = sys.argv[1] if len(sys.argv) > 1 else ""
+HEAD = sys.argv[2] if len(sys.argv) > 2 else ""
+if not WT or not HEAD:
+    sys.exit(__doc__)
+
+E.REPO = WT
+E.BIN = f"{WT}/.build/release/LogicProMCP"
+missing = E.have_tools()
+if missing:
+    sys.exit(f"cannot run: missing {missing}")
+
+ev = E.Evidence(HEAD, os.environ["LPM_EVIDENCE_ROOT"], surface="non_ui")
+
+
+def parse_stamp(text):
+    if not isinstance(text, str) or not text:
+        return None
+    try:
+        return datetime.datetime.strptime(text, "%Y-%m-%dT%H:%M:%S.%fZ").replace(
+            tzinfo=datetime.timezone.utc
+        )
+    except ValueError:
+        return None
+
+
+d = E.Driver()
+
+samples = []
+# Read across the staleness boundary without driving the project. The first read lands while
+# Logic's answer to the startup device query is still inside the window; the rest land after it has
+# aged out. 2s is inside the 5s window, 2+3 is on the far side.
+for delay in (2, 3, 7):
+    time.sleep(delay)
+    # The wall clock is read as close to the call as this harness can manage. It is only ever used
+    # to age a timestamp the product itself published, never to time the product.
+    asked_at = datetime.datetime.now(datetime.timezone.utc)
+    health = d.tool("logic_system", "health")
+    mcu = health.get("mcu") or {}
+    stamp = parse_stamp(mcu.get("last_feedback_at"))
+    published = mcu.get("feedback_stale")
+    connected = mcu.get("connected")
+    age = None if stamp is None else (asked_at - stamp).total_seconds()
+    # `nil` timestamp means no feedback has ever arrived, which both former spellings read as
+    # infinitely old.
+    expected = bool(connected) and (True if age is None else age > STALE_AFTER_SEC)
+    samples.append({
+        "connected": connected,
+        "feedback_stale": published,
+        "last_feedback_at": mcu.get("last_feedback_at"),
+        "age_sec_at_ask": None if age is None else round(age, 3),
+        "rule_says_stale": expected,
+        "published_matches_rule": isinstance(published, bool) and published == expected,
+        # A sample whose age sits within a few milliseconds of the threshold cannot arbitrate
+        # between the product's clock and this harness's, and is excluded from the comparison
+        # rather than counted as either outcome.
+        "near_boundary": age is not None and abs(age - STALE_AFTER_SEC) < 0.25,
+    })
+
+decidable = [s for s in samples if not s["near_boundary"] and isinstance(s["feedback_stale"], bool)]
+
+reading = {
+    "samples": len(samples),
+    "decidable_samples": len(decidable),
+    "samples_excluded_near_the_boundary": sum(1 for s in samples if s["near_boundary"]),
+    "samples_where_the_bit_follows_the_rule": sum(1 for s in decidable if s["published_matches_rule"]),
+    "fresh_readings": sum(1 for s in decidable if s["feedback_stale"] is False),
+    "stale_readings": sum(1 for s in decidable if s["feedback_stale"] is True),
+    "connected_readings": sum(1 for s in decidable if s["connected"] is True),
+    "observed": samples,
+}
+
+ev.falsifiable(
+    "849/the-published-staleness-bit-follows-its-own-snapshot",
+    lambda o: (o["decidable_samples"] >= 2
+               and o["samples_where_the_bit_follows_the_rule"] == o["decidable_samples"]
+               and o["fresh_readings"] > 0
+               and o["stale_readings"] > 0
+               and o["connected_readings"] == o["decidable_samples"]),
+    reading,
+    {"samples": 3, "decidable_samples": 3, "samples_excluded_near_the_boundary": 0,
+     "samples_where_the_bit_follows_the_rule": 3,
+     "fresh_readings": 0, "stale_readings": 3, "connected_readings": 3,
+     "observed": [{"connected": True, "feedback_stale": True,
+                   "last_feedback_at": "2026-09-11T02:43:43.756Z", "age_sec_at_ask": 611.2,
+                   "rule_says_stale": True, "published_matches_rule": True, "near_boundary": False}]},
+    "`mcu.feedback_stale` follows the rule recomputed from `connected` and `last_feedback_at` in the "
+    "same snapshot, and the sweep contains BOTH answers -- a fresh reading and a stale one -- so what "
+    "passed is a rule and not a constant. The counterexample is the shape that satisfies every other "
+    "clause: three samples that all agree and are all stale, which is exactly what a server with no "
+    "MCU binding produces, and what a `feedback_stale` hardwired to `true` would produce. `connected` "
+    "is required across the sweep for the same reason -- a disconnected port is not stale under either "
+    "former spelling, so agreement on a dead port measures nothing",
+    mutation="`MCUConnectionState.isFeedbackStale` returns `false` unconditionally. Every sample then "
+             "publishes a fresh bit while its own `last_feedback_at` ages past five seconds, so "
+             "`samples_where_the_bit_follows_the_rule` falls below `decidable_samples` and "
+             "`stale_readings` reaches zero -- two clauses, not one. The narrower mutation of dropping "
+             "the `isConnected` guard is NOT claimed here: this run never observes a disconnected "
+             "port, so nothing in this document would move",
+)
+
+ev.write()

--- a/Sources/LogicProMCP/Channels/MCUChannel.swift
+++ b/Sources/LogicProMCP/Channels/MCUChannel.swift
@@ -497,8 +497,7 @@ actor MCUChannel: Channel {
                     + workBudgetDetail
             )
         }
-        let age = conn.lastFeedbackAt.map { Date().timeIntervalSince($0) } ?? .infinity
-        let stale = age > 5.0
+        let stale = conn.isFeedbackStale()
         let registered = conn.registeredAsDevice ? "device registration confirmed" : "MIDI feedback active, device registration not confirmed"
         // The AGE stays out of the prose. `last_feedback_at` already carries it as a machine field,
         // and rendering it here made the same fact live in two places with only one of them

--- a/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
+++ b/Sources/LogicProMCP/Dispatchers/SystemDispatcher.swift
@@ -386,7 +386,6 @@ struct SystemDispatcher: OperationTraceDispatching {
             let mcu = await cache.getMCUConnection()
             let permissions = PermissionChecker.check()
             let process = ProcessUtils.currentProcessMetrics()
-            let lastFeedbackAge = mcu.lastFeedbackAt.map { Date().timeIntervalSince($0) }
             // Single source of truth shared with `project.is_running` so the
             // two signals can never disagree. AppleScript availability is
             // already surfaced separately in the `channels` array; mixing it
@@ -416,7 +415,7 @@ struct SystemDispatcher: OperationTraceDispatching {
                     connected: mcu.isConnected,
                     registeredAsDevice: mcu.registeredAsDevice,
                     lastFeedbackAt: mcu.lastFeedbackAt,
-                    feedbackStale: mcu.isConnected && (lastFeedbackAge ?? .infinity) > 5.0,
+                    feedbackStale: mcu.isFeedbackStale(),
                     portName: mcu.portName,
                     portCensus: .init(
                         state: mcu.portCensus.state.rawValue,

--- a/Sources/LogicProMCP/State/StateModels.swift
+++ b/Sources/LogicProMCP/State/StateModels.swift
@@ -302,6 +302,33 @@ extension MCUConnectionState {
         guard let last = lastFeedbackAt else { return nil }
         return max(0, Int(now.timeIntervalSince(last) * 1000.0))
     }
+
+    /// How long inbound MCU feedback may be silent before the connection counts
+    /// as stale.
+    static let feedbackStaleAfter: TimeInterval = 5.0
+
+    /// Whether inbound MCU feedback has gone silent.
+    ///
+    /// The rule used to be written twice — `MCUChannel.health` computed
+    /// `age > 5.0` after an early return on `!isConnected`, and
+    /// `SystemDispatcher` computed `isConnected && age > 5.0` inline for the
+    /// `feedback_stale` wire field. The two agreed, but only because one of them
+    /// hoisted the guard the other spelled out; nothing made them agree, and the
+    /// threshold itself lived as a bare literal in two files. Whoever moved one
+    /// would have had to know to move the other.
+    ///
+    /// Kept in `TimeInterval` rather than derived from `lastFeedbackAgeMs`: that
+    /// function truncates to whole milliseconds, so routing through it would move
+    /// the boundary for ages in (5.0, 5.001) seconds. This predicate is the same
+    /// comparison both sites already made.
+    ///
+    /// A connection that has never received feedback is stale, not fresh — both
+    /// former sites spelled that `?? .infinity`.
+    func isFeedbackStale(now: Date = Date()) -> Bool {
+        guard isConnected else { return false }
+        guard let last = lastFeedbackAt else { return true }
+        return now.timeIntervalSince(last) > Self.feedbackStaleAfter
+    }
 }
 
 /// MCU LCD display state.

--- a/Tests/LogicProMCPTests/MCUFeedbackStalenessRuleTests.swift
+++ b/Tests/LogicProMCPTests/MCUFeedbackStalenessRuleTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Testing
+
+@testable import LogicProMCP
+
+/// The MCU staleness rule used to be written twice: `MCUChannel.health` compared
+/// `age > 5.0` behind an early return on `!isConnected`, and `SystemDispatcher`
+/// compared `isConnected && age > 5.0` inline for the `feedback_stale` wire
+/// field. Both spellings agreed, so no behaviour test could have told them apart
+/// — which is exactly why the duplication survived. These rows pin the single
+/// predicate they now share, including the two rows that separate the guard from
+/// the threshold.
+@Suite("MCU feedback staleness is one rule")
+struct MCUFeedbackStalenessRuleTests {
+    private let now = Date(timeIntervalSince1970: 1_000_000)
+
+    private func state(connected: Bool, feedbackAgo seconds: TimeInterval?) -> MCUConnectionState {
+        MCUConnectionState(
+            isConnected: connected,
+            lastFeedbackAt: seconds.map { now.addingTimeInterval(-$0) }
+        )
+    }
+
+    @Test("a disconnected port is never stale, however old its last feedback")
+    func disconnectedIsNeverStale() {
+        #expect(!state(connected: false, feedbackAgo: 3600).isFeedbackStale(now: now))
+        #expect(!state(connected: false, feedbackAgo: nil).isFeedbackStale(now: now))
+    }
+
+    @Test("a connected port that has never received feedback is stale, not fresh")
+    func connectedWithoutFeedbackIsStale() {
+        #expect(state(connected: true, feedbackAgo: nil).isFeedbackStale(now: now))
+    }
+
+    @Test("a connected port inside the window is fresh")
+    func connectedAndRecentIsFresh() {
+        #expect(!state(connected: true, feedbackAgo: 0).isFeedbackStale(now: now))
+        #expect(!state(connected: true, feedbackAgo: 4.9).isFeedbackStale(now: now))
+    }
+
+    @Test("a connected port past the window is stale")
+    func connectedAndSilentIsStale() {
+        #expect(state(connected: true, feedbackAgo: 5.1).isFeedbackStale(now: now))
+        #expect(state(connected: true, feedbackAgo: 600).isFeedbackStale(now: now))
+    }
+
+    /// The threshold is exclusive on both former sites (`> 5.0`, never `>= 5.0`).
+    /// Pinned so a later rewrite through `lastFeedbackAgeMs` — which truncates to
+    /// whole milliseconds — cannot move the boundary unnoticed.
+    @Test("the boundary is exclusive and survives sub-millisecond ages")
+    func boundaryIsExclusive() {
+        let threshold = MCUConnectionState.feedbackStaleAfter
+        #expect(!state(connected: true, feedbackAgo: threshold).isFeedbackStale(now: now))
+        #expect(state(connected: true, feedbackAgo: threshold + 0.0005).isFeedbackStale(now: now))
+    }
+
+    /// A backwards system-clock adjustment must not read as silence.
+    @Test("a clock that ran backwards is not stale")
+    func negativeAgeIsNotStale() {
+        #expect(!state(connected: true, feedbackAgo: -120).isFeedbackStale(now: now))
+    }
+}


### PR DESCRIPTION
`age > 5.0` was written twice. `MCUChannel.health` compared it after an early return on
`!conn.isConnected`; `SystemDispatcher` compared `mcu.isConnected && (age ?? .infinity) > 5.0`
inline for the `feedback_stale` wire field.

The two agreed — but only because one hoisted the guard the other spelled out, and the threshold
itself sat as a bare literal in two files. Nothing made them agree, and **no behaviour test could
have separated them**, which is why the duplication survived a fix that landed right next to it.

`MCUConnectionState.isFeedbackStale(now:)` is now the one spelling, beside `lastFeedbackAgeMs(now:)`
where the age semantics already live. Both call sites call it; `SystemDispatcher`'s `lastFeedbackAge`
binding had no other reader and is gone.

## Kept in TimeInterval on purpose

Deriving from `lastFeedbackAgeMs` was rejected: that function truncates to whole milliseconds, so
routing through it would have moved the boundary for ages in (5.0, 5.001) seconds. This is the same
comparison both sites already made — the threshold does not move.

## The rows were shown able to fail

Six rows with an injected clock, and each mutant killed exactly the row aimed at it:

| mutant | row that caught it |
|---|---|
| drop the `isConnected` guard | a disconnected port is never stale |
| a never-fed connection reads fresh | connected-without-feedback is stale |
| boundary becomes inclusive | the boundary is exclusive |
| threshold widened to 6.0 | a connected port past the window is stale |

## The live harness, and what it does NOT claim

Said in the file rather than implied: **this harness would have passed before the change.** The two
former spellings agreed. `MCUFeedbackStalenessRuleTests` carries that load; the harness pins the
exposed rule at the boundary where a reader meets it.

It also does **not** compare the bit against the word in `channels[].detail`. That was its first
shape and it was wrong: those two fields ship in one payload but come from **two separate cache
reads** (`SystemDispatcher.swift:371` and `:386`), so a check requiring them to match would have been
green by luck and red on a race. That gap is filed as #851 — folding a fix for it in here would have
widened the definition this branch narrowed.

So the harness checks the published bit against the rule recomputed from `connected` and
`last_feedback_at` in the **same snapshot**, and the sweep must contain both a fresh reading and a
stale one or it fails — "the bit matches the timestamp" is also true of a server whose MCU never
connects. Measured on this head: one fresh, one stale, one excluded for sitting within 250ms of the
threshold where the two clocks cannot arbitrate.