### PR TITLE
fix(#856): the MCU display reaches the parser

### DIFF
--- a/Sources/LogicProMCP/MIDI/MIDIFeedback.swift
+++ b/Sources/LogicProMCP/MIDI/MIDIFeedback.swift
@@ -56,6 +56,12 @@ enum MIDIFeedback {
         var out: [UInt8] = []
         var unconverted = 0
         var i = 0
+        // SysEx7 assembly state, for a message split across several words of THIS packet. A message
+        // that starts here and ends in a later CoreMIDI packet is not assembled — this function is
+        // called per packet and holds no state between calls — and its words are counted as
+        // unconverted at the end rather than emitted as a truncated frame.
+        var sysExPending: [UInt8] = []
+        var inSysEx = false
         while i < words.count {
             let word = words[i]
             let messageType = UInt8((word >> 28) & 0xF)
@@ -93,12 +99,81 @@ enum MIDIFeedback {
                 default:
                     unconverted += size
                 }
+            case 0x3:
+                // SysEx7. Skipping this whole is what hid the MCU display: the surface reports WHAT
+                // it is controlling on its LCD, by name, and every one of those messages arrives
+                // here. Measured 2026-09-11 with a Mackie Control bound, plug-in assignment mode
+                // wrote `Cha EQ` per strip and pan mode wrote `Angle Divers LFE Spread` — none of
+                // which reached `parseBytes`, which has handled `.sysEx` all along.
+                //
+                //   word0 = mt(4) group(4) status(4) numBytes(4) data0(8) data1(8)
+                //   word1 = data2(8) data3(8) data4(8) data5(8)
+                //
+                // status: 0 complete, 1 start, 2 continue, 3 end. The `F0`/`F7` framing is IMPLIED
+                // by the status and is not in the data, so it is added back here.
+                let status = UInt8((word >> 20) & 0xF)
+                let declared = Int((word >> 16) & 0xF)
+                // `numBytes` is a claim by the sender and six is the physical maximum. A larger
+                // value would read past the two words that exist, so it is refused rather than
+                // clamped. Clamping to six was rejected: a packet that lies about its length is
+                // not one to half-believe, and a truncated display write would read as a real one.
+                guard declared <= 6 else {
+                    unconverted += size
+                    sysExPending = []
+                    inSysEx = false
+                    i += size
+                    continue
+                }
+                let word1 = words[i + 1]
+                let available: [UInt8] = [
+                    UInt8((word >> 8) & 0xFF), UInt8(word & 0xFF),
+                    UInt8((word1 >> 24) & 0xFF), UInt8((word1 >> 16) & 0xFF),
+                    UInt8((word1 >> 8) & 0xFF), UInt8(word1 & 0xFF),
+                ]
+                let payload = Array(available.prefix(declared))
+                switch status {
+                case 0x0:
+                    out.append(0xF0)
+                    out.append(contentsOf: payload)
+                    out.append(0xF7)
+                    sysExPending = []
+                    inSysEx = false
+                case 0x1:
+                    sysExPending = payload
+                    inSysEx = true
+                case 0x2:
+                    // A continue with no start is a fragment whose head this call never saw. It is
+                    // counted rather than emitted: half a display write is not a display write.
+                    if inSysEx {
+                        sysExPending.append(contentsOf: payload)
+                    } else {
+                        unconverted += size
+                    }
+                case 0x3:
+                    if inSysEx {
+                        out.append(0xF0)
+                        out.append(contentsOf: sysExPending)
+                        out.append(contentsOf: payload)
+                        out.append(0xF7)
+                    } else {
+                        unconverted += size
+                    }
+                    sysExPending = []
+                    inSysEx = false
+                default:
+                    unconverted += size
+                }
             default:
-                // Everything else is a message this converter does not read: SysEx7 data, MIDI 2.0
-                // channel voice, Data128, Flex Data, UMP Stream. It is skipped WHOLE.
+                // Everything else is a message this converter does not read: MIDI 2.0 channel voice,
+                // Data128, Flex Data, UMP Stream. It is skipped WHOLE.
                 unconverted += size
             }
             i += size
+        }
+        // A SysEx left open when the packet ended is not a message. Counting its words keeps the
+        // gap visible instead of letting a partial display write look like a complete one.
+        if inSysEx {
+            unconverted += (sysExPending.count + 5) / 6 * 2
         }
         return (out, unconverted)
     }

--- a/Tests/LogicProMCPTests/MIDIFeedbackSysExConversionTests.swift
+++ b/Tests/LogicProMCPTests/MIDIFeedbackSysExConversionTests.swift
@@ -1,0 +1,102 @@
+import Testing
+
+@testable import LogicProMCP
+
+/// The UMP converter skipped SysEx7 whole, so the MCU display never reached `parseBytes` — which
+/// has handled `.sysEx` all along. That is where the surface says WHAT it is controlling, by name,
+/// and #856 could only read it through a throwaway raw-word dump.
+///
+/// The `F0`/`F7` framing is implied by the SysEx7 status and absent from the data, so these rows
+/// assert it is added back, and that a fragment whose other half is not in this packet is COUNTED
+/// rather than emitted — half a display write is not a display write.
+@Suite("UMP SysEx7 reaches the parser")
+struct MIDIFeedbackSysExConversionTests {
+    /// word0 = mt(4) group(4) status(4) numBytes(4) data0(8) data1(8)
+    private func word0(status: UInt32, count: UInt32, _ d0: UInt32, _ d1: UInt32) -> UInt32 {
+        (0x3 << 28) | (0 << 24) | (status << 20) | (count << 16) | (d0 << 8) | d1
+    }
+    private func word1(_ d2: UInt32, _ d3: UInt32, _ d4: UInt32, _ d5: UInt32) -> UInt32 {
+        (d2 << 24) | (d3 << 16) | (d4 << 8) | d5
+    }
+
+    @Test("a complete SysEx7 in one message becomes a framed F0…F7")
+    func completeMessageIsFramed() {
+        // MCU display header: 00 00 66 14 12 00
+        let words = [word0(status: 0, count: 6, 0x00, 0x00), word1(0x66, 0x14, 0x12, 0x00)]
+        let result = MIDIFeedback.midi1Bytes(fromUMPWords: words)
+        #expect(result.bytes == [0xF0, 0x00, 0x00, 0x66, 0x14, 0x12, 0x00, 0xF7])
+        #expect(result.unconverted == 0)
+    }
+
+    @Test("a start/end pair is joined into one message")
+    func startAndEndAreJoined() {
+        let words = [
+            word0(status: 1, count: 6, 0x00, 0x00), word1(0x66, 0x14, 0x12, 0x00),
+            word0(status: 3, count: 2, 0x41, 0x42), word1(0, 0, 0, 0),
+        ]
+        let result = MIDIFeedback.midi1Bytes(fromUMPWords: words)
+        #expect(result.bytes == [0xF0, 0x00, 0x00, 0x66, 0x14, 0x12, 0x00, 0x41, 0x42, 0xF7])
+        #expect(result.unconverted == 0)
+    }
+
+    @Test("a continue between start and end carries its bytes")
+    func continueIsCarried() {
+        let words = [
+            word0(status: 1, count: 2, 0x01, 0x02), word1(0, 0, 0, 0),
+            word0(status: 2, count: 2, 0x03, 0x04), word1(0, 0, 0, 0),
+            word0(status: 3, count: 2, 0x05, 0x06), word1(0, 0, 0, 0),
+        ]
+        let result = MIDIFeedback.midi1Bytes(fromUMPWords: words)
+        #expect(result.bytes == [0xF0, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0xF7])
+    }
+
+    @Test("a SysEx left open when the packet ends is counted, not emitted")
+    func unterminatedIsCounted() {
+        let words = [word0(status: 1, count: 6, 0x00, 0x00), word1(0x66, 0x14, 0x12, 0x00)]
+        let result = MIDIFeedback.midi1Bytes(fromUMPWords: words)
+        #expect(result.bytes.isEmpty)
+        #expect(result.unconverted > 0)
+    }
+
+    @Test("a continue with no start is counted, not emitted")
+    func orphanContinueIsCounted() {
+        let words = [word0(status: 2, count: 2, 0x41, 0x42), word1(0, 0, 0, 0)]
+        let result = MIDIFeedback.midi1Bytes(fromUMPWords: words)
+        #expect(result.bytes.isEmpty)
+        #expect(result.unconverted == 2)
+    }
+
+    @Test("numBytes larger than the two words can hold is refused, not clamped")
+    func overlongCountIsRefused() {
+        let words = [word0(status: 0, count: 7, 0x41, 0x42), word1(0, 0, 0, 0)]
+        let result = MIDIFeedback.midi1Bytes(fromUMPWords: words)
+        #expect(result.bytes.isEmpty)
+        #expect(result.unconverted == 2)
+    }
+
+    @Test("the assembled bytes parse back into a sysEx event")
+    func assembledBytesReachTheParser() {
+        let words = [word0(status: 0, count: 6, 0x00, 0x00), word1(0x66, 0x14, 0x12, 0x00)]
+        let events = MIDIFeedback.parseBytes(MIDIFeedback.midi1Bytes(fromUMPWords: words).bytes)
+        var sawSysEx = false
+        for event in events {
+            if case .sysEx = event { sawSysEx = true }
+        }
+        #expect(sawSysEx)
+    }
+
+    /// Channel voice alongside SysEx must still convert — the new branch must not swallow the
+    /// stream it shares a loop with.
+    @Test("channel voice around a SysEx still converts")
+    func channelVoiceSurvives() {
+        let noteOn: UInt32 = (0x2 << 28) | (0x90 << 16) | (0x3C << 8) | 0x7F
+        let words = [
+            noteOn,
+            word0(status: 0, count: 2, 0x11, 0x22), word1(0, 0, 0, 0),
+            noteOn,
+        ]
+        let result = MIDIFeedback.midi1Bytes(fromUMPWords: words)
+        #expect(result.bytes == [0x90, 0x3C, 0x7F, 0xF0, 0x11, 0x22, 0xF7, 0x90, 0x3C, 0x7F])
+        #expect(result.unconverted == 0)
+    }
+}

--- a/Tests/LogicProMCPTests/MIDIFeedbackUMPConversionTests.swift
+++ b/Tests/LogicProMCPTests/MIDIFeedbackUMPConversionTests.swift
@@ -70,10 +70,15 @@ struct MIDIFeedbackUMPConversionTests {
     /// the case failed for the right reason. The fabrication is only visible when a real message
     /// follows: with the proper stride the continuation is consumed and one event comes out; with a
     /// one-word stride the continuation is read as a header and a second, invented event appears.
+    ///
+    /// The witness was SysEx7 until #856, which taught this converter to read it. That made the case
+    /// fail for a reason that had nothing to do with the stride, so the witness moved to a type that
+    /// is still skipped whole. What it proves is unchanged: a 64-bit message costs two words and a
+    /// converter that advanced one would read its tail as a header.
     @Test("a continuation word that looks like channel voice is not read as a header")
     func aContinuationWordIsNotReadAsAHeader() {
         let (bytes, unconverted) = MIDIFeedback.midi1Bytes(
-            fromUMPWords: [0x30060000, 0x20903C64, 0x20B03010])
+            fromUMPWords: [0x40903C00, 0x20903C64, 0x20B03010])
         let events = MIDIFeedback.parseBytes(bytes)
         #expect(events.count == 1)          // the control change only; the note-on would be invented
         #expect(unconverted == 2)           // the 64-bit message is two words of loss, not one
@@ -110,8 +115,10 @@ struct MIDIFeedbackUMPConversionTests {
     @Test("every multi-word message type is skipped whole, not walked into")
     func multiWordStridesDoNotFabricate() {
         let fakeChannelVoice: UInt32 = 0x20903C64      // reads as note-on if walked into
+        // SysEx7 (0x3) is DELIBERATELY absent: #856 taught this converter to read it, because the
+        // MCU display arrives that way and was being discarded. Its stride is asserted below
+        // instead, so dropping it from this sweep does not drop the coverage.
         let cases: [(name: String, header: UInt32, words: Int)] = [
-            ("SysEx7 / Data64", 0x30060000, 2),
             ("MIDI 2.0 channel voice", 0x40903C00, 2),
             ("Data128", 0x50000000, 4),
             ("64-bit reserved 0x8", 0x80000000, 2),
@@ -127,6 +134,23 @@ struct MIDIFeedbackUMPConversionTests {
             // Words, not messages: a message this converter skips costs its whole width.
             #expect(unconverted == testCase.words, "\(testCase.name) reported \(unconverted)")
         }
+
+        // SysEx7's stride, asserted here rather than assumed: a complete message consumes BOTH its
+        // words, so the note-on that follows is the only channel-voice event. A one-word stride
+        // would read the payload word as a header and invent one.
+        let sysExThenNote: [UInt32] = [0x30060000, 0x20903C64, 0x20B03010]
+        let (bytes, unconverted) = MIDIFeedback.midi1Bytes(fromUMPWords: sysExThenNote)
+        let events = MIDIFeedback.parseBytes(bytes)
+        #expect(unconverted == 0, "SysEx7 is read now, so nothing is lost")
+        #expect(events.count == 2, "the SysEx and the control change, and no invented note-on")
+        var sawSysEx = false
+        var sawControlChange = false
+        for event in events {
+            if case .sysEx = event { sawSysEx = true }
+            if case .controlChange = event { sawControlChange = true }
+        }
+        #expect(sawSysEx)
+        #expect(sawControlChange)
     }
 
     /// A message whose words are not all present. Walking into the remainder reads a truncated tail


### PR DESCRIPTION
The UMP converter skipped SysEx7 whole, so every MCU display write was counted as "not read" and
discarded. That is where the surface says **what it is controlling, by name** — and `parseBytes` has
handled `.sysEx` all along, so the gap was only in the conversion.

Through the shipped path, with no spike:

```
rx_frames          111 -> 160
sysex_frames         0 -> 49
unconverted_words   49 -> 0
lcd  "DelCls DelCls DelCls StdGrn StdGrn ...  0  0  0  0"
```

## How this was found

#856 asked whether the MCU plane could carry a plug-in parameter with a readback. Chasing it turned
up something larger, recorded in `docs/observations/2026-09-11-the-mcu-plane-was-never-connected-and-plug-in-mode-works.json`:
**this host had no control surface installed at all.** Logic's Control Surface Setup listed zero
devices and its Input Port read `Invalid Port`. Four MCU button classes were verified sent and
produced no effect and no echo, while an AX selection readback moved in the same run — which is what
makes those zeros readings rather than silence.

With a `Mackie Control` installed and both ports bound, plug-in assignment mode remaps the V-Pots and
the surface reports it two ways: ring values (`86 -> [1,1,1,5,5,5,5,5] -> 86`) and the LCD naming
what it controls (`Cha EQ` per strip). The LCD is SysEx. That is this change.

## What it does

The `F0`/`F7` framing is implied by the SysEx7 status rather than carried in the data, so it is added
back. Two things are **counted rather than emitted**: a continue whose start this packet never saw,
and a message still open when the packet ends — half a display write is not a display write, and the
function is called per packet with no state between calls. An over-long `numBytes` is refused rather
than clamped, because a packet that lies about its length is not one to half-believe.

Eight new rows, and each branch shown able to fail: dropping the terminator, accepting an over-long
count, emitting an orphan continue, and no longer counting an unterminated message each killed the
row aimed at it.

## Two #736 rows pinned the old contract

They asserted SysEx7 is *skipped*, which this change makes false. Their subject is the **stride** — a
64-bit message costs two words, and a converter advancing one reads its tail as a header and invents
an event no device sent. That is kept: the witness moved to MIDI 2.0 channel voice, which is still
skipped, and SysEx7's own stride is asserted alongside the sweep rather than dropped from it.

Shown rather than claimed: breaking the SysEx7 stride to one word and breaking the MIDI 2.0 stride to
one word each fail the rows aimed at them. The coverage survived the edit.

## Not covered

Cross-packet assembly on real traffic. Every display write observed on this host arrived inside one
packet, so the multi-packet path has synthetic rows and no live evidence, and the source says so.

**#856 stays open.** The issue asks whether `.mixerSetPluginParam` can have a State A, and
that needs the `assignPlugin` route and a V-Pot write wired as well. SysEx was the critical path and
the piece that was silently discarding evidence.
